### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Cate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] - 2026-05-13
+
+Patch release with a single terminal-startup fix.
+
+### Fixed
+
+- **"Failed to create terminal: path is outside allowed directories"** — `setWorkspaceRootPath` applied the new `rootPath` optimistically in the renderer but the main-process `workspace:update` that registers the path with `allowedRoots` is async; a `terminal:create` firing in that window failed `validateCwd` in main and surfaced as a red error in the terminal panel (with a restart as the only workaround, because `SESSION_LOAD` preemptively re-adds persisted roots). `terminalRegistry.getOrCreate` now awaits a new `awaitWorkspaceSync()` helper exported from `appStore` before sending `terminal:create`, so any pending workspace create/update lands first.
+
 ## [0.3.1] - 2026-05-13
 
 Patch release with two papercut fixes from the v0.3.0 cycle and a file-explorer feature.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.3.1
+  <strong>Current source version:</strong> v0.3.2
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@ Cate is an Electron desktop app for arranging development tools in freeform spac
 
 ## Download
 
-This repository currently targets **v0.3.1**.
+This repository currently targets **v0.3.2**.
 
 | Platform | Formats | Link |
 |----------|---------|------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Patch release with a single terminal-startup fix:

- #20 await pending workspace sync before `terminal:create`, so picking a folder and immediately opening a terminal no longer races the `workspace:update` IPC and fails `validateCwd` with "outside allowed directories" (restart was the only workaround before).

## Test plan
- [ ] CI green
- [ ] After merge, tag `v0.3.2` to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)