### PR TITLE
feat(ai-config): MCP server editor dialog with env input and validate probe

### DIFF
--- a/src/main/ipc/mcp.ts
+++ b/src/main/ipc/mcp.ts
@@ -48,6 +48,35 @@ function filterRendererEnv(env: Record<string, string>): Record<string, string> 
   return filtered
 }
 
+/**
+ * Convert a JSON-RPC initialize response into an MCPTestResult.
+ * Surfaces serverInfo, advertised capabilities, and protocol version so the UI
+ * can preview what the server actually supports before it's spawned for real.
+ */
+function extractTestResult(parsed: unknown): import('../../shared/types').MCPTestResult {
+  if (!parsed || typeof parsed !== 'object') return { success: true }
+  const resp = parsed as { result?: Record<string, unknown>; error?: { message?: string } }
+  if (resp.error?.message) {
+    return { success: false, error: resp.error.message }
+  }
+  const result = resp.result
+  if (!result || typeof result !== 'object') return { success: true }
+  const serverInfo = (result as { serverInfo?: { name?: string; version?: string } }).serverInfo
+  const caps = (result as { capabilities?: Record<string, unknown> }).capabilities ?? {}
+  const protocolVersion = (result as { protocolVersion?: string }).protocolVersion
+  return {
+    success: true,
+    serverInfo: serverInfo && typeof serverInfo === 'object' ? { name: serverInfo.name, version: serverInfo.version } : undefined,
+    capabilities: {
+      tools: !!caps.tools,
+      resources: !!caps.resources,
+      prompts: !!caps.prompts,
+      logging: !!caps.logging,
+    },
+    protocolVersion,
+  }
+}
+
 // Map from server name to its running child process + owning window
 const runningServers: Map<string, { process: ChildProcess; ownerWindowId: number }> = new Map()
 
