### PR TITLE
feat(shell): enhance Windows shell resolution and fallback logic

### DIFF
--- a/src/main/shellResolver.test.ts
+++ b/src/main/shellResolver.test.ts
@@ -53,15 +53,25 @@ describe('isExecutable', () => {
 describe('resolveShell', () => {
   const originalPlatform = process.platform
   const originalShell = process.env.SHELL
+  const originalComspec = process.env.COMSPEC
+  const originalSystemRoot = process.env.SystemRoot
+  const originalProgramFiles = process.env.ProgramFiles
 
   function setPlatform(p: NodeJS.Platform) {
     Object.defineProperty(process, 'platform', { value: p, configurable: true })
   }
 
+  function restoreEnv(name: string, value: string | undefined) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
-    if (originalShell === undefined) delete process.env.SHELL
-    else process.env.SHELL = originalShell
+    restoreEnv('SHELL', originalShell)
+    restoreEnv('COMSPEC', originalComspec)
+    restoreEnv('SystemRoot', originalSystemRoot)
+    restoreEnv('ProgramFiles', originalProgramFiles)
   })
 
   test('uses the requested path when it is executable', () => {
@@ -152,5 +162,62 @@ describe('resolveShell', () => {
     expect(r.path).toBe('/bin/bash')
     expect(r.fallback).toBe(true)
     expect(r.reason).toBe('not-executable')
+  })
+
+  describe('Windows', () => {
+    const POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    const CMD = 'C:\\Windows\\System32\\cmd.exe'
+    const PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+
+    beforeEach(() => {
+      setPlatform('win32')
+      process.env.SystemRoot = 'C:\\Windows'
+      process.env.ProgramFiles = 'C:\\Program Files'
+      delete process.env.SHELL
+      delete process.env.COMSPEC
+    })
+
+    test('falls back through the Windows chain when no preferred path is set (the empty-settings case that produced "No usable shell found")', () => {
+      stubFs({ [POWERSHELL]: 'exec', [CMD]: 'exec' })
+      const r = resolveShell()
+      expect(r.path).toBe(POWERSHELL)
+    })
+
+    test('prefers pwsh.exe when PowerShell 7 is installed', () => {
+      stubFs({ [PWSH]: 'exec', [POWERSHELL]: 'exec', [CMD]: 'exec' })
+      const r = resolveShell()
+      expect(r.path).toBe(PWSH)
+    })
+
+    test('honours $COMSPEC ahead of the hardcoded cmd path', () => {
+      const customCmd = 'D:\\custom\\cmd.exe'
+      process.env.COMSPEC = customCmd
+      stubFs({ [customCmd]: 'exec', [CMD]: 'exec' })
+      const r = resolveShell()
+      expect(r.path).toBe(customCmd)
+    })
+
+    test('ignores $SHELL on Windows (Git Bash/MSYS leak /usr/bin/bash, which we cannot pty-spawn natively)', () => {
+      process.env.SHELL = '/usr/bin/bash'
+      stubFs({ [CMD]: 'exec' })
+      const r = resolveShell()
+      expect(r.path).toBe(CMD)
+    })
+
+    test('matches Windows shell basenames case-insensitively', () => {
+      const upper = 'C:\\Windows\\System32\\CMD.EXE'
+      stubFs({ [upper]: 'exec' })
+      const r = resolveShell(upper)
+      expect(r.path).toBe(upper)
+      expect(r.fallback).toBe(false)
+    })
+
+    test('falls back to cmd.exe when the configured shell is missing', () => {
+      stubFs({ [CMD]: 'exec' })
+      const r = resolveShell('C:\\nope\\pwsh.exe')
+      expect(r.path).toBe(CMD)
+      expect(r.fallback).toBe(true)
+      expect(r.reason).toBe('missing')
+    })
   })
 })

--- a/src/main/shellResolver.ts
+++ b/src/main/shellResolver.ts
@@ -27,11 +27,13 @@ function isWindows(): boolean {
 
 function isAllowedBasename(candidate: string): boolean {
   if (!candidate) return false
-  const base = path.basename(candidate)
+  // Use the explicit platform variant so tests that stub process.platform on a
+  // POSIX host still parse Windows paths correctly (default `path.basename`
+  // follows the host OS, not the value we're branching on).
   if (isWindows()) {
-    return ALLOWED_SHELL_BASENAMES_WIN.has(base.toLowerCase())
+    return ALLOWED_SHELL_BASENAMES_WIN.has(path.win32.basename(candidate).toLowerCase())
   }
-  return ALLOWED_SHELL_BASENAMES_POSIX.has(base)
+  return ALLOWED_SHELL_BASENAMES_POSIX.has(path.posix.basename(candidate))
 }
 
 /** Build the Windows fallback chain from environment + canonical install paths. */
@@ -42,11 +44,11 @@ function windowsFallbacks(): string[] {
   // Honour the user's COMSPEC ahead of hardcoded paths when set.
   if (process.env.COMSPEC) fallbacks.push(process.env.COMSPEC)
   // PowerShell 7+ default install location (modern shell, opt-in install).
-  fallbacks.push(path.join(programFiles, 'PowerShell', '7', 'pwsh.exe'))
+  fallbacks.push(path.win32.join(programFiles, 'PowerShell', '7', 'pwsh.exe'))
   // Windows PowerShell 5.1 — ships with every supported Windows version.
-  fallbacks.push(path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'))
+  fallbacks.push(path.win32.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'))
   // cmd.exe — bedrock, always present.
-  fallbacks.push(path.join(systemRoot, 'System32', 'cmd.exe'))
+  fallbacks.push(path.win32.join(systemRoot, 'System32', 'cmd.exe'))
   return fallbacks
 }
 

--- a/src/main/shellResolver.ts
+++ b/src/main/shellResolver.ts
@@ -3,21 +3,71 @@
 // falls back to a platform-appropriate alternative when it isn't.
 //
 // Fixes a class of failures where a stored `defaultShellPath` (e.g. `/bin/zsh`
-// on a Linux system without zsh installed) makes every terminal spawn die
-// immediately with `execvp(3) failed.: No such file or directory`.
+// on a Linux system without zsh installed, or an empty value on Windows where
+// the resolver previously had no fallback chain at all) makes every terminal
+// spawn die immediately with `execvp(3) failed.: No such file or directory`
+// — or, on Windows, with `No usable shell found on this system`.
 // =============================================================================
 
 import fs from 'fs'
 import path from 'path'
 
-const ALLOWED_SHELL_BASENAMES = new Set(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'])
+const ALLOWED_SHELL_BASENAMES_POSIX = new Set(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'])
+const ALLOWED_SHELL_BASENAMES_WIN = new Set([
+  'cmd.exe',
+  'powershell.exe',
+  'pwsh.exe',
+  'bash.exe',
+  'wsl.exe',
+])
+
+function isWindows(): boolean {
+  return process.platform === 'win32'
+}
+
+function isAllowedBasename(candidate: string): boolean {
+  if (!candidate) return false
+  const base = path.basename(candidate)
+  if (isWindows()) {
+    return ALLOWED_SHELL_BASENAMES_WIN.has(base.toLowerCase())
+  }
+  return ALLOWED_SHELL_BASENAMES_POSIX.has(base)
+}
+
+/** Build the Windows fallback chain from environment + canonical install paths. */
+function windowsFallbacks(): string[] {
+  const systemRoot = process.env.SystemRoot || process.env.windir || 'C:\\Windows'
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+  const fallbacks: string[] = []
+  // Honour the user's COMSPEC ahead of hardcoded paths when set.
+  if (process.env.COMSPEC) fallbacks.push(process.env.COMSPEC)
+  // PowerShell 7+ default install location (modern shell, opt-in install).
+  fallbacks.push(path.join(programFiles, 'PowerShell', '7', 'pwsh.exe'))
+  // Windows PowerShell 5.1 — ships with every supported Windows version.
+  fallbacks.push(path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'))
+  // cmd.exe — bedrock, always present.
+  fallbacks.push(path.join(systemRoot, 'System32', 'cmd.exe'))
+  return fallbacks
+}
 
 /** Fallback chain by platform, in priority order. */
-const PLATFORM_FALLBACKS: Partial<Record<NodeJS.Platform, string[]>> & { default: string[] } = {
+const POSIX_FALLBACKS: Partial<Record<NodeJS.Platform, string[]>> & { default: string[] } = {
   darwin: ['/bin/zsh', '/bin/bash', '/bin/sh'],
   linux: ['/bin/bash', '/usr/bin/bash', '/bin/sh', '/usr/bin/sh', '/bin/dash'],
-  win32: [], // PTY shell handling on Windows is not validated by this resolver
   default: ['/bin/sh'],
+}
+
+function getPlatformChain(): string[] {
+  if (isWindows()) return windowsFallbacks()
+  return POSIX_FALLBACKS[process.platform] ?? POSIX_FALLBACKS.default
+}
+
+// $SHELL is irrelevant on Windows — when set (by Git Bash / MSYS / WSL) it
+// points at POSIX paths like /usr/bin/bash that node-pty can't spawn natively.
+// Use $COMSPEC there instead.
+function getEnvShell(): string | undefined {
+  if (isWindows()) return process.env.COMSPEC
+  return process.env.SHELL
 }
 
 export interface ResolvedShell {
@@ -46,8 +96,7 @@ export function isExecutable(candidate: string): boolean {
 
 function rejectionReason(candidate: string): ResolvedShell['reason'] {
   if (!candidate) return 'unset'
-  const base = path.basename(candidate)
-  if (!ALLOWED_SHELL_BASENAMES.has(base)) return 'disallowed'
+  if (!isAllowedBasename(candidate)) return 'disallowed'
   try {
     fs.statSync(candidate)
   } catch {
@@ -59,31 +108,30 @@ function rejectionReason(candidate: string): ResolvedShell['reason'] {
 /**
  * Resolve a usable shell path. Tries, in order:
  *   1. `preferred` (from settings / IPC options)
- *   2. `process.env.SHELL`
+ *   2. The platform's "env shell" ($SHELL on POSIX, $COMSPEC on Windows)
  *   3. Platform fallback chain
  *
  * Each candidate is rejected if its basename is not in the allowlist or if
  * the file does not exist / is not executable. Throws only if every option
- * fails — extremely unlikely, since `/bin/sh` is part of POSIX.
+ * fails.
  */
 export function resolveShell(preferred?: string): ResolvedShell {
-  const platformChain = PLATFORM_FALLBACKS[process.platform] ?? PLATFORM_FALLBACKS.default
+  const platformChain = getPlatformChain()
+  const envShell = getEnvShell()
 
   // 1. Caller-supplied (settings / IPC option)
   if (preferred && preferred.trim()) {
     const trimmed = preferred.trim()
-    const base = path.basename(trimmed)
-    if (ALLOWED_SHELL_BASENAMES.has(base) && isExecutable(trimmed)) {
+    if (isAllowedBasename(trimmed) && isExecutable(trimmed)) {
       return { path: trimmed, fallback: false }
     }
     const reason = rejectionReason(trimmed)
-    const fb = pickFallback([process.env.SHELL, ...platformChain])
+    const fb = pickFallback([envShell, ...platformChain])
     if (fb) return { path: fb, fallback: true, requested: trimmed, reason }
   }
 
-  // 2. process.env.SHELL
-  const envShell = process.env.SHELL
-  if (envShell && isExecutable(envShell) && ALLOWED_SHELL_BASENAMES.has(path.basename(envShell))) {
+  // 2. Env shell ($SHELL or $COMSPEC)
+  if (envShell && isExecutable(envShell) && isAllowedBasename(envShell)) {
     return { path: envShell, fallback: false }
   }
 
@@ -97,7 +145,7 @@ export function resolveShell(preferred?: string): ResolvedShell {
 function pickFallback(candidates: Array<string | undefined>): string | null {
   for (const c of candidates) {
     if (!c) continue
-    if (!ALLOWED_SHELL_BASENAMES.has(path.basename(c))) continue
+    if (!isAllowedBasename(c)) continue
     if (isExecutable(c)) return c
   }
   return null


### PR DESCRIPTION
## Summary
- On Windows, opening a terminal panel failed immediately with `Failed to create terminal: Error invoking remote method 'terminal:create': Error No usable shell found on this system`.
- Root cause: `resolveShell()` in `src/main/shellResolver.ts` had `PLATFORM_FALLBACKS.win32 = []` and an allowlist containing only POSIX shell basenames (`bash`, `zsh`, `sh`, …). With the default `defaultShellPath: ''`, the resolver had nothing to validate, nothing to fall back to, and threw before any PTY was spawned. The inline comment claimed Windows was "not validated by this resolver", but in practice the throw was unreachable to skip.
- The resolver now understands Windows: it allowlists `cmd.exe` / `powershell.exe` / `pwsh.exe` / `bash.exe` / `wsl.exe` (case-insensitive), reads `$COMSPEC` instead of `$SHELL` (which on Windows is typically set by Git Bash / MSYS to a POSIX path node-pty can't spawn), and walks a fallback chain of `$COMSPEC` → PowerShell 7 → Windows PowerShell 5.1 → `cmd.exe`.
- `src/main/shellEnv.ts` already short-circuits on Windows, so no changes were needed there.

