### PR TITLE
fix(crash-reporter): stop the "Cate crashed" dialog from re-showing on every launch

### DIFF
--- a/src/main/crashReporter.ts
+++ b/src/main/crashReporter.ts
@@ -62,19 +62,14 @@ function crashReportArchiveDir(): string {
 }
 
 /**
- * Save a copy of a sent report to the archive directory so reports remain
- * available locally regardless of whether the remote upload succeeds. Prunes
- * the oldest entries once MAX_ARCHIVED_REPORTS is exceeded.
+ * Drop archived reports past the retention cap. Safe to call any time.
+ * Extracted so `checkPendingCrashReport` can apply the cap after its
+ * rename-based claim instead of duplicating the logic.
  */
-function archiveCrashReport(report: CrashReport): void {
+function pruneArchivedReports(): void {
   try {
     const dir = crashReportArchiveDir()
-    fs.mkdirSync(dir, { recursive: true })
-    const safeStamp = report.timestamp.replace(/[:.]/g, '-')
-    const filename = `crash-${safeStamp}.json`
-    fs.writeFileSync(path.join(dir, filename), JSON.stringify(report, null, 2), 'utf-8')
-    log.info('Archived crash report to %s', path.join(dir, filename))
-
+    if (!fs.existsSync(dir)) return
     const entries = fs
       .readdirSync(dir)
       .filter((name) => name.startsWith('crash-') && name.endsWith('.json'))
@@ -85,7 +80,7 @@ function archiveCrashReport(report: CrashReport): void {
       }
     }
   } catch (err) {
-    log.warn('Failed to archive crash report:', err)
+    log.warn('Failed to prune crash archive: %s', err instanceof Error ? err.message : String(err))
   }
 }
 
@@ -153,30 +148,80 @@ export function saveCrashReport(
 
 /**
  * Check for a pending crash report from a previous session. If one exists,
- * show a native dialog asking the user whether to send it. The report file
- * is always deleted after the dialog is dismissed regardless of the choice.
+ * show a native dialog asking the user whether to send it.
+ *
+ * The pending report is atomically renamed into the archive directory as
+ * the *first* step — before any parsing or dialog. That way the pending
+ * file is guaranteed gone from the pickup path before the UI promises
+ * anything, even if parsing throws or the user kills the app mid-dialog.
+ * This replaces the old "dialog then tryUnlink" flow, which would
+ * silently leave the file behind on any filesystem hiccup and re-show
+ * the dialog on every subsequent startup.
  *
  * Call this after the main window has been created so the dialog can be
  * parented to it.
  */
 export async function checkPendingCrashReport(): Promise<void> {
   const reportPath = crashReportPath()
+  if (!fs.existsSync(reportPath)) return
+
+  const dir = crashReportArchiveDir()
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+  } catch (err) {
+    log.warn('Failed to ensure crash archive dir: %s', err instanceof Error ? err.message : String(err))
+    // Fall through — rename will fail below, we'll fall back to delete.
+  }
+
+  // Atomic claim: rename the pending report into the archive with a
+  // timestamped name. Same filesystem → this is guaranteed atomic on
+  // POSIX and on NTFS.
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const archivedPath = path.join(dir, `crash-${stamp}.json`)
+  let claimedPath: string
+  try {
+    fs.renameSync(reportPath, archivedPath)
+    claimedPath = archivedPath
+  } catch (err) {
+    // Cross-device rename (rare, but e.g. if userData lives on a
+    // different volume than the archive dir) — copy + delete instead.
+    try {
+      fs.copyFileSync(reportPath, archivedPath)
+      fs.unlinkSync(reportPath)
+      claimedPath = archivedPath
+    } catch (fallbackErr) {
+      log.warn(
+        'Failed to claim pending crash report (rename: %s; copy fallback: %s). Discarding to avoid re-showing the dialog.',
+        err instanceof Error ? err.message : String(err),
+        fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr),
+      )
+      // Last resort — if we can't move it, at least delete it so it
+      // doesn't keep re-triggering the dialog. If *that* fails too,
+      // tryUnlink logs the failure so we can diagnose.
+      tryUnlink(reportPath)
+      return
+    }
+  }
 
   let raw: string
   try {
-    raw = fs.readFileSync(reportPath, 'utf-8')
-  } catch {
-    return // No pending report — normal startup
+    raw = fs.readFileSync(claimedPath, 'utf-8')
+  } catch (err) {
+    log.warn('Failed to read claimed crash report: %s', err instanceof Error ? err.message : String(err))
+    return
   }
 
   let report: CrashReport
   try {
     report = JSON.parse(raw) as CrashReport
   } catch {
-    // Corrupted report — just remove it
-    tryUnlink(reportPath)
+    log.warn('Claimed crash report was not valid JSON — discarding')
+    tryUnlink(claimedPath)
     return
   }
