### PR TITLE
feat(file-explorer): copy/paste support, fix folder-dblclick

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -19,6 +19,7 @@ import {
   FS_DELETE,
   FS_RENAME,
   FS_MKDIR,
+  FS_COPY,
   FS_SEARCH,
 } from '../../shared/ipc-channels'
 import { FileTreeNode, FileSearchResult, FileSearchOptions, FILE_EXCLUSIONS } from '../../shared/types'
@@ -454,6 +455,52 @@ export function registerHandlers(): void {
       await fs.rename(await validatePathStrict(oldPath), await validatePathForCreation(newPath))
     } catch (error) {
       log.error(`[${FS_RENAME}]`, error)
+      throw error instanceof Error ? error : new Error(String(error))
+    }
+  })
+
+  ipcMain.handle(FS_COPY, async (_event, srcPath: string, destDir: string) => {
+    try {
+      const safeSrc = await validatePathStrict(srcPath)
+      const safeDestDir = await validatePathStrict(destDir)
+
+      // If copying into the same parent, append "copy" suffix so we don't
+      // collide with the original. Otherwise keep the source name.
+      const srcParent = path.dirname(safeSrc)
+      const baseName = path.basename(safeSrc)
+      const ext = path.extname(baseName)
+      const stem = ext ? baseName.slice(0, -ext.length) : baseName
+
+      const intoSameDir = srcParent === safeDestDir
+      let candidate = intoSameDir ? `${stem} copy${ext}` : baseName
+      let n = 2
+      // Find a non-existing destination name in destDir.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const target = path.join(safeDestDir, candidate)
+        try {
+          await fs.lstat(target)
+        } catch {
+          // ENOENT — safe to use
+          break
+        }
+        candidate = intoSameDir
+          ? `${stem} copy ${n}${ext}`
+          : `${stem} (${n})${ext}`
+        n++
+      }
+
+      const finalDest = await validatePathForCreation(path.join(safeDestDir, candidate))
+
+      // Refuse to copy a directory into itself or one of its descendants.
+      if (finalDest === safeSrc || finalDest.startsWith(safeSrc + path.sep)) {
+        throw new Error('Cannot copy a folder into itself')
+      }
+
+      await fs.cp(safeSrc, finalDest, { recursive: true, errorOnExist: true, force: false })
+      return finalDest
+    } catch (error) {
+      log.error(`[${FS_COPY}]`, error)
       throw error instanceof Error ? error : new Error(String(error))
     }
   })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,6 +75,7 @@ import {
   FS_DELETE,
   FS_RENAME,
   FS_MKDIR,
+  FS_COPY,
   FS_SEARCH,
   SHELL_SHOW_IN_FOLDER,
   HTTP_FETCH,
@@ -580,6 +581,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   fsMkdir(dirPath: string): Promise<void> {
     return ipcRenderer.invoke(FS_MKDIR, dirPath)
+  },
+
+  fsCopy(srcPath: string, destDir: string): Promise<string> {
+    return ipcRenderer.invoke(FS_COPY, srcPath, destDir)
   },
 
   shellShowInFolder(filePath: string): Promise<void> {

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -8,6 +8,7 @@ import log from '../lib/logger'
 import { ArrowClockwise, FilePlus, FolderPlus, MagnifyingGlass, X, Folder, File } from '@phosphor-icons/react'
 import type { FileTreeNode as FileTreeNodeType, FileSearchResult } from '../../shared/types'
 import { FileTreeNode } from './FileTreeNode'
+import { getClipboard, hasClipboard } from './fileClipboard'
 import { useAppStore } from '../stores/appStore'
 import { useDockStore } from '../stores/dockStore'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
@@ -317,6 +318,8 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       { id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' },
       { id: 'open-terminal', label: 'Open in Integrated Terminal' },
       { type: 'separator' },
+      { id: 'paste', label: 'Paste', accelerator: 'Cmd+V', enabled: hasClipboard() },
+      { type: 'separator' },
       { id: 'remove-workspace', label: 'Remove Folder from Workspace' },
       { type: 'separator' },
       { id: 'find-in-folder', label: 'Find in Folder…', accelerator: 'Alt+Shift+F' },
@@ -331,6 +334,18 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       case 'open-terminal':
         createTerminal(selectedWorkspaceId, undefined, undefined, { target: 'dock', zone: 'bottom' })
         break
+      case 'paste': {
+        const sources = getClipboard()
+        for (const src of sources) {
+          try {
+            await window.electronAPI.fsCopy(src, rootPath)
+          } catch (err) {
+            console.error('[file-explorer] Paste failed:', err)
+          }
+        }
+        handleReload()
+        break
+      }
       case 'remove-workspace':
         if (window.confirm(`Remove "${folderName}" from your workspaces?`)) {
           removeWorkspace(selectedWorkspaceId)

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -19,6 +19,7 @@ import {
 } from '@phosphor-icons/react'
 import log from '../lib/logger'
 import type { FileTreeNode as FileTreeNodeType } from '../../shared/types'
+import { getClipboard, hasClipboard, setClipboard } from './fileClipboard'
 
 // -----------------------------------------------------------------------------
 // Icon mapping — extension to inline SVG icons with colors
@@ -206,30 +207,15 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     }
   }, [node, isExpanded, children.length, onSelect])
 
-  const handleDoubleClick = useCallback(async (e: React.MouseEvent) => {
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    if (node.isDirectory) return
     e.preventDefault()
     e.stopPropagation()
-    if (node.isDirectory) {
-      // Double-click a folder: open all direct file children as dock tabs.
-      let entries = children
-      if (entries.length === 0 && window.electronAPI) {
-        try {
-          entries = await window.electronAPI.fsReadDir(node.path)
-          setChildren(entries)
-        } catch {
-          entries = []
-        }
-      }
-      const filePaths = entries.filter((c) => !c.isDirectory).map((c) => c.path)
-      if (filePaths.length > 0) onFileOpen(filePaths, 'dock')
-    } else {
-      // Double-click a file: if it's part of a multi-selection, open all selected files.
-      const paths = selectedPaths.has(node.path) && selectedPaths.size > 1
-        ? [...selectedPaths]
-        : [node.path]
-      onFileOpen(paths, 'dock')
-    }
-  }, [node, children, selectedPaths, onFileOpen])
+    const paths = selectedPaths.has(node.path) && selectedPaths.size > 1
+      ? [...selectedPaths]
+      : [node.path]
+    onFileOpen(paths, 'dock')
+  }, [node, selectedPaths, onFileOpen])
 
   // Forward declarations are filled in below; handleContextMenu uses them via refs
   // through closure on the latest functions defined later in render.
