### PR TITLE
feat(layouts): saved layouts manager with Spotlight-style UI

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -38,6 +38,7 @@ import { GlobalSearch } from './ui/GlobalSearch'
 import { SettingsWindow } from './settings/SettingsWindow'
 import { ToastContainer } from './ui/ToastContainer'
 import { AISetupDialog } from './dialogs/AISetupDialog'
+import { SavedLayoutsDialog } from './dialogs/SavedLayoutsDialog'
 import { loadSession, restoreSession, restoreMultiWorkspaceSession, restoreDetachedWindows, setupAutoSave, saveSession } from './lib/session'
 import type { MultiWorkspaceSession } from '../shared/types'
 import { useDockStore } from './stores/dockStore'
@@ -455,6 +456,7 @@ function MainApp() {
       {showAISetupDialog && (
         <AISetupDialog workspaceId={selectedWorkspaceId} />
       )}
+      <SavedLayoutsDialog />
 
       <ToastContainer />
       <DragGhost />

--- a/src/renderer/dialogs/SavedLayoutsDialog.tsx
+++ b/src/renderer/dialogs/SavedLayoutsDialog.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { FloppyDisk, Trash, FolderOpen, SquaresFour } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
-import { useAppStore } from '../stores/appStore'
+import { useAppStore, getWorkspaceCanvasStore } from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import log from '../lib/logger'
 
@@ -89,7 +89,12 @@ export function SavedLayoutsDialog() {
         | null
       if (!snap) { setError('Layout not found'); return }
       const wsId = useAppStore.getState().selectedWorkspaceId
-      useAppStore.getState().closeAllPanels(wsId)
+      const app = useAppStore.getState()
+      app.closeAllPanels(wsId)
+      // closeAllPanels wipes every panel — including the 'canvas' host panel
+      // that owns the dock center zone. Recreate it before we start adding
+      // nodes so the fresh canvas exists to receive them.
+      app.ensureCenterCanvas(wsId)
       for (const node of snap.nodes ?? []) {
         switch (node.panelType) {
           case 'terminal': useAppStore.getState().createTerminal(wsId, undefined, node.origin); break
@@ -97,10 +102,13 @@ export function SavedLayoutsDialog() {
           case 'browser':  useAppStore.getState().createBrowser(wsId, node.url, node.origin); break
         }
       }
+      // Use the *new* canvas store, not the one captured at mount time — the
+      // previous one was disposed along with its panel.
+      const freshCanvas = getWorkspaceCanvasStore(wsId) ?? canvasApi
       for (const region of snap.regions ?? []) {
-        canvasApi.getState().addRegion(region.label, region.origin, region.size, region.color)
+        freshCanvas.getState().addRegion(region.label, region.origin, region.size, region.color)
       }
-      canvasApi.getState().zoomToFit()
+      freshCanvas.getState().zoomToFit()
       close()
     } catch (err) {
       log.error('[SavedLayoutsDialog] load failed', err)

--- a/src/renderer/dialogs/SavedLayoutsDialog.tsx
+++ b/src/renderer/dialogs/SavedLayoutsDialog.tsx
@@ -1,0 +1,218 @@
+// =============================================================================
+// SavedLayoutsDialog — Manager for named canvas layouts.
+// Save the current canvas arrangement, load one, or delete it.
+// =============================================================================
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { X, FloppyDisk, Trash, FolderOpen } from '@phosphor-icons/react'
+import { useUIStore } from '../stores/uiStore'
+import { useAppStore } from '../stores/appStore'
+import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import log from '../lib/logger'
+
+export function SavedLayoutsDialog() {
+  const show = useUIStore((s) => s.showLayoutsDialog)
+  const setShow = useUIStore((s) => s.setShowLayoutsDialog)
+  const canvasApi = useCanvasStoreApi()
+
+  const [names, setNames] = useState<string[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+  const [saveName, setSaveName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await window.electronAPI.layoutList()
+      setNames(list.sort((a, b) => a.localeCompare(b)))
+    } catch (err) {
+      log.warn('[SavedLayoutsDialog] list failed', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (show) {
+      refresh()
+      setSaveName('')
+      setSelected(null)
+      setError(null)
+    }
+  }, [show, refresh])
+
+  const close = useCallback(() => setShow(false), [setShow])
+
+  const buildSnapshot = useCallback(() => {
+    const state = canvasApi.getState()
+    const appState = useAppStore.getState()
+    const workspace = appState.workspaces.find((w) => w.id === appState.selectedWorkspaceId)
+    return {
+      nodes: Object.values(state.nodes).map((n) => {
+        const panel = workspace?.panels[n.panelId]
+        return {
+          panelType: panel?.type ?? 'terminal',
+          origin: n.origin,
+          size: n.size,
+          filePath: panel?.filePath,
+          url: panel?.url,
+        }
+      }),
+      regions: Object.values(state.regions).map((r) => ({
+        origin: r.origin, size: r.size, label: r.label, color: r.color,
+      })),
+      zoomLevel: state.zoomLevel,
+      viewportOffset: state.viewportOffset,
+    }
+  }, [canvasApi])
+
+  const handleSave = useCallback(async () => {
+    const name = saveName.trim()
+    if (!name) { setError('Name is required'); return }
+    setBusy(true); setError(null)
+    try {
+      await window.electronAPI.layoutSave(name, buildSnapshot())
+      setSaveName('')
+      await refresh()
+      setSelected(name)
+    } catch (err) {
+      log.error('[SavedLayoutsDialog] save failed', err)
+      setError('Save failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [saveName, buildSnapshot, refresh])
+
+  const handleLoad = useCallback(async (name: string) => {
+    setBusy(true); setError(null)
+    try {
+      const snap = await window.electronAPI.layoutLoad(name) as
+        | { nodes?: Array<{ panelType: string; origin: { x: number; y: number }; size: { width: number; height: number }; filePath?: string; url?: string }>; regions?: Array<{ label: string; origin: { x: number; y: number }; size: { width: number; height: number }; color?: string }> }
+        | null
+      if (!snap) { setError('Layout not found'); return }
+      const wsId = useAppStore.getState().selectedWorkspaceId
+      useAppStore.getState().closeAllPanels(wsId)
+      for (const node of snap.nodes ?? []) {
+        switch (node.panelType) {
+          case 'terminal': useAppStore.getState().createTerminal(wsId, undefined, node.origin); break
+          case 'editor':   useAppStore.getState().createEditor(wsId, node.filePath, node.origin); break
+          case 'browser':  useAppStore.getState().createBrowser(wsId, node.url, node.origin); break
+        }
+      }
+      for (const region of snap.regions ?? []) {
+        canvasApi.getState().addRegion(region.label, region.origin, region.size, region.color)
+      }
+      canvasApi.getState().zoomToFit()
+      close()
+    } catch (err) {
+      log.error('[SavedLayoutsDialog] load failed', err)
+      setError('Load failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [canvasApi, close])
+
+  const handleDelete = useCallback(async (name: string) => {
+    if (!window.confirm(`Delete layout "${name}"?`)) return
+    setBusy(true); setError(null)
+    try {
+      await window.electronAPI.layoutDelete(name)
+      if (selected === name) setSelected(null)
+      await refresh()
+    } catch (err) {
+      log.error('[SavedLayoutsDialog] delete failed', err)
+      setError('Delete failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [selected, refresh])
+
+  if (!show) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={close}
+    >
+      <div
+        className="w-[520px] max-h-[600px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-subtle">
+          <div className="text-primary text-sm font-medium">Saved Layouts</div>
+          <button
+            onClick={close}
+            className="text-muted hover:text-primary transition-colors p-1 rounded hover:bg-hover"
+            title="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="p-3 border-b border-subtle flex gap-2">
+          <input
+            type="text"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSave() }}
+            className="flex-1 bg-surface-3 text-primary text-sm px-3 py-2 rounded-lg border border-subtle outline-none focus:border-blue-500/50"
+            placeholder="Save current canvas as…"
+            disabled={busy}
+          />
+          <button
+            onClick={handleSave}
+            disabled={busy || !saveName.trim()}
+            className="flex items-center gap-1.5 text-xs px-3 py-2 rounded-lg bg-blue-600/80 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <FloppyDisk size={14} />
+            Save
+          </button>
+        </div>
+
+        {error && (
+          <div className="px-4 py-2 text-xs text-red-400 bg-red-600/10 border-b border-subtle">
+            {error}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto">
+          {names.length === 0 ? (
+            <div className="px-4 py-10 text-sm text-muted text-center">
+              No saved layouts yet.
+            </div>
+          ) : (
+            names.map((name) => (
+              <div
+                key={name}
+                className={`group flex items-center justify-between gap-2 px-4 py-2 text-sm cursor-pointer ${
+                  selected === name ? 'bg-blue-600/20' : 'hover:bg-hover'
+                }`}
+                onClick={() => setSelected(name)}
+                onDoubleClick={() => handleLoad(name)}
+              >
+                <span className="text-primary truncate">{name}</span>
+                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleLoad(name) }}
+                    disabled={busy}
+                    className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-surface-6 hover:bg-hover text-primary"
+                    title="Load"
+                  >
+                    <FolderOpen size={12} />
+                    Load
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleDelete(name) }}
+                    disabled={busy}
+                    className="flex items-center gap-1 text-xs px-2 py-1 rounded text-red-400 hover:bg-red-600/20"
+                    title="Delete"
+                  >
+                    <Trash size={12} />
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/dialogs/SavedLayoutsDialog.tsx
+++ b/src/renderer/dialogs/SavedLayoutsDialog.tsx
@@ -6,7 +6,13 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { FloppyDisk, Trash, FolderOpen, SquaresFour } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
-import { useAppStore, getWorkspaceCanvasStore } from '../stores/appStore'
+import {
+  useAppStore,
+  getWorkspaceCanvasStore,
+  getWorkspaceCanvasPanelId,
+  ensureCanvasOpsForPanel,
+  setActiveCanvasPanelId,
+} from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import log from '../lib/logger'
 
@@ -95,6 +101,16 @@ export function SavedLayoutsDialog() {
       // that owns the dock center zone. Recreate it before we start adding
       // nodes so the fresh canvas exists to receive them.
       app.ensureCenterCanvas(wsId)
+      // The React CanvasPanel that would normally register the canvas's
+      // store + mark it active hasn't mounted yet. Register them
+      // synchronously so create* calls below resolve to the *new* canvas,
+      // not the disposed one — otherwise the Welcome screen would show
+      // because the new canvas ends up with zero nodes.
+      const newCanvasId = getWorkspaceCanvasPanelId(wsId)
+      if (newCanvasId) {
+        ensureCanvasOpsForPanel(newCanvasId)
+        setActiveCanvasPanelId(newCanvasId)
+      }
       for (const node of snap.nodes ?? []) {
         switch (node.panelType) {
           case 'terminal': useAppStore.getState().createTerminal(wsId, undefined, node.origin); break

--- a/src/renderer/dialogs/SavedLayoutsDialog.tsx
+++ b/src/renderer/dialogs/SavedLayoutsDialog.tsx
@@ -4,7 +4,7 @@
 // =============================================================================
 
 import React, { useCallback, useEffect, useState } from 'react'
-import { X, FloppyDisk, Trash, FolderOpen } from '@phosphor-icons/react'
+import { FloppyDisk, Trash, FolderOpen, SquaresFour } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
@@ -125,91 +125,102 @@ export function SavedLayoutsDialog() {
     }
   }, [selected, refresh])
 
+  // Escape to close
+  useEffect(() => {
+    if (!show) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); close() }
+    }
+    document.addEventListener('keydown', handler, { capture: true })
+    return () => document.removeEventListener('keydown', handler, { capture: true })
+  }, [show, close])
+
   if (!show) return null
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-40 bg-black/40"
       onClick={close}
     >
       <div
-        className="w-[520px] max-h-[600px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle shadow-2xl"
+        className="w-[640px] max-h-[560px] rounded-3xl overflow-hidden flex flex-col bg-surface-4/85 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between px-4 py-3 border-b border-subtle">
-          <div className="text-primary text-sm font-medium">Saved Layouts</div>
-          <button
-            onClick={close}
-            className="text-muted hover:text-primary transition-colors p-1 rounded hover:bg-hover"
-            title="Close"
-          >
-            <X size={16} />
-          </button>
-        </div>
-
-        <div className="p-3 border-b border-subtle flex gap-2">
+        {/* Save input — primary action, mirrors the search-bar treatment */}
+        <div className="flex items-center gap-3 px-5 h-14">
+          <FloppyDisk size={20} className="text-muted shrink-0" weight="bold" />
           <input
+            autoFocus
             type="text"
             value={saveName}
             onChange={(e) => setSaveName(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handleSave() }}
-            className="flex-1 bg-surface-3 text-primary text-sm px-3 py-2 rounded-lg border border-subtle outline-none focus:border-blue-500/50"
+            className="flex-1 bg-transparent text-primary text-base font-medium outline-none placeholder:text-muted placeholder:font-normal"
             placeholder="Save current canvas as…"
             disabled={busy}
           />
           <button
             onClick={handleSave}
             disabled={busy || !saveName.trim()}
-            className="flex items-center gap-1.5 text-xs px-3 py-2 rounded-lg bg-blue-600/80 text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="text-xs font-medium px-3 py-1.5 rounded-full bg-blue-600/80 text-white hover:bg-blue-600 disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
           >
-            <FloppyDisk size={14} />
             Save
           </button>
         </div>
 
         {error && (
-          <div className="px-4 py-2 text-xs text-red-400 bg-red-600/10 border-b border-subtle">
+          <div className="mx-2 mb-2 px-3 py-2 text-xs text-red-400 bg-red-600/10 rounded-lg">
             {error}
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto">
+        {/* Layout list */}
+        <div className="flex-1 overflow-y-auto pb-2">
           {names.length === 0 ? (
-            <div className="px-4 py-10 text-sm text-muted text-center">
-              No saved layouts yet.
+            <div className="px-5 py-8 text-sm text-muted text-center">
+              No saved layouts yet. Type a name above and hit Enter.
             </div>
           ) : (
-            names.map((name) => (
-              <div
-                key={name}
-                className={`group flex items-center justify-between gap-2 px-4 py-2 text-sm cursor-pointer ${
-                  selected === name ? 'bg-blue-600/20' : 'hover:bg-hover'
-                }`}
-                onClick={() => setSelected(name)}
-                onDoubleClick={() => handleLoad(name)}
-              >
-                <span className="text-primary truncate">{name}</span>
-                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <button
-                    onClick={(e) => { e.stopPropagation(); handleLoad(name) }}
-                    disabled={busy}
-                    className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-surface-6 hover:bg-hover text-primary"
-                    title="Load"
+            <>
+              <div className="mx-5 my-1 border-t border-white/10" />
+              {names.map((name) => {
+                const isSelected = selected === name
+                return (
+                  <div
+                    key={name}
+                    className={`group flex items-center gap-3 mx-2 px-3 py-2 cursor-pointer rounded-lg ${
+                      isSelected ? 'bg-blue-600/30' : 'hover:bg-white/5'
+                    }`}
+                    onClick={() => setSelected(name)}
+                    onDoubleClick={() => handleLoad(name)}
                   >
-                    <FolderOpen size={12} />
-                    Load
-                  </button>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); handleDelete(name) }}
-                    disabled={busy}
-                    className="flex items-center gap-1 text-xs px-2 py-1 rounded text-red-400 hover:bg-red-600/20"
-                    title="Delete"
-                  >
-                    <Trash size={12} />
-                  </button>
-                </div>
-              </div>
-            ))
+                    <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 bg-violet-500/15 text-violet-400">
+                      <SquaresFour size={16} weight="bold" />
+                    </div>
+                    <span className="flex-1 text-primary text-sm font-medium truncate">{name}</span>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleLoad(name) }}
+                        disabled={busy}
+                        className="flex items-center gap-1 text-[11px] px-2 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary"
+                        title="Load"
+                      >
+                        <FolderOpen size={12} />
+                        Load
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleDelete(name) }}
+                        disabled={busy}
+                        className="p-1.5 rounded-md text-muted hover:text-red-400 hover:bg-red-600/10"
+                        title="Delete"
+                      >
+                        <Trash size={12} />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </>
           )}
         </div>
       </div>

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -54,6 +54,7 @@ interface UIStoreState {
   showGlobalSearch: boolean
   showAISetupDialog: boolean
   showAIConfigDialog: boolean
+  showLayoutsDialog: boolean
   fileExplorerVisible: boolean
   /** Pre-captured page screenshot for panel switcher previews. */
   panelSwitcherScreenshot: string | null
@@ -76,6 +77,7 @@ interface UIStoreActions {
   setShowGlobalSearch: (show: boolean) => void
   setShowAISetupDialog: (show: boolean) => void
   setShowAIConfigDialog: (show: boolean) => void
+  setShowLayoutsDialog: (show: boolean) => void
   toggleSidebar: () => void
   toggleFileExplorer: () => void
   setFileExplorerVisible: (visible: boolean) => void
@@ -101,6 +103,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   showGlobalSearch: false,
   showAISetupDialog: false,
   showAIConfigDialog: false,
+  showLayoutsDialog: false,
   fileExplorerVisible: false,
   marquee: null,
   sidebarLayout: loadLayout(),
@@ -132,6 +135,10 @@ export const useUIStore = create<UIStore>((set, get) => ({
 
   setShowAIConfigDialog(show) {
     set({ showAIConfigDialog: show })
+  },
+
+  setShowLayoutsDialog(show) {
+    set({ showLayoutsDialog: show })
   },
 
   toggleSidebar() {

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -16,8 +16,6 @@ import {
   ArrowsOutSimple,
   Square,
   FloppyDisk,
-  Download,
-  Upload,
 } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
@@ -48,8 +46,6 @@ const ZoomResetIcon = () => <MagnifyingGlass size={ICON_SIZE} />
 const ZoomToFitIcon = () => <ArrowsOutSimple size={ICON_SIZE} />
 const RectangleIcon = () => <Square size={ICON_SIZE} />
 const SaveIcon = () => <FloppyDisk size={ICON_SIZE} />
-const DownloadIcon = () => <Download size={ICON_SIZE} />
-const UploadIcon = () => <Upload size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
 // Component
@@ -135,7 +131,7 @@ export const CommandPalette: React.FC = () => {
       {
         id: 'toggleFileExplorer',
         title: 'Toggle File Explorer',
-        shortcutText: '\u2318\u21E7F',
+        shortcutText: '\u2318\u21E7X',
         icon: <FolderOpenIcon />,
         action: () => { setActiveRightSidebarView('explorer') },
       },
@@ -180,87 +176,6 @@ export const CommandPalette: React.FC = () => {
         shortcutText: '',
         icon: <SaveIcon />,
         action: () => useUIStore.getState().setShowLayoutsDialog(true),
-      },
-      {
-        id: 'exportWorkspace',
-        title: 'Export Workspace Layout',
-        shortcutText: '',
-        icon: <UploadIcon />,
-        action: async () => {
-          const state = canvasApi.getState()
-          const appState = useAppStore.getState()
-          const workspace = appState.workspaces.find((w) => w.id === appState.selectedWorkspaceId)
-          if (!workspace) return
-
-          const exportData = {
-            version: 1,
-            name: workspace.name,
-            nodes: Object.values(state.nodes).map((n) => {
-              const panel = workspace.panels[n.panelId]
-              return {
-                panelType: panel?.type || 'terminal',
-                title: panel?.title || 'Panel',
-                origin: n.origin,
-                size: n.size,
-                filePath: panel?.filePath,
-                url: panel?.url,
-              }
-            }),
-            regions: Object.values(state.regions).map((r) => ({
-              origin: r.origin, size: r.size, label: r.label, color: r.color,
-            })),
-            zoomLevel: state.zoomLevel,
-            viewportOffset: state.viewportOffset,
-          }
-
-          const filePath = await window.electronAPI.saveFileDialog({
-            defaultPath: `${workspace.name}-layout.json`,
-            filters: [{ name: 'Workspace Layout', extensions: ['json'] }],
-          })
-          if (filePath) {
-            await window.electronAPI.fsWriteFile(filePath, JSON.stringify(exportData, null, 2))
-          }
-        },
-      },
-      {
-        id: 'importWorkspace',
-        title: 'Import Workspace Layout',
-        shortcutText: '',
-        icon: <DownloadIcon />,
-        action: async () => {
-          const filePath = window.prompt('Enter path to layout JSON file:')
-          if (!filePath?.trim()) return
-
-          try {
-            const content = await window.electronAPI.fsReadFile(filePath.trim())
-            const data = JSON.parse(content) as any
-            if (!data.version || !data.nodes) {
-              alert('Invalid layout file')
-              return
-            }
-
-            const wsId = useAppStore.getState().selectedWorkspaceId
-            useAppStore.getState().closeAllPanels(wsId)
-
-            for (const node of data.nodes) {
-              switch (node.panelType) {
-                case 'terminal': useAppStore.getState().createTerminal(wsId, undefined, node.origin); break
-                case 'editor': useAppStore.getState().createEditor(wsId, node.filePath, node.origin); break
-                case 'browser': useAppStore.getState().createBrowser(wsId, node.url, node.origin); break
-
-              }
-            }
-
-            for (const region of data.regions || []) {
-              canvasApi.getState().addRegion(region.label, region.origin, region.size, region.color)
-            }
-
-            if (data.zoomLevel) canvasApi.getState().setZoom(data.zoomLevel)
-            if (data.viewportOffset) canvasApi.getState().setViewportOffset(data.viewportOffset)
-          } catch {
-            alert('Failed to load layout file')
-          }
-        },
       },
     ],
     [
@@ -375,15 +290,16 @@ export const CommandPalette: React.FC = () => {
 
   return (
     <div
-      className="fixed inset-0 bg-black/20 flex items-start justify-center pt-[20vh] z-50"
+      className="fixed inset-0 bg-black/40 flex items-start justify-center pt-40 z-50"
       onClick={close}
     >
       <div
-        className="w-96 bg-surface-5 rounded-xl border border-subtle shadow-2xl overflow-hidden"
+        className="w-[640px] max-h-[560px] rounded-3xl overflow-hidden flex flex-col bg-surface-4/85 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)]"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Search input */}
-        <div className="px-3 py-2">
+        {/* Search input — matches the Spotlight-style bar used by Cmd+Shift+F */}
+        <div className="flex items-center gap-3 px-5 h-14">
+          <MagnifyingGlass size={20} className="text-muted shrink-0" weight="bold" />
           <input
             ref={inputRef}
             type="text"
@@ -392,54 +308,53 @@ export const CommandPalette: React.FC = () => {
               setSearchText(e.target.value)
               setSelectedIndex(0)
             }}
-            placeholder="Type a command..."
-            className="w-full h-10 bg-transparent text-sm text-primary placeholder:text-muted outline-none"
+            placeholder="Type a command…"
+            className="flex-1 bg-transparent text-primary text-base font-medium outline-none placeholder:text-muted placeholder:font-normal"
           />
         </div>
 
-        {/* Divider */}
-        <div className="border-b border-subtle" />
-
-        {/* Commands list */}
-        <div className="max-h-[300px] overflow-y-auto py-1">
+        {/* Commands + files list */}
+        <div className="flex-1 overflow-y-auto pb-2">
           {filteredCommands.length === 0 && matchingFiles.length === 0 ? (
-            <div className="text-muted text-sm text-center py-4">
+            <div className="text-muted text-sm text-center py-6">
               No matching commands
             </div>
           ) : (
             <>
-              {filteredCommands.map((cmd, index) => (
-                <div
-                  key={cmd.id}
-                  className={`flex items-center px-3 py-2 gap-3 cursor-pointer transition-colors ${
-                    index === selectedIndex
-                      ? 'bg-surface-6'
-                      : 'hover:bg-hover'
-                  }`}
-                  onClick={() => executeCommand(cmd)}
-                  onMouseEnter={() => setSelectedIndex(index)}
-                >
-                  <span className="text-secondary flex-shrink-0">{cmd.icon}</span>
-                  <span className="text-sm text-primary flex-1">{cmd.title}</span>
-                  <span className="text-xs text-muted flex-shrink-0">
-                    {cmd.shortcutText}
-                  </span>
-                </div>
-              ))}
+              {filteredCommands.map((cmd, index) => {
+                const isSelected = index === selectedIndex
+                return (
+                  <div
+                    key={cmd.id}
+                    className={`flex items-center gap-3 mx-2 px-3 py-2 cursor-pointer rounded-lg ${
+                      isSelected ? 'bg-blue-600/30' : 'hover:bg-white/5'
+                    }`}
+                    onClick={() => executeCommand(cmd)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                  >
+                    <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 bg-blue-500/15 text-blue-400">
+                      {cmd.icon}
+                    </div>
+                    <span className="text-sm text-primary font-medium flex-1 truncate">{cmd.title}</span>
+                    {cmd.shortcutText && (
+                      <span className="text-[11px] text-muted flex-shrink-0 font-mono">
+                        {cmd.shortcutText}
+                      </span>
+                    )}
+                  </div>
+                )
+              })}
               {matchingFiles.length > 0 && (
                 <>
-                  <div className="px-3 py-1 text-xs text-muted uppercase tracking-wider">
-                    Files
-                  </div>
+                  {filteredCommands.length > 0 && <div className="mx-5 my-1 border-t border-white/10" />}
                   {matchingFiles.map((file, i) => {
                     const fileIndex = filteredCommands.length + i
+                    const isSelected = fileIndex === selectedIndex
                     return (
                       <div
                         key={file}
-                        className={`flex items-center px-3 py-2 gap-3 cursor-pointer transition-colors ${
-                          fileIndex === selectedIndex
-                            ? 'bg-surface-6'
-                            : 'hover:bg-hover'
+                        className={`flex items-center gap-3 mx-2 px-3 py-2 cursor-pointer rounded-lg ${
+                          isSelected ? 'bg-blue-600/30' : 'hover:bg-white/5'
                         }`}
                         onClick={() => {
                           const wsId = useAppStore.getState().selectedWorkspaceId
@@ -449,10 +364,10 @@ export const CommandPalette: React.FC = () => {
                         }}
                         onMouseEnter={() => setSelectedIndex(fileIndex)}
                       >
-                        <span className="text-secondary flex-shrink-0">
+                        <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 bg-amber-500/15 text-amber-400">
                           <FileTextIcon />
-                        </span>
-                        <span className="text-sm text-primary flex-1 truncate">{file}</span>
+                        </div>
+                        <span className="text-sm text-primary font-medium flex-1 truncate">{file}</span>
                       </div>
                     )
                   })}

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -175,54 +175,11 @@ export const CommandPalette: React.FC = () => {
         action: () => canvasApi.getState().addRegion('Region', { x: 200, y: 200 }, { width: 400, height: 300 }),
       },
       {
-        id: 'saveLayout',
-        title: 'Save Layout As...',
+        id: 'manageLayouts',
+        title: 'Saved Layouts…',
         shortcutText: '',
         icon: <SaveIcon />,
-        action: async () => {
-          const name = window.prompt('Layout name:')
-          if (!name?.trim()) return
-          const state = canvasApi.getState()
-          const appState = useAppStore.getState()
-          const workspace = appState.workspaces.find((w) => w.id === appState.selectedWorkspaceId)
-          const snapshot = {
-            nodes: Object.values(state.nodes).map((n) => {
-              const panel = workspace?.panels[n.panelId]
-              return { panelType: panel?.type ?? 'terminal', origin: n.origin, size: n.size }
-            }),
-            regions: Object.values(state.regions).map((r) => ({
-              origin: r.origin, size: r.size, label: r.label, color: r.color,
-            })),
-          }
-          await window.electronAPI.layoutSave(name.trim(), snapshot)
-        },
-      },
-      {
-        id: 'loadLayout',
-        title: 'Load Layout...',
-        shortcutText: '',
-        icon: <DownloadIcon />,
-        action: async () => {
-          const names = await window.electronAPI.layoutList()
-          if (names.length === 0) { alert('No saved layouts'); return }
-          const name = window.prompt('Available layouts:\n' + names.join('\n') + '\n\nEnter name:')
-          if (!name?.trim()) return
-          const snapshot = await window.electronAPI.layoutLoad(name.trim()) as any
-          if (!snapshot) { alert('Layout not found'); return }
-          const wsId = useAppStore.getState().selectedWorkspaceId
-          useAppStore.getState().closeAllPanels(wsId)
-          for (const node of snapshot.nodes || []) {
-            switch (node.panelType) {
-              case 'terminal': useAppStore.getState().createTerminal(wsId, undefined, node.origin); break
-              case 'editor': useAppStore.getState().createEditor(wsId, undefined, node.origin); break
-              case 'browser': useAppStore.getState().createBrowser(wsId, undefined, node.origin); break
-            }
-          }
-          for (const region of snapshot.regions || []) {
-            canvasApi.getState().addRegion(region.label, region.origin, region.size, region.color)
-          }
-          canvasApi.getState().zoomToFit()
-        },
+        action: () => useUIStore.getState().setShowLayoutsDialog(true),
       },
       {
         id: 'exportWorkspace',


### PR DESCRIPTION
## Summary
- Replace the `window.prompt`/`alert`-based save/load palette commands with a proper **Saved Layouts** modal. Lists existing layouts alphabetically, saves the current canvas arrangement (nodes + regions + zoom + viewport) under a name, loads / deletes with proper validation and error states. Reuses the existing `layoutSave/List/Load/Delete` IPC surface — no backend changes.
- Drop the legacy **Export Workspace Layout** (native save dialog) and **Import Workspace Layout** (`window.prompt`) palette commands — superseded by the in-app modal per user request ("save layout with name in app not external").
- Restyle the **command palette** to match the Cmd+Shift+F search overlay: `rounded-3xl`, `white/20` outline, backdrop blur, leading magnifying-glass icon, bolder text, type-tinted circular icon tiles on rows, inset selection highlight. Three overlays (search / palette / layouts) now share one visual language.
- Fix the stale "Toggle File Explorer" shortcut hint — was advertising `⌘⇧F`, now shows `⌘⇧X` after the collision move in `feat/canvas-wide-search`.

## Bug fixes folded into this branch
- **`fix(layouts): restore canvas panel after load`** — `closeAllPanels` wipes every panel including the host `canvas` panel that owns the dock center zone; load flow didn't recreate it, so the center came back empty. Call `ensureCenterCanvas(wsId)` right after the reset and use the fresh canvas store for regions/zoomToFit.
- **`fix(layouts): register new canvas store before adding restored nodes`** — the React `CanvasPanel` mounts async, so its store/ops registered *after* our sync `createTerminal/createEditor/createBrowser` calls. Nodes landed nowhere and the Welcome screen showed. Fix: explicitly `ensureCanvasOpsForPanel` + `setActiveCanvasPanelId` on the newly-minted canvas before creating nodes.

## Test plan
- [ ] `Cmd+K` → "Saved Layouts…" opens the modal.
- [ ] Type a name, hit Enter → layout appears in the list.
- [ ] Double-click (or Load button) on a row restores the canvas: nodes appear in the saved positions, regions restored, `zoomToFit` re-frames.
- [ ] Deleting asks for confirmation, then removes from the list.
- [ ] Escape closes the modal.
- [ ] Export/Import Workspace Layout commands are gone from the palette.
- [ ] Palette visually matches the Cmd+Shift+F overlay.
- [ ] "Toggle File Explorer" shows `⌘⇧X` in the palette row.

## Known scope limits
- Loaded layouts create fresh empty terminals — they don't restore running PTYs or scrollback (that's what the session-autosave is for).
- Dock-zone panels (file explorer, git) aren't part of the snapshot — only canvas nodes + regions.
- No tags / rename yet. Flat alphabetical list.

## Depends on
- Blocked-by only in visual polish: the palette restyle references the same Spotlight treatment introduced by #3 (`feat/canvas-wide-search`). Either PR can merge first; the other just picks up a trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)