### PR TITLE
feat(canvas): center toolbar/welcome between sidebars, polish minimap, fix recent-folder open

### DIFF
--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -129,8 +129,14 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
 
   return (
     <>
-    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50">
-      <div ref={menuRef} className="relative">
+    <div
+      className="absolute bottom-4 z-50 flex justify-center pointer-events-none"
+      style={{
+        left: 'var(--cate-left-sidebar-width, 0px)',
+        right: 'var(--cate-right-sidebar-width, 0px)',
+      }}
+    >
+      <div ref={menuRef} className="relative pointer-events-auto">
         {/* Drop-up menu */}
         {menuOpen && (
           <div

--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useCanvasStoreContext, useCanvasStoreApi, shallow } from '../stores/CanvasStoreContext'
 import { useWorkspacePanels } from '../stores/appStore'
+import { panelColor as brandPanelColor } from '../panels/types'
 
 const MINIMAP_DEFAULT_WIDTH = 200
 const MINIMAP_DEFAULT_HEIGHT = 150
@@ -33,7 +34,7 @@ const loadSize = (): { w: number; h: number } => {
   return { w: MINIMAP_DEFAULT_WIDTH, h: MINIMAP_DEFAULT_HEIGHT }
 }
 
-function panelColor(panelType: string): string {
+function mutedPanelColor(panelType: string): string {
   switch (panelType) {
     case 'terminal': return '#4a9960'
     case 'editor': return '#b07440'
@@ -355,7 +356,7 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
               top: toMiniY(node.origin.y),
               width: Math.max(node.size.width * scale, 2),
               height: Math.max(node.size.height * scale, 2),
-              backgroundColor: panelColor(type),
+              backgroundColor: isPopover ? brandPanelColor(type as any) : mutedPanelColor(type),
               borderRadius: 1,
               opacity: 1,
             }}

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -193,6 +193,11 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
   // so off-screen terminals/editors don't hold live xterm/Monaco instances.
   const nodeIds = useNodeIds(store)
   const visibleNodeIds = useVisibleNodeIds(store)
+  // Welcome page only shows on a brand-new workspace (no rootPath chosen yet).
+  // After a folder is picked, deleting all panels leaves a blank canvas.
+  const workspaceRootPath = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.rootPath ?? '',
+  )
 
   const onCreateAtPoint = useCallback(
     (type: PanelType, canvasPoint: Point) => {
@@ -307,8 +312,10 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
   return (
     <CanvasStoreProvider store={store}>
       <div className="relative w-full h-full" onPointerDown={handlePointerDown}>
-        {/* Welcome page when canvas is empty */}
-        {nodeIds.length === 0 && (
+        {/* Welcome page only on a fresh, uninitialized workspace (no panels
+            yet AND no rootPath). Once a folder is picked, the canvas stays
+            blank when emptied — the start page does not return. */}
+        {nodeIds.length === 0 && !workspaceRootPath && (
           <WelcomePage workspaceId={workspaceId} />
         )}
 

--- a/src/renderer/ui/WelcomePage.tsx
+++ b/src/renderer/ui/WelcomePage.tsx
@@ -31,18 +31,17 @@ export default function WelcomePage({ workspaceId }: { workspaceId: string }) {
 
   const openFolder = useCallback(async () => {
     const path = await window.electronAPI.openFolderDialog()
-    if (path) {
-      const app = useAppStore.getState()
-      app.setWorkspaceRootPath(workspaceId, path)
-      app.createTerminal(workspaceId)
-    }
+    if (!path) return
+    const app = useAppStore.getState()
+    const ok = await app.setWorkspaceRootPath(workspaceId, path)
+    if (ok) app.createTerminal(workspaceId)
   }, [workspaceId])
 
   const openRecentProject = useCallback(
-    (path: string) => {
+    async (path: string) => {
       const app = useAppStore.getState()
-      app.setWorkspaceRootPath(workspaceId, path)
-      app.createTerminal(workspaceId)
+      const ok = await app.setWorkspaceRootPath(workspaceId, path)
+      if (ok) app.createTerminal(workspaceId)
     },
     [workspaceId],
   )
@@ -63,7 +62,13 @@ export default function WelcomePage({ workspaceId }: { workspaceId: string }) {
   }, [workspaceId])
 
   return (
-    <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
+    <div
+      className="absolute top-0 bottom-0 flex items-center justify-center pointer-events-none z-10"
+      style={{
+        left: 'var(--cate-left-sidebar-width, 0px)',
+        right: 'var(--cate-right-sidebar-width, 0px)',
+      }}
+    >
       <div className="pointer-events-auto max-w-2xl w-full px-8">
         {/* Header */}
         <div className="flex flex-col items-center mb-10">


### PR DESCRIPTION
## Summary
- Toolbar and WelcomePage inset by `--cate-left/right-sidebar-width` so they stay centered in the *visible* canvas area as either sidebar opens/closes.
- Minimap popover uses the canonical brand palette (`panels/types.ts`) instead of the muted floating-mode tones.
- Recent-path click in WelcomePage now awaits `setWorkspaceRootPath` before spawning the terminal — fixes a race where the folder appeared unset and a follow-up New Terminal click re-prompted for a folder.
- Welcome page is gated on `workspace.rootPath` being empty: after init, deleting the last panel leaves a blank canvas instead of falling back to the start page.

## Test plan
- [ ] Open/close left and right sidebars — bottom toolbar and empty-canvas welcome content stay centered in the visible area.
- [ ] Toggle the minimap popover — terminal/editor/browser rectangles render in brand green/orange/blue.
- [ ] Click a recent path in the welcome page — folder is set on the workspace and a terminal opens in that cwd; deleting the terminal leaves an empty canvas (no start page).
- [ ] Open Folder… flow still works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)