### PR TITLE
feat(editor): render workspace-relative path breadcrumb above Monaco

### DIFF
--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -622,5 +622,37 @@ export default function EditorPanel({
   // Render
   // ---------------------------------------------------------------------------
 
-  return <div ref={containerRef} className="w-full h-full" />
+  const showBreadcrumb = !!filePath && !diffMode
+  return (
+    <div className="w-full h-full flex flex-col">
+      {showBreadcrumb && <EditorBreadcrumb filePath={filePath!} rootPath={rootPath} />}
+      <div ref={containerRef} className="flex-1 min-h-0 w-full" />
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Breadcrumb strip — workspace-relative path segments above the editor
+// -----------------------------------------------------------------------------
+
+function EditorBreadcrumb({ filePath, rootPath }: { filePath: string; rootPath?: string }) {
+  const rel = rootPath && filePath.startsWith(rootPath + '/')
+    ? filePath.slice(rootPath.length + 1)
+    : filePath
+  const segments = rel.split('/').filter(Boolean)
+  return (
+    <div
+      className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-neutral-500 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-800 overflow-hidden whitespace-nowrap select-none"
+      title={filePath}
+    >
+      {segments.map((seg, i) => (
+        <span key={i} className="flex items-center gap-1 min-w-0">
+          {i > 0 && <span className="opacity-50">›</span>}
+          <span className={i === segments.length - 1 ? 'text-neutral-700 dark:text-neutral-200 truncate' : 'truncate'}>
+            {seg}
+          </span>
+        </span>
+      ))}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
File-backed editor panels now show a thin breadcrumb strip above the Monaco editor with the workspace-relative path split into segments (`folder › folder › file.ts`). Helps when several editor panels of unfamiliar files are open on the canvas and only the filename was visible in the tab.

Scoped to regular file editors — hidden for diff mode and scratch (no-filePath) editors. Clicking segments is a no-op for now; the breadcrumb is display-only in v1 to keep the surface minimal.

**Symbol part of the breadcrumb is deferred.** Standalone Monaco doesn't expose symbol providers without pulling in LSP-style plumbing; keeping that for a later PR so this one ships now.

## Files touched
- `src/renderer/panels/EditorPanel.tsx` — flex-col wrapper around the editor container, new `EditorBreadcrumb` component splitting the workspace-relative path into span segments.

## Test plan
- [ ] Open any file-backed editor — breadcrumb strip appears above Monaco, segments separated by `›`.
- [ ] Hover the strip — full absolute path shows as a tooltip (truncates gracefully on narrow panels).
- [ ] Open a scratch editor (no file) — no breadcrumb.
- [ ] Open a git-diff editor — no breadcrumb (diff mode hides it).
- [ ] Path outside the workspace root — falls back to showing the absolute path segments.