### PR TITLE
fix(terminal): await pending workspace sync before terminal:create

### DIFF
--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -14,6 +14,7 @@ import { SearchAddon } from '@xterm/addon-search'
 import { useStatusStore } from '../stores/statusStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { terminalRestoreData, replayTerminalLog } from './session'
+import { awaitWorkspaceSync } from '../stores/appStore'
 import { getResolvedTheme, subscribeTheme, type ResolvedTheme } from './themeManager'
 
 /** Read the configured scrollback limit, clamped to a sane range. */
@@ -244,6 +245,14 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
 
     // Resolve cwd: prefer explicit opt, then fall back to restore data
     const resolvedCwd = opts.cwd ?? terminalRestoreData.get(panelId)?.cwd
+
+    // If cwd points at a workspace rootPath that was just picked, the main
+    // process may not have registered it as an allowed root yet (workspace
+    // create/update is async). Wait for any pending sync so validateCwd in
+    // main sees the up-to-date allowedRoots set.
+    if (resolvedCwd) {
+      await awaitWorkspaceSync()
+    }
 
     const shell = await electronAPI.settingsGet('defaultShellPath')
     const ptyId = await electronAPI.terminalCreate({

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -193,6 +193,15 @@ function enqueueWorkspaceSync<T>(label: string, fn: () => Promise<T>): Promise<T
   return resultPromise
 }
 
+// Callers that need to invoke main-process IPC depending on a workspace's
+// rootPath (e.g. terminal:create with cwd=rootPath) must await this first.
+// Otherwise the IPC can race a pending workspace:create / workspace:update and
+// fail validation with "outside allowed directories" because the new root
+// hasn't been registered in allowedRoots yet.
+export function awaitWorkspaceSync(): Promise<void> {
+  return workspaceSyncQueue.then(() => undefined, () => undefined)
+}
+
 function applyWorkspaceInfo(ws: WorkspaceState, info: WorkspaceInfo): WorkspaceState {
   return {
     ...ws,


### PR DESCRIPTION
## Summary
- Fixes intermittent `Failed to create terminal: ... is outside allowed directories` when opening a terminal shortly after picking a folder.
- `appStore.setWorkspaceRootPath` updates `rootPath` optimistically in the renderer, but the main-process `workspace:update` (which calls `addAllowedRoot`) is queued and async. A `terminal:create` firing in that window failed `validateCwd` because the new root wasn't in `allowedRoots` yet. A restart masked it because `SESSION_LOAD` preemptively re-adds persisted roots.
- `terminalRegistry.getOrCreate` now awaits a new `awaitWorkspaceSync()` helper (exposed from `appStore`) before sending `terminal:create`, so any pending workspace create/update lands first.

## Test plan
- [ ] Pick a new folder for an empty workspace and immediately open a terminal — no "outside allowed directories" error.
- [ ] Repeat with a quick folder swap on an existing workspace.
- [ ] Existing terminal restore on session load still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)