### PR TITLE
feat(terminal): URL auto-open + portal registry + inline notifications

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -53,6 +53,7 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   terminalScrollback: 'number',
   browserHomepage: 'string',
   browserSearchEngine: 'string',
+  autoOpenUrlsFromTerminal: 'boolean',
   sidebarTintOpacity: 'number',
   showFileExplorerOnLaunch: 'boolean',
   notificationsEnabled: 'boolean',

--- a/src/renderer/lib/portalRegistry.ts
+++ b/src/renderer/lib/portalRegistry.ts
@@ -1,0 +1,61 @@
+// =============================================================================
+// portalRegistry — renderer-side map of BrowserPanel <webview> elements.
+//
+// The main-process orchestrator addresses portals by name (PanelState.title).
+// To drive a portal's underlying webContents from main, we need to translate
+// panelId → webContentsId. BrowserPanel registers its <webview> here once
+// `dom-ready` fires (which is when getWebContentsId() returns a stable id),
+// and unregisters on unmount.
+//
+// Note: refs (the @e1/@e2 mapping returned by `portal snapshot`) live in main
+// rather than here — main injects `data-cate-ref` attributes onto the DOM
+// during the snapshot and looks them up directly via executeJavaScript() on
+// subsequent commands.
+// =============================================================================
+
+/** Minimal subset of the Electron <webview> tag interface we depend on. */
+export interface PortalWebview {
+  getWebContentsId(): number
+  getURL(): string
+  getTitle(): string
+  loadURL(url: string): void
+}
+
+interface Entry {
+  webview: PortalWebview
+}
+
+const byPanelId = new Map<string, Entry>()
+
+/** Push a (panelId, webContentsId, alive) tuple to main so it can build a
+ *  webContents → portal-panel reverse map. Used by webSecurity's popup
+ *  handler to resolve the parent portal name synchronously when a webview
+ *  calls window.open(). Non-fatal if main hasn't wired up the listener. */
+function pushToMain(panelId: string, webContentsId: number, alive: boolean): void {
+  try {
+    const ipc = (window as any).electronAPI
+    if (!ipc?.orchRegisterPortalWc) return
+    ipc.orchRegisterPortalWc({ panelId, webContentsId, alive })
+  } catch { /* best effort */ }
+}
+
+export const portalRegistry = {
+  register(panelId: string, webview: PortalWebview): void {
+    byPanelId.set(panelId, { webview })
+    let wcId = 0
+    try { wcId = webview.getWebContentsId() } catch { /* fine */ }
+    if (wcId) pushToMain(panelId, wcId, true)
+  },
+  unregister(panelId: string): void {
+    const entry = byPanelId.get(panelId)
+    if (entry) {
+      let wcId = 0
+      try { wcId = entry.webview.getWebContentsId() } catch { /* fine */ }
+      if (wcId) pushToMain(panelId, wcId, false)
+    }
+    byPanelId.delete(panelId)
+  },
+  get(panelId: string): PortalWebview | null {
+    return byPanelId.get(panelId)?.webview ?? null
+  },
+} as const

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -16,6 +16,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { terminalRestoreData, replayTerminalLog } from './session'
 import { awaitWorkspaceSync } from '../stores/appStore'
 import { getResolvedTheme, subscribeTheme, type ResolvedTheme } from './themeManager'
+import { scanTerminalChunkForUrls } from './terminalUrlAutoOpen'
 
 /** Read the configured scrollback limit, clamped to a sane range. */
 function getScrollback(): number {
@@ -349,6 +350,7 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
       } else {
         terminal.write(data)
       }
+      scanTerminalChunkForUrls(panelId, opts.workspaceId, data)
     })
     cleanupListeners.push(removeDataListener)
 
@@ -504,6 +506,7 @@ async function reconnectTerminal(
     } else {
       terminal.write(data)
     }
+    scanTerminalChunkForUrls(panelId, opts.workspaceId, data)
   })
   cleanupListeners.push(removeDataListener)
 

