### PR TITLE
feat(editor): persist unsaved scratch buffers across canvas switches

### DIFF
--- a/src/renderer/lib/session.ts
+++ b/src/renderer/lib/session.ts
@@ -136,6 +136,9 @@ export async function saveSession(): Promise<void> {
         filePath: panel?.filePath ?? undefined,
         url: panel?.url ?? undefined,
         regionId: node.regionId ?? undefined,
+        unsavedContent: panel?.type === 'editor' && !panel?.filePath
+          ? panel?.unsavedContent
+          : undefined,
       }
     })
 
@@ -363,6 +366,9 @@ export async function restoreSession(snapshot: SessionSnapshot, canvasStoreApi?:
       }
       case 'editor': {
         const panelId = appStore.createEditor(wsId, nodeSnap.filePath ?? undefined)
+        if (!nodeSnap.filePath && nodeSnap.unsavedContent) {
+          appStore.setPanelUnsavedContent(wsId, panelId, nodeSnap.unsavedContent)
+        }
         const canvasState = getCanvasState()
         if (canvasState) {
           const newNodeId = canvasState.nodeForPanel(panelId)

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -516,11 +516,18 @@ export default function EditorPanel({
           })
       }
     } else {
-      const model = monaco.editor.createModel('', 'plaintext')
+      const restored = useAppStore.getState().workspaces
+        .find((w) => w.id === workspaceId)?.panels[panelId]?.unsavedContent ?? ''
+      const model = monaco.editor.createModel(restored, 'plaintext')
       createdModel = model
       editor.setModel(model)
+      if (restored) {
+        isDirtyRef.current = true
+        useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
+      }
     }
 
+    let unsavedSaveTimer: ReturnType<typeof setTimeout> | null = null
     const changeDisposable = editor.onDidChangeModelContent(() => {
       if (!isDirtyRef.current) {
         isDirtyRef.current = true
@@ -533,12 +540,30 @@ export default function EditorPanel({
             .updatePanelTitle(workspaceId, panelId, `${fileName} \u2022`)
         }
       }
+
+      // Persist scratch-editor content to the store (debounced) so it
+      // survives canvas/workspace switches and app restarts.
+      if (!filePathRef.current) {
+        if (unsavedSaveTimer) clearTimeout(unsavedSaveTimer)
+        unsavedSaveTimer = setTimeout(() => {
+          const value = editor.getModel()?.getValue() ?? ''
+          useAppStore.getState().setPanelUnsavedContent(workspaceId, panelId, value || undefined)
+        }, 300)
+      }
     })
 
     return () => {
       cancelled = true
       layoutObserver.disconnect()
       changeDisposable.dispose()
+      if (unsavedSaveTimer) {
+        clearTimeout(unsavedSaveTimer)
+        unsavedSaveTimer = null
+      }
+      if (!filePath) {
+        const value = editor.getModel()?.getValue() ?? ''
+        useAppStore.getState().setPanelUnsavedContent(workspaceId, panelId, value || undefined)
+      }
       if (filePath && modelRetained) {
         releaseModel(filePath)
       } else if (!filePath && createdModel && !createdModel.isDisposed()) {

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -271,6 +271,7 @@ interface AppStoreActions {
   updatePanelTitle: (workspaceId: string, panelId: string, title: string) => void
   updatePanelUrl: (workspaceId: string, panelId: string, url: string) => void
   setPanelDirty: (workspaceId: string, panelId: string, dirty: boolean) => void
+  setPanelUnsavedContent: (workspaceId: string, panelId: string, content: string | undefined) => void
   addPanel: (workspaceId: string, panel: PanelState) => void
 
   // Helpers
@@ -940,6 +941,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
         return {
           ...ws,
           panels: { ...ws.panels, [panelId]: { ...panel, isDirty: dirty } },
+        }
+      }),
+    }))
+  },
+
+  setPanelUnsavedContent(workspaceId, panelId, content) {
+    set((state) => ({
+      workspaces: state.workspaces.map((ws) => {
+        if (ws.id !== workspaceId) return ws
+        const panel = ws.panels[panelId]
+        if (!panel) return ws
+        return {
+          ...ws,
+          panels: { ...ws.panels, [panelId]: { ...panel, unsavedContent: content } },
         }
       }),
     }))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -150,6 +150,9 @@ export interface PanelState {
   url?: string
   /** When set, EditorPanel renders as a Monaco diff editor. */
   diffMode?: 'staged' | 'working'
+  /** Unsaved buffer content for scratch (no-filePath) editors. Persisted so
+   *  content survives canvas switches and app restarts. */
+  unsavedContent?: string
 }
 
 // -----------------------------------------------------------------------------
@@ -602,6 +605,8 @@ export interface NodeSnapshot {
   workingDirectory?: string | null
   ptyId?: string
   regionId?: string
+  /** Unsaved scratch-editor content, restored on load. */
+  unsavedContent?: string
 }
 
 export interface SessionSnapshot {


### PR DESCRIPTION
## Summary
Scratch editors (editor panels with no filePath) used to lose their content the moment the workspace or canvas switched, because Monaco's text model was disposed on unmount and nothing captured the contents first. The fix treats unsaved buffer content as first-class panel state:

- **`PanelState.unsavedContent`** (new optional field) holds the latest content for scratch editors.
- On each keystroke, `EditorPanel` debounces 300 ms then writes `editor.getValue()` into the store via a new `setPanelUnsavedContent` action; on unmount it flushes synchronously so a switch can't drop the last tick.
- On mount, a scratch editor seeds its Monaco model from `panel.unsavedContent` and re-marks itself dirty if the value was non-empty.
- Session save includes `unsavedContent` in `NodeSnapshot` for editor nodes that have no filePath; session restore re-applies it with `setPanelUnsavedContent` right after `createEditor`, before the React panel mounts.

## Scope limits (intentional)
- **Only scratch editors.** File-backed editors with a dirty buffer still lose their in-memory edits on switch. The disk-vs-buffer conflict case is a bigger design decision and wasn't bundled here.
- No sidecar file — content lives in Zustand and rides the existing electron-store session file.

## Potential issues (known)
- Large pasted content (multi-MB) will bloat every session save, since the whole string is re-serialized on each 30 s periodic write.
- Force-kill between the 300 ms debounce and the next flush loses those keystrokes.
- Each debounce tick fires a store mutation; any subscriber reading `workspace.panels` with shallow equality would re-render on every tick of typing. No current subscriber does this, but worth knowing.

Neither is a correctness bug, and both have straightforward mitigations (cap the stored length / shorten the debounce / move >N-KB to a `.cate/scratch/` sidecar) if they start biting.

## Files touched
- `src/shared/types.ts` — add optional `unsavedContent` to `PanelState` and `NodeSnapshot`.
- `src/renderer/stores/appStore.ts` — new `setPanelUnsavedContent` action.
- `src/renderer/panels/EditorPanel.tsx` — seed / write-back / unmount flush for scratch editors.
- `src/renderer/lib/session.ts` — include `unsavedContent` in save, re-apply on restore.

## Test plan
- [ ] Open a new editor panel with no file (Cmd+K → New Editor, or the + menu).
- [ ] Type some text, switch to another workspace, switch back — content is still there.
- [ ] Quit and relaunch — content is still there.
- [ ] Open an editor via file — dirty-dot behavior unchanged; buffer persistence should NOT kick in for file-backed editors (verified: no snapshot written when `filePath` is set).
- [ ] Close the scratch panel — content discarded (no orphaned `unsavedContent` in the session JSON).