### PR TITLE
feat(canvas): freehand pencil drawings

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -15,6 +15,7 @@ import CanvasGrid from './CanvasGrid'
 import SnapGuides from './SnapGuides'
 import CanvasRegionComponent from './CanvasRegionComponent'
 import CanvasAnnotationComponent from './CanvasAnnotationComponent'
+import CanvasDrawings from './CanvasDrawings'
 import type { Point, PanelType } from '../../shared/types'
 
 // Module-level style injection — shared across all Canvas instances
@@ -142,16 +143,63 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint }) => {
   }), [])
 
   const marquee = useUIStore((s) => s.marquee)
+  const drawMode = useCanvasStoreContext((s) => s.drawMode)
 
   const {
     handleWheel,
-    handleMouseDown,
+    handleMouseDown: baseHandleMouseDown,
     handleMouseMove,
     handleMouseUp,
     handleContextMenu,
     canvasContextMenu,
     closeCanvasContextMenu,
   } = useCanvasInteraction(canvasRef, canvasApi)
+
+  // Freehand drawing capture — when drawMode is on, mousedown on empty canvas
+  // begins a stroke. Points accumulate in a ref; mousemove appends; mouseup
+  // commits to the store as a CanvasDrawing. Suppresses pan/marquee while drawing.
+  const drawPointsRef = useRef<Point[] | null>(null)
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (drawMode && e.button === 0) {
+      const target = e.target as HTMLElement
+      // Only start drawing on the canvas background, not on a node/region/annotation.
+      const onNode = target.closest('[data-canvas-node],[data-region],[data-annotation]')
+      if (!onNode) {
+        const rect = canvasRef.current?.getBoundingClientRect()
+        if (rect) {
+          const state = canvasApi.getState()
+          const p = viewToCanvas({ x: e.clientX - rect.left, y: e.clientY - rect.top }, state.zoomLevel, state.viewportOffset)
+          drawPointsRef.current = [p]
+          e.preventDefault()
+          e.stopPropagation()
+          return
+        }
+      }
+    }
+    baseHandleMouseDown(e)
+  }, [drawMode, canvasApi, baseHandleMouseDown])
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!drawPointsRef.current) return
+      const rect = canvasRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const state = canvasApi.getState()
+      const p = viewToCanvas({ x: e.clientX - rect.left, y: e.clientY - rect.top }, state.zoomLevel, state.viewportOffset)
+      drawPointsRef.current.push(p)
+    }
+    const onUp = () => {
+      const pts = drawPointsRef.current
+      drawPointsRef.current = null
+      if (pts && pts.length >= 2) canvasApi.getState().addDrawing(pts)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [canvasApi])
 
   // Inject the canvas-interacting style once at module level (not per mount)
   useEffect(injectCanvasInteractingStyle, [])
