### PR TITLE
feat(update): inline progress in pill, auto-restart, layering polish (v0.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/renderer/canvas/UpdateButton.tsx
+++ b/src/renderer/canvas/UpdateButton.tsx
@@ -1,35 +1,32 @@
 // =============================================================================
-// UpdateButton — subtle blue pill in the bottom-right toolbar, shown only
-// when the auto-updater has a new release available. Replaces the native OS
-// popup with an in-app affordance + small popover.
+// UpdateButton — single blue pill in the bottom-right toolbar.
+// Click to download → progress fills inside the pill → auto-restart to install.
+// No popover; the button itself is the affordance.
 // =============================================================================
 
-import React, { useEffect, useRef, useState } from 'react'
-import { ArrowCircleUp, X } from '@phosphor-icons/react'
+import React, { useEffect, useRef } from 'react'
+import { ArrowCircleUp } from '@phosphor-icons/react'
 import { useUpdateStore } from '../stores/updateStore'
 
 export const UpdateButton: React.FC = () => {
   const status = useUpdateStore((s) => s.status)
-  const [open, setOpen] = useState(false)
-  const wrapRef = useRef<HTMLDivElement | null>(null)
+  // Guard so the auto-install transition fires exactly once per "downloaded" event.
+  const installedRef = useRef(false)
 
+  // When the download completes, trigger restart-to-install automatically.
   useEffect(() => {
-    if (!open) return
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    if (status.state === 'downloaded' && !installedRef.current) {
+      installedRef.current = true
+      // Small delay lets the user see the "Restarting…" label flash before quit.
+      const t = setTimeout(() => window.electronAPI.updateInstall(), 600)
+      return () => clearTimeout(t)
     }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+    if (status.state !== 'downloaded' && status.state !== 'downloading') {
+      installedRef.current = false
     }
-    window.addEventListener('mousedown', onDown)
-    window.addEventListener('keydown', onKey)
-    return () => {
-      window.removeEventListener('mousedown', onDown)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [open])
+  }, [status.state])
 
-  // Only render for states that have an actionable update to offer.
+  // Only render for states with an actionable update.
   if (
     status.state !== 'available' &&
     status.state !== 'downloading' &&
@@ -39,13 +36,20 @@ export const UpdateButton: React.FC = () => {
     return null
   }
 
+  const percent =
+    status.state === 'downloading' && typeof status.percent === 'number'
+      ? Math.max(0, Math.min(100, status.percent))
+      : status.state === 'downloaded'
+        ? 100
+        : 0
+
   const label =
     status.state === 'downloading'
       ? typeof status.percent === 'number'
         ? `Updating… ${Math.round(status.percent)}%`
         : 'Updating…'
       : status.state === 'downloaded'
-        ? 'Restart to update'
+        ? 'Restarting…'
         : status.state === 'manual'
           ? `Update v${status.version}`
           : `Update v${status.version}`
@@ -54,12 +58,12 @@ export const UpdateButton: React.FC = () => {
     status.state === 'downloading'
       ? 'Downloading update'
       : status.state === 'downloaded'
-        ? 'Update ready — click to restart and install'
+        ? 'Restarting to install update…'
         : status.state === 'manual'
           ? 'Open release page to download manually'
-          : 'A new version of Cate is available'
+          : 'Click to download and install update'
 
-  const onPrimary = () => {
+  const onClick = () => {
     if (status.state === 'available') {
       window.electronAPI.updateDownload()
     } else if (status.state === 'downloaded') {
@@ -67,91 +71,30 @@ export const UpdateButton: React.FC = () => {
     } else if (status.state === 'manual') {
       window.electronAPI.updateOpenRelease(status.releaseUrl)
     }
+    // 'downloading' → no-op; button is non-interactive while progress fills.
   }
 
-  const primaryLabel =
-    status.state === 'available'
-      ? 'Download'
-      : status.state === 'downloading'
-        ? 'Downloading…'
-        : status.state === 'downloaded'
-          ? 'Restart & Install'
-          : 'Open Release Page'
+  const isProgressing = status.state === 'downloading' || status.state === 'downloaded'
 
   return (
-    <div ref={wrapRef} className="relative">
-      {/* Popover */}
-      {open && (
-        <div
-          data-theme="dark-warm"
-          className="absolute right-0 bottom-full mb-2 w-[260px] rounded-lg border border-subtle bg-surface-4/95 backdrop-blur-xl backdrop-saturate-150 shadow-[0_18px_40px_-12px_var(--shadow-node)] p-3"
-        >
-          <div className="flex items-start justify-between gap-2 mb-2">
-            <div>
-              <div className="text-[13px] font-semibold text-primary">
-                {status.state === 'downloaded'
-                  ? 'Update ready'
-                  : status.state === 'manual'
-                    ? 'Update available'
-                    : status.state === 'downloading'
-                      ? 'Downloading update'
-                      : 'Update available'}
-              </div>
-              {('version' in status) && status.version && (
-                <div className="text-[11px] text-secondary mt-0.5">Cate v{status.version}</div>
-              )}
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false)
-                window.electronAPI.updateDismiss()
-              }}
-              title="Dismiss"
-              className="w-5 h-5 flex items-center justify-center rounded text-secondary hover:bg-hover-strong focus:outline-none"
-            >
-              <X size={12} />
-            </button>
-          </div>
-          <div className="text-[12px] text-secondary leading-snug mb-3">
-            {status.state === 'downloaded'
-              ? 'The new version has been downloaded. Restart Cate to apply.'
-              : status.state === 'manual'
-                ? 'Automatic installation is unavailable in this build. Open the release page to download manually.'
-                : status.state === 'downloading'
-                  ? 'Download in progress. You can keep working — Cate will prompt to restart when ready.'
-                  : 'A new version of Cate is ready to install.'}
-          </div>
-          {status.state === 'downloading' && typeof status.percent === 'number' && (
-            <div className="h-1 rounded-full bg-surface-5 overflow-hidden mb-3">
-              <div
-                className="h-full bg-[var(--focus-blue,#3b82f6)] transition-[width] duration-200"
-                style={{ width: `${Math.max(2, Math.min(100, status.percent))}%` }}
-              />
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={onPrimary}
-            disabled={status.state === 'downloading'}
-            className="w-full px-3 py-1.5 rounded-md bg-[var(--focus-blue,#3b82f6)] text-white text-[12px] font-medium hover:brightness-110 disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none transition-all"
-          >
-            {primaryLabel}
-          </button>
-        </div>
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isProgressing}
+      title={title}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+      className="group relative overflow-hidden flex items-center gap-1.5 h-[34px] pl-2.5 pr-3 rounded-full bg-[var(--focus-blue,#3b82f6)] text-white text-[11px] font-medium shadow-[0_0_24px_-2px_rgba(59,130,246,0.7),0_8px_24px_-6px_rgba(59,130,246,0.55)] hover:brightness-110 active:scale-[0.97] disabled:active:scale-100 focus:outline-none transition-all"
+    >
+      {/* Progress fill — lighter blue overlay that grows left-to-right while downloading. */}
+      {isProgressing && (
+        <span
+          aria-hidden
+          className="absolute inset-y-0 left-0 bg-white/25 transition-[width] duration-200 ease-out pointer-events-none"
+          style={{ width: `${percent}%` }}
+        />
       )}
-
-      {/* Pill button */}
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        title={title}
-        style={{ WebkitTapHighlightColor: 'transparent' }}
-        className="group flex items-center gap-1.5 h-[34px] pl-2.5 pr-3 rounded-full border border-[var(--focus-blue,#3b82f6)]/40 bg-[var(--focus-blue,#3b82f6)] text-white text-[11px] font-medium shadow-[0_8px_24px_-6px_rgba(59,130,246,0.55)] hover:brightness-110 active:scale-[0.97] focus:outline-none transition-all"
-      >
-        <ArrowCircleUp size={14} weight="fill" />
-        <span className="whitespace-nowrap">{label}</span>
-      </button>
-    </div>
+      <ArrowCircleUp size={14} weight="fill" className="relative z-[1]" />
+      <span className="relative z-[1] whitespace-nowrap">{label}</span>
+    </button>
   )
 }

--- a/src/renderer/ui/ShortcutHintOverlay.tsx
+++ b/src/renderer/ui/ShortcutHintOverlay.tsx
@@ -102,7 +102,7 @@ export const ShortcutHintOverlay: React.FC = () => {
 
   return (
     <div
-      className="fixed z-40 pointer-events-none animate-in fade-in slide-in-from-bottom-1 duration-150"
+      className="fixed z-[60] pointer-events-none animate-in fade-in slide-in-from-bottom-1 duration-150"
       style={{
         // Sit above the minimap toggle (bottom-4 + ~44px button + gap).
         bottom: 'calc(1rem + 44px + 0.5rem)',


### PR DESCRIPTION
## Summary
- UpdateButton: removed the popover. The pill is now the entire affordance — no border, blue glow only. Click while `available` starts the download; `Updating… N%` label with a translucent fill grows inside the pill; on `downloaded` an effect auto-fires `updateInstall` so `autoUpdater.quitAndInstall` actually restarts the app (previously the user had to find the popup → click Restart, which often never happened).
- ShortcutHintOverlay bumped to `z-[60]` so the ⌘-hold dialog renders above the minimap popover (toolbar groups are `z-50`).
- Version bumped to 0.4.2.

## Test plan
- [ ] When an update is available, the pill appears in the bottom-right with blue glow and no border.
- [ ] Clicking the pill starts the download; progress fill grows inside, label cycles `Updating… N%`.
- [ ] On download complete, label flips to `Restarting…` and the app quits & reinstalls without further interaction.
- [ ] Hold ⌘ — shortcut overlay appears above the minimap popover (not hidden behind it).