### PR TITLE
fix: open new terminal in picked folder; stop crash dialog after clean quit

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
     root: '.',
     build: {
       outDir: 'dist/renderer',
+      // Emit source maps in production so crash-report stacks point at real
+      // source locations instead of opaque bundled offsets like
+      // "index-DULzyrhX.js:33061:54".
+      sourcemap: true,
       rollupOptions: {
         input: {
           index: resolve(__dirname, 'index.html')

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -6,22 +6,33 @@ import './styles/globals.css'
 
 log.info('Renderer starting (window type=%s)', new URLSearchParams(window.location.search).get('type') ?? 'main')
 
+// Recognise non-informative error payloads — usually a DOM Event or plain
+// object that was thrown / rejected somewhere and got stringified into the
+// message. React 18's logCaughtError prefixes these with "Uncaught ", so
+// match both shapes. These aren't real crashes; persisting them resurfaces
+// the "Cate crashed unexpectedly" dialog on the next launch.
+function isNonInformativeMessage(message: string | undefined | null): boolean {
+  if (!message) return true
+  const m = message.trim()
+  return (
+    m === '[object Event]' ||
+    m === '[object Object]' ||
+    m === 'Uncaught [object Event]' ||
+    m === 'Uncaught [object Object]' ||
+    /^Uncaught \[object [A-Za-z]+\]$/.test(m)
+  )
+}
+
 window.addEventListener('error', (e) => {
   // Resource-load failures (img/script/link) fire a plain Event on the
-  // failing element with no `.error` / `.message`. They aren't app
-  // crashes and should not produce a crash report — otherwise every
-  // transient asset hiccup triggers the "Cate crashed unexpectedly"
-  // dialog on the next launch.
+  // failing element with no `.error` / `.message`. They aren't app crashes.
   if (!(e instanceof ErrorEvent)) return
 
   const err = e.error instanceof Error
     ? e.error
     : new Error(typeof e.message === 'string' && e.message ? e.message : 'Unknown error')
 
-  // Defence against the classic `[object Event]` / `[object Object]`
-  // stringification artefacts — those mean the handler received a
-  // non-Error payload, not a real crash. Log but don't persist.
-  if (err.message === '[object Event]' || err.message === '[object Object]' || !err.message) {
+  if (isNonInformativeMessage(err.message)) {
     log.warn('Ignoring non-informative error event:', e.error ?? e.message)
     return
   }
@@ -43,6 +54,7 @@ class ErrorBoundary extends React.Component<
   }
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     log.error('React render error:', error.message, errorInfo.componentStack)
+    if (isNonInformativeMessage(error.message)) return
     window.electronAPI?.crashReportSave({
       name: error.name,
       message: error.message,

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -1007,16 +1007,25 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   setWorkspaceRootPath(wsId, rootPath) {
-    set((state) => ({
-      workspaces: state.workspaces.map((ws) => {
-        if (ws.id !== wsId) return ws
-        return { ...ws, isRootPathPending: true, rootPathError: null }
-      }),
-    }))
     const ws = get().workspaces.find((w) => w.id === wsId)
     if (!ws) return Promise.resolve(false)
     const folderName = rootPath.split('/').filter(Boolean).pop() ?? rootPath
     const desiredName = ws.name === 'Workspace' ? folderName : ws.name
+    // Apply optimistically so any panel created synchronously after this call
+    // (e.g. WelcomePage spawning a terminal right after picking a folder)
+    // sees the new rootPath and uses it as cwd instead of falling back to $HOME.
+    set((state) => ({
+      workspaces: state.workspaces.map((candidate) => {
+        if (candidate.id !== wsId) return candidate
+        return {
+          ...candidate,
+          rootPath,
+          name: desiredName,
+          isRootPathPending: true,
+          rootPathError: null,
+        }
+      }),
+    }))
     return syncUpdateToMain(wsId, { rootPath, name: desiredName }).then((result) => {
       if (!result?.ok) {
         const message = result?.error?.message ?? 'Failed to update workspace root'


### PR DESCRIPTION
## Summary
- **Workspace cwd**: `setWorkspaceRootPath` now applies `rootPath` optimistically before the main-process IPC roundtrip, so the terminal `WelcomePage` spawns right after picking a folder opens in that folder instead of `~`.
- **Crash dialog**: `"Cate crashed unexpectedly"` kept resurfacing after clean shutdowns because React 18's `logCaughtError` wraps a thrown DOM `Event` as `"Uncaught [object Event]"` — the existing filter only matched the bare `"[object Event]"` form. Extracted `isNonInformativeMessage()` (also matches `"Uncaught [object Object]"` and the generic `^Uncaught \[object …\]$` shape) and applied it on both the `window` error path and the `ErrorBoundary`.
- **Sourcemaps**: enabled renderer sourcemaps in production so future crash reports point at real source locations instead of opaque bundle offsets like `index-DULzyrhX.js:33061:54`, which we'll need to track down whoever is throwing the raw `Event`.

## Test plan
- [ ] Launch a packaged build, pick a folder from Welcome → confirm the auto-spawned terminal's cwd is the picked folder, not `$HOME`.
- [ ] Quit cleanly, relaunch → confirm no "Cate crashed unexpectedly" dialog.
- [ ] Trigger a real renderer error (e.g. throw in a click handler) → confirm the dialog still appears next launch with a usable stack.