@@ -402,6 +450,7 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint }) => {
         />
         <RegionsLayer />
         <AnnotationsLayer />
+        <CanvasDrawings />
         <SnapGuides />
         {marqueeRect && (
           <div

--- a/src/renderer/canvas/CanvasDrawings.tsx
+++ b/src/renderer/canvas/CanvasDrawings.tsx
@@ -1,0 +1,242 @@
+// =============================================================================
+// CanvasDrawings — renders freehand pen strokes inside the world transform.
+// Strokes are stored in canvas-space, so they pan/zoom with the canvas.
+// Click a stroke to select it (or click-drag to move it). Delete/Backspace
+// removes the selected stroke. Right-click opens a color/size context menu.
+// =============================================================================
+
+import React, { useEffect, useRef, useState } from 'react'
+import { useCanvasStoreContext, useCanvasStoreApi, shallow } from '../stores/CanvasStoreContext'
+import type { CanvasDrawing } from '../../shared/types'
+import type { NativeContextMenuItem } from '../../shared/electron-api'
+
+// Color palette for the right-click "Stroke Color" submenu. Matches the rest
+// of the canvas annotations' palette so all canvas marks feel consistent.
+const STROKE_COLORS: Array<{ label: string; value: string }> = [
+  { label: 'Red', value: 'rgba(255,90,90,0.95)' },
+  { label: 'Orange', value: 'rgba(255,165,80,0.95)' },
+  { label: 'Yellow', value: 'rgba(255,221,87,0.95)' },
+  { label: 'Green', value: 'rgba(134,219,143,0.95)' },
+  { label: 'Blue', value: 'rgba(138,180,248,0.95)' },
+  { label: 'Purple', value: 'rgba(197,167,233,0.95)' },
+  { label: 'White', value: 'rgba(240,240,240,0.95)' },
+  { label: 'Black', value: 'rgba(20,20,20,0.95)' },
+]
+
+function pointsToPath(points: CanvasDrawing['points']): string {
+  if (points.length === 0) return ''
+  let d = `M ${points[0].x} ${points[0].y}`
+  for (let i = 1; i < points.length; i++) d += ` L ${points[i].x} ${points[i].y}`
+  return d
+}
+
+function boundsOf(points: CanvasDrawing['points']): { x: number; y: number; w: number; h: number } {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const p of points) {
+    if (p.x < minX) minX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.x > maxX) maxX = p.x
+    if (p.y > maxY) maxY = p.y
+  }
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+}
+
+const Stroke: React.FC<{ drawing: CanvasDrawing; selected: boolean }> = React.memo(({ drawing, selected }) => {
+  const canvasApi = useCanvasStoreApi()
+  // Live translation during drag — applied as an SVG transform on the inner
+  // group so we don't churn the store on every mousemove. Committed to the
+  // store on mouseup via moveDrawing(delta).
+  const [drag, setDrag] = useState<{ dx: number; dy: number } | null>(null)
+  const dragRef = useRef<{ dx: number; dy: number } | null>(null)
+  const dragStartRef = useRef<{ x: number; y: number; moved: boolean } | null>(null)
+  // Track drag listeners so a context-menu open can abort them — otherwise a
+  // mouseup that lands on the native menu never reaches the window and the
+  // stroke stays glued to the cursor.
+  const dragAbortRef = useRef<AbortController | null>(null)
+
+  useEffect(() => () => { dragAbortRef.current?.abort() }, [])
+
+  const b = boundsOf(drawing.points)
+  // Pad so wide strokes (and the selection halo) aren't clipped by the SVG viewBox.
+  const pad = Math.max(12, drawing.strokeWidth * 3)
+
+  const onPointerDown = (e: React.MouseEvent) => {
+    // Always stop propagation so a right-click on the stroke doesn't trigger
+    // canvas right-click panning beneath us (which the native context menu
+    // would otherwise leave stuck because it eats the mouseup).
+    e.stopPropagation()
+    if (e.button !== 0) return
+    // Select on press so a no-drag click leaves the stroke selected.
+    canvasApi.getState().selectDrawing(drawing.id)
+    dragStartRef.current = { x: e.clientX, y: e.clientY, moved: false }
+    const onMove = (ev: MouseEvent) => {
+      const s = dragStartRef.current
+      if (!s) return
+      const zoom = canvasApi.getState().zoomLevel
+      const rawDx = ev.clientX - s.x
+      const rawDy = ev.clientY - s.y
+      if (!s.moved && rawDx * rawDx + rawDy * rawDy < 9) return
+      s.moved = true
+      const next = { dx: rawDx / zoom, dy: rawDy / zoom }
+      dragRef.current = next
+      setDrag(next)
+    }
+    const onUp = () => {
+      dragAbortRef.current?.abort()
+      dragAbortRef.current = null
+      const s = dragStartRef.current
+      dragStartRef.current = null
+      const finalDrag = dragRef.current
+      dragRef.current = null
+      if (s?.moved && finalDrag) {
+        canvasApi.getState().moveDrawing(drawing.id, { x: finalDrag.dx, y: finalDrag.dy })
+      }
+      setDrag(null)
+    }
+    dragAbortRef.current?.abort()
+    const controller = new AbortController()
+    dragAbortRef.current = controller
+    const { signal } = controller
+    window.addEventListener('mousemove', onMove, { signal })
+    window.addEventListener('mouseup', onUp, { signal })
+    // If the controller is aborted from elsewhere (e.g. a native context menu
+    // opened mid-drag), drop any in-progress drag state without committing.
+    signal.addEventListener('abort', () => {
+      dragStartRef.current = null
+      dragRef.current = null
+      setDrag(null)
+    })
+  }
+
+  const onContextMenu = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // Cancel any in-progress drag — the menu will eat the mouseup, so we
+    // can't rely on the normal release to clear listeners.
+    dragAbortRef.current?.abort()
+    dragAbortRef.current = null
+    canvasApi.getState().selectDrawing(drawing.id)
+    if (!window.electronAPI) return
+    const colorSubmenu: NativeContextMenuItem[] = STROKE_COLORS.map((c, i) => ({
+      id: `color:${i}`,
+      label: drawing.color === c.value ? `${c.label} ✓` : c.label,
+    }))
+    const id = await window.electronAPI.showContextMenu([
+      { label: 'Stroke Color', submenu: colorSubmenu },
+      { type: 'separator' as const },
+      { id: 'delete', label: 'Delete Stroke' },
+    ])
+    if (!id) return
+    if (id.startsWith('color:')) {
+      const idx = parseInt(id.slice(6), 10)
+      canvasApi.getState().setDrawingColor(drawing.id, STROKE_COLORS[idx].value)
+      return
+    }
+    if (id === 'delete') canvasApi.getState().removeDrawing(drawing.id)
+  }
+
+  // Note: when dragging, the live `drag` offset shifts the visible stroke but
+  // the SVG viewBox/bounds were computed from the un-translated points. The
+  // outer SVG is large enough (pad-padded) that small drags don't clip; on
+  // commit (mouseup) we update the store and the SVG re-anchors on next render.
+  const liveTransform = drag ? `translate(${-b.x + pad + drag.dx}, ${-b.y + pad + drag.dy})` : `translate(${-b.x + pad}, ${-b.y + pad})`
+
+  return (
+    <svg
+      style={{
+        position: 'absolute',
+        left: b.x - pad,
+        top: b.y - pad,
+        width: b.w + pad * 2,
+        height: b.h + pad * 2,
+        pointerEvents: 'none',
+        overflow: 'visible',
+        zIndex: 100000, // always in front of panels & other canvas content
+      }}
+    >
+      <g transform={liveTransform}>
+        {/* Wide invisible hit target so thin strokes are easy to grab. */}
+        <path
+          d={pointsToPath(drawing.points)}
+          stroke="transparent"
+          strokeWidth={Math.max(14, drawing.strokeWidth + 10)}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+          onMouseDown={onPointerDown}
+          onContextMenu={onContextMenu}
+          style={{ pointerEvents: 'stroke', cursor: 'move' }}
+        />
+        {selected && (
+          <path
+            d={pointsToPath(drawing.points)}
+            stroke="rgba(74,158,255,0.55)"
+            strokeWidth={drawing.strokeWidth + 6}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+            style={{ pointerEvents: 'none' }}
+          />
+        )}
+        <path
+          d={pointsToPath(drawing.points)}
+          stroke={drawing.color}
+          strokeWidth={drawing.strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+          style={{ pointerEvents: 'none' }}
+        />
+      </g>
+    </svg>
+  )
+})
+
+const CanvasDrawings: React.FC = () => {
+  const drawings = useCanvasStoreContext((s) => Object.values(s.drawings), shallow)
+  const selectedId = useCanvasStoreContext((s) => s.selectedDrawingId)
+  const canvasApi = useCanvasStoreApi()
+
+  // Delete/Backspace removes the selected drawing. Escape clears selection.
+  // Skip if the user is typing into an input — let the field handle the key.
+  useEffect(() => {
+    if (!selectedId) return
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null
+      const inEditable = !!t && (
+        t.tagName === 'INPUT' ||
+        t.tagName === 'TEXTAREA' ||
+        t.isContentEditable
+      )
+      if (inEditable) return
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault()
+        canvasApi.getState().removeDrawing(selectedId)
+      } else if (e.key === 'Escape') {
+        canvasApi.getState().selectDrawing(null)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [selectedId, canvasApi])
+
+  // Click on empty canvas (or anything that isn't a stroke path) clears the
+  // current drawing selection.
+  useEffect(() => {
+    if (!selectedId) return
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as HTMLElement | null
+      if (!t || t.tagName !== 'path') canvasApi.getState().selectDrawing(null)
+    }
+    window.addEventListener('mousedown', onDown, true)
+    return () => window.removeEventListener('mousedown', onDown, true)
+  }, [selectedId, canvasApi])
+
+  return (
+    <>
+      {drawings.map((d) => <Stroke key={d.id} drawing={d} selected={d.id === selectedId} />)}
+    </>
+  )
+}
+
+export default React.memo(CanvasDrawings)

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -16,8 +16,9 @@ import {
   ArrowsOutSimple,
   DotsThree,
   SquaresFour,
+  PencilSimple,
 } from '@phosphor-icons/react'
-import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { useCanvasStoreApi, useCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { ShortcutHintBadge } from '../ui/ShortcutHintBadge'
 import type { ShortcutAction, StoredShortcut } from '../../shared/types'
@@ -129,6 +130,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   onZoomOut,
 }) => {
   const canvasApi = useCanvasStoreApi()
+  const drawMode = useCanvasStoreContext((s) => s.drawMode)
   const zoomText = `${Math.round(zoom * 100)}%`
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement | null>(null)
@@ -216,6 +218,16 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
               </ToolbarButton>
               <ToolbarHintBadge action="newEditor" />
             </span>
+
+            {/* Draw mode toggle */}
+            <ToolbarButton
+              onClick={() => canvasApi.getState().setDrawMode(!drawMode)}
+              title={drawMode ? 'Draw: On (click to disable)' : 'Draw on canvas'}
+              size="panel"
+              active={drawMode}
+            >
+              <PencilSimple size={14} weight={drawMode ? 'fill' : 'regular'} />
+            </ToolbarButton>
 
             {/* Divider */}
             <div className="w-px h-4 bg-surface-5 mx-0.5" />

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -10,6 +10,7 @@ import type {
   CanvasNodeId,
   CanvasNodeState,
   CanvasAnnotation,
+  CanvasDrawing,
   CanvasRegion,
   DockLayoutNode,
   Point,
@@ -36,6 +37,13 @@ export interface CanvasStoreState {
   nodes: Record<CanvasNodeId, CanvasNodeState>
   regions: Record<string, CanvasRegion>
   annotations: Record<string, CanvasAnnotation>
+  /** Freehand pen strokes laid down with the draw tool. */
+  drawings: Record<string, CanvasDrawing>
+  /** True when the draw tool is active — canvas mouse events become stroke
+   *  capture instead of pan/marquee. Transient, never persisted. */
+  drawMode: boolean
+  /** Currently-selected drawing (for click-to-select-then-delete). */
+  selectedDrawingId: string | null
   /** Stable id list for regions — derived from `regions`. Maintained in every
    *  mutator that adds/removes regions so per-id selectors don't re-render the
    *  whole layer when an existing region's properties change. */
@@ -162,6 +170,14 @@ export interface CanvasStoreActions {
   setAnnotationBold: (id: string, bold: boolean) => void
   setAnnotationFontSizePx: (id: string, fontSizePx: number) => void
   resizeAnnotation: (id: string, size: { width: number; height: number }) => void
+
+  // Drawing management — freehand pen strokes
+  setDrawMode: (active: boolean) => void
+  addDrawing: (points: Point[], opts?: { color?: string; strokeWidth?: number }) => string
+  removeDrawing: (id: string) => void
+  selectDrawing: (id: string | null) => void
+  moveDrawing: (id: string, delta: Point) => void
+  setDrawingColor: (id: string, color: string) => void
 
   // Per-node dock layout — replaces split/stack actions. Each canvas node owns
   // a tree (rendered via the dock primitives) that lives here as serialised
@@ -329,6 +345,9 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
   nodes: {},
   regions: {},
   annotations: {},
+  drawings: {},
+  drawMode: false,
+  selectedDrawingId: null,
   regionIdList: [],
   annotationIdList: [],
   viewportOffset: { x: 0, y: 0 },
@@ -1272,6 +1291,61 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
           [id]: { ...ann, size: { width: w, height: h } },
         },
       }
+    })
+  },
+
+  // ---------------------------------------------------------------------------
+  // Drawing management — freehand pen strokes
+  // ---------------------------------------------------------------------------
+
+  setDrawMode(active) {
+    set({ drawMode: active, selectedDrawingId: active ? null : get().selectedDrawingId })
+  },
+
+  addDrawing(points, opts) {
+    const id = `drawing-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const drawing: CanvasDrawing = {
+      id,
+      points: points.map((p) => ({ x: p.x, y: p.y })),
+      color: opts?.color ?? 'rgba(240,240,240,0.95)',
+      strokeWidth: opts?.strokeWidth ?? 2,
+    }
+    set((state) => ({ drawings: { ...state.drawings, [id]: drawing } }))
+    return id
+  },
+
+  removeDrawing(id) {
+    set((state) => {
+      if (!state.drawings[id]) return state
+      const { [id]: _omit, ...rest } = state.drawings
+      return {
+        drawings: rest,
+        selectedDrawingId: state.selectedDrawingId === id ? null : state.selectedDrawingId,
+      }
+    })
+  },
+
+  selectDrawing(id) {
+    set({ selectedDrawingId: id })
+  },
+
+  moveDrawing(id, delta) {
+    set((state) => {
+      const d = state.drawings[id]
+      if (!d) return state
+      const moved: CanvasDrawing = {
+        ...d,
+        points: d.points.map((p) => ({ x: p.x + delta.x, y: p.y + delta.y })),
+      }
+      return { drawings: { ...state.drawings, [id]: moved } }
+    })
+  },
+
+  setDrawingColor(id, color) {
+    set((state) => {
+      const d = state.drawings[id]
+      if (!d) return state
+      return { drawings: { ...state.drawings, [id]: { ...d, color } } }
     })
   },
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,6 +76,17 @@ export interface CanvasRegion {
 }
 
 // -----------------------------------------------------------------------------
+// Canvas drawing (freehand pen stroke)
+// -----------------------------------------------------------------------------
+
+export interface CanvasDrawing {
+  id: string
+  points: Point[]
+  color: string
+  strokeWidth: number
+}
+
+// -----------------------------------------------------------------------------
 // Canvas annotation (sticky notes and text labels)
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds a pencil tool that draws freehand strokes directly on the canvas. Strokes live in canvas-space so they pan and zoom with the workspace.
- New \`CanvasDrawing\` type; new canvas-store fields (\`drawings\`, \`drawMode\`, \`selectedDrawingId\`) and actions (\`setDrawMode\`, \`addDrawing\`, \`removeDrawing\`, \`selectDrawing\`, \`moveDrawing\`, \`setDrawingColor\`).
- \`CanvasDrawings\` renders inside the world transform; strokes are click-to-select, draggable, and have a right-click color palette + delete.
- New pencil button in the canvas toolbar toggles draw mode; while active, dragging on empty canvas captures the stroke and commits it as a \`CanvasDrawing\` on mouseup.

## Test plan
- [x] \`npm run build\` passes
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 18/18 passing
- [ ] Manual smoke: click pencil → draw a stroke → release → stroke appears; pan/zoom moves it with the canvas; click stroke → Delete → it disappears.