--- a/src/renderer/lib/terminalUrlAutoOpen.ts
+++ b/src/renderer/lib/terminalUrlAutoOpen.ts
@@ -1,0 +1,183 @@
+// =============================================================================
+// terminalUrlAutoOpen
+//
+// Watches PTY output for printable URLs and surfaces them in a browser panel.
+//
+// Behavior (see "Auto-open URLs from terminal" setting):
+//   - Watches each data chunk for http(s) URLs and bare localhost / loopback
+//     addresses with an optional port and path.
+//   - Reuses an existing browser panel in the same workspace by calling
+//     loadURL on its <webview>. Only creates a new panel when none exists.
+//   - Each URL is opened at most once per session (canonicalized).
+// =============================================================================
+
+import { useSettingsStore } from '../stores/settingsStore'
+import { useAppStore } from '../stores/appStore'
+import { portalRegistry } from './portalRegistry'
+
+// Disallowed characters inside a URL match: whitespace, ASCII control bytes,
+// quote/angle-bracket characters, and the bracket families. Excluding
+// brackets/parens prevents prose like "running at http://x (API on :3002)"
+// from being captured as a single URL ending with "(API".
+const URL_BODY = '[^\\s\\u0000-\\u001f"<>()\\[\\]{}`]'
+const URL_REGEX = new RegExp(
+  '\\b(?:https?:\\/\\/' + URL_BODY + '+|' +
+    '(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0|\\[::1\\])(?::\\d{1,5})(?:\\/' + URL_BODY + '*)?)',
+  'gi',
+)
+
+// Strip common terminal escape sequences before scanning so ANSI color codes
+// do not break URL matching.
+const ANSI_REGEX = /\x1b\[[0-9;?]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[PX^_][\s\S]*?(?:\x07|\x1b\\)/g
+
+// Per-panel rolling buffer so URLs split across PTY writes still match. ~2 KB
+// is generous; URLs printed by dev servers are typically followed by a newline
+// within a single chunk.
+const BUFFERS = new Map<string, string>()
+const MAX_BUFFER = 2048
+
+// Session-scoped dedupe: every URL that has triggered an auto-open OR has
+// been deliberately skipped (e.g. labeled as an API endpoint). Either way we
+// never want to act on the same URL twice.
+const OPENED = new Set<string>()
+const MAX_OPENED = 500
+
+// Labels appearing just before a URL ("API:", "Backend:", "GraphQL:") that
+// indicate the URL is a machine-facing endpoint, not a UI to open in a browser.
+const NON_UI_LABELS = new Set([
+  'api', 'apis', 'backend', 'server', 'graphql', 'gql', 'rpc', 'grpc',
+  'ws', 'wss', 'websocket', 'socket', 'db', 'database', 'postgres', 'postgresql',
+  'mysql', 'redis', 'mongo', 'mongodb', 'kafka', 'metrics', 'prometheus',
+  'healthcheck', 'healthz', 'readyz', 'livez', 'admin',
+])
+
+// Labels appearing just before a URL that strongly indicate a UI surface.
+const UI_LABELS = new Set([
+  'frontend', 'front', 'web', 'ui', 'app', 'client', 'site', 'page',
+  'local', 'localhost', 'dev', 'preview', 'storybook', 'docs', 'documentation',
+  'vite', 'next', 'nuxt',
+])
+
+function labelBefore(buffer: string, matchIndex: number): string | null {
+  // Look back to the start of the line and grab the last word-ish token
+  // immediately before the URL (allowing for a trailing colon / dash / space).
+  const lineStart = buffer.lastIndexOf('\n', matchIndex - 1) + 1
+  const prefix = buffer.slice(lineStart, matchIndex)
+  // Match "label" optionally followed by ":" / "=" / "-" and trailing spaces.
+  const m = prefix.match(/([A-Za-z][A-Za-z0-9_-]{1,24})\s*[:=-]?\s*$/)
+  return m ? m[1].toLowerCase() : null
+}
+
+function classify(buffer: string, matchIndex: number): 'ui' | 'non-ui' | 'unknown' {
+  const label = labelBefore(buffer, matchIndex)
+  if (!label) return 'unknown'
+  if (NON_UI_LABELS.has(label)) return 'non-ui'
+  if (UI_LABELS.has(label)) return 'ui'
+  return 'unknown'
+}
+
+function canonicalize(rawUrl: string): string {
+  let url = rawUrl
+  // Strip trailing punctuation commonly adjacent to URLs in prose / log output.
+  url = url.replace(/[)\].,;:!?'>]+$/, '')
+  if (!/^https?:\/\//i.test(url)) {
+    url = 'http://' + url
+  }
+  try {
+    const parsed = new URL(url)
+    parsed.hash = ''
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+function findBrowserPanelId(workspaceId: string): string | null {
+  const ws = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
+  if (!ws) return null
+  for (const panel of Object.values(ws.panels)) {
+    if (panel.type === 'browser') return panel.id
+  }
+  return null
+}
+
+function openInBrowser(workspaceId: string, url: string): void {
+  const existing = findBrowserPanelId(workspaceId)
+  if (existing) {
+    const webview = portalRegistry.get(existing)
+    if (webview) {
+      try {
+        webview.loadURL(url)
+        useAppStore.getState().updatePanelUrl(workspaceId, existing, url)
+        return
+      } catch {
+        // Fall through if the guest webContents is not dom-ready yet.
+      }
+    }
+    // Browser panel exists but webview is not registered yet — still prefer
+    // updating its URL so it picks it up on next mount.
+    useAppStore.getState().updatePanelUrl(workspaceId, existing, url)
+    return
+  }
+  useAppStore.getState().createBrowser(workspaceId, url)
+}
+
+export function scanTerminalChunkForUrls(
+  panelId: string,
+  workspaceId: string,
+  chunk: string,
+): void {
+  if (!useSettingsStore.getState().autoOpenUrlsFromTerminal) return
+  if (!chunk) return
+
+  const cleaned = chunk.replace(ANSI_REGEX, '')
+  const prev = BUFFERS.get(panelId) ?? ''
+  let buffer = prev + cleaned
+  if (buffer.length > MAX_BUFFER) buffer = buffer.slice(-MAX_BUFFER)
+
+  // Only act on matches whose end is not at the buffer tail — the tail may
+  // still be receiving more bytes, so a URL there might be incomplete.
+  let lastFullyConsumed = 0
+  type Match = { url: string; kind: 'ui' | 'non-ui' | 'unknown' }
+  const matches: Match[] = []
+  URL_REGEX.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = URL_REGEX.exec(buffer)) !== null) {
+    const end = m.index + m[0].length
+    if (end === buffer.length) break
+    matches.push({ url: m[0], kind: classify(buffer, m.index) })
+    lastFullyConsumed = end
+  }
+
+  // When a batch contains both a UI-labeled URL and a non-UI one (typical
+  // "Frontend: …  API: …" output from dev scripts), only the UI URL is worth
+  // opening. If no UI label is present, fall back to unknown-labeled URLs
+  // (still skipping anything explicitly tagged API/backend/etc.).
+  const hasUi = matches.some((x) => x.kind === 'ui')
+  const eligible = matches.filter((x) =>
+    hasUi ? x.kind === 'ui' : x.kind === 'unknown',
+  )
+  // Cap to one open per batch to avoid the second URL clobbering the first
+  // in the shared browser panel.
+  const toOpen = eligible.slice(0, 1)
+  // Mark every matched URL as seen — including ones we deliberately skip —
+  // so future chunks don't re-trigger them.
+  for (const { url } of matches) {
+    const canonical = canonicalize(url)
+    if (OPENED.has(canonical)) continue
+    OPENED.add(canonical)
+    if (OPENED.size > MAX_OPENED) {
+      const first = OPENED.values().next().value as string | undefined
+      if (first !== undefined) OPENED.delete(first)
+    }
+  }
+  for (const { url } of toOpen) {
+    openInBrowser(workspaceId, canonicalize(url))
+  }
+
+  BUFFERS.set(panelId, buffer.slice(lastFullyConsumed))
+}
+
+export function clearTerminalUrlBuffer(panelId: string): void {
+  BUFFERS.delete(panelId)
+}

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { SEARCH_ENGINE_URLS } from '../../shared/types'
 import type { BrowserPanelProps } from './types'
+import { portalRegistry, type PortalWebview } from '../lib/portalRegistry'
 
 // -----------------------------------------------------------------------------
 // Type declarations for Electron's <webview> element
@@ -264,6 +265,10 @@ export default function BrowserPanel({
       }
     }
 
+    const onDomReady = () => {
+      portalRegistry.register(panelId, webview as unknown as PortalWebview)
+    }
+
     webview.addEventListener('did-navigate', onDidNavigate)
     webview.addEventListener('did-navigate-in-page', onDidNavigateInPage)
     webview.addEventListener('page-title-updated', onPageTitleUpdated)
@@ -272,8 +277,10 @@ export default function BrowserPanel({
     webview.addEventListener('did-stop-loading', onDidStopLoading)
     webview.addEventListener('will-navigate', onWillNavigate)
     webview.addEventListener('new-window', onNewWindow)
+    webview.addEventListener('dom-ready', onDomReady)
 
     return () => {
+      portalRegistry.unregister(panelId)
       try {
         // May throw if webview was never attached / dom-ready before unmount
         webview.loadURL('about:blank')
@@ -288,6 +295,7 @@ export default function BrowserPanel({
       webview.removeEventListener('did-stop-loading', onDidStopLoading)
       webview.removeEventListener('will-navigate', onWillNavigate)
       webview.removeEventListener('new-window', onNewWindow)
+      webview.removeEventListener('dom-ready', onDomReady)
     }
   }, [panelId, workspaceId, updatePanelTitle, updatePanelUrl])
 

--- a/src/renderer/sidebar/TerminalNotificationsButton.tsx
+++ b/src/renderer/sidebar/TerminalNotificationsButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { DotsThree } from '@phosphor-icons/react'
+import { useShallow } from 'zustand/shallow'
+import { useNotificationStore } from '../stores/notificationStore'
+import type { Notification } from '../stores/notificationStore'
+import { terminalRegistry } from '../lib/terminalRegistry'
+
+export function useTerminalNotifications(panelId: string): Notification[] {
+  return useNotificationStore(useShallow((s) =>
+    s.notifications.filter((n) => {
+      const action = n.action
+      if (!action || action.type !== 'focusTerminal') return false
+      const targetPanelId = terminalRegistry.panelIdForPty(action.terminalId) ?? action.terminalId
+      return targetPanelId === panelId
+    }),
+  ))
+}
+
+interface InlineProps {
+  notifications: Notification[]
+}
+
+export const TerminalNotificationInline: React.FC<InlineProps> = ({ notifications }) => {
+  if (notifications.length === 0) return null
+  const latest = notifications[0]
+  return (
+    <>
+      <span className="flex-shrink min-w-0 truncate text-[12px] text-muted opacity-70 italic">
+        {latest.title}
+      </span>
+      <span className="flex-shrink-0 text-muted opacity-50">
+        <DotsThree size={14} weight="bold" />
+      </span>
+    </>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -655,6 +655,9 @@ export interface AppSettings {
   // Browser
   browserHomepage: string
   browserSearchEngine: BrowserSearchEngine
+  /** When enabled, http(s) URLs printed in any terminal are auto-opened in a
+   *  reused browser panel within the same workspace. */
+  autoOpenUrlsFromTerminal: boolean
 
   // Sidebar
   sidebarTintOpacity: number
@@ -702,6 +705,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // Browser
   browserHomepage: 'about:blank',
   browserSearchEngine: 'google',
+  autoOpenUrlsFromTerminal: false,
 
   // Sidebar
   sidebarTintOpacity: 1.0,


### PR DESCRIPTION
## Summary
- **portalRegistry**: renderer-side map of BrowserPanel \`<webview>\` elements. Lets external callers drive an existing portal's \`loadURL\` without recreating the panel. \`BrowserPanel\` registers on \`dom-ready\` and unregisters on unmount.
- **terminalUrlAutoOpen**: scans PTY data chunks for \`http(s)://\` URLs and bare localhost / loopback addresses and routes them into an existing browser panel in the same workspace (creating one if none exists). Gated by a new \`autoOpenUrlsFromTerminal\` app setting (default off).
- **TerminalNotificationsButton / TerminalNotificationInline**: notification UI tied to a terminal panel. Component is exported and ready to be rendered by \`TerminalPanel\` in a follow-up.

## Test plan
- [x] \`npm run build\` passes
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 18/18 passing
- [ ] Manual smoke: enable \"Auto-open URLs from terminal\" in Settings → run a server in a terminal → the browser panel jumps to the printed URL.