+
+  // Apply the archive retention cap now that we've added one.
+  pruneArchivedReports()
 
   log.info('Found pending crash report from %s (%s: %s)', report.timestamp, report.error.name, report.error.message)
 
@@ -199,15 +244,10 @@ export async function checkPendingCrashReport(): Promise<void> {
     checkboxChecked: true,
   })
 
-  // Always remove the report file after the dialog
-  tryUnlink(reportPath)
-
   if (response === 0) {
-    // User opted in — send the report
     if (!checkboxChecked) {
       report.recentLogs = []
     }
-    archiveCrashReport(report)
     await sendCrashReport(report)
   } else {
     log.info('User declined to send crash report')
@@ -262,7 +302,10 @@ async function sendCrashReport(report: CrashReport): Promise<void> {
 function tryUnlink(filePath: string): void {
   try {
     fs.unlinkSync(filePath)
-  } catch {
-    // Best-effort removal
+  } catch (err) {
+    // Silent failure here is what caused the "dialog on every restart"
+    // regression — log it so a future silent failure is diagnosable.
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return
+    log.warn('Failed to unlink %s: %s', filePath, err instanceof Error ? err.message : String(err))
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -994,7 +994,13 @@ app.whenReady().then(async () => {
   mainWin.once('ready-to-show', () => {
     mainWindowReady = true
     flushPendingOpenPaths()
-    checkPendingCrashReport().catch((err) => log.warn('Crash report check failed:', err))
+    // Skip the crash-report prompt in development — dev sessions hit a
+    // lot of transient renderer errors while iterating, and those
+    // shouldn't interrupt every launch with a "Cate crashed" dialog.
+    // Production builds keep the full flow.
+    if (app.isPackaged) {
+      checkPendingCrashReport().catch((err) => log.warn('Crash report check failed:', err))
+    }
     if (process.env.CATE_SMOKE_TEST === '1') {
       runSmokeAssertions(mainWin)
         .then(() => app.exit(0))

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -7,8 +7,26 @@ import './styles/globals.css'
 log.info('Renderer starting (window type=%s)', new URLSearchParams(window.location.search).get('type') ?? 'main')
 
 window.addEventListener('error', (e) => {
-  log.error('Uncaught error:', e.error ?? e.message)
-  const err = e.error instanceof Error ? e.error : new Error(String(e.error ?? e.message))
+  // Resource-load failures (img/script/link) fire a plain Event on the
+  // failing element with no `.error` / `.message`. They aren't app
+  // crashes and should not produce a crash report — otherwise every
+  // transient asset hiccup triggers the "Cate crashed unexpectedly"
+  // dialog on the next launch.
+  if (!(e instanceof ErrorEvent)) return
+
+  const err = e.error instanceof Error
+    ? e.error
+    : new Error(typeof e.message === 'string' && e.message ? e.message : 'Unknown error')
+
+  // Defence against the classic `[object Event]` / `[object Object]`
+  // stringification artefacts — those mean the handler received a
+  // non-Error payload, not a real crash. Log but don't persist.
+  if (err.message === '[object Event]' || err.message === '[object Object]' || !err.message) {
+    log.warn('Ignoring non-informative error event:', e.error ?? e.message)
+    return
+  }
+
+  log.error('Uncaught error:', err)
   window.electronAPI?.crashReportSave({ name: err.name, message: err.message, stack: err.stack })
 })
 window.addEventListener('unhandledrejection', (e) => {


### PR DESCRIPTION
## Summary

The packaged app was showing the **"Cate crashed unexpectedly"** dialog on every single launch. Root-cause: \`checkPendingCrashReport()\` read \`crash-report.json\`, showed the dialog, then called \`tryUnlink()\` which **silently swallowed any deletion error** — any filesystem hiccup left the pending report in place and the next startup picked it up again, ad infinitum.

Three layered fixes in this PR.

### 1. Atomic claim on startup
Rename \`crash-report.json\` directly into the archive dir as the first step, *before* parsing or dialog. Rename is atomic on the same filesystem, so once it succeeds the pending file is off the pickup path forever — the dialog cannot re-trigger even if parsing throws or the user kills the app mid-dialog.

Cross-device rename is covered by a \`copy + unlink\` fallback. If both fail, we delete the pending file as a last resort instead of looping the dialog. \`tryUnlink\` now **logs** on failure (skipping ENOENT) so a future silent deletion failure is diagnosable instead of invisible.

### 2. Stop emitting \`[object Event]\` noise reports from the renderer
\`window.addEventListener('error')\` also fires for **resource-load failures** (img / script / link) — those are plain \`Event\`s with no \`.error\` and no \`.message\`, so stringifying them produced the \`[object Event]\` / \`[object Object]\` reports that filled the recent crash archive. Guarded the handler:
- Skip non-\`ErrorEvent\` events entirely.
- Extract message carefully — prefer \`e.error.message\`, fall back to \`e.message\` only if it's a non-empty string.
- Explicitly ignore the \`[object Event]\` / \`[object Object]\` / empty messages with a log line instead of persisting.

### 3. Skip the dialog in development
Dev sessions hit a lot of transient renderer errors during iteration; those shouldn't interrupt every launch. Gate \`checkPendingCrashReport()\` on \`app.isPackaged\`. Packaged builds keep the full flow.

## What the user's stuck file contained

A renderer \`Error: [object Event]\` with source \`renderer\`, stack \`at file:///Applications/Cate.app/Contents/Resources/app.asar/dist/renderer/assets/index-*.js\`. Classic mis-stringified resource-load event from the guard-less \`error\` listener fix 2 addresses. Stuck because fix 1 wasn't in place.

## Files touched
- \`src/main/crashReporter.ts\` — atomic claim flow, shared \`pruneArchivedReports\`, logging \`tryUnlink\`.
- \`src/renderer/main.tsx\` — filter resource-load errors + non-informative messages.
- \`src/main/index.ts\` — gate \`checkPendingCrashReport\` on \`app.isPackaged\`.

## Test plan
- [ ] Simulate a pending report: while the app is closed, drop a synthetic \`crash-report.json\` into \`~/Library/Application Support/Cate/\`. Relaunch (packaged build) — dialog appears **once**, the file moves to \`crash-reports/crash-<ts>.json\` immediately. Relaunch again — no dialog.
- [ ] \`npm run dev\` — no crash dialog regardless of what \`crash-report.json\` says (dev skips the prompt entirely).
- [ ] Trigger a resource-load error (e.g. a broken \`<img src>\`) in the renderer — nothing saved, no dialog on next launch.
- [ ] Trigger a real renderer exception (\`throw new Error('boom')\`) — saved with the real message, dialog fires exactly once on next packaged launch, file archived.
- [ ] Retention cap still applies: archive trimmed to 50 most recent.

## Notes
- This does not touch the \`sendCrashReport\` HTTP path. The endpoint (\`crashes.cate.dev\`) is DNS-failing for the user, so reports never send — that's a separate thing and not what was causing the dialog loop.