### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Bump version to v0.4.0.

Highlights since v0.3.3:
- Sentry crash reporting integration (opt-in via Privacy setting)
- Canvas pencil/drawing tool
- Restored visual polish: glowing active nodes, transparent sidebars, canvas background
- Drop-priority fix: 'Drop into canvas' pill always wins on hover with stronger highlight
- Empty-canvas drops reliably create new nodes (no longer get absorbed by tab bars)
- Orchestrator (cate CLI socket bridge) removed
- Various performance + UX improvements merged from main