### PR TITLE
style(docking): clearer tab bar — type icon, active accent, no x-scroll

### DIFF
--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -27,6 +27,30 @@ const PANEL_TYPE_LABELS: Record<PanelType, string> = {
   canvas: 'Canvas',
 }
 
+// Type → icon/tint mirrors the Spotlight overlay so tabs, search results, and
+// the command palette speak the same visual language.
+const PANEL_TYPE_TINT: Record<PanelType, string> = {
+  terminal: 'text-emerald-400',
+  browser: 'text-sky-400',
+  editor: 'text-orange-400',
+  git: 'text-red-400',
+  fileExplorer: 'text-cyan-400',
+  projectList: 'text-yellow-400',
+  canvas: 'text-violet-400',
+}
+
+function TabIcon({ type, size }: { type: PanelType; size: number }) {
+  switch (type) {
+    case 'terminal':     return <TerminalIcon size={size} />
+    case 'browser':      return <Globe size={size} />
+    case 'editor':       return <FileText size={size} />
+    case 'git':          return <GitBranch size={size} />
+    case 'fileExplorer': return <TreeStructure size={size} />
+    case 'projectList':  return <List size={size} />
+    case 'canvas':       return <SquaresFour size={size} />
+  }
+}
+
 // Items shown in the long-press split menu (order = display order).
 type SplitMenuItem = { type: PanelType; label: string; Icon: React.ComponentType<any> }
 const SPLIT_MENU_ITEMS: SplitMenuItem[] = [
@@ -578,7 +602,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
       {/* Tab bar — VS Code style: dark strip with active tab merging into the
           content area below via a top accent border. */}
       <div
-        className={`dock-tab-bar flex items-stretch bg-surface-1 overflow-x-auto ${compact ? 'min-h-[24px]' : 'min-h-[35px]'}`}
+        className={`dock-tab-bar flex items-stretch bg-surface-1 overflow-hidden ${compact ? 'min-h-[26px]' : 'min-h-[36px]'}`}
         onContextMenu={handleTabBarContextMenu}
         onMouseDown={(e) => {
           // Empty area of the tab bar — host (e.g. canvas node) may want to
@@ -597,15 +621,19 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         >
           {stack.panelIds.map((panelId, i) => {
             const isActive = i === stack.activeIndex
+            const panel = getPanelProp?.(panelId)
+              ?? useAppStore.getState().workspaces.find((w) => w.id === (workspaceIdProp ?? useAppStore.getState().selectedWorkspaceId))?.panels[panelId]
+            const panelType = (panel?.type ?? 'editor') as PanelType
             return (
               <div
                 key={panelId}
                 className={`
                   group relative flex items-center gap-1.5 whitespace-nowrap
-                  cursor-grab select-none
+                  cursor-grab select-none min-w-0 flex-1 max-w-[200px]
+                  border-r border-white/5
                   ${compact ? 'pl-2 pr-1.5 text-[11px]' : 'pl-3 pr-2 text-xs'}
                   ${isActive
-                    ? 'bg-surface-3 text-primary'
+                    ? 'bg-surface-3 text-primary font-medium'
                     : 'bg-surface-1 text-secondary hover:text-primary hover:bg-surface-2'
                   }
                 `}
@@ -631,11 +659,20 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
                   }
                 }}
                 style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+                title={getPanelTitle(panelId)}
               >
-                <span className="truncate max-w-[160px]">{getPanelTitle(panelId)}</span>
+                {/* Top accent bar on the active tab — VS Code convention, but
+                    brighter so it reads against the dark surface. */}
+                {isActive && (
+                  <span className="absolute left-0 right-0 top-0 h-[2px] bg-blue-500" />
+                )}
+                <span className={`shrink-0 ${isActive ? PANEL_TYPE_TINT[panelType] : 'text-muted'}`}>
+                  <TabIcon type={panelType} size={compact ? 11 : 13} />
+                </span>
+                <span className="truncate flex-1 min-w-0">{getPanelTitle(panelId)}</span>
                 {onClosePanel && (
                   <span
-                    className={`p-0.5 rounded-sm hover:bg-hover ${
+                    className={`shrink-0 p-0.5 rounded-sm hover:bg-hover ${
                       isActive ? 'opacity-80' : 'opacity-0 group-hover:opacity-70'
                     }`}
                     onClick={(e) => {


### PR DESCRIPTION
## Summary
Panel tabs on canvas nodes were hard to distinguish when more than two or three were open, and a horizontal scrollbar appeared inside small canvas nodes as soon as the tab row overflowed.

**Changes:**
- **Type icon on every tab** — terminal / editor / browser / git / file-explorer / projects / canvas. Icon is tinted (emerald / orange / sky / red / cyan / yellow / violet) on the *active* tab and muted on inactives. Same palette as the Cmd+Shift+F search result tiles, so the whole app now speaks one visual language.
- **Active accent bar** — 2 px bright-blue top border on the active tab, plus `font-medium` on the label. Replaces the previous one-shade-of-grey-different active indication.
- **No horizontal scrollbar** — `overflow-x-auto` → `overflow-hidden`, and tabs become `flex-1 min-w-0 max-w-[200px]` so they shrink and truncate instead of triggering a scrollbar. A thin `border-r border-white/5` between tabs gives the row rhythm.
- **Full title in tooltip** — truncation never hides the name anymore.

## Before / after
- Three tabs named "Terminal", "Untitled", "Untitled" on a narrow canvas node: before, they were indistinguishable and one was hidden behind a scrollbar; after, each shows its type icon and truncates gracefully.
- Detached dock window with many tabs: before, scrollbar appeared; after, tabs shrink proportionally.

## Test plan
- [ ] Open a canvas node with one panel — tab bar shows type icon, blue accent on top, label readable.
- [ ] Add several tabs via the `+` button until the row would overflow — no scrollbar, tabs shrink and truncate, active tab still distinguishable.
- [ ] Switch tabs by clicking — accent and icon tint move correctly.
- [ ] Hover a truncated tab — tooltip shows the full title.
- [ ] Close button appears on hover for inactives and stays visible on the active tab.
- [ ] Drag-to-reorder / drag-out still works (no regressions to the drag initiation code).
- [ ] Compact mode (canvas-node mini-dock) — smaller icon size (11 px) and text (`text-[11px]`) render correctly.

## Non-goals / not in scope
- No overflow dropdown ("show hidden tabs") — with tabs shrinking + Cmd+E panel switcher this isn't needed yet. Easy add later if you want it.
- Light-theme pass — the borders use `white/5` which still reads on light backgrounds but could be refined.