### PR TITLE
fix(terminal,explorer): retry on terminal-create failure; un-dim tracked files (v0.4.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -275,6 +275,16 @@ const registry = new Map<string, RegistryEntry>()
 // window.  getOrCreate() checks this map and enters reconnect mode if found.
 const pendingTransfers = new Map<string, { ptyId: string; scrollback?: string }>()
 
+// Per-panel last-known create failure, surfaced by TerminalPanel as a Retry
+// overlay so a dead panel can recover without restarting the app.
+const failures = new Map<string, string>()
+const failureListeners = new Set<(panelId: string) => void>()
+function notifyFailure(panelId: string): void {
+  for (const fn of failureListeners) {
+    try { fn(panelId) } catch { /* ignore listener errors */ }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Live theme swap — update all live terminals when the app theme changes
 // ---------------------------------------------------------------------------
@@ -309,6 +319,9 @@ useSettingsStore.subscribe((state) => {
 async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryEntry> {
   const existing = registry.get(panelId)
   if (existing) return existing
+  // A retry starts here — clear any prior failure so observers re-render
+  // back into the live terminal view.
+  if (failures.delete(panelId)) notifyFailure(panelId)
 
   // Check for a pending cross-window transfer — reconnect to existing PTY
   const transfer = pendingTransfers.get(panelId)
@@ -493,9 +506,20 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
       replayTerminalLog(panelId).catch((err) => log.warn('[terminal] Replay log failed:', err))
     }
   } catch (err) {
-    if (registry.has(panelId)) {
-      terminal.write(`\r\n\x1b[31mFailed to create terminal: ${err}\x1b[0m\r\n`)
+    // Tear down the half-built entry so retry() can rebuild from scratch
+    // instead of leaving a permanent tombstone with the red error frozen in it.
+    const message =
+      err instanceof Error
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : String(err)
+    failures.set(panelId, message)
+    if (registry.get(panelId) === entry) {
+      registry.delete(panelId)
+      try { terminal.dispose() } catch { /* ignore */ }
     }
+    notifyFailure(panelId)
   }
 
   return entry
@@ -941,6 +965,17 @@ function getEntry(panelId: string): RegistryEntry | undefined {
   return registry.get(panelId)
 }
 
+/** Returns the last create-failure message for panelId, or null. */
+function getFailure(panelId: string): string | null {
+  return failures.get(panelId) ?? null
+}
+
+/** Subscribe to failure-state changes for any panel. Returns an unsubscribe fn. */
+function subscribeFailure(listener: (panelId: string) => void): () => void {
+  failureListeners.add(listener)
+  return () => failureListeners.delete(listener)
+}
+
 /** Returns true if an entry exists for panelId. */
 function has(panelId: string): boolean {
   return registry.has(panelId)
@@ -998,6 +1033,8 @@ export const terminalRegistry = {
   setPendingTransfer,
   getEntry,
   has,
+  getFailure,
+  subscribeFailure,
   panelIdForPty,
   findNext,
   findPrevious,

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -68,6 +68,27 @@ export default function TerminalPanel({
 
   const [showSearch, setShowSearch] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  // Bumping this re-runs the create effect — used by the Retry button after
+  // a terminal create failure (issue #39).
+  const [retryKey, setRetryKey] = useState(0)
+  const [createError, setCreateError] = useState<string | null>(() =>
+    terminalRegistry.getFailure(panelId),
+  )
+
+  // Subscribe to create-failure changes for this panel so the Retry overlay
+  // appears (and disappears) without polling.
+  useEffect(() => {
+    setCreateError(terminalRegistry.getFailure(panelId))
+    const unsubscribe = terminalRegistry.subscribeFailure((id) => {
+      if (id === panelId) setCreateError(terminalRegistry.getFailure(panelId))
+    })
+    return unsubscribe
+  }, [panelId])
+
+  const handleRetry = useCallback(() => {
+    setCreateError(null)
+    setRetryKey((k) => k + 1)
+  }, [])
 
   const workspaces = useAppStore((state) => state.workspaces)
   const themePreset = useAppStore(
@@ -303,7 +324,7 @@ export default function TerminalPanel({
 
       detachAndDisconnect()
     }
-  }, [panelId, workspaceId, nodeId, initialInput])
+  }, [panelId, workspaceId, nodeId, initialInput, retryKey])
 
   // Hot-apply theme preset changes without recreating the terminal.
   useEffect(() => {
@@ -591,6 +612,25 @@ export default function TerminalPanel({
         {isDragOver && (
           <div className="absolute inset-0 z-50 flex items-center justify-center bg-blue-500/10 border-2 border-dashed border-blue-500/40 rounded pointer-events-none">
             <span className="text-blue-400 text-sm font-medium">Drop to paste path</span>
+          </div>
+        )}
+        {createError && (
+          <div className="absolute inset-0 z-50 flex items-center justify-center bg-surface-1/85 backdrop-blur-sm">
+            <div className="max-w-md mx-6 rounded-lg border border-subtle bg-surface-3 shadow-[0_18px_40px_-12px_var(--shadow-node)] p-4 text-center">
+              <div className="text-[13px] font-semibold text-primary mb-1">
+                Failed to start terminal
+              </div>
+              <div className="text-[12px] text-secondary mb-3 break-words whitespace-pre-wrap leading-snug">
+                {createError}
+              </div>
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="px-3 py-1.5 rounded-md bg-[var(--focus-blue,#3b82f6)] text-white text-[12px] font-medium hover:brightness-110 active:scale-[0.97] focus:outline-none transition-all"
+              >
+                Retry
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -109,7 +109,9 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       const isGit = await window.electronAPI.gitIsRepo(dirPath)
       if (isGit) {
         const trackedFiles = await window.electronAPI.gitLsFiles(dirPath)
-        setGitFiles(new Set(trackedFiles))
+        // gitLsFiles returns paths relative to repo root; convert to absolute
+        // so they match node.path in the tree.
+        setGitFiles(new Set(trackedFiles.map((p) => `${dirPath}/${p}`)))
       } else {
         setGitFiles(undefined)
       }


### PR DESCRIPTION
## Summary
- **#39 — terminal create no longer leaves a dead panel.** `getOrCreate` now tears down the half-built registry entry on failure and records the error message in a new `failures` map (broadcast via `subscribeFailure`). TerminalPanel subscribes and renders a "Failed to start terminal" overlay with a **Retry** button in place of the dead xterm. Retry clears the failure, bumps a local `retryKey`, and the create effect re-runs from scratch — no app restart, no need to open a fresh canvas.
- **Explorer dim fix.** `gitLsFiles` returns repo-relative paths, but the tree's `node.path` is absolute, so the tracked-files `Set` never matched anything and every file rendered dimmed as 'untracked'. Prefixing the relative paths with `dirPath` lets the comparison succeed.
- **#34** (Windows "No usable shell") was root-caused in #24; this release ships that fix.
- Version bumped to 0.4.3.

## Test plan
- [ ] Force terminal create to fail (e.g. point Default shell path at a missing executable) → red error overlay appears with Retry; clicking Retry recreates the terminal in the same panel once you fix the setting.
- [ ] Repeated retries don't accumulate registry entries or stale listeners.
- [ ] Default-shell-blank on Windows 11 now spawns cmd.exe / PowerShell via the new fallback chain (#24).
- [ ] In the file explorer for a git repo, tracked files render at full opacity; only untracked files dim.

Closes #34, closes #39.