### PR TITLE
fix(git-monitor): refresh branch list after external `git branch -d`

### DIFF
--- a/src/main/ipc/git-monitor.ts
+++ b/src/main/ipc/git-monitor.ts
@@ -23,61 +23,85 @@ interface MonitorEntry {
 }
 
 const activeMonitors: Map<string, MonitorEntry> = new Map()
-const lastState: Map<string, { branch: string; isDirty: boolean }> = new Map()
+const lastState: Map<string, { branch: string; isDirty: boolean; branchesKey: string }> = new Map()
 
-function pollGitStatus(
+function runGit(rootPath: string, args: string[], signal: AbortSignal): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      ['-C', rootPath, ...args],
+      { timeout: 3000, signal },
+      (err, stdout, stderr) => {
+        if (err) {
+          if ((err as NodeJS.ErrnoException).code === 'ABORT_ERR') {
+            reject(err)
+            return
+          }
+          // Surface stderr when available so the caller can log it.
+          reject(new Error(stderr?.trim() || err.message))
+          return
+        }
+        resolve(stdout)
+      },
+    )
+  })
+}
+
+async function pollGitStatus(
   ownerWindowId: number,
   workspaceId: string,
   rootPath: string,
   entry: MonitorEntry,
-): void {
+): Promise<void> {
   // Abort any previous in-flight calls for this workspace
   entry.abortController?.abort()
   const ac = new AbortController()
   entry.abortController = ac
 
-  execFile(
-    'git',
-    ['-C', rootPath, 'branch', '--show-current'],
-    { timeout: 3000, signal: ac.signal },
-    (err, branchOut, branchErr) => {
-      if (err) {
-        // Ignore AbortError — this is intentional cancellation on stop
-        if ((err as NodeJS.ErrnoException).code === 'ABORT_ERR') return
-        log.debug('git branch failed for %s: %s', rootPath, branchErr || err.message)
-        return
-      }
+  try {
+    // Current branch, dirty flag, and the full local branch list run in
+    // parallel — deletion of a non-current branch doesn't change the
+    // first two, so we need the third to detect it and re-notify the UI.
+    const [branchOut, statusOut, branchesOut] = await Promise.all([
+      runGit(rootPath, ['branch', '--show-current'], ac.signal),
+      runGit(rootPath, ['status', '--porcelain', '-uno'], ac.signal),
+      runGit(rootPath, ['for-each-ref', '--format=%(refname:short)', 'refs/heads'], ac.signal),
+    ])
 
-      const branch = branchOut.trim()
-      if (!branch) return
+    if (entry.abortController === ac) entry.abortController = null
 
-      execFile(
-        'git',
-        ['-C', rootPath, 'status', '--porcelain', '-uno'],
-        { timeout: 3000, signal: ac.signal },
-        (err2, statusOut, statusErr) => {
-          if (err2) {
-            if ((err2 as NodeJS.ErrnoException).code === 'ABORT_ERR') return
-            log.debug('git status failed for %s: %s', rootPath, statusErr || err2.message)
-            return
-          }
+    const branch = branchOut.trim()
+    if (!branch) return
 
-          // Clear the in-flight controller now that this poll completed
-          if (entry.abortController === ac) {
-            entry.abortController = null
-          }
+    const isDirty = statusOut.trim().length > 0
+    // Sort so reordering (e.g. committerdate changes) doesn't spuriously
+    // look like a list change; a newline-joined canonical string is
+    // cheaper to diff than the array.
+    const branchesKey = branchesOut
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .sort()
+      .join('\n')
 
-          const isDirty = statusOut.trim().length > 0
+    const prev = lastState.get(workspaceId)
+    if (
+      prev
+      && prev.branch === branch
+      && prev.isDirty === isDirty
+      && prev.branchesKey === branchesKey
+    ) return
 
-          const prev = lastState.get(workspaceId)
-          if (prev && prev.branch === branch && prev.isDirty === isDirty) return
-
-          lastState.set(workspaceId, { branch, isDirty })
-          sendToWindow(ownerWindowId, GIT_BRANCH_UPDATE, workspaceId, branch, isDirty)
-        },
-      )
-    },
-  )
+    lastState.set(workspaceId, { branch, isDirty, branchesKey })
+    sendToWindow(ownerWindowId, GIT_BRANCH_UPDATE, workspaceId, branch, isDirty)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === 'ABORT_ERR') return
+    log.debug(
+      'git monitor poll failed for %s: %s',
+      rootPath,
+      err instanceof Error ? err.message : String(err),
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
The git sidebar / panel kept showing local branches that had been deleted in an external terminal until the panel was remounted or the user clicked the refresh button.

**Root cause**: the monitor poll (`src/main/ipc/git-monitor.ts`) only broadcast `GIT_BRANCH_UPDATE` on changes to the *current* branch name or the dirty flag. Deleting a non-current branch changes neither, so the broadcast never fired, and the renderer's `onGitBranchUpdate(() => refresh())` listener never kicked in.

**Fix**: widen the poll to also fetch `git for-each-ref refs/heads` and track a canonical sorted-joined key of the local branch refs. Any change (name, dirty, or list membership) triggers the same broadcast. The renderer continues to re-fetch the full branch list via the existing `gitBranchList` IPC handler — no renderer or IPC-shape changes needed.

Also tidied the three git invocations into a small `runGit` promise wrapper that runs them in parallel, which shortens the poll cycle and keeps error handling uniform.

## Behaviour before / after
- **Before**: `git branch -d foo` in a terminal → sidebar still shows `foo` for up to a full app session.
- **After**: `git branch -d foo` → sidebar drops `foo` within the next 5 s poll cycle.

## Test plan
- [ ] Open a workspace with a git repo, confirm its branches show in the sidebar.
- [ ] In an external terminal, create a branch (`git branch tmp/test`) — within 5 s it appears in the sidebar.
- [ ] Delete it (`git branch -d tmp/test`) — within 5 s it disappears.
- [ ] Rename a non-current branch — old name vanishes, new name appears.
- [ ] Change to a different branch — current-branch highlight follows (regression check for the old path).
- [ ] Edit a file to go dirty / revert to go clean — dot indicator updates (regression check).

## Notes
- Poll cadence is unchanged at 5 s; the extra git call is cheap (`for-each-ref` is native plumbing), and the three calls now run in parallel.
- Remote branches aren't tracked here — if a user runs `git fetch` externally, remotes won't refresh until a manual action. That's the same behaviour as before this PR; fixing it is a separate change.