### PR TITLE
fix(sidebar): per-workspace canvas focus + rename UX

### DIFF
--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -23,7 +23,7 @@ export const ProjectList: React.FC = () => {
   return (
     <div className="flex flex-col h-full">
       <SidebarSectionHeader
-        title="Projects"
+        title="Workspace"
         actions={
           <SidebarHeaderButton onClick={handleNewWorkspace} title="New Workspace">
             <Plus size={14} weight="bold" />

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
+import React, { useMemo, useState, useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
 import { useShallow } from 'zustand/shallow'
-import { CaretRight, Terminal as TerminalIcon, Globe, FileCode, GitBranch, Folder, FolderPlus, SquaresFour, List, PencilSimple, DotsThree } from '@phosphor-icons/react'
-import type { WorkspaceState, PanelType, PanelLocation } from '../../shared/types'
+import { CaretRight, Terminal as TerminalIcon, Globe, FileCode, GitBranch, Folder, FolderPlus, SquaresFour, List, DotsThree } from '@phosphor-icons/react'
+import type { WorkspaceState, PanelType, PanelLocation, DockLayoutNode } from '../../shared/types'
 import { ALL_ZONES } from '../../shared/types'
 import { useStatusStore } from '../stores/statusStore'
-import { useAppStore, WORKSPACE_COLORS, getCanvasOperations } from '../stores/appStore'
+import { useAppStore, WORKSPACE_COLORS, getCanvasOperations, getWorkspaceCanvasPanelId, ensureCanvasOpsForPanel } from '../stores/appStore'
 import { useDockStore } from '../stores/dockStore'
-import { useCanvasStore } from '../stores/canvasStore'
+import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { findTabStack, findStackContainingPanel } from '../stores/dockTreeUtils'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import { TerminalNotificationInline, useTerminalNotifications } from './TerminalNotificationsButton'
@@ -49,10 +49,63 @@ async function focusWorkspacePanel(workspaceId: string, panelId: string): Promis
       return
     }
 
-    const ops = getCanvasOperations()
+    // Resolve the canvas ops for THIS workspace's canvas panel (not the
+    // global singleton — that may point at a different workspace's store).
+    const canvasPanelId = getWorkspaceCanvasPanelId(workspaceId)
+    const ops = canvasPanelId ? ensureCanvasOpsForPanel(canvasPanelId) : getCanvasOperations()
     const nodeId = ops?.storeApi?.getState()?.nodeForPanel(panelId)
     if (nodeId) { ops!.focusPanelNode(panelId); return }
   }
+}
+
+// Subscribe to a workspace's canvas store and return the set of panel ids
+// that currently live on that canvas. Resolves the correct store per-workspace
+// (the singleton `useCanvasStore` only mirrors whichever workspace's canvas
+// happened to mount first).
+function useWorkspaceCanvasPanelIds(workspaceId: string): Set<string> {
+  const canvasPanelId = useAppStore((s) => {
+    const ws = s.workspaces.find((w) => w.id === workspaceId)
+    if (!ws) return null
+    for (const p of Object.values(ws.panels)) if (p.type === 'canvas') return p.id
+    return null
+  })
+  const store = useMemo(
+    () => (canvasPanelId ? getOrCreateCanvasStoreForPanel(canvasPanelId) : null),
+    [canvasPanelId],
+  )
+  const subscribe = useCallback(
+    (cb: () => void) => (store ? store.subscribe(cb) : () => {}),
+    [store],
+  )
+  const getSnapshot = useCallback(() => (store ? store.getState().nodes : null), [store])
+  const nodes = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  return useMemo(() => {
+    const ids = new Set<string>()
+    if (nodes) {
+      for (const node of Object.values(nodes)) {
+        // Each canvas node has its own mini-dock layout; a node may host
+        // several tabbed panels. `node.panelId` is only the seed — walk the
+        // full layout so additional tabs (e.g. Terminal 2, Terminal 4
+        // dragged into the same canvas node) still classify as canvas
+        // children in the sidebar.
+        collectPanelIdsFromDockLayout(node.dockLayout, ids)
+        if (node.panelId) ids.add(node.panelId)
+      }
+    }
+    return ids
+  }, [nodes])
+}
+
+function collectPanelIdsFromDockLayout(
+  layout: DockLayoutNode | null | undefined,
+  out: Set<string>,
+): void {
+  if (!layout) return
+  if (layout.type === 'tabs') {
+    for (const id of layout.panelIds) out.add(id)
+    return
+  }
+  for (const child of layout.children) collectPanelIdsFromDockLayout(child, out)
 }
 
 interface TerminalPanelRowProps {
@@ -158,11 +211,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
 
   // Set of panelIds living on a canvas (for the selected workspace, use the
   // live canvasStore; otherwise fall back to the workspace's persisted nodes).
-  const liveCanvasPanelIds = useCanvasStore(useShallow((s) => {
-    const ids = new Set<string>()
-    for (const node of Object.values(s.nodes)) ids.add(node.panelId)
-    return ids
-  }))
+  const liveCanvasPanelIds = useWorkspaceCanvasPanelIds(workspace.id)
   const canvasPanelIds = useMemo(() => {
     if (isSelected) return liveCanvasPanelIds
     const ids = new Set<string>()
@@ -280,11 +329,18 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     await focusWorkspacePanel(workspace.id, panelId)
   }, [workspace.id])
 
-  const handleRenameClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
+  const beginRename = useCallback(() => {
     setRenameValue(workspace.name || workspace.rootPath?.split('/').pop() || 'Workspace')
     setIsRenaming(true)
   }, [workspace.name, workspace.rootPath])
+
+  const handleTitleClick = useCallback((e: React.MouseEvent) => {
+    // First click selects the workspace (parent handler). Once selected, a
+    // click on the title enters rename mode — replacing the dedicated pencil.
+    if (!isSelected) return
+    e.stopPropagation()
+    beginRename()
+  }, [isSelected, beginRename])
 
   // Empty state: workspace has no folder selected yet — flat row that opens picker
   if (!workspace.rootPath) {
@@ -454,8 +510,10 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
           />
         ) : (
           <span
-            className="flex-1 min-w-0 text-[14px] truncate"
-            title={workspace.rootPath}
+            className={`flex-1 min-w-0 text-[14px] truncate ${isSelected ? 'cursor-text' : ''}`}
+            title={isSelected ? 'Click to rename' : workspace.rootPath}
+            onClick={handleTitleClick}
+            onDoubleClick={(e) => { e.stopPropagation(); beginRename() }}
           >
             {displayTitle}
           </span>
@@ -468,20 +526,13 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
           </span>
         )}
 
-        {/* Hover actions: dots menu + rename */}
+        {/* Hover actions: dots menu (rename happens via clicking the title) */}
         <button
           className="flex-shrink-0 w-5 h-5 flex items-center justify-center opacity-0 group-hover:opacity-80 hover:!opacity-100 text-secondary hover:text-primary transition-opacity focus:outline-none"
           onClick={(e) => { e.stopPropagation(); handleContextMenu(e) }}
           title="More actions"
         >
           <DotsThree size={14} weight="bold" />
-        </button>
-        <button
-          className="flex-shrink-0 w-5 h-5 flex items-center justify-center opacity-0 group-hover:opacity-80 hover:!opacity-100 text-secondary hover:text-primary transition-opacity focus:outline-none"
-          onClick={handleRenameClick}
-          title="Rename"
-        >
-          <PencilSimple size={12} weight="bold" />
         </button>
       </div>
 

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { CaretRight, Terminal as TerminalIcon, Globe, FileCode, GitBranch, Folder, FolderPlus, SquaresFour, List, DotsThree } from '@phosphor-icons/react'
 import type { WorkspaceState, PanelType, PanelLocation, DockLayoutNode } from '../../shared/types'
@@ -58,31 +58,29 @@ async function focusWorkspacePanel(workspaceId: string, panelId: string): Promis
   }
 }
 
