### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Cate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.3] - 2026-05-13
+
+Patch release with one canvas-placement papercut.
+
+### Fixed
+
+- **New panels always opened to the right of the focused one**, even when an empty slot sat directly above, below, or to the left. `findFreePosition` in `canvasStore` now rays out in all four cardinal directions from the reference node, jumps past obstructing nodes along each ray, and returns the slot whose center is closest to the reference — so opening a terminal next to a focused panel uses whichever side actually has open space.
+
 ## [0.3.2] - 2026-05-13
 
 Patch release with a single terminal-startup fix.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.3.2
+  <strong>Current source version:</strong> v0.3.3
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@ Cate is an Electron desktop app for arranging development tools in freeform spac
 
 ## Download
 
-This repository currently targets **v0.3.2**.
+This repository currently targets **v0.3.3**.
 
 | Platform | Formats | Link |
 |----------|---------|------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Patch release with one canvas-placement papercut.

### Fixed
- **New panels always opened to the right of the focused one** (#22) — `findFreePosition` in `canvasStore` now rays out in all four cardinal directions from the reference node, jumps past obstructing nodes, and returns the slot whose center is closest to the reference, so a new terminal next to a focused panel uses whichever side actually has open space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)