### PR TITLE
feat(updater): wire renderer auto-updater UI

### DIFF
--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -4,13 +4,25 @@
 // fallback path only performs version discovery and manual release-page routing.
 // It intentionally does not mount, spawn, or replace downloaded assets unless
 // a verified installer path is added in the future.
+//
+// UI: status is pushed to the renderer via UPDATE_STATUS. The renderer renders
+// a subtle in-app affordance (no native popups). Renderer dispatches
+// UPDATE_DOWNLOAD / UPDATE_INSTALL / UPDATE_OPEN_RELEASE / UPDATE_DISMISS back.
 // =============================================================================
 
-import { app, dialog, BrowserWindow, shell, ipcMain } from 'electron'
+import { app, BrowserWindow, shell, ipcMain, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import log from './logger'
 import { flushAllLoggers } from './ipc/terminal'
-import { SESSION_FLUSH_SAVE, SESSION_FLUSH_SAVE_DONE } from '../shared/ipc-channels'
+import {
+  SESSION_FLUSH_SAVE,
+  SESSION_FLUSH_SAVE_DONE,
+  UPDATE_STATUS,
+  UPDATE_INSTALL,
+  UPDATE_DOWNLOAD,
+  UPDATE_OPEN_RELEASE,
+  UPDATE_DISMISS,
+} from '../shared/ipc-channels'
 import { getWindowType } from './windowRegistry'
 
 // ---------------------------------------------------------------------------
@@ -23,6 +35,31 @@ const API_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_RE
 
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = true
+
+// ---------------------------------------------------------------------------
+// Update status broadcast
+// ---------------------------------------------------------------------------
+
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string }
+  | { state: 'downloading'; version: string; percent?: number }
+  | { state: 'downloaded'; version: string }
+  | { state: 'manual'; version: string; releaseUrl: string }
+  | { state: 'error'; message: string }
+
+let currentStatus: UpdateStatus = { state: 'idle' }
+let latestReleaseUrl: string | null = null
+
+function broadcastStatus(status: UpdateStatus): void {
+  currentStatus = status
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(UPDATE_STATUS, status)
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pre-update session flush — ask the renderer to persist session state before
@@ -71,30 +108,6 @@ function compareSemver(a: string, b: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// Native-updater dialog (shown when electron-updater finds an update)
-// ---------------------------------------------------------------------------
-
-function showUpdateDialog(info: { version: string }): void {
-  const win = BrowserWindow.getFocusedWindow()
-  dialog
-    .showMessageBox({
-      ...(win ? { parentWindow: win } : {}),
-      type: 'info',
-      title: 'Update Available',
-      message: `A new version of Cate (v${info.version}) is available.`,
-      detail: 'Would you like to download and install it?',
-      buttons: ['Update', 'Later'],
-      defaultId: 0,
-      cancelId: 1,
-    })
-    .then(({ response }) => {
-      if (response === 0) {
-        autoUpdater.downloadUpdate()
-      }
-    })
-}
-
-// ---------------------------------------------------------------------------
 // Fallback update check via GitHub Releases API
 // ---------------------------------------------------------------------------
 
@@ -128,6 +141,7 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
 
     if (compareSemver(latestVersion, currentVersion) <= 0) {
       if (manual) {
+        // Surface "no updates" only for manual checks via a single quiet dialog.
         const win = BrowserWindow.getFocusedWindow()
         dialog.showMessageBox({
           ...(win ? { parentWindow: win } : {}),
@@ -136,24 +150,18 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
           message: 'You are running the latest version of Cate.',
         })
       }
+      broadcastStatus({ state: 'idle' })
       return
     }
 
     // Native fallback intentionally avoids installing downloaded binaries until
-    // a verified installer path exists.
-    const parentWin = BrowserWindow.getFocusedWindow()
-    const { response } = await dialog.showMessageBox({
-      ...(parentWin ? { parentWindow: parentWin } : {}),
-      type: 'info',
-      title: 'Update Available',
-      message: `Cate ${latestVersion} is available (you have v${currentVersion}).`,
-      detail: 'Automatic installation is unavailable in this build. Open the release page to download the verified installer manually?',
-      buttons: ['Open Release Page', 'Later'],
-      defaultId: 0,
-      cancelId: 1,
+    // a verified installer path exists. Surface via in-app affordance.
+    latestReleaseUrl = data.html_url
+    broadcastStatus({
+      state: 'manual',
+      version: latestVersion.replace(/^v/, ''),
+      releaseUrl: data.html_url,
     })
-    if (response !== 0) return
-    shell.openExternal(data.html_url)
   } catch (err: any) {
     log.error('[fallback-updater] Error:', err)
     if (manual) {
@@ -166,6 +174,7 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
         detail: err.message || 'Please check your internet connection.',
       })
     }
+    broadcastStatus({ state: 'error', message: err?.message || 'Update check failed' })
   } finally {
     fallbackInProgress = false
   }
@@ -176,6 +185,35 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export function initAutoUpdater(): void {
+  // Wire renderer-initiated actions regardless of dev/packaged so the UI never
+  // races against handler registration.
+  ipcMain.on(UPDATE_DOWNLOAD, () => {
+    if (!app.isPackaged) return
+    log.info('[auto-updater] Renderer requested download')
+    autoUpdater.downloadUpdate().catch((err) => {
+      log.error('[auto-updater] downloadUpdate failed:', err)
+      broadcastStatus({ state: 'error', message: err?.message || 'Download failed' })
+    })
+  })
+
+  ipcMain.on(UPDATE_INSTALL, async () => {
+    if (!app.isPackaged) return
+    log.info('[auto-updater] Renderer requested install')
+    await flushSessionBeforeUpdate()
+    autoUpdater.quitAndInstall()
+  })
+
+  ipcMain.on(UPDATE_OPEN_RELEASE, (_e, url?: string) => {
+    const target = url || latestReleaseUrl
+    if (target) shell.openExternal(target)
+  })
+
+  ipcMain.on(UPDATE_DISMISS, () => {
+    broadcastStatus({ state: 'idle' })
+  })
+
+  ipcMain.handle('update:getStatus', () => currentStatus)
+
   // Don't check for updates in dev mode
   if (!app.isPackaged) return
 
@@ -183,7 +221,11 @@ export function initAutoUpdater(): void {
 
   autoUpdater.on('update-available', (info) => {
     log.info('Update available: v%s', info.version)
-    showUpdateDialog(info)
+    broadcastStatus({
+      state: 'available',
+      version: String(info.version),
+      canAutoInstall: true,
+    })
   })
 
   autoUpdater.on('update-not-available', () => {
@@ -198,32 +240,29 @@ export function initAutoUpdater(): void {
         message: 'You are running the latest version of Cate.',
       })
     }
+    broadcastStatus({ state: 'idle' })
   })
 
-  autoUpdater.on('update-downloaded', () => {
+  autoUpdater.on('download-progress', (progress) => {
+    const cur = currentStatus
+    const version = cur.state === 'downloading' || cur.state === 'available' || cur.state === 'downloaded'
+      ? cur.version
+      : ''
+    broadcastStatus({
+      state: 'downloading',
+      version,
+      percent: typeof progress?.percent === 'number' ? progress.percent : undefined,
+    })
+  })
+
+  autoUpdater.on('update-downloaded', (info) => {
     log.info('Update downloaded, ready to install')
-    const win = BrowserWindow.getFocusedWindow()
-    dialog
-      .showMessageBox({
-        ...(win ? { parentWindow: win } : {}),
-        type: 'info',
-        title: 'Update Ready',
-        message: 'The update has been downloaded.',
-        detail: 'Restart Cate now to apply the update?',
-        buttons: ['Restart', 'Later'],
-        defaultId: 0,
-        cancelId: 1,
-      })
-      .then(async ({ response }) => {
-        if (response === 0) {
-          await flushSessionBeforeUpdate()
-          autoUpdater.quitAndInstall()
-        }
-      })
+    broadcastStatus({ state: 'downloaded', version: String(info?.version ?? '') })
   })
 
   autoUpdater.on('checking-for-update', () => {
     log.info('Checking for updates...')
+    if (currentStatus.state === 'idle') broadcastStatus({ state: 'checking' })
   })
 
   autoUpdater.on('error', (err) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -83,6 +83,11 @@ import {
   FS_SEARCH,
   SHELL_SHOW_IN_FOLDER,
   HTTP_FETCH,
+  UPDATE_STATUS,
+  UPDATE_INSTALL,
+  UPDATE_DOWNLOAD,
+  UPDATE_OPEN_RELEASE,
+  UPDATE_DISMISS,
   NOTIFY_OS,
   NOTIFY_ACTION,
   WINDOW_CREATE,
@@ -816,4 +821,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => { ipcRenderer.removeListener(MENU_TRIGGER_ACTION, listener) }
   },
 
+  // ---------------------------------------------------------------------------
+  // Auto-updater
+  // ---------------------------------------------------------------------------
+
+  onUpdateStatus(callback: (status: unknown) => void): () => void {
+    const listener = (_e: Electron.IpcRendererEvent, status: unknown): void => callback(status)
+    ipcRenderer.on(UPDATE_STATUS, listener)
+    return () => { ipcRenderer.removeListener(UPDATE_STATUS, listener) }
+  },
+
+  updateGetStatus(): Promise<unknown> {
+    return ipcRenderer.invoke('update:getStatus')
+  },
+
+  updateDownload(): void { ipcRenderer.send(UPDATE_DOWNLOAD) },
+  updateInstall(): void { ipcRenderer.send(UPDATE_INSTALL) },
+  updateOpenRelease(url?: string): void { ipcRenderer.send(UPDATE_OPEN_RELEASE, url) },
+  updateDismiss(): void { ipcRenderer.send(UPDATE_DISMISS) },
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { setCanvasOperations } from './stores/appStore'
 import { createCanvasOps } from './lib/canvasBridge'
 import { useSettingsStore } from './stores/settingsStore'
 import { useUIStore } from './stores/uiStore'
+import { useUpdateStore, type UpdateStatus } from './stores/updateStore'
 import { useShortcuts } from './hooks/useShortcuts'
 import { useProcessMonitor } from './hooks/useProcessMonitor'
 import { Sidebar, RightSidebar } from './sidebar/Sidebar'
@@ -242,6 +243,19 @@ function MainApp() {
   useEffect(() => {
     return window.electronAPI.onMenuOpenSettings(() => {
       setShowSettings((s) => !s)
+    })
+  }, [])
+
+  // ---------------------------------------------------------------------------
+  // Auto-updater status — push from main, surfaced as a subtle in-app pill.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    const setStatus = useUpdateStore.getState().setStatus
+    window.electronAPI.updateGetStatus?.().then((s: unknown) => {
+      if (s && typeof s === 'object') setStatus(s as UpdateStatus)
+    }).catch(() => {})
+    return window.electronAPI.onUpdateStatus((status: unknown) => {
+      setStatus(status as UpdateStatus)
     })
   }, [])
 

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -21,6 +21,7 @@ import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { ShortcutHintBadge } from '../ui/ShortcutHintBadge'
 import type { ShortcutAction, StoredShortcut } from '../../shared/types'
+import { UpdateButton } from './UpdateButton'
 
 // Format a shortcut into a badge label (modifiers other than ⌘ + key).
 // The ⌘ glyph is rendered by ShortcutHintBadge itself.
@@ -158,7 +159,8 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   }
 
   return (
-    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50">
+    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2">
+      <UpdateButton />
       <div ref={menuRef} className="relative">
         {/* Drop-up menu */}
         {menuOpen && (

--- a/src/renderer/canvas/UpdateButton.tsx
+++ b/src/renderer/canvas/UpdateButton.tsx
@@ -1,0 +1,157 @@
+// =============================================================================
+// UpdateButton — subtle blue pill in the bottom-right toolbar, shown only
+// when the auto-updater has a new release available. Replaces the native OS
+// popup with an in-app affordance + small popover.
+// =============================================================================
+
+import React, { useEffect, useRef, useState } from 'react'
+import { ArrowCircleUp, X } from '@phosphor-icons/react'
+import { useUpdateStore } from '../stores/updateStore'
+
+export const UpdateButton: React.FC = () => {
+  const status = useUpdateStore((s) => s.status)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  // Only render for states that have an actionable update to offer.
+  if (
+    status.state !== 'available' &&
+    status.state !== 'downloading' &&
+    status.state !== 'downloaded' &&
+    status.state !== 'manual'
+  ) {
+    return null
+  }
+
+  const label =
+    status.state === 'downloading'
+      ? typeof status.percent === 'number'
+        ? `Updating… ${Math.round(status.percent)}%`
+        : 'Updating…'
+      : status.state === 'downloaded'
+        ? 'Restart to update'
+        : status.state === 'manual'
+          ? `Update v${status.version}`
+          : `Update v${status.version}`
+
+  const title =
+    status.state === 'downloading'
+      ? 'Downloading update'
+      : status.state === 'downloaded'
+        ? 'Update ready — click to restart and install'
+        : status.state === 'manual'
+          ? 'Open release page to download manually'
+          : 'A new version of Cate is available'
+
+  const onPrimary = () => {
+    if (status.state === 'available') {
+      window.electronAPI.updateDownload()
+    } else if (status.state === 'downloaded') {
+      window.electronAPI.updateInstall()
+    } else if (status.state === 'manual') {
+      window.electronAPI.updateOpenRelease(status.releaseUrl)
+    }
+  }
+
+  const primaryLabel =
+    status.state === 'available'
+      ? 'Download'
+      : status.state === 'downloading'
+        ? 'Downloading…'
+        : status.state === 'downloaded'
+          ? 'Restart & Install'
+          : 'Open Release Page'
+
+  return (
+    <div ref={wrapRef} className="relative">
+      {/* Popover */}
+      {open && (
+        <div
+          data-theme="dark-warm"
+          className="absolute right-0 bottom-full mb-2 w-[260px] rounded-lg border border-subtle bg-surface-4/95 backdrop-blur-xl backdrop-saturate-150 shadow-[0_18px_40px_-12px_var(--shadow-node)] p-3"
+        >
+          <div className="flex items-start justify-between gap-2 mb-2">
+            <div>
+              <div className="text-[13px] font-semibold text-primary">
+                {status.state === 'downloaded'
+                  ? 'Update ready'
+                  : status.state === 'manual'
+                    ? 'Update available'
+                    : status.state === 'downloading'
+                      ? 'Downloading update'
+                      : 'Update available'}
+              </div>
+              {('version' in status) && status.version && (
+                <div className="text-[11px] text-secondary mt-0.5">Cate v{status.version}</div>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                window.electronAPI.updateDismiss()
+              }}
+              title="Dismiss"
+              className="w-5 h-5 flex items-center justify-center rounded text-secondary hover:bg-hover-strong focus:outline-none"
+            >
+              <X size={12} />
+            </button>
+          </div>
+          <div className="text-[12px] text-secondary leading-snug mb-3">
+            {status.state === 'downloaded'
+              ? 'The new version has been downloaded. Restart Cate to apply.'
+              : status.state === 'manual'
+                ? 'Automatic installation is unavailable in this build. Open the release page to download manually.'
+                : status.state === 'downloading'
+                  ? 'Download in progress. You can keep working — Cate will prompt to restart when ready.'
+                  : 'A new version of Cate is ready to install.'}
+          </div>
+          {status.state === 'downloading' && typeof status.percent === 'number' && (
+            <div className="h-1 rounded-full bg-surface-5 overflow-hidden mb-3">
+              <div
+                className="h-full bg-[var(--focus-blue,#3b82f6)] transition-[width] duration-200"
+                style={{ width: `${Math.max(2, Math.min(100, status.percent))}%` }}
+              />
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onPrimary}
+            disabled={status.state === 'downloading'}
+            className="w-full px-3 py-1.5 rounded-md bg-[var(--focus-blue,#3b82f6)] text-white text-[12px] font-medium hover:brightness-110 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none transition-all"
+          >
+            {primaryLabel}
+          </button>
+        </div>
+      )}
+
+      {/* Pill button */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={title}
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+        className="group flex items-center gap-1.5 h-[34px] pl-2.5 pr-3 rounded-full border border-[var(--focus-blue,#3b82f6)]/40 bg-[var(--focus-blue,#3b82f6)] text-white text-[11px] font-medium shadow-[0_8px_24px_-6px_rgba(59,130,246,0.55)] hover:brightness-110 active:scale-[0.97] focus:outline-none transition-all"
+      >
+        <ArrowCircleUp size={14} weight="fill" />
+        <span className="whitespace-nowrap">{label}</span>
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/stores/updateStore.ts
+++ b/src/renderer/stores/updateStore.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// Update Store — tracks auto-updater status pushed from the main process.
+// The CanvasToolbar reads this to render a subtle blue "update" pill next to
+// the minimap button when a new version is available.
+// =============================================================================
+
+import { create } from 'zustand'
+
+export type UpdateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string }
+  | { state: 'downloading'; version: string; percent?: number }
+  | { state: 'downloaded'; version: string }
+  | { state: 'manual'; version: string; releaseUrl: string }
+  | { state: 'error'; message: string }
+
+interface UpdateStore {
+  status: UpdateStatus
+  setStatus: (status: UpdateStatus) => void
+}
+
+export const useUpdateStore = create<UpdateStore>((set) => ({
+  status: { state: 'idle' },
+  setStatus(status) {
+    set({ status })
+  },
+}))

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -464,6 +464,22 @@ export interface ElectronAPI {
   /** Show a native context menu. Returns the clicked item id, or null if dismissed. */
   showContextMenu(items: NativeContextMenuItem[]): Promise<string | null>
 
+  // ---------------------------------------------------------------------------
+  // Auto-updater
+  // ---------------------------------------------------------------------------
+
+  /** Subscribe to update-status broadcasts from the main process. */
+  onUpdateStatus(callback: (status: unknown) => void): () => void
+  /** Fetch the current update status (e.g. on window mount). */
+  updateGetStatus(): Promise<unknown>
+  /** Start downloading the available update (electron-updater path only). */
+  updateDownload(): void
+  /** Apply the downloaded update and restart the app. */
+  updateInstall(): void
+  /** Open the GitHub release page for the available update. */
+  updateOpenRelease(url?: string): void
+  /** Dismiss the in-app update affordance (reverts status to idle). */
+  updateDismiss(): void
 }
 
 declare global {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -119,6 +119,13 @@ export const LAYOUT_LIST = 'layout:list'
 export const LAYOUT_LOAD = 'layout:load'
 export const LAYOUT_DELETE = 'layout:delete'
 
+// Auto-updater (main -> renderer for status; renderer -> main for actions)
+export const UPDATE_STATUS = 'update:status'
+export const UPDATE_INSTALL = 'update:install'
+export const UPDATE_DOWNLOAD = 'update:download'
+export const UPDATE_OPEN_RELEASE = 'update:openRelease'
+export const UPDATE_DISMISS = 'update:dismiss'
+
 // Notifications
 export const NOTIFY_OS = 'notify:os'
 export const NOTIFY_ACTION = 'notify:action' // main -> renderer (OS notification clicked)


### PR DESCRIPTION
## Summary
- Adds the renderer-side auto-updater affordance: a subtle in-app pill (\`UpdateButton\`) rendered next to the canvas toolbar.
- Wires the main-process auto-updater to broadcast \`update:status\` events (idle / checking / available / downloading / downloaded / manual / error) and accept \`update:install\`, \`update:download\`, \`update:openRelease\`, \`update:dismiss\` actions from the renderer.
- Adds the matching IPC channel constants, preload bindings, ElectronAPI type declarations, and an \`updateStore\` (Zustand) to keep the UI in sync.

## Test plan
- [x] \`npm run build\` passes
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 18/18 passing
- [ ] Manual smoke: launch the app; with no update available, no pill appears. When the main process emits an \`available\` status, the pill appears and Click → Open Release works.