-// Subscribe to a workspace's canvas store and return the set of panel ids
-// that currently live on that canvas. Resolves the correct store per-workspace
-// (the singleton `useCanvasStore` only mirrors whichever workspace's canvas
-// happened to mount first).
+// Subscribe to every canvas store in a workspace and return the union of
+// panel ids that currently live on those canvases. A workspace can host
+// multiple canvas panels, and the legacy singleton `useCanvasStore` only
+// mirrors whichever canvas mounted first — so we scan ALL canvas panels in
+// the workspace and union their live nodes' dockLayouts.
 function useWorkspaceCanvasPanelIds(workspaceId: string): Set<string> {
-  const canvasPanelId = useAppStore((s) => {
+  const canvasPanelIds = useAppStore(useShallow((s) => {
     const ws = s.workspaces.find((w) => w.id === workspaceId)
-    if (!ws) return null
-    for (const p of Object.values(ws.panels)) if (p.type === 'canvas') return p.id
-    return null
-  })
-  const store = useMemo(
-    () => (canvasPanelId ? getOrCreateCanvasStoreForPanel(canvasPanelId) : null),
-    [canvasPanelId],
+    if (!ws) return [] as string[]
+    return Object.values(ws.panels)
+      .filter((p) => p.type === 'canvas')
+      .map((p) => p.id)
+  }))
+
+  const stores = useMemo(
+    () => canvasPanelIds.map((id) => getOrCreateCanvasStoreForPanel(id)),
+    [canvasPanelIds],
   )
-  const subscribe = useCallback(
-    (cb: () => void) => (store ? store.subscribe(cb) : () => {}),
-    [store],
-  )
-  const getSnapshot = useCallback(() => (store ? store.getState().nodes : null), [store])
-  const nodes = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
-  return useMemo(() => {
+
+  const compute = useCallback(() => {
     const ids = new Set<string>()
-    if (nodes) {
-      for (const node of Object.values(nodes)) {
+    for (const store of stores) {
+      for (const node of Object.values(store.getState().nodes)) {
         // Each canvas node has its own mini-dock layout; a node may host
         // several tabbed panels. `node.panelId` is only the seed — walk the
         // full layout so additional tabs (e.g. Terminal 2, Terminal 4
@@ -93,7 +91,21 @@ function useWorkspaceCanvasPanelIds(workspaceId: string): Set<string> {
       }
     }
     return ids
-  }, [nodes])
+  }, [stores])
+
+  const [ids, setIds] = useState<Set<string>>(compute)
+
+  useEffect(() => {
+    // Recompute immediately on store-set change so we don't render one frame
+    // of stale ids after switching workspaces.
+    setIds(compute())
+    const unsubs = stores.map((s) => s.subscribe(() => setIds(compute())))
+    return () => {
+      for (const fn of unsubs) fn()
+    }
+  }, [stores, compute])
+
+  return ids
 }
 
 function collectPanelIdsFromDockLayout(

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -133,7 +133,7 @@ const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, dot,
   return (
     <button
       className={`group/panel flex items-center gap-1.5 h-7 pr-2 rounded text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 focus:outline-none ${
-        indent ? 'pl-14' : 'pl-7'
+        indent ? 'pl-10' : 'pl-7'
       }`}
       onClick={handleRowClick}
       title={panel.filePath || panel.url || label}
@@ -215,7 +215,12 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const canvasPanelIds = useMemo(() => {
     if (isSelected) return liveCanvasPanelIds
     const ids = new Set<string>()
-    for (const node of Object.values(workspace.canvasNodes ?? {})) ids.add(node.panelId)
+    for (const node of Object.values(workspace.canvasNodes ?? {})) {
+      // Same logic as the live path: a canvas node's dockLayout can hold
+      // multiple tabbed panels; the seed `node.panelId` is only one of them.
+      collectPanelIdsFromDockLayout(node.dockLayout, ids)
+      if (node.panelId) ids.add(node.panelId)
+    }
     return ids
   }, [isSelected, liveCanvasPanelIds, workspace.canvasNodes])
 
@@ -438,7 +443,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       <button
         key={p.id}
         className={`group/panel flex items-center gap-1.5 h-7 pr-2 rounded text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 focus:outline-none ${
-          indent ? 'pl-14' : 'pl-7'
+          indent ? 'pl-10' : 'pl-7'
         }`}
         onClick={(e) => handlePanelClick(e, p.id)}
         title={p.filePath || p.url || label}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -221,20 +221,23 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     return ws?.panels ?? workspace.panels
   }))
 
-  // Set of panelIds living on a canvas (for the selected workspace, use the
-  // live canvasStore; otherwise fall back to the workspace's persisted nodes).
+  // Set of panel ids living on this workspace's canvases. Union of:
+  //   (a) live canvas stores (covers the active workspace + any other
+  //       workspace whose canvas was mounted earlier this session — those
+  //       stores stay alive in the registry even after switching away), and
+  //   (b) the workspace's persisted canvasNodes (cold-start fallback before
+  //       any canvas has mounted in this session).
+  // Used regardless of isSelected so active and non-active workspaces apply
+  // the same classification rule.
   const liveCanvasPanelIds = useWorkspaceCanvasPanelIds(workspace.id)
   const canvasPanelIds = useMemo(() => {
-    if (isSelected) return liveCanvasPanelIds
-    const ids = new Set<string>()
+    const ids = new Set<string>(liveCanvasPanelIds)
     for (const node of Object.values(workspace.canvasNodes ?? {})) {
-      // Same logic as the live path: a canvas node's dockLayout can hold
-      // multiple tabbed panels; the seed `node.panelId` is only one of them.
       collectPanelIdsFromDockLayout(node.dockLayout, ids)
       if (node.panelId) ids.add(node.panelId)
     }
     return ids
-  }, [isSelected, liveCanvasPanelIds, workspace.canvasNodes])
+  }, [liveCanvasPanelIds, workspace.canvasNodes])
 
   // Map terminal panel id → agent state for activity dots
   const agentStateByPanel = wsStatus?.agentState ?? {}


### PR DESCRIPTION
## Summary
- Sidebar resolves the **workspace's own** canvas store/ops when listing canvas children and when jumping to a panel. The global `useCanvasStore` singleton only mirrors whichever workspace's canvas mounted first, so once you switched workspaces the sidebar lost track of which panels lived on its canvas — children stopped indenting and clicking Terminal/Canvas rows no longer focused them.
- Walks each canvas node's `dockLayout` when classifying canvas children, so multiple tabbed panels inside a single canvas node (e.g. Terminal 2, Terminal 4 dragged into the same node) all indent under Canvas instead of falling through to the free-panels group.
- Removed the pencil rename button. Renaming is triggered by clicking (or double-clicking) the title of an already-selected workspace. The context menu's *Rename Workspace* action still works.
- Renamed the sidebar section header **Projects → Workspace**.

User reports addressed:
> in der Sidebar wenn man auf terminals drückt wird das nicht mehr gefocused
> das einrücken mit terminals und canvas ist nur wenn aktuell nicht in dem workspace drin ist

Deferred (separate follow-up): drag flicker + tab-drag vs tab-bar-drag inconsistency — different code paths (tab drag = dock-drag out of canvas; empty-bar drag = canvas node move). Needs a UX decision and dedicated repro.

## Test plan
- [ ] Switch workspaces; expand each in the sidebar — terminal/editor rows indent under their Canvas row in *every* workspace, not just the inactive ones.
- [ ] Drag a second terminal into an existing canvas node (so the node has multiple tabs) — both terminals still indent under Canvas in the sidebar.
- [ ] Click a Terminal/Canvas row in the sidebar — the canvas pans and focuses that panel.
- [ ] Click the workspace title once it's selected — inline rename input appears; Enter saves, Escape cancels.
- [ ] Right-click workspace → Rename Workspace still works.
- [ ] Sidebar section header reads "Workspace".