### PR TITLE
fix(git-monitor): don't crash main when workspace root isn't allowed yet

### DIFF
--- a/src/main/ipc/git-monitor.ts
+++ b/src/main/ipc/git-monitor.ts
@@ -120,7 +120,23 @@ export function stopMonitorsForWindow(windowId: number): void {
 
 export function registerHandlers(): void {
   ipcMain.on(GIT_MONITOR_START, (event, workspaceId: string, rootPath: string) => {
-    const validRoot = validateCwd(rootPath)
+    // `ipcMain.on` handlers have no promise boundary, so any throw inside
+    // escapes as an uncaught exception and crashes the main process with a
+    // fatal Electron dialog. Path validation is legitimately expected to fail
+    // here during session restore (renderer requests monitoring before the
+    // workspace root has been registered as an allowed root), so treat a
+    // validation failure as "don't start monitoring" instead of a hard error.
+    let validRoot: string
+    try {
+      validRoot = validateCwd(rootPath)
+    } catch (err) {
+      log.warn(
+        '[git-monitor] skipping monitor for workspace %s: %s',
+        workspaceId,
+        err instanceof Error ? err.message : String(err),
+      )
+      return
+    }
     const existing = activeMonitors.get(workspaceId)
     if (existing) {
       clearInterval(existing.interval)


### PR DESCRIPTION
## Summary
Session restore fires \`GIT_MONITOR_START\` as soon as a workspace mounts in the renderer. That can race ahead of the main-process call that registers the workspace's rootPath as an allowed directory. The monitor handler then calls \`validateCwd(rootPath)\` and throws \"outside allowed directories\".

Because the handler is registered with \`ipcMain.on\` (not \`.handle\`), **there is no promise boundary** — the throw bubbles out as an uncaught exception and Electron shows a fatal \`\"JavaScript error occurred in the browser process\"\` dialog. App dead, user sees a confusing stack trace.

**Fix** (tiny, in \`src/main/ipc/git-monitor.ts\`): wrap the \`validateCwd\` call in try/catch, log a warning, and return early if validation fails. If the race happens, git monitoring just doesn't start for that workspace — which is fully recoverable (re-opening the folder re-registers the root and starts monitoring normally). Far better than crashing the entire main process.

## Background
This bug was hit during the canvas-loading / session-restore work earlier in the iteration — saw the literal \"A JavaScript error occurred in the browser process\" dialog pop up when a workspace's rootPath wasn't in the allowed set yet. Root-caused to the \`.on\` / \`.handle\` asymmetry.

## Test plan
- [ ] Normal session restore — git monitor starts for workspaces with known-allowed roots (regression check).
- [ ] Close the app mid-session, remove a workspace's rootPath from allowed roots (or hand-craft a session with a root that doesn't re-register), relaunch — no fatal dialog, monitor simply doesn't start for that workspace.
- [ ] Re-open the affected folder via the folder picker — root gets re-registered, monitor starts emitting updates.

## Notes
- This is strictly a crash-prevention fix; no behavioural change for the happy path.
- The \`ipcMain.on\` vs \`.handle\` distinction is subtle; a broader audit of other \`.on\` handlers that call \`validateCwd\` could be useful as a follow-up. Not bundled here.