### PR TITLE
style(panel-switcher): centered wrapping grid, no horizontal scrollbar

### DIFF
--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -156,12 +156,13 @@ export function PanelSwitcher() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center p-8"
       style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
       onClick={close}
     >
       <div
-        className="flex gap-4 px-2 py-3 max-w-[90vw] overflow-x-auto"
+        className="flex flex-wrap items-start justify-center gap-4 overflow-y-auto"
+        style={{ maxWidth: 'min(90vw, 1400px)', maxHeight: '85vh' }}
         onClick={(e) => e.stopPropagation()}
       >
         {nodeList.map((node, i) => {

--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Terminal, Globe, FileText, GitBranch, TreeStructure, SquaresFour, List } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useSelectedWorkspace } from '../stores/appStore'
@@ -13,6 +14,19 @@ function panelColor(type: PanelType): string {
     case 'fileExplorer': return '#5AC8FA'
     case 'projectList': return '#FFD60A'
     case 'canvas': return '#BF5AF2'
+  }
+}
+
+function PlaceholderIcon({ type, color }: { type: PanelType; color: string }) {
+  const size = 44
+  switch (type) {
+    case 'terminal':     return <Terminal size={size} color={color} weight="light" />
+    case 'browser':      return <Globe size={size} color={color} weight="light" />
+    case 'editor':       return <FileText size={size} color={color} weight="light" />
+    case 'git':          return <GitBranch size={size} color={color} weight="light" />
+    case 'fileExplorer': return <TreeStructure size={size} color={color} weight="light" />
+    case 'projectList':  return <List size={size} color={color} weight="light" />
+    case 'canvas':       return <SquaresFour size={size} color={color} weight="light" />
   }
 }
 
