### PR TITLE
docs: add star history to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ src/
 - **Tailwind CSS** for styling
 - **electron-vite** for bundling
 
+## Star History
+
+<a href="https://www.star-history.com/#0-AI-UG/cate&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+  </picture>
+</a>
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adds a Star History chart (via star-history.com) to the README with light/dark theme support.