@@ -127,7 +156,7 @@ export function registerHandlers(): void {
       command: string,
       args: string[],
       env: Record<string, string>,
-    ): Promise<{ success: boolean; error?: string }> => {
+    ): Promise<import('../../shared/types').MCPTestResult> => {
       try {
         validateCommand(command)
       } catch (err) {
@@ -143,7 +172,7 @@ export function registerHandlers(): void {
           stdio: ['pipe', 'pipe', 'pipe'],
         })
 
-        const done = (result: { success: boolean; error?: string }) => {
+        const done = (result: import('../../shared/types').MCPTestResult) => {
           if (settled) return
           settled = true
           try {
@@ -189,10 +218,9 @@ export function registerHandlers(): void {
             if (!trimmed) continue
             try {
               const parsed = JSON.parse(trimmed)
-              // A valid JSON-RPC 2.0 response has an 'id' field
               if (parsed && typeof parsed === 'object' && 'id' in parsed) {
                 clearTimeout(timeout)
-                done({ success: true })
+                done(extractTestResult(parsed))
                 return
               }
             } catch {
@@ -200,13 +228,12 @@ export function registerHandlers(): void {
             }
           }
 
-          // Also try the full buffer in case the server doesn't send newlines
           if (buffer.trim()) {
             try {
               const parsed = JSON.parse(buffer.trim())
               if (parsed && typeof parsed === 'object' && 'id' in parsed) {
                 clearTimeout(timeout)
-                done({ success: true })
+                done(extractTestResult(parsed))
               }
             } catch {
               // incomplete JSON, wait for more data

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -602,7 +602,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(MCP_STOP, name)
   },
 
-  mcpTest(command: string, args: string[], env: Record<string, string>): Promise<{ success: boolean; error?: string }> {
+  mcpTest(command: string, args: string[], env: Record<string, string>) {
     return ipcRenderer.invoke(MCP_TEST, command, args, env)
   },
 

--- a/src/renderer/dialogs/MCPServerEditor.tsx
+++ b/src/renderer/dialogs/MCPServerEditor.tsx
@@ -1,0 +1,267 @@
+// =============================================================================
+// MCPServerEditor — Modal for adding or editing a `.mcp.json` server entry.
+// Covers name / command / args / env plus an inline validate probe that
+// surfaces the server's advertised capabilities before the entry is saved.
+// =============================================================================
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { X, Plus, Trash, CheckCircle, Warning, CircleNotch } from '@phosphor-icons/react'
+import type { MCPServerDefinition, MCPTestResult } from '../../shared/types'
+import { useAIConfigStore } from '../stores/aiConfigStore'
+
+const INPUT_CLS =
+  'bg-surface-3 text-primary text-[11px] px-2 py-1 rounded border border-subtle outline-none focus:border-blue-500/50 w-full font-mono'
+
+interface Props {
+  rootPath: string
+  /** When set, prefill with this server's config and save via updateMcpServer. */
+  editingServer?: MCPServerDefinition
+  onClose: () => void
+}
+
+interface EnvRow { key: string; value: string }
+
+function envToRows(env: Record<string, string>): EnvRow[] {
+  return Object.entries(env).map(([key, value]) => ({ key, value }))
+}
+
+function rowsToEnv(rows: EnvRow[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const row of rows) {
+    const k = row.key.trim()
+    if (!k) continue
+    out[k] = row.value
+  }
+  return out
+}
+
+export function MCPServerEditor({ rootPath, editingServer, onClose }: Props) {
+  const addMcpServer = useAIConfigStore((s) => s.addMcpServer)
+  const updateMcpServer = useAIConfigStore((s) => s.updateMcpServer)
+  const existingServers = useAIConfigStore((s) => s.mcpServers)
+
+  const isEdit = !!editingServer
+  const [name, setName] = useState(editingServer?.name ?? '')
+  const [command, setCommand] = useState(editingServer?.command ?? '')
+  const [argsText, setArgsText] = useState((editingServer?.args ?? []).join(' '))
+  const [envRows, setEnvRows] = useState<EnvRow[]>(envToRows(editingServer?.env ?? {}))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [probing, setProbing] = useState(false)
+  const [probeResult, setProbeResult] = useState<MCPTestResult | null>(null)
+
+  const nameTrimmed = name.trim()
+  const commandTrimmed = command.trim()
+
+  // args split is whitespace-aware but keeps quoted segments as a single arg.
+  const parsedArgs = useMemo(() => {
+    const matches = argsText.match(/("[^"]*"|'[^']*'|\S+)/g) ?? []
+    return matches.map((m) => m.replace(/^["']|["']$/g, ''))
+  }, [argsText])
+
+  const validationError = useMemo(() => {
+    if (!nameTrimmed) return 'Name is required'
+    if (!commandTrimmed) return 'Command is required'
+    if (!isEdit && existingServers[nameTrimmed]) return `"${nameTrimmed}" already exists`
+    if (isEdit && nameTrimmed !== editingServer!.name && existingServers[nameTrimmed]) {
+      return `"${nameTrimmed}" already exists`
+    }
+    return null
+  }, [nameTrimmed, commandTrimmed, isEdit, editingServer, existingServers])
+
+  const buildDefinition = useCallback((): MCPServerDefinition => ({
+    name: nameTrimmed,
+    command: commandTrimmed,
+    args: parsedArgs,
+    env: rowsToEnv(envRows),
+  }), [nameTrimmed, commandTrimmed, parsedArgs, envRows])
+
+  const handleSave = useCallback(async () => {
+    if (validationError) { setError(validationError); return }
+    setSaving(true); setError(null)
+    try {
+      const def = buildDefinition()
+      if (isEdit) await updateMcpServer(editingServer!.name, def, rootPath)
+      else await addMcpServer(def, rootPath)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [validationError, buildDefinition, isEdit, updateMcpServer, addMcpServer, editingServer, rootPath, onClose])
+
+  const handleProbe = useCallback(async () => {
+    if (!commandTrimmed) { setError('Command is required to validate'); return }
+    setProbing(true); setProbeResult(null); setError(null)
+    try {
+      const def = buildDefinition()
+      const result = await window.electronAPI.mcpTest(def.command, def.args, def.env)
+      setProbeResult(result)
+    } catch (err) {
+      setProbeResult({ success: false, error: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setProbing(false)
+    }
+  }, [commandTrimmed, buildDefinition])
+
+  // Env row operations
+  const addEnvRow = () => setEnvRows((rs) => [...rs, { key: '', value: '' }])
+  const updateEnvRow = (i: number, patch: Partial<EnvRow>) =>
+    setEnvRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+  const removeEnvRow = (i: number) => setEnvRows((rs) => rs.filter((_, idx) => idx !== i))
+
+  // Escape to close
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose() }
+    }
+    document.addEventListener('keydown', handler, { capture: true })
+    return () => document.removeEventListener('keydown', handler, { capture: true })
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="w-[560px] max-h-[640px] rounded-xl overflow-hidden flex flex-col bg-surface-4 border border-subtle shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-subtle">
+          <div className="text-primary text-sm font-medium">
+            {isEdit ? `Edit MCP Server — ${editingServer!.name}` : 'Add MCP Server'}
+          </div>
+          <button onClick={onClose} className="text-muted hover:text-primary p-1 rounded hover:bg-hover" title="Close">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+          {/* Name + Command */}
+          <div className="grid grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-[10px] uppercase tracking-wider text-muted">Name</span>
+              <input className={INPUT_CLS} value={name} onChange={(e) => setName(e.target.value)} placeholder="filesystem" autoFocus />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[10px] uppercase tracking-wider text-muted">Command</span>
+              <input className={INPUT_CLS} value={command} onChange={(e) => setCommand(e.target.value)} placeholder="npx" />
+            </label>
+          </div>
+
+          {/* Args */}
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-muted">Args (space-separated, quote for spaces)</span>
+            <input className={INPUT_CLS} value={argsText} onChange={(e) => setArgsText(e.target.value)} placeholder="-y @modelcontextprotocol/server-filesystem /path" />
+            {parsedArgs.length > 0 && (
+              <span className="text-[10px] text-muted">
+                → {parsedArgs.map((a, i) => <code key={i} className="mr-1 px-1 rounded bg-surface-3">{a}</code>)}
+              </span>
+            )}
+          </label>
+
+          {/* Env */}
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] uppercase tracking-wider text-muted">Environment</span>
+              <button onClick={addEnvRow} className="flex items-center gap-1 text-[10px] text-muted hover:text-primary">
+                <Plus size={10} /> Add
+              </button>
+            </div>
+            {envRows.length === 0 ? (
+              <div className="text-[11px] text-muted italic">No environment variables</div>
+            ) : (
+              <div className="space-y-1">
+                {envRows.map((row, i) => (
+                  <div key={i} className="flex items-center gap-1">
+                    <input className={INPUT_CLS} style={{ flex: 1 }} value={row.key} onChange={(e) => updateEnvRow(i, { key: e.target.value })} placeholder="KEY" />
+                    <input className={INPUT_CLS} style={{ flex: 2 }} value={row.value} onChange={(e) => updateEnvRow(i, { value: e.target.value })} placeholder="value" />
+                    <button onClick={() => removeEnvRow(i)} className="text-muted hover:text-red-400 p-1"><Trash size={11} /></button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <span className="text-[10px] text-muted">
+              LD_*, DYLD_*, NODE_OPTIONS, PYTHONSTARTUP, PYTHONPATH are stripped on spawn.
+            </span>
+          </div>
+
+          {/* Validate */}
+          <div className="pt-2 border-t border-subtle">
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleProbe}
+                disabled={probing || !commandTrimmed}
+                className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded bg-surface-6 hover:bg-hover text-primary disabled:opacity-40"
+              >
+                {probing ? <CircleNotch size={12} className="animate-spin" /> : null}
+                Validate
+              </button>
+              <span className="text-[10px] text-muted">Spawns the server, sends `initialize`, then stops.</span>
+            </div>
+            {probeResult && <ProbeResultView result={probeResult} />}
+          </div>
+        </div>
+
+        {error && (
+          <div className="px-4 py-2 text-xs text-red-400 bg-red-600/10 border-t border-subtle">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-subtle">
+          <button onClick={onClose} className="text-xs px-3 py-1.5 rounded text-muted hover:text-primary hover:bg-hover">Cancel</button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !!validationError}
+            className="text-xs px-3 py-1.5 rounded bg-blue-600/80 text-white hover:bg-blue-600 disabled:opacity-40"
+          >
+            {isEdit ? 'Save' : 'Add Server'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Probe result preview
+// -----------------------------------------------------------------------------
+
+function ProbeResultView({ result }: { result: MCPTestResult }) {
+  if (!result.success) {
+    return (
+      <div className="mt-2 flex items-start gap-2 text-[11px] text-red-400 bg-red-600/10 rounded px-2 py-1.5">
+        <Warning size={12} className="mt-0.5 shrink-0" />
+        <span className="font-mono break-all">{result.error ?? 'Probe failed'}</span>
+      </div>
+    )
+  }
+
+  const caps = result.capabilities ?? {}
+  const advertised: string[] = []
+  if (caps.tools) advertised.push('tools')
+  if (caps.resources) advertised.push('resources')
+  if (caps.prompts) advertised.push('prompts')
+  if (caps.logging) advertised.push('logging')
+
+  return (
+    <div className="mt-2 flex items-start gap-2 text-[11px] text-emerald-400 bg-emerald-600/10 rounded px-2 py-1.5">
+      <CheckCircle size={12} className="mt-0.5 shrink-0" />
+      <div className="flex-1 space-y-0.5 text-secondary">
+        <div>
+          <span className="text-emerald-400">OK</span>
+          {result.serverInfo?.name && <> — <span className="font-mono">{result.serverInfo.name}</span></>}
+          {result.serverInfo?.version && <span className="text-muted"> v{result.serverInfo.version}</span>}
+          {result.protocolVersion && <span className="text-muted"> · protocol {result.protocolVersion}</span>}
+        </div>
+        <div className="text-muted">
+          Capabilities: {advertised.length > 0 ? advertised.join(', ') : <em className="italic">none advertised</em>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/sidebar/AIConfigSidebarView.tsx
+++ b/src/renderer/sidebar/AIConfigSidebarView.tsx
@@ -5,11 +5,12 @@
 
 import React, { useEffect, useCallback, useState, type DragEvent } from 'react'
 import {
-  Check, X, Plus, Trash, Play, Square, Lightning,
+  Check, X, Plus, Trash, Play, Square, Lightning, PencilSimple,
   ArrowsClockwise, FolderOpen, CircleNotch, Eye, EyeSlash,
   Download, CaretDown, CaretRight, BookOpen, HardDrives,
 } from '@phosphor-icons/react'
-import type { AIToolId, AIToolPresence, MCPServerConfig, DockLayoutNode } from '../../shared/types'
+import type { AIToolId, AIToolPresence, MCPServerConfig, MCPServerDefinition, DockLayoutNode } from '../../shared/types'
+import { MCPServerEditor } from '../dialogs/MCPServerEditor'
 import { useAIConfigStore } from '../stores/aiConfigStore'
 import { useAppStore } from '../stores/appStore'
 import { useDockStore } from '../stores/dockStore'
@@ -547,13 +548,18 @@ function MCPCard({ rootPath }: { rootPath: string }) {
   const spawn = useAIConfigStore((s) => s.spawnMcpServer)
   const stop = useAIConfigStore((s) => s.stopMcpServer)
   const remove = useAIConfigStore((s) => s.removeMcpServer)
-  const addServer = useAIConfigStore((s) => s.addMcpServer)
-  const [adding, setAdding] = useState(false)
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editingServer, setEditingServer] = useState<MCPServerDefinition | undefined>(undefined)
   const [showReg, setShowReg] = useState(false)
-  const [name, setName] = useState(''); const [cmd, setCmd] = useState(''); const [args, setArgs] = useState('')
 
   useEffect(() => { if (expanded) load(rootPath) }, [expanded, rootPath, load])
   const servers = Object.values(mcpServers)
+
+  const openAdd = () => { setEditingServer(undefined); setEditorOpen(true) }
+  const openEdit = (s: MCPServerConfig) => {
+    setEditingServer({ name: s.name, command: s.command, args: s.args, env: s.env })
+    setEditorOpen(true)
+  }
 
   return (
     <div className="rounded-md bg-surface-5 border border-subtle overflow-hidden">
@@ -574,32 +580,21 @@ function MCPCard({ rootPath }: { rootPath: string }) {
                 <span className="text-[10px] text-secondary flex-1 truncate">{s.name}</span>
                 <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                   {s.status === 'running'
-                    ? <button onClick={() => stop(s.name)} className="p-0.5 text-muted hover:text-primary"><Square size={9} /></button>
-                    : <button onClick={() => spawn(s.name)} className="p-0.5 text-muted hover:text-primary"><Play size={9} /></button>
+                    ? <button onClick={() => stop(s.name)} className="p-0.5 text-muted hover:text-primary" title="Stop"><Square size={9} /></button>
+                    : <button onClick={() => spawn(s.name)} className="p-0.5 text-muted hover:text-primary" title="Start"><Play size={9} /></button>
                   }
-                  <button onClick={() => remove(s.name, rootPath)} className="p-0.5 text-muted hover:text-red-400"><Trash size={9} /></button>
+                  <button onClick={() => openEdit(s)} className="p-0.5 text-muted hover:text-primary" title="Edit"><PencilSimple size={9} /></button>
+                  <button onClick={() => remove(s.name, rootPath)} className="p-0.5 text-muted hover:text-red-400" title="Delete"><Trash size={9} /></button>
                 </div>
               </div>
             )
           })}
-          {servers.length === 0 && !adding && <div className="text-[11px] text-muted px-2 py-2">None configured</div>}
+          {servers.length === 0 && <div className="text-[11px] text-muted px-2 py-2">None configured</div>}
 
-          {adding ? (
-            <div className="px-2 pt-1.5 space-y-1">
-              <div className="flex gap-1"><input value={name} onChange={(e) => setName(e.target.value)} placeholder="name" className={INPUT_CLS} style={{ flex: 1 }} />
-                <input value={cmd} onChange={(e) => setCmd(e.target.value)} placeholder="cmd" className={INPUT_CLS} style={{ flex: 1 }} /></div>
-              <input value={args} onChange={(e) => setArgs(e.target.value)} placeholder="args" className={INPUT_CLS} />
-              <div className="flex gap-2">
-                <button onClick={async () => { if (name.trim() && cmd.trim()) { await addServer({ name: name.trim(), command: cmd.trim(), args: args.split(/\s+/).filter(Boolean), env: {} }, rootPath); setName(''); setCmd(''); setArgs(''); setAdding(false) } }} className="text-[10px] text-secondary hover:text-primary">Add</button>
-                <button onClick={() => setAdding(false)} className="text-[10px] text-muted">Cancel</button>
-              </div>
-            </div>
-          ) : (
-            <div className="flex gap-3 px-2 pt-1.5">
-              <button onClick={() => setAdding(true)} className="text-[10px] text-muted hover:text-primary">+ Add</button>
-              <button onClick={() => setShowReg(!showReg)} className="text-[10px] text-muted hover:text-primary">{showReg ? 'Hide' : 'Browse'}</button>
-            </div>
-          )}
+          <div className="flex gap-3 px-2 pt-1.5">
+            <button onClick={openAdd} className="text-[10px] text-muted hover:text-primary">+ Add</button>
+            <button onClick={() => setShowReg(!showReg)} className="text-[10px] text-muted hover:text-primary">{showReg ? 'Hide' : 'Browse'}</button>
+          </div>
 
           {showReg && (() => {
             const Reg = () => {
@@ -628,6 +623,14 @@ function MCPCard({ rootPath }: { rootPath: string }) {
             return <Reg />
           })()}
         </div>
+      )}
+
+      {editorOpen && (
+        <MCPServerEditor
+          rootPath={rootPath}
+          editingServer={editingServer}
+          onClose={() => setEditorOpen(false)}
+        />
       )}
     </div>
   )

--- a/src/renderer/stores/aiConfigStore.ts
+++ b/src/renderer/stores/aiConfigStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import log from '../lib/logger'
-import type { AIToolId, AIToolPresence, MCPServerConfig, MCPServerDefinition } from '../../shared/types'
+import type { AIToolId, AIToolPresence, MCPServerConfig, MCPServerDefinition, MCPTestResult } from '../../shared/types'
 import { scanWorkspace } from '../lib/aiConfig/scanner'
 import { getTemplateContent, type ProjectContext } from '../lib/aiConfig/templates'
 import { parseMcpJson, serializeMcpJson } from '../lib/aiConfig/mcpConfig'
@@ -18,11 +18,12 @@ interface AIConfigStoreActions {
   createAllForTool: (toolId: AIToolId, rootPath: string) => Promise<void>
   loadMcpServers: (rootPath: string) => Promise<void>
   addMcpServer: (def: MCPServerDefinition, rootPath: string) => Promise<void>
+  updateMcpServer: (originalName: string, def: MCPServerDefinition, rootPath: string) => Promise<void>
   removeMcpServer: (name: string, rootPath: string) => Promise<void>
   updateMcpServerStatus: (name: string, status: MCPServerConfig['status'], error?: string) => void
   spawnMcpServer: (name: string) => Promise<void>
   stopMcpServer: (name: string) => Promise<void>
-  testMcpServer: (name: string) => Promise<{ success: boolean; error?: string }>
+  testMcpServer: (name: string) => Promise<MCPTestResult>
   watchConfigFiles: (rootPath: string) => () => void
   reset: () => void
 }
@@ -131,6 +132,25 @@ export const useAIConfigStore = create<AIConfigStore>((set, get) => ({
     const defs: Record<string, MCPServerDefinition> = {}
     for (const [name, server] of Object.entries(updated)) {
       defs[name] = { name: server.name, command: server.command, args: server.args, env: server.env }
+    }
+    await window.electronAPI.fsWriteFile(`${rootPath}/.mcp.json`, serializeMcpJson(defs))
+  },
+
+  async updateMcpServer(originalName: string, def: MCPServerDefinition, rootPath: string) {
+    const { mcpServers } = get()
+    const existing = mcpServers[originalName]
+    const updated: Record<string, MCPServerConfig> = { ...mcpServers }
+    if (originalName !== def.name) delete updated[originalName]
+    updated[def.name] = {
+      ...def,
+      status: existing?.status ?? 'stopped',
+      error: existing?.error,
+    }
+    set({ mcpServers: updated })
+
+    const defs: Record<string, MCPServerDefinition> = {}
+    for (const [n, server] of Object.entries(updated)) {
+      defs[n] = { name: server.name, command: server.command, args: server.args, env: server.env }
     }
     await window.electronAPI.fsWriteFile(`${rootPath}/.mcp.json`, serializeMcpJson(defs))
   },

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -331,7 +331,7 @@ export interface ElectronAPI {
 
   mcpSpawn(name: string, command: string, args: string[], env: Record<string, string>): Promise<void>
   mcpStop(name: string): Promise<void>
-  mcpTest(command: string, args: string[], env: Record<string, string>): Promise<{ success: boolean; error?: string }>
+  mcpTest(command: string, args: string[], env: Record<string, string>): Promise<import('./types').MCPTestResult>
   onMcpStatusUpdate(callback: (update: { name: string; status: string; error?: string }) => void): () => void
 
   // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,23 @@ export interface MCPStatusUpdate {
   error?: string
 }
 
+/** Result of a one-shot MCP server probe — advertised capabilities + server info. */
+export interface MCPTestResult {
+  success: boolean
+  error?: string
+  /** Server `serverInfo` from the initialize response. */
+  serverInfo?: { name?: string; version?: string }
+  /** Capability flags the server advertised. */
+  capabilities?: {
+    tools?: boolean
+    resources?: boolean
+    prompts?: boolean
+    logging?: boolean
+  }
+  /** Protocol version the server responded with. */
+  protocolVersion?: string
+}
+
 // -----------------------------------------------------------------------------
 // Canvas node
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Phase 2 of the AI Config work. The sidebar MCP card previously had a cramped inline add form with no way to edit an existing server, no environment-variable input, and no way to validate a config before saving it to \`.mcp.json\`. Those gaps forced users to hand-edit \`.mcp.json\` for anything non-trivial.

This PR adds a proper editor dialog and a capability-aware validate probe.

## Changes

### Backend — \`mcpTest\` now returns server capabilities
- Extended \`src/shared/types.ts\` with \`MCPTestResult\` — \`serverInfo\`, advertised \`capabilities\` (tools / resources / prompts / logging), \`protocolVersion\`.
- \`src/main/ipc/mcp.ts\` already spoke the JSON-RPC \`initialize\` dance; it threw the response away on success. Parse it instead and populate the new fields.
- Preload + \`electron-api.d.ts\` updated to reflect the richer return type.

### Store — edit path for existing servers
- \`src/renderer/stores/aiConfigStore.ts\`: new \`updateMcpServer(originalName, def, rootPath)\` action that handles rename + field edits without the old delete + re-add round-trip (which lost runtime status and broke identity). Preserves current run state when the name doesn't change.

### UI — proper modal editor
- New \`src/renderer/dialogs/MCPServerEditor.tsx\`. Handles both add *and* edit. Fields:
  - **Name + Command** (with validation for collisions and empty values).
  - **Args** as a whitespace-separated list; live preview of parsed tokens so quoting mistakes are visible before saving.
  - **Environment** as a key/value list with add/remove row controls. Note that LD_*, DYLD_*, NODE_OPTIONS, PYTHONSTARTUP, PYTHONPATH are stripped on spawn (documented inline).
- **Validate** button runs \`mcpTest\` against the current form state and previews the outcome inline: \`serverInfo\`, advertised capabilities, and protocol version on success, or the error message on failure. Probing writes nothing to \`.mcp.json\` so users can iterate safely.
- Sidebar MCP card (\`AIConfigSidebarView.tsx\`): row-level **Edit** (pencil) and **Delete** (trash) buttons, both revealed on hover. Registry browser is unchanged.

## Out of scope (deferred)
- **Curated template library.** The existing registry browser already covers the one-click add use case via \`searchRegistry\`.
- **Import-from-other-tools** (Claude Desktop / Codex globals). Needs a main-process scanner for those paths; not required to unblock Phase 3 orchestrator work.

## Test plan
- [ ] Sidebar → MCP Servers card → \`+ Add\` opens the modal.
- [ ] Fill in a known-good server (e.g. \`npx -y @modelcontextprotocol/server-filesystem /tmp\`) → click **Validate** → see serverInfo + capabilities.
- [ ] Click **Add Server** → entry appears in sidebar and in \`.mcp.json\`.
- [ ] Hover a row → pencil icon opens the editor pre-filled with current values; change env → Save persists.
- [ ] Rename a server — old name gone from \`.mcp.json\`, new name present.
- [ ] Try a bogus command (e.g. \`broken-mcp-xyz\`) → Validate reports the error cleanly, no save happens.
- [ ] Existing registry browser still works; running / stop / delete unchanged.