@@ -163,72 +177,89 @@ export function PanelSwitcher() {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center p-10 bg-black/70 overflow-y-auto [&::-webkit-scrollbar]:hidden"
-      style={{ scrollbarWidth: 'none' }}
+      className="fixed inset-0 z-50 bg-black/80"
       onClick={close}
     >
+      {/* Scroll container — the flex centering on its inner grid lives in a
+          separate layer so `justify-center` isn't fighting `overflow-y-auto`
+          on the same element (caused left-hugging in the previous pass). */}
       <div
-        className="[column-gap:20px]"
-        style={{
-          width: 'min(92vw, 1200px)',
-          columnWidth: `${TILE_W}px`,
-        }}
-        onClick={(e) => e.stopPropagation()}
+        className="absolute inset-0 overflow-y-auto [&::-webkit-scrollbar]:hidden flex items-start justify-center p-10"
+        style={{ scrollbarWidth: 'none' }}
+        onClick={close}
       >
-        {nodeList.map((node, i) => {
-          const panel = workspace?.panels[node.panelId]
-          const type = panel?.type || 'terminal'
-          const title = panel?.title || 'Panel'
-          const isSelected = i === selectedIndex
-          const color = panelColor(type)
-          const thumb = thumbnails[node.id]
+        <div
+          className="[column-gap:20px]"
+          style={{
+            width: 'min(92vw, 1200px)',
+            columnWidth: `${TILE_W}px`,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {nodeList.map((node, i) => {
+            const panel = workspace?.panels[node.panelId]
+            const type = panel?.type || 'terminal'
+            const title = panel?.title || 'Panel'
+            const isSelected = i === selectedIndex
+            const color = panelColor(type)
+            const thumb = thumbnails[node.id]
 
-          const aspect = node.size.width / Math.max(node.size.height, 1)
-          const rawH = TILE_W / aspect
-          const tileH = Math.max(MIN_TILE_H, Math.min(MAX_TILE_H, rawH))
+            const aspect = node.size.width / Math.max(node.size.height, 1)
+            const rawH = TILE_W / aspect
+            const tileH = Math.max(MIN_TILE_H, Math.min(MAX_TILE_H, rawH))
 
-          return (
-            <div
-              key={node.id}
-              ref={isSelected ? selectedRef : undefined}
-              className="flex flex-col items-center cursor-pointer transition-all duration-150 mb-5"
-              style={{
-                breakInside: 'avoid',
-                opacity: isSelected ? 1 : 0.65,
-                transform: isSelected ? 'scale(1.03)' : 'scale(1)',
-              }}
-              onClick={() => selectItem(i)}
-            >
+            return (
               <div
+                key={node.id}
+                ref={isSelected ? selectedRef : undefined}
+                className="flex flex-col items-center cursor-pointer transition-all duration-150 mb-5"
                 style={{
-                  width: TILE_W,
-                  height: tileH,
-                  borderRadius: 10,
-                  overflow: 'hidden',
-                  border: isSelected ? `2px solid ${color}` : `1px solid rgba(255,255,255,0.08)`,
-                  boxShadow: isSelected
-                    ? `0 0 24px ${color}44, 0 4px 20px rgba(0,0,0,0.4)`
-                    : '0 2px 10px rgba(0,0,0,0.25)',
-                  transition: 'border-color 0.15s, box-shadow 0.15s, transform 0.15s',
-                  backgroundColor: 'var(--surface-5)',
+                  breakInside: 'avoid',
+                  opacity: isSelected ? 1 : 0.75,
+                  transform: isSelected ? 'scale(1.03)' : 'scale(1)',
                 }}
+                onClick={() => selectItem(i)}
               >
-                {thumb ? (
-                  <img
-                    src={thumb}
-                    alt={title}
-                    style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                  />
-                ) : (
-                  <div style={{
-                    width: '100%', height: '100%',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    color: 'var(--text-muted)', fontSize: 11,
-                  }}>
-                    ...
-                  </div>
-                )}
-              </div>
+                <div
+                  style={{
+                    width: TILE_W,
+                    height: tileH,
+                    borderRadius: 10,
+                    overflow: 'hidden',
+                    border: isSelected ? `2px solid ${color}` : `1px solid rgba(255,255,255,0.08)`,
+                    boxShadow: isSelected
+                      ? `0 0 24px ${color}44, 0 4px 20px rgba(0,0,0,0.4)`
+                      : '0 2px 10px rgba(0,0,0,0.25)',
+                    transition: 'border-color 0.15s, box-shadow 0.15s, transform 0.15s',
+                    backgroundColor: 'var(--surface-5)',
+                  }}
+                >
+                  {thumb ? (
+                    <img
+                      src={thumb}
+                      alt={title}
+                      style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                    />
+                  ) : (
+                    // Fallback when the node was off-screen at capture time:
+                    // show a type-tinted icon + label so tiles still convey
+                    // what panel they represent instead of a blank "...".
+                    <div
+                      style={{
+                        width: '100%', height: '100%',
+                        display: 'flex', flexDirection: 'column',
+                        alignItems: 'center', justifyContent: 'center',
+                        gap: 6,
+                        background: `linear-gradient(135deg, ${color}12 0%, transparent 70%)`,
+                      }}
+                    >
+                      <PlaceholderIcon type={type} color={color} />
+                      <span style={{ fontSize: 10, color: 'var(--text-muted)', textTransform: 'capitalize' }}>
+                        {type === 'fileExplorer' ? 'File Explorer' : type === 'projectList' ? 'Projects' : type}
+                      </span>
+                    </div>
+                  )}
+                </div>
               <span
                 className="truncate text-center mt-2"
                 style={{
@@ -242,7 +273,8 @@ export function PanelSwitcher() {
               </span>
             </div>
           )
-        })}
+          })}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -154,96 +154,95 @@ export function PanelSwitcher() {
 
   if (!show || nodeList.length === 0) return null
 
-  // Uniform tile size so the grid aligns cleanly. Thumbnails keep their
-  // aspect ratio via `objectFit: contain` inside the fixed box.
+  // Fixed tile width; height follows each node's true aspect ratio so the
+  // grid flows as real masonry. Clamped so extreme aspects don't produce
+  // absurdly tall/short tiles.
   const TILE_W = 220
-  const TILE_H = 140
+  const MIN_TILE_H = 110
+  const MAX_TILE_H = 260
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-8 bg-black/60"
+      className="fixed inset-0 z-50 flex items-start justify-center p-10 bg-black/70 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+      style={{ scrollbarWidth: 'none' }}
       onClick={close}
     >
       <div
-        className="rounded-3xl bg-surface-4/90 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)] p-6 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+        className="[column-gap:20px]"
         style={{
           width: 'min(92vw, 1200px)',
-          maxHeight: '82vh',
-          scrollbarWidth: 'none',
+          columnWidth: `${TILE_W}px`,
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div
-          className="grid gap-5"
-          style={{
-            gridTemplateColumns: `repeat(auto-fit, ${TILE_W}px)`,
-            justifyContent: 'center',
-          }}
-        >
-          {nodeList.map((node, i) => {
-            const panel = workspace?.panels[node.panelId]
-            const type = panel?.type || 'terminal'
-            const title = panel?.title || 'Panel'
-            const isSelected = i === selectedIndex
-            const color = panelColor(type)
-            const thumb = thumbnails[node.id]
+        {nodeList.map((node, i) => {
+          const panel = workspace?.panels[node.panelId]
+          const type = panel?.type || 'terminal'
+          const title = panel?.title || 'Panel'
+          const isSelected = i === selectedIndex
+          const color = panelColor(type)
+          const thumb = thumbnails[node.id]
 
-            return (
+          const aspect = node.size.width / Math.max(node.size.height, 1)
+          const rawH = TILE_W / aspect
+          const tileH = Math.max(MIN_TILE_H, Math.min(MAX_TILE_H, rawH))
+
+          return (
+            <div
+              key={node.id}
+              ref={isSelected ? selectedRef : undefined}
+              className="flex flex-col items-center cursor-pointer transition-all duration-150 mb-5"
+              style={{
+                breakInside: 'avoid',
+                opacity: isSelected ? 1 : 0.65,
+                transform: isSelected ? 'scale(1.03)' : 'scale(1)',
+              }}
+              onClick={() => selectItem(i)}
+            >
               <div
-                key={node.id}
-                ref={isSelected ? selectedRef : undefined}
-                className="flex flex-col items-center cursor-pointer transition-all duration-150"
                 style={{
-                  opacity: isSelected ? 1 : 0.65,
-                  transform: isSelected ? 'scale(1.04)' : 'scale(1)',
+                  width: TILE_W,
+                  height: tileH,
+                  borderRadius: 10,
+                  overflow: 'hidden',
+                  border: isSelected ? `2px solid ${color}` : `1px solid rgba(255,255,255,0.08)`,
+                  boxShadow: isSelected
+                    ? `0 0 24px ${color}44, 0 4px 20px rgba(0,0,0,0.4)`
+                    : '0 2px 10px rgba(0,0,0,0.25)',
+                  transition: 'border-color 0.15s, box-shadow 0.15s, transform 0.15s',
+                  backgroundColor: 'var(--surface-5)',
                 }}
-                onClick={() => selectItem(i)}
               >
-                <div
-                  style={{
-                    width: TILE_W,
-                    height: TILE_H,
-                    borderRadius: 10,
-                    overflow: 'hidden',
-                    border: isSelected ? `2px solid ${color}` : `1px solid rgba(255,255,255,0.08)`,
-                    boxShadow: isSelected
-                      ? `0 0 24px ${color}44, 0 4px 20px rgba(0,0,0,0.4)`
-                      : '0 2px 10px rgba(0,0,0,0.25)',
-                    transition: 'border-color 0.15s, box-shadow 0.15s, transform 0.15s',
-                    backgroundColor: 'var(--surface-5)',
-                  }}
-                >
-                  {thumb ? (
-                    <img
-                      src={thumb}
-                      alt={title}
-                      style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-                    />
-                  ) : (
-                    <div style={{
-                      width: '100%', height: '100%',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      color: 'var(--text-muted)', fontSize: 11,
-                    }}>
-                      ...
-                    </div>
-                  )}
-                </div>
-                <span
-                  className="truncate text-center mt-2"
-                  style={{
-                    fontSize: 12,
-                    color: isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
-                    maxWidth: TILE_W,
-                    fontWeight: isSelected ? 600 : 400,
-                  }}
-                >
-                  {title}
-                </span>
+                {thumb ? (
+                  <img
+                    src={thumb}
+                    alt={title}
+                    style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                  />
+                ) : (
+                  <div style={{
+                    width: '100%', height: '100%',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: 'var(--text-muted)', fontSize: 11,
+                  }}>
+                    ...
+                  </div>
+                )}
               </div>
-            )
-          })}
-        </div>
+              <span
+                className="truncate text-center mt-2"
+                style={{
+                  fontSize: 12,
+                  color: isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  maxWidth: TILE_W,
+                  fontWeight: isSelected ? 600 : 400,
+                }}
+              >
+                {title}
+              </span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -154,92 +154,92 @@ export function PanelSwitcher() {
 
   if (!show || nodeList.length === 0) return null
 
+  // Uniform tile size so the grid aligns cleanly. Thumbnails keep their
+  // aspect ratio via `objectFit: contain` inside the fixed box.
+  const TILE_W = 220
+  const TILE_H = 140
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-8"
-      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-8 bg-black/60"
       onClick={close}
     >
       <div
-        className="flex flex-wrap items-start justify-center gap-4 overflow-y-auto"
-        style={{ maxWidth: 'min(90vw, 1400px)', maxHeight: '85vh' }}
+        className="rounded-3xl bg-surface-4/90 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)] p-6 overflow-y-auto"
+        style={{ maxWidth: 'min(92vw, 1200px)', maxHeight: '82vh' }}
         onClick={(e) => e.stopPropagation()}
       >
-        {nodeList.map((node, i) => {
-          const panel = workspace?.panels[node.panelId]
-          const type = panel?.type || 'terminal'
-          const title = panel?.title || 'Panel'
-          const isSelected = i === selectedIndex
-          const color = panelColor(type)
-          const thumb = thumbnails[node.id]
+        <div
+          className="grid gap-5"
+          style={{
+            gridTemplateColumns: `repeat(auto-fit, ${TILE_W}px)`,
+            justifyContent: 'center',
+          }}
+        >
+          {nodeList.map((node, i) => {
+            const panel = workspace?.panels[node.panelId]
+            const type = panel?.type || 'terminal'
+            const title = panel?.title || 'Panel'
+            const isSelected = i === selectedIndex
+            const color = panelColor(type)
+            const thumb = thumbnails[node.id]
 
-          const maxThumbW = 180
-          const maxThumbH = 120
-          const aspect = node.size.width / Math.max(node.size.height, 1)
-          let thumbW: number, thumbH: number
-          if (aspect > maxThumbW / maxThumbH) {
-            thumbW = maxThumbW
-            thumbH = maxThumbW / aspect
-          } else {
-            thumbH = maxThumbH
-            thumbW = maxThumbH * aspect
-          }
-
-          return (
-            <div
-              key={node.id}
-              ref={isSelected ? selectedRef : undefined}
-              className="flex flex-col items-center cursor-pointer transition-all duration-150"
-              style={{
-                opacity: isSelected ? 1 : 0.5,
-                transform: isSelected ? 'scale(1.08)' : 'scale(1)',
-              }}
-              onClick={() => selectItem(i)}
-            >
+            return (
               <div
+                key={node.id}
+                ref={isSelected ? selectedRef : undefined}
+                className="flex flex-col items-center cursor-pointer transition-all duration-150"
                 style={{
-                  width: thumbW,
-                  height: thumbH,
-                  borderRadius: 8,
-                  overflow: 'hidden',
-                  border: isSelected ? `2px solid ${color}` : `2px solid var(--border-subtle)`,
-                  boxShadow: isSelected
-                    ? `0 0 20px ${color}33, 0 4px 16px var(--shadow-node)`
-                    : 'var(--shadow-node)',
-                  transition: 'border-color 0.15s, box-shadow 0.15s',
-                  backgroundColor: 'var(--surface-4)',
+                  opacity: isSelected ? 1 : 0.65,
+                  transform: isSelected ? 'scale(1.04)' : 'scale(1)',
                 }}
+                onClick={() => selectItem(i)}
               >
-                {thumb ? (
-                  <img
-                    src={thumb}
-                    alt={title}
-                    style={{ width: '100%', height: '100%', objectFit: 'fill', display: 'block' }}
-                  />
-                ) : (
-                  <div style={{
-                    width: '100%', height: '100%',
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    color: 'var(--text-muted)', fontSize: 10,
-                  }}>
-                    ...
-                  </div>
-                )}
+                <div
+                  style={{
+                    width: TILE_W,
+                    height: TILE_H,
+                    borderRadius: 10,
+                    overflow: 'hidden',
+                    border: isSelected ? `2px solid ${color}` : `1px solid rgba(255,255,255,0.08)`,
+                    boxShadow: isSelected
+                      ? `0 0 24px ${color}44, 0 4px 20px rgba(0,0,0,0.4)`
+                      : '0 2px 10px rgba(0,0,0,0.25)',
+                    transition: 'border-color 0.15s, box-shadow 0.15s, transform 0.15s',
+                    backgroundColor: 'var(--surface-5)',
+                  }}
+                >
+                  {thumb ? (
+                    <img
+                      src={thumb}
+                      alt={title}
+                      style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                    />
+                  ) : (
+                    <div style={{
+                      width: '100%', height: '100%',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      color: 'var(--text-muted)', fontSize: 11,
+                    }}>
+                      ...
+                    </div>
+                  )}
+                </div>
+                <span
+                  className="truncate text-center mt-2"
+                  style={{
+                    fontSize: 12,
+                    color: isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    maxWidth: TILE_W,
+                    fontWeight: isSelected ? 600 : 400,
+                  }}
+                >
+                  {title}
+                </span>
               </div>
-              <span
-                className="truncate text-center mt-2"
-                style={{
-                  fontSize: 11,
-                  color: isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
-                  maxWidth: thumbW,
-                  fontWeight: isSelected ? 500 : 400,
-                }}
-              >
-                {title}
-              </span>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -165,8 +165,12 @@ export function PanelSwitcher() {
       onClick={close}
     >
       <div
-        className="rounded-3xl bg-surface-4/90 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)] p-6 overflow-y-auto"
-        style={{ maxWidth: 'min(92vw, 1200px)', maxHeight: '82vh' }}
+        className="rounded-3xl bg-surface-4/90 backdrop-blur-2xl border border-white/20 shadow-[0_24px_64px_rgba(0,0,0,0.5)] p-6 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+        style={{
+          width: 'min(92vw, 1200px)',
+          maxHeight: '82vh',
+          scrollbarWidth: 'none',
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         <div


### PR DESCRIPTION
## Summary
With enough open canvas panels, the **Cmd+E Panel Switcher** overlay showed a horizontal scrollbar running across the bottom — tiles spilled off both sides of the viewport (see user screenshot). This was happening routinely with 8+ panels.

**Fix:** replace the single-row \`flex ... overflow-x-auto\` container with a wrapping flex grid:
- \`flex-wrap items-start justify-center\` so tiles flow onto multiple rows and stay centered horizontally.
- Cap the container at \`min(90vw, 1400px)\` wide and \`85vh\` tall.
- Container scrolls *vertically* only if the count genuinely exceeds the cap. No horizontal scroll anymore.

Tile rendering, keyboard navigation (arrow keys + Tab cycle + spring-loaded selection), and the screenshot-thumbnail cropping hook are all unchanged — the only change is the layout container.

## Test plan
- [ ] Open 2–3 panels — overlay shows a single centered row like before.
- [ ] Open 8+ panels — tiles wrap onto rows, centered, no horizontal scrollbar.
- [ ] Open 20+ panels — container scrolls vertically; no horizontal overflow.
- [ ] Arrow keys / Tab navigation still cycles through tiles in creation order.
- [ ] Clicking a tile still focuses the corresponding canvas node.