@@ -265,6 +251,9 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       { type: 'separator' },
       { id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' },
       { type: 'separator' },
+      { id: 'copy', label: pathsToOpen.length > 1 ? `Copy ${pathsToOpen.length} Items` : 'Copy', accelerator: 'Cmd+C' },
+      { id: 'paste', label: 'Paste', accelerator: 'Cmd+V', enabled: hasClipboard() },
+      { type: 'separator' },
       { id: 'rename', label: 'Rename…', accelerator: 'Return' },
       { id: 'copy-path', label: 'Copy Path', accelerator: 'Alt+Cmd+C' },
       { id: 'copy-rel-path', label: 'Copy Relative Path', accelerator: 'Alt+Shift+Cmd+C' },
@@ -280,6 +269,8 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       case 'new-file': startCreate('file'); break
       case 'new-folder': startCreate('folder'); break
       case 'reveal': window.electronAPI.shellShowInFolder(node.path); break
+      case 'copy': setClipboard(pathsToOpen); break
+      case 'paste': await handlePaste(); break
       case 'rename': startRename(); break
       case 'copy-path': navigator.clipboard.writeText(node.path); break
       case 'copy-rel-path': navigator.clipboard.writeText(relPath); break
@@ -365,6 +356,24 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       console.error('[file-tree] Failed to create entry:', err)
     }
   }, [isCreating, createValue, node.isDirectory, node.path, parentDir, reloadChildren, onTreeChanged])
+
+  // --- Paste (copy from clipboard) ---
+  const handlePaste = useCallback(async () => {
+    if (!window.electronAPI) return
+    const sources = getClipboard()
+    if (sources.length === 0) return
+    const destDir = node.isDirectory ? node.path : parentDir
+    if (node.isDirectory && !isExpanded) setIsExpanded(true)
+    for (const src of sources) {
+      try {
+        await window.electronAPI.fsCopy(src, destDir)
+      } catch (err) {
+        console.error('[file-tree] Paste failed:', err)
+      }
+    }
+    onTreeChanged?.()
+    if (node.isDirectory) await reloadChildren()
+  }, [node.isDirectory, node.path, parentDir, isExpanded, reloadChildren, onTreeChanged])
 
   // --- Delete ---
   const handleDelete = useCallback(async () => {

--- a/src/renderer/sidebar/fileClipboard.ts
+++ b/src/renderer/sidebar/fileClipboard.ts
@@ -1,0 +1,23 @@
+// Shared file-explorer clipboard (Copy / Paste).
+// Module-level singleton — only one clipboard across all FileTreeNode instances.
+
+let clipboardPaths: string[] = []
+const listeners = new Set<() => void>()
+
+export function setClipboard(paths: string[]): void {
+  clipboardPaths = [...paths]
+  for (const fn of listeners) fn()
+}
+
+export function getClipboard(): string[] {
+  return clipboardPaths
+}
+
+export function hasClipboard(): boolean {
+  return clipboardPaths.length > 0
+}
+
+export function subscribeClipboard(fn: () => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -322,6 +322,7 @@ export interface ElectronAPI {
   fsDelete(filePath: string): Promise<void>
   fsRename(oldPath: string, newPath: string): Promise<void>
   fsMkdir(dirPath: string): Promise<void>
+  fsCopy(srcPath: string, destDir: string): Promise<string>
   shellShowInFolder(filePath: string): Promise<void>
   httpFetch(url: string): Promise<{ ok: boolean; status: number; text: string }>
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -25,6 +25,7 @@ export const FS_STAT = 'fs:stat'
 export const FS_DELETE = 'fs:delete'
 export const FS_RENAME = 'fs:rename'
 export const FS_MKDIR = 'fs:mkdir'
+export const FS_COPY = 'fs:copy'
 export const FS_SEARCH = 'fs:search'
 
 // Shell utilities


### PR DESCRIPTION
## Summary
- Adds Copy / Paste for files and folders to the file explorer context menu (file, folder, and root background), backed by a new `FS_COPY` IPC that uses `fs.cp` recursively with collision-safe renaming.
- Fixes the file viewer issue where double-clicking a folder opened every direct file child as a tab — folders now ignore double-click (single-click still toggles expansion).

## Test plan
- [ ] Right-click a file → Copy → right-click a folder → Paste; file appears inside.
- [ ] Copy a folder, paste into the same parent → name gets `copy` / `copy 2` suffix.
- [ ] Multi-select files → Copy → Paste into another folder.
- [ ] Paste is disabled when clipboard is empty.
- [ ] Double-clicking a folder does nothing; single-click still expands.