### PR TITLE
feat(search): canvas-wide multi-source search (Cmd+Shift+F)

### DIFF
--- a/src/renderer/ui/GlobalSearch.tsx
+++ b/src/renderer/ui/GlobalSearch.tsx
@@ -243,12 +243,6 @@ export function GlobalSearch() {
     return () => document.removeEventListener('keydown', handleKeyDown, { capture: true })
   }, [show, results, selectedIndex, close, selectResult])
 
-  const sectionLabel = useMemo(() => ({
-    panel: 'Open Panels',
-    terminal: 'Terminal Output',
-    file: 'Workspace Files',
-  } as Record<ResultKind, string>), [])
-
   // Group results by kind for rendering while preserving global order.
   const grouped = useMemo(() => {
     const seen = new Set<ResultKind>()
@@ -265,7 +259,7 @@ export function GlobalSearch() {
   let flatIndex = 0
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-20 bg-black/40"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-40 bg-black/40"
       onClick={close}
     >
       <div
@@ -289,9 +283,6 @@ export function GlobalSearch() {
             {grouped.map((section, si) => (
               <div key={section.kind}>
                 {si > 0 && <div className="mx-5 my-1 border-t border-white/10" />}
-                <div className="px-5 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted font-semibold">
-                  {sectionLabel[section.kind]}
-                </div>
                 {section.items.map((r) => {
                   const thisIndex = flatIndex++
                   const isSelected = thisIndex === selectedIndex
@@ -331,7 +322,7 @@ export function GlobalSearch() {
 // -----------------------------------------------------------------------------
 
 function ResultIcon({ result }: { result: SearchResult }) {
-  const tile = 'w-8 h-8 rounded-md flex items-center justify-center shrink-0'
+  const tile = 'w-8 h-8 rounded-full flex items-center justify-center shrink-0'
   if (result.kind === 'file') {
     return <div className={`${tile} bg-amber-500/15 text-amber-400`}><FileText size={16} weight="bold" /></div>
   }

--- a/src/renderer/ui/GlobalSearch.tsx
+++ b/src/renderer/ui/GlobalSearch.tsx
@@ -5,7 +5,8 @@
 // =============================================================================
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
-import { MagnifyingGlass } from '@phosphor-icons/react'
+import { MagnifyingGlass, FileText, Terminal, Globe, Folder, Stack, GitBranch, Square } from '@phosphor-icons/react'
+import type { PanelType } from '../../shared/types'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
@@ -36,6 +37,7 @@ interface FileResult extends BaseResult {
 interface PanelResult extends BaseResult {
   kind: 'panel'
   panelId: string
+  panelType: PanelType
   nodeId?: string
 }
 
@@ -104,6 +106,7 @@ export function GlobalSearch() {
         secondary: fp || url || panel.type,
         score: 2000 + recency,
         panelId: panel.id,
+        panelType: panel.type,
         nodeId: n?.id,
       })
     }
@@ -266,26 +269,27 @@ export function GlobalSearch() {
       onClick={close}
     >
       <div
-        className="w-[640px] max-h-[520px] rounded-2xl overflow-hidden flex flex-col bg-surface-4/85 backdrop-blur-xl border border-subtle shadow-2xl"
+        className="w-[640px] max-h-[560px] rounded-3xl overflow-hidden flex flex-col bg-surface-4/85 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center gap-3 px-4 h-12">
-          <MagnifyingGlass size={18} className="text-muted shrink-0" />
+        <div className="flex items-center gap-3 px-5 h-14">
+          <MagnifyingGlass size={20} className="text-muted shrink-0" weight="bold" />
           <input
             autoFocus
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="flex-1 bg-transparent text-primary text-base outline-none placeholder:text-muted"
+            className="flex-1 bg-transparent text-primary text-base font-medium outline-none placeholder:text-muted placeholder:font-normal"
             placeholder="Search files, terminals, panels…"
           />
         </div>
 
         {results.length > 0 && (
-          <div className="flex-1 overflow-y-auto border-t border-subtle">
-            {grouped.map((section) => (
+          <div className="flex-1 overflow-y-auto pb-2">
+            {grouped.map((section, si) => (
               <div key={section.kind}>
-                <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted">
+                {si > 0 && <div className="mx-5 my-1 border-t border-white/10" />}
+                <div className="px-5 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted font-semibold">
                   {sectionLabel[section.kind]}
                 </div>
                 {section.items.map((r) => {
@@ -294,13 +298,16 @@ export function GlobalSearch() {
                   return (
                     <div
                       key={r.key}
-                      className={`px-3 py-1.5 cursor-pointer text-sm ${
-                        isSelected ? 'bg-blue-600/20' : 'hover:bg-hover'
+                      className={`flex items-center gap-3 mx-2 px-3 py-2 cursor-pointer rounded-lg ${
+                        isSelected ? 'bg-blue-600/30' : 'hover:bg-white/5'
                       }`}
                       onClick={() => selectResult(r)}
                     >
-                      <div className="text-primary text-xs font-mono truncate">{r.primary}</div>
-                      <div className="text-muted text-[11px] font-mono truncate mt-0.5">{r.secondary}</div>
+                      <ResultIcon result={r} />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-primary text-sm font-medium truncate">{r.primary}</div>
+                        <div className="text-muted text-xs truncate mt-0.5">{r.secondary}</div>
+                      </div>
                     </div>
                   )
                 })}
@@ -310,11 +317,34 @@ export function GlobalSearch() {
         )}
 
         {query.length >= 2 && results.length === 0 && !busy && (
-          <div className="px-3 py-4 text-sm text-muted text-center border-t border-subtle">
+          <div className="px-5 py-5 text-sm text-muted text-center border-t border-white/10">
             No results
           </div>
         )}
       </div>
     </div>
   )
+}
+
+// -----------------------------------------------------------------------------
+// Result icon — type-aware glyph in a tinted square tile
+// -----------------------------------------------------------------------------
+
+function ResultIcon({ result }: { result: SearchResult }) {
+  const tile = 'w-8 h-8 rounded-md flex items-center justify-center shrink-0'
+  if (result.kind === 'file') {
+    return <div className={`${tile} bg-amber-500/15 text-amber-400`}><FileText size={16} weight="bold" /></div>
+  }
+  if (result.kind === 'terminal') {
+    return <div className={`${tile} bg-emerald-500/15 text-emerald-400`}><Terminal size={16} weight="bold" /></div>
+  }
+  // panel — type-specific
+  const { panelType } = result
+  if (panelType === 'terminal') return <div className={`${tile} bg-emerald-500/15 text-emerald-400`}><Terminal size={16} weight="bold" /></div>
+  if (panelType === 'browser')  return <div className={`${tile} bg-sky-500/15 text-sky-400`}><Globe size={16} weight="bold" /></div>
+  if (panelType === 'editor')   return <div className={`${tile} bg-orange-500/15 text-orange-400`}><FileText size={16} weight="bold" /></div>
+  if (panelType === 'git')      return <div className={`${tile} bg-red-500/15 text-red-400`}><GitBranch size={16} weight="bold" /></div>
+  if (panelType === 'fileExplorer') return <div className={`${tile} bg-cyan-500/15 text-cyan-400`}><Folder size={16} weight="bold" /></div>
+  if (panelType === 'projectList')  return <div className={`${tile} bg-yellow-500/15 text-yellow-400`}><Stack size={16} weight="bold" /></div>
+  return <div className={`${tile} bg-violet-500/15 text-violet-400`}><Square size={16} weight="bold" /></div>
 }

--- a/src/renderer/ui/GlobalSearch.tsx
+++ b/src/renderer/ui/GlobalSearch.tsx
@@ -5,6 +5,7 @@
 // =============================================================================
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
+import { MagnifyingGlass } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
@@ -265,16 +266,17 @@ export function GlobalSearch() {
       onClick={close}
     >
       <div
-        className="w-[640px] max-h-[520px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle"
+        className="w-[640px] max-h-[520px] rounded-2xl overflow-hidden flex flex-col bg-surface-4/85 backdrop-blur-xl border border-subtle shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-3">
+        <div className="flex items-center gap-3 px-4 h-12">
+          <MagnifyingGlass size={18} className="text-muted shrink-0" />
           <input
             autoFocus
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full bg-surface-3 text-primary text-sm px-3 py-2 rounded-lg border border-subtle outline-none focus:border-blue-500/50"
+            className="flex-1 bg-transparent text-primary text-base outline-none placeholder:text-muted"
             placeholder="Search files, terminals, panels…"
           />
         </div>

--- a/src/renderer/ui/GlobalSearch.tsx
+++ b/src/renderer/ui/GlobalSearch.tsx
@@ -1,24 +1,51 @@
 // =============================================================================
-// GlobalSearch — Overlay for searching across all open editor panels.
-// Triggered by the globalSearch shortcut (Cmd+Shift+H).
+// GlobalSearch — Canvas-wide search overlay.
+// Searches workspace files, terminal scrollback, and open panels.
+// Triggered by the globalSearch shortcut (Cmd+Shift+F).
 // =============================================================================
 
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { useDockStore } from '../stores/dockStore'
+import { findTabStack } from '../stores/dockTreeUtils'
+import { terminalRegistry } from '../lib/terminalRegistry'
 
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
 
-interface SearchResult {
-  filePath: string
-  panelId: string
-  nodeId: string
-  line: number
-  text: string
+type ResultKind = 'file' | 'panel' | 'terminal'
+
+interface BaseResult {
+  key: string
+  kind: ResultKind
+  primary: string
+  secondary: string
+  score: number
 }
+
+interface FileResult extends BaseResult {
+  kind: 'file'
+  filePath: string
+  line?: number
+}
+
+interface PanelResult extends BaseResult {
+  kind: 'panel'
+  panelId: string
+  nodeId?: string
+}
+
+interface TerminalResult extends BaseResult {
+  kind: 'terminal'
+  panelId: string
+  nodeId?: string
+  line: number
+}
+
+type SearchResult = FileResult | PanelResult | TerminalResult
 
 // -----------------------------------------------------------------------------
 // Component
@@ -30,6 +57,7 @@ export function GlobalSearch() {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [busy, setBusy] = useState(false)
 
   const close = useCallback(() => {
     useUIStore.getState().setShowGlobalSearch(false)
@@ -37,12 +65,12 @@ export function GlobalSearch() {
     setResults([])
   }, [])
 
-  // Search across open editor files
   const doSearch = useCallback(async (searchText: string) => {
     if (!searchText || searchText.length < 2) {
       setResults([])
       return
     }
+    const q = searchText.toLowerCase()
 
     const workspace = useAppStore.getState().workspaces.find(
       (w) => w.id === useAppStore.getState().selectedWorkspaceId,
@@ -50,65 +78,151 @@ export function GlobalSearch() {
     if (!workspace) return
 
     const canvasNodes = canvasApi.getState().nodes
-    const found: SearchResult[] = []
-
-    for (const [panelId, panel] of Object.entries(workspace.panels)) {
-      if (panel.type !== 'editor' || !panel.filePath) continue
-
-      try {
-        const content = await window.electronAPI.fsReadFile(panel.filePath)
-        const lines = content.split('\n')
-        const lowerQuery = searchText.toLowerCase()
-
-        for (let i = 0; i < lines.length; i++) {
-          if (lines[i].toLowerCase().includes(lowerQuery)) {
-            const nodeId =
-              Object.values(canvasNodes).find((n) => n.panelId === panelId)?.id || ''
-            found.push({
-              filePath: panel.filePath,
-              panelId,
-              nodeId,
-              line: i + 1,
-              text: lines[i].trim(),
-            })
-            if (found.length >= 50) break
-          }
-        }
-      } catch {
-        /* file not readable */
-      }
-      if (found.length >= 50) break
+    const focusedNodeId = canvasApi.getState().focusedNodeId
+    const nodeByPanelId = new Map<string, { id: string; creationIndex: number }>()
+    for (const n of Object.values(canvasNodes)) {
+      nodeByPanelId.set(n.panelId, { id: n.id, creationIndex: n.creationIndex })
     }
 
-    setResults(found)
+    const out: SearchResult[] = []
+
+    // 1) Open panels (title + file path)
+    for (const panel of Object.values(workspace.panels)) {
+      const title = panel.title ?? ''
+      const fp = panel.filePath ?? ''
+      const url = panel.url ?? ''
+      const hay = `${title}\n${fp}\n${url}`.toLowerCase()
+      if (!hay.includes(q)) continue
+      const n = nodeByPanelId.get(panel.id)
+      // Recent-focus ranking: currently-focused panel first, then higher creationIndex.
+      const recency = n ? (focusedNodeId === n.id ? 1_000_000 : n.creationIndex) : 0
+      out.push({
+        key: `panel:${panel.id}`,
+        kind: 'panel',
+        primary: title || panel.type,
+        secondary: fp || url || panel.type,
+        score: 2000 + recency,
+        panelId: panel.id,
+        nodeId: n?.id,
+      })
+    }
+
+    // 2) Terminal scrollback
+    const terminalPanels = Object.values(workspace.panels).filter((p) => p.type === 'terminal')
+    for (const panel of terminalPanels) {
+      const entry = terminalRegistry.getEntry(panel.id)
+      if (!entry) continue
+      const buffer = entry.terminal.buffer.active
+      const last = buffer.baseY + buffer.cursorY
+      let matches = 0
+      for (let i = 0; i < last && matches < 5; i++) {
+        const line = buffer.getLine(i)
+        if (!line) continue
+        const text = line.translateToString(true)
+        if (text.toLowerCase().includes(q)) {
+          matches++
+          const n = nodeByPanelId.get(panel.id)
+          out.push({
+            key: `term:${panel.id}:${i}`,
+            kind: 'terminal',
+            primary: `${panel.title}:${i + 1}`,
+            secondary: text.trim().slice(0, 200),
+            score: 1000 + (n ? n.creationIndex : 0),
+            panelId: panel.id,
+            nodeId: n?.id,
+            line: i + 1,
+          })
+        }
+      }
+    }
+
+    // 3) Workspace files (names + content) via fsSearch
+    if (workspace.rootPath) {
+      try {
+        const hits = await window.electronAPI.fsSearch(workspace.rootPath, searchText, { maxResults: 50 })
+        for (const h of hits) {
+          if (h.isDirectory) continue
+          out.push({
+            key: `file:${h.path}${h.contentLine ?? ''}`,
+            kind: 'file',
+            primary: h.name + (h.contentLine ? `:${h.contentLine}` : ''),
+            secondary: h.contentPreview?.trim().slice(0, 200) || h.relativePath,
+            score: h.nameMatch ? 500 : 100,
+            filePath: h.path,
+            line: h.contentLine,
+          })
+        }
+      } catch {
+        /* filesystem search unavailable */
+      }
+    }
+
+    out.sort((a, b) => b.score - a.score)
+    setResults(out.slice(0, 80))
     setSelectedIndex(0)
-  }, [])
+  }, [canvasApi])
 
   // Debounced search
   useEffect(() => {
     if (!show) return
-    const timer = setTimeout(() => doSearch(query), 300)
-    return () => clearTimeout(timer)
+    setBusy(true)
+    const timer = setTimeout(async () => {
+      await doSearch(query)
+      setBusy(false)
+    }, 250)
+    return () => { clearTimeout(timer); setBusy(false) }
   }, [query, show, doSearch])
 
   const selectResult = useCallback(
-    (result: SearchResult) => {
-      if (result.nodeId) {
-        canvasApi.getState().focusAndCenter(result.nodeId)
+    async (result: SearchResult) => {
+      const appStore = useAppStore.getState()
+      const wsId = appStore.selectedWorkspaceId
+      if (result.kind === 'file') {
+        // Open in an editor panel. If an editor for this file already exists, focus it.
+        const ws = appStore.workspaces.find((w) => w.id === wsId)
+        let panelId: string | undefined
+        if (ws) {
+          const existing = Object.values(ws.panels).find(
+            (p) => p.type === 'editor' && p.filePath === result.filePath,
+          )
+          panelId = existing?.id
+        }
+        if (!panelId) {
+          panelId = appStore.createEditor(wsId, result.filePath)
+        }
+        const cs = canvasApi.getState()
+        const node = panelId ? Object.values(cs.nodes).find((n) => n.panelId === panelId) : undefined
+        if (node) cs.focusAndCenter(node.id)
+      } else if (result.kind === 'panel' || result.kind === 'terminal') {
+        if (result.nodeId) {
+          canvasApi.getState().focusAndCenter(result.nodeId)
+        } else {
+          // Dock panel — reveal in dock zone.
+          const dock = useDockStore.getState()
+          const loc = dock.getPanelLocation(result.panelId)
+          if (loc && loc.type === 'dock') {
+            const zone = dock.zones[loc.zone]
+            if (!zone.visible) dock.toggleZone(loc.zone)
+            if (zone.layout) {
+              const stack = findTabStack(zone.layout, loc.stackId)
+              if (stack) {
+                const idx = stack.panelIds.indexOf(result.panelId)
+                if (idx >= 0) dock.setActiveTab(loc.stackId, idx)
+              }
+            }
+          }
+        }
       }
       close()
     },
-    [close],
+    [canvasApi, close],
   )
 
   // Keyboard navigation
   useEffect(() => {
     if (!show) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close()
-        return
-      }
+      if (e.key === 'Escape') { close(); return }
       if (e.key === 'ArrowDown') {
         e.preventDefault()
         setSelectedIndex((prev) => Math.min(prev + 1, results.length - 1))
@@ -125,15 +239,33 @@ export function GlobalSearch() {
     return () => document.removeEventListener('keydown', handleKeyDown, { capture: true })
   }, [show, results, selectedIndex, close, selectResult])
 
+  const sectionLabel = useMemo(() => ({
+    panel: 'Open Panels',
+    terminal: 'Terminal Output',
+    file: 'Workspace Files',
+  } as Record<ResultKind, string>), [])
+
+  // Group results by kind for rendering while preserving global order.
+  const grouped = useMemo(() => {
+    const seen = new Set<ResultKind>()
+    const sections: { kind: ResultKind; items: SearchResult[] }[] = []
+    for (const r of results) {
+      if (!seen.has(r.kind)) { seen.add(r.kind); sections.push({ kind: r.kind, items: [] }) }
+      sections.find((s) => s.kind === r.kind)!.items.push(r)
+    }
+    return sections
+  }, [results])
+
   if (!show) return null
 
+  let flatIndex = 0
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-20 bg-black/40"
       onClick={close}
     >
       <div
-        className="w-[600px] max-h-[500px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle"
+        className="w-[640px] max-h-[520px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-3">
@@ -143,36 +275,41 @@ export function GlobalSearch() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             className="w-full bg-surface-3 text-primary text-sm px-3 py-2 rounded-lg border border-subtle outline-none focus:border-blue-500/50"
-            placeholder="Search in open editors..."
+            placeholder="Search files, terminals, panels…"
           />
         </div>
 
         {results.length > 0 && (
           <div className="flex-1 overflow-y-auto border-t border-subtle">
-            {results.map((result, i) => (
-              <div
-                key={`${result.filePath}:${result.line}`}
-                className={`px-3 py-2 cursor-pointer text-sm ${
-                  i === selectedIndex ? 'bg-blue-600/20' : 'hover:bg-hover'
-                }`}
-                onClick={() => selectResult(result)}
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-muted text-xs font-mono">
-                    {result.filePath.split('/').pop()}:{result.line}
-                  </span>
+            {grouped.map((section) => (
+              <div key={section.kind}>
+                <div className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-muted">
+                  {sectionLabel[section.kind]}
                 </div>
-                <div className="text-primary text-xs font-mono truncate mt-0.5">
-                  {result.text}
-                </div>
+                {section.items.map((r) => {
+                  const thisIndex = flatIndex++
+                  const isSelected = thisIndex === selectedIndex
+                  return (
+                    <div
+                      key={r.key}
+                      className={`px-3 py-1.5 cursor-pointer text-sm ${
+                        isSelected ? 'bg-blue-600/20' : 'hover:bg-hover'
+                      }`}
+                      onClick={() => selectResult(r)}
+                    >
+                      <div className="text-primary text-xs font-mono truncate">{r.primary}</div>
+                      <div className="text-muted text-[11px] font-mono truncate mt-0.5">{r.secondary}</div>
+                    </div>
+                  )
+                })}
               </div>
             ))}
           </div>
         )}
 
-        {query.length >= 2 && results.length === 0 && (
+        {query.length >= 2 && results.length === 0 && !busy && (
           <div className="px-3 py-4 text-sm text-muted text-center border-t border-subtle">
-            No results found
+            No results
           </div>
         )}
       </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -512,7 +512,9 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   newEditor: storedShortcut('e', { command: true, shift: true }),
   closePanel: storedShortcut('w', { command: true }),
   toggleSidebar: storedShortcut('\\', { command: true }),
-  toggleFileExplorer: storedShortcut('f', { command: true, shift: true }),
+  // Moved from Cmd+Shift+F so `globalSearch` can take the find-in-files
+  // standard binding without a collision.
+  toggleFileExplorer: storedShortcut('x', { command: true, shift: true }),
   toggleMinimap: storedShortcut('m', { command: true, shift: true }),
   nodeSwitcher: storedShortcut(' ', { control: true }),
   panelSwitcher: storedShortcut('e', { command: true }),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -525,7 +525,7 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   saveFile: storedShortcut('s', { command: true }),
   zoomToFit: storedShortcut('1', { command: true }),
   autoLayout: storedShortcut('l', { command: true, shift: true }),
-  globalSearch: storedShortcut('h', { command: true, shift: true }),
+  globalSearch: storedShortcut('f', { command: true, shift: true }),
   undo: storedShortcut('z', { command: true }),
   redo: storedShortcut('z', { command: true, shift: true }),
   deleteNode: storedShortcut('Backspace', { command: true }),


### PR DESCRIPTION
## Summary
- Rewrite Global Search from "find in open editor files" to a unified lookup across **workspace files**, **live terminal scrollback**, and **open panel titles/paths**. Rebinds to `Cmd+Shift+F` (moved `toggleFileExplorer` off that slot to `Cmd+Shift+X` to avoid the collision that silently shadowed the search).
- Results are grouped by source and ranked with recent-focus first — the currently-focused panel always wins, then creation order, then match quality. File content hits come from the existing `fsSearch` main handler; terminal scrollback hits read the live xterm buffer for every terminal panel.
- Visual pass to match the Spotlight look the user asked for: `rounded-3xl`, brighter `white/20` outline, backdrop blur, offset from the top, bolder input text, bolder magnifying-glass icon, type-colored circular icon tiles on each row, inset selection highlight, section dividers inset with `mx-5` (not full width).

## Test plan
- [ ] `Cmd+Shift+F` opens the search overlay (was being eaten by `toggleFileExplorer`; collision is fixed).
- [ ] Typing 2+ chars returns hits from files, terminal scrollback, and open panels.
- [ ] Enter on a file hit reuses an existing editor panel if one already targets that path, otherwise creates one and focuses it.
- [ ] Enter on a canvas panel centers it; Enter on a dock panel (git / file explorer) reveals that zone and activates the tab.
- [ ] `Cmd+Shift+X` now toggles the file explorer.
- [ ] Escape closes the overlay; `Cmd+F` inside an editor still invokes Monaco's find-in-file (shortcut is intercepted in capture phase only for `Cmd+Shift+F`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)