### PR TITLE
release(v0.4.4): docking UX overhaul + reliable update restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -36,6 +36,14 @@ const API_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_RE
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = true
 
+/** True after the user clicked "Update & Restart". The will-quit handler in
+ *  src/main/index.ts reads this to skip its `process.reallyExit(0)` fallback —
+ *  reallyExit bypasses Electron's relaunch hooks, so the app would install
+ *  the update but never come back up. With this flag set, we let Electron's
+ *  natural quit path complete so the updater's relaunch fires. */
+let updateInstalling = false
+export function isInstallingUpdate(): boolean { return updateInstalling }
+
 // ---------------------------------------------------------------------------
 // Update status broadcast
 // ---------------------------------------------------------------------------
@@ -199,8 +207,12 @@ export function initAutoUpdater(): void {
   ipcMain.on(UPDATE_INSTALL, async () => {
     if (!app.isPackaged) return
     log.info('[auto-updater] Renderer requested install')
+    updateInstalling = true
     await flushSessionBeforeUpdate()
-    autoUpdater.quitAndInstall()
+    // (isSilent=false, isForceRunAfter=true) — force relaunch after install
+    // on every platform. The default `isForceRunAfter=false` makes Win/Linux
+    // exit without coming back up after the install completes.
+    autoUpdater.quitAndInstall(false, true)
   })
 
   ipcMain.on(UPDATE_OPEN_RELEASE, (_e, url?: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,7 +28,7 @@ import { registerWorkspaceHandlers } from './workspaceManager'
 import { addAllowedRoot, clearScopedWriteAllowancesForWindow, registerScopedWriteAllowance, validatePath } from './ipc/pathValidation'
 import { buildApplicationMenu, rebuildApplicationMenu, setNewMainWindowFn } from './menu'
 import { initShellEnv } from './shellEnv'
-import { initAutoUpdater } from './auto-updater'
+import { initAutoUpdater, isInstallingUpdate } from './auto-updater'
 import { initSentry } from './sentry'
 import { saveCrashReport, checkPendingCrashReport } from './crashReporter'
 import { beginTerminalTransfer, acknowledgeTerminalTransfer } from './ipc/terminal'
@@ -1261,6 +1261,16 @@ app.on('will-quit', () => {
   // during Environment::CleanupHandles, node-pty's ThreadSafeFunction exit
   // callback throws into a torn-down context and SIGABRTs the process.
   killAllTerminals()
+  // When an update install is in flight, DO NOT reallyExit — that bypasses
+  // Electron's relaunch hook (queued by autoUpdater.quitAndInstall(_, true)).
+  // We need the natural quit path to run so the updater can launch the new
+  // version. The PTY/SIGABRT risk we guard against below is only a problem
+  // when many native handles are still alive; the updater install path takes
+  // over the process shortly anyway, so a plain return is safe here.
+  if (isInstallingUpdate()) {
+    log.info('will-quit: update install in progress, deferring to Electron relaunch')
+    return
+  }
   // Force immediate exit to bypass node::FreeEnvironment → CleanupHandles →
   // uv_run, which drains pending ThreadSafeFunction callbacks and can SIGABRT
   // after node-pty teardown. process.reallyExit is Node's binding to libc

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -192,6 +192,15 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   // lower stacking-context z-index) is visible. Without this, dropping a tab
   // onto an unfocused canvas panel shows no visual feedback.
   const isDockDragging = useDockDragStore((s) => s.isDragging)
+  // True while this canvas node is the source of an active dock-drag — i.e.
+  // the user has grabbed its (only) tab and is moving it as a dock ghost.
+  // The node is faded out so it doesn't sit duplicated next to the ghost
+  // during the drag; on drop it either reappears at the new location
+  // (canvas reposition) or is removed (docked elsewhere).
+  const isDockDragSource = useDockDragStore((s) => {
+    if (!s.isDragging || s.dragSource?.type !== 'dock') return false
+    return s.sourceDockStoreApi === dockStoreApi
+  })
 
   const { handleDragStart, wasDragged } = useNodeDrag(nodeId, zoomLevel, canvasApi)
 
@@ -362,15 +371,40 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
   // --- Dock layout renderer --------------------------------------------------
 
-  const getPanelTitle = useCallback(
-    (panelId: string) => currentWorkspace?.panels[panelId]?.title ?? 'Panel',
+  // Both lookups fall back to a fresh appStore read so a brief gap in the
+  // selected-workspace subscription (e.g. mid-switch) doesn't make every tab
+  // collapse to a generic "Panel" / editor-icon label.
+  const resolvePanel = useCallback(
+    (panelId: string) => {
+      const p = currentWorkspace?.panels[panelId]
+      if (p) return p
+      const s = useAppStore.getState()
+      const ws = s.workspaces.find((w) => w.id === s.selectedWorkspaceId)
+      return ws?.panels[panelId]
+    },
     [currentWorkspace],
   )
 
-  const getPanel = useCallback(
-    (panelId: string) => currentWorkspace?.panels[panelId],
-    [currentWorkspace],
+  const getPanelTitle = useCallback(
+    (panelId: string) => {
+      const p = resolvePanel(panelId)
+      if (p?.title) return p.title
+      // Panel exists but its title was cleared (e.g. browser nav to a blank
+      // page). Use the type label so the tab still reads as "Terminal" /
+      // "Browser" instead of a meaningless "Panel".
+      if (p?.type) {
+        const labels: Record<PanelType, string> = {
+          terminal: 'Terminal', browser: 'Browser', editor: 'Editor',
+          git: 'Git', fileExplorer: 'File Explorer', projectList: 'Projects', canvas: 'Canvas',
+        }
+        return labels[p.type] ?? 'Panel'
+      }
+      return 'Panel'
+    },
+    [resolvePanel],
   )
+
+  const getPanel = useCallback((panelId: string) => resolvePanel(panelId), [resolvePanel])
 
   // Collect all panel ids contained in a dock layout subtree.
   const collectPanelIds = useCallback((n: DockLayoutNode | null): string[] => {
@@ -433,6 +467,39 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     toggleMaximize(nodeId, viewportSize)
     setTimeout(() => setIsAnimatingLayout(false), 300)
   }, [toggleMaximize, nodeId])
+
+  // Spring-load: when ANY dock drag is active AND this node is maximized
+  // (covering the canvas), un-maximize after a short delay so the user can
+  // see the canvas underneath and target a drop point. Subscribes directly
+  // to the drag store (not via React selectors) so the timer is scheduled
+  // off React render cycles — re-renders of CanvasNode would otherwise tear
+  // down the effect and reset the timer before it fires.
+  const toggleMaximizeRef = useRef(handleToggleMaximize)
+  toggleMaximizeRef.current = handleToggleMaximize
+  const maximizedRef = useRef(maximized)
+  maximizedRef.current = maximized
+  useEffect(() => {
+    let timerId: number | null = null
+    const tryArm = () => {
+      const s = useDockDragStore.getState()
+      if (!s.isDragging || s.draggedPanelType === 'canvas') return
+      if (!maximizedRef.current) return
+      if (timerId !== null) return
+      timerId = window.setTimeout(() => {
+        timerId = null
+        if (maximizedRef.current) toggleMaximizeRef.current()
+      }, 200)
+    }
+    const cancel = () => {
+      if (timerId !== null) { window.clearTimeout(timerId); timerId = null }
+    }
+    tryArm()
+    const unsub = useDockDragStore.subscribe((s, prev) => {
+      if (s.isDragging && !prev.isDragging) tryArm()
+      else if (!s.isDragging && prev.isDragging) cancel()
+    })
+    return () => { cancel(); unsub() }
+  }, [])
 
   const handleTogglePin = useCallback(() => {
     canvasApi.getState().togglePin(nodeId)
@@ -620,7 +687,13 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
     const baseTransition =
       'border-color 150ms ease, box-shadow 200ms ease, outline-color 200ms ease, transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 150ms ease-out'
-    const layoutTransition = isAnimatingLayout
+    // Skip layout transitions while this node is the dock-drag source.
+    // Spring-load un-maximize sets isAnimatingLayout=true and the resulting
+    // left/top/width/height CSS transition makes the dimmed source visibly
+    // "scale" alongside the dock ghost — confusing the user. Snapping
+    // instantly to the un-maximized size keeps the source still while only
+    // the ghost moves.
+    const layoutTransition = isAnimatingLayout && !isDockDragSource
       ? ', left 250ms cubic-bezier(0.16, 1, 0.3, 1), top 250ms cubic-bezier(0.16, 1, 0.3, 1), width 250ms cubic-bezier(0.16, 1, 0.3, 1), height 250ms cubic-bezier(0.16, 1, 0.3, 1)'
       : ''
 
@@ -651,11 +724,18 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
       ['--node-chrome-accent' as any]: chromeTint?.accent ?? 'var(--focus-blue)',
       transition: baseTransition + layoutTransition,
       transform: isEntering ? 'scale(0.85)' : isExiting ? 'scale(0.9)' : 'scale(1)',
-      opacity: isEntering ? 0 : isExiting ? 0 : 1,
-      pointerEvents: isExiting ? 'none' : undefined,
+      // Hide the source entirely during a dock-drag. Showing it at 0.25
+      // opacity left a visible outline that overlapped the ghost, and any
+      // background re-render that touched the node's size/transform read as
+      // it "scaling with movement" since the ghost moved with the cursor.
+      // The ghost itself is the only thing the user should track during a
+      // dock-drag; the source reappears either at the new location (canvas
+      // reposition) or is removed (docked elsewhere).
+      opacity: isEntering ? 0 : isExiting ? 0 : isDockDragSource ? 0 : 1,
+      pointerEvents: isExiting || isDockDragSource ? 'none' : undefined,
       userSelect: 'none',
     }
-  }, [node, isFocused, isSelected, activityState, zoomLevel, isAnimatingLayout, isHovered, chromeTint])
+  }, [node, isFocused, isSelected, activityState, zoomLevel, isAnimatingLayout, isHovered, chromeTint, isDockDragSource])
 
   // Colored focus/selection glow rendered as a sibling at a fixed low z-index
   // so it sits behind every node — its halo can't bleed over neighbouring
@@ -665,7 +745,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     if (!(isFocused || isSelected)) return null
     const isEntering = node.animationState === 'entering'
     const isExiting = node.animationState === 'exiting'
-    const layoutTransition = isAnimatingLayout
+    const layoutTransition = isAnimatingLayout && !isDockDragSource
       ? 'left 250ms cubic-bezier(0.16, 1, 0.3, 1), top 250ms cubic-bezier(0.16, 1, 0.3, 1), width 250ms cubic-bezier(0.16, 1, 0.3, 1), height 250ms cubic-bezier(0.16, 1, 0.3, 1), '
       : ''
     return {
@@ -679,10 +759,10 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
       boxShadow: FOCUS_GLOW,
       pointerEvents: 'none',
       transform: isEntering ? 'scale(0.85)' : isExiting ? 'scale(0.9)' : 'scale(1)',
-      opacity: isEntering || isExiting ? 0 : 1,
+      opacity: isEntering || isExiting || isDockDragSource ? 0 : 1,
       transition: `${layoutTransition}transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 150ms ease-out`,
     }
-  }, [node, isFocused, isSelected, isAnimatingLayout])
+  }, [node, isFocused, isSelected, isAnimatingLayout, isDockDragSource])
 
   if (!node) return null
 
@@ -785,7 +865,15 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
           }}
           style={{
             position: 'absolute',
-            inset: 0,
+            // When this node uses its dock tab bar as the header (isHeaderHost),
+            // leave the tab strip uncovered so a mousedown on a tab can start
+            // a dock-drag in a single gesture instead of requiring a prior
+            // click-to-focus. Tab strip height matches DockTabStack's compact
+            // mode (min-h-[26px]).
+            top: rootIsTabs ? 26 : 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
             backgroundColor: 'var(--node-dim-overlay)',
             pointerEvents: isFocused || isDockDragging ? 'none' : 'auto',
             cursor: isFocused ? undefined : 'default',
@@ -797,7 +885,17 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
         {/* Dock primitives */}
         <DockStoreProvider store={dockStoreApi}>
-          <div style={{ position: 'relative', zIndex: 0, width: '100%', height: '100%' }}>
+          <div
+            style={{ position: 'relative', zIndex: 0, width: '100%', height: '100%' }}
+            // Capture-phase: any mousedown inside the (now uncovered) dock tab
+            // bar should focus this canvas node before the tab handler runs, so
+            // a single click+hold on a tab both focuses the node and starts the
+            // dock drag in one gesture.
+            onMouseDownCapture={(e) => {
+              if (e.button !== 0 || isFocused) return
+              focusNode(nodeId)
+            }}
+          >
             {layout ? renderLayoutNode(layout) : (
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--text-muted)', fontSize: 12 }}>
                 Empty

--- a/src/renderer/docking/CanvasDropZone.tsx
+++ b/src/renderer/docking/CanvasDropZone.tsx
@@ -6,11 +6,15 @@
 // =============================================================================
 
 import { useEffect, useRef, useState } from 'react'
+import { useStore } from 'zustand'
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from '../stores/canvasStore'
 import { findCanvasStoreForNode } from '../stores/canvasStore'
-import { useDockDragStore, getDropZoneEntries } from '../hooks/useDockDrag'
+import { useDockDragStore } from '../hooks/useDockDrag'
 import { useDockStore } from '../stores/dockStore'
+import { findNodeIdForDockStore } from '../panels/CanvasPanel'
+import { snapNodeToGrid } from '../canvas/layoutEngine'
+import { useSettingsStore } from '../stores/settingsStore'
 import type { PanelType } from '../../shared/types'
 import { PANEL_DEFAULT_SIZES } from '../../shared/types'
 
@@ -23,6 +27,15 @@ export let canvasDropZoneHovered = false
 
 interface CanvasDropZoneProps {
   canvasStoreApi: StoreApi<CanvasStore>
+}
+
+/** Mirror the canvas-drag drop behavior: when the user's snap-to-grid
+ *  setting is on, align the just-moved/created node to the grid so dock
+ *  drops feel consistent with body drags. */
+function snapToGridIfEnabled(canvasStoreApi: StoreApi<CanvasStore>, nodeId: string) {
+  const settings = useSettingsStore.getState()
+  if (!settings.snapToGridEnabled) return
+  snapNodeToGrid(canvasStoreApi, nodeId, settings.gridSpacing, true)
 }
 
 const PANEL_TYPE_LABELS: Record<PanelType, string> = {
@@ -48,11 +61,13 @@ export default function CanvasDropZone({ canvasStoreApi }: CanvasDropZoneProps) 
   return <CanvasDropZoneInner canvasStoreApi={canvasStoreApi} />
 }
 
-/** Outer strip (in px) reserved for the underlying DockTabStack's split-edge
- *  targets (top / bottom / left / right). When the cursor is inside this strip
- *  we deactivate the canvas drop so the dock's normal split indicator wins.
- *  Kept tight so most of the canvas reads as drop-into-canvas territory. */
-const EDGE_STRIP = 32
+/** Outer strip (in px) along each canvas edge that the canvas overlay does
+ *  NOT claim as a drop target. When the cursor is inside this strip the
+ *  canvas drop yields to the underlying dock-zone drop indicators (left /
+ *  right / bottom edge of the window), so the user can still dock a panel
+ *  into a hidden side zone by dragging to the edge. Matches the 60 px width
+ *  used by MainWindowShell's DockZoneDropIndicator slots. */
+const EDGE_STRIP = 60
 
 function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -68,44 +83,57 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
   const dragSource = useDockDragStore((s) => s.dragSource)
   const grabOffsetCanvas = useDockDragStore((s) => s.dragGrabOffset)
   const dockSourceSize = useDockDragStore((s) => s.dragSourceSize)
+  const dragSourceNodeSize = useDockDragStore((s) => s.dragSourceNodeSize)
+  // Subscribe reactively so the ghost rescales live when the user zooms the
+  // target canvas mid-drag. Previously this was a one-shot getState().
+  const targetZoom = useStore(canvasStoreApi, (s) => s.zoomLevel)
+  const viewportOffset = useStore(canvasStoreApi, (s) => s.viewportOffset)
+  // Snap settings — read reactively so toggling snap mid-drag updates the
+  // ghost positioning. The ghost mirrors the body-drag behavior: while
+  // dragging, the preview rectangle snaps to the grid so the user sees where
+  // the node will actually land.
+  const snapEnabled = useSettingsStore((s) => s.snapToGridEnabled)
+  const gridSpacing = useSettingsStore((s) => s.gridSpacing)
 
-  // Source size in canvas-space units. This is the size the new node will
-  // have when added to the target canvas.
+  // ---- Unified source-size resolution ---------------------------------
+  // sourceSize is the canvas-space size the dropped/moved node will have.
+  // The ghost is rendered at sourceSize × targetZoom, and the dropped node
+  // is also sized to sourceSize, so what you see is what you get.
+  // Priority:
+  //   1. canvas source → the actual node's current size (real)
+  //   2. dock source backed by a canvas node → that node's size (mini-dock,
+  //      real — preserves a tab dragged out of a canvas-node back onto canvas)
+  //   3. fallback → PANEL_DEFAULT_SIZES — used for tabs coming from the main
+  //      dock (no canvas counterpart). The user expects these to land at a
+  //      sensible default size, not at the (often huge) dock-panel rect.
   let sourceSize =
     (draggedPanelType && PANEL_DEFAULT_SIZES[draggedPanelType]) ??
     { width: 600, height: 400 }
-  // Ghost is rendered in screen-space, so scale by the target canvas zoom
-  // to match what the node will actually look like once dropped.
-  const targetZoom = canvasStoreApi.getState().zoomLevel
-  // Screen-pixel offset from cursor to ghost top-left. Preference order:
-  //   1. canvas source → use grabOffset × targetZoom (canvas-space)
-  //   2. dock source → use dock rect directly in screen-pixels (no scaling)
-  //   3. fallback → center on cursor
-  let ghostPxSize: { width: number; height: number }
-  let ghostOffset: { x: number; y: number }
   if (dragSource?.type === 'canvas') {
     const sourceCanvas = findCanvasStoreForNode(dragSource.nodeId)
     const srcNode = sourceCanvas?.getState().nodes[dragSource.nodeId]
-    if (srcNode) {
-      sourceSize = { width: srcNode.size.width, height: srcNode.size.height }
+    if (srcNode) sourceSize = { width: srcNode.size.width, height: srcNode.size.height }
+  } else if (dragSourceNodeSize) {
+    sourceSize = dragSourceNodeSize
+  }
+
+  // Ghost is rendered in screen-space (px), scaled to match the target zoom.
+  const ghostPxSize = { width: sourceSize.width * targetZoom, height: sourceSize.height * targetZoom }
+  // Cursor → ghost-top-left offset, also in screen-px. Anchor the cursor at
+  // the same relative point inside the ghost that the user grabbed. The grab
+  // offset is in screen pixels (relative to the source's on-screen rect), so
+  // we proportionally remap it to the ghost's screen-px size.
+  let ghostOffset: { x: number; y: number } = { x: ghostPxSize.width / 2, y: ghostPxSize.height / 2 }
+  if (grabOffsetCanvas) {
+    if (dragSource?.type === 'canvas') {
+      // grab offset is in canvas-space here (set by useNodeDrag)
+      ghostOffset = { x: grabOffsetCanvas.x * targetZoom, y: grabOffsetCanvas.y * targetZoom }
+    } else if (dockSourceSize) {
+      ghostOffset = {
+        x: (grabOffsetCanvas.x / dockSourceSize.width) * ghostPxSize.width,
+        y: (grabOffsetCanvas.y / dockSourceSize.height) * ghostPxSize.height,
+      }
     }
-    ghostPxSize = { width: sourceSize.width * targetZoom, height: sourceSize.height * targetZoom }
-    ghostOffset = grabOffsetCanvas
-      ? { x: grabOffsetCanvas.x * targetZoom, y: grabOffsetCanvas.y * targetZoom }
-      : { x: ghostPxSize.width / 2, y: ghostPxSize.height / 2 }
-  } else if (dragSource?.type === 'dock' && dockSourceSize && grabOffsetCanvas) {
-    // Preview at the canvas-default size (what the dropped node will actually
-    // be), not the source dock rect — otherwise the ghost looks huge compared
-    // to the resulting node. Rescale the grab offset proportionally so the
-    // cursor stays at the same relative spot inside the ghost.
-    ghostPxSize = { width: sourceSize.width * targetZoom, height: sourceSize.height * targetZoom }
-    ghostOffset = {
-      x: (grabOffsetCanvas.x / dockSourceSize.width) * ghostPxSize.width,
-      y: (grabOffsetCanvas.y / dockSourceSize.height) * ghostPxSize.height,
-    }
-  } else {
-    ghostPxSize = { width: sourceSize.width * targetZoom, height: sourceSize.height * targetZoom }
-    ghostOffset = { x: ghostPxSize.width / 2, y: ghostPxSize.height / 2 }
   }
   const defaults = ghostPxSize
 
@@ -120,37 +148,22 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
   const updateCursor = (clientX: number, clientY: number, rect: DOMRect) => {
     const x = clientX - rect.left
     const y = clientY - rect.top
-    const inEdgeStrip =
-      !(x > EDGE_STRIP &&
-        y > EDGE_STRIP &&
-        x < rect.width - EDGE_STRIP &&
-        y < rect.height - EDGE_STRIP)
-    // Pill-hover override: when the cursor is over the "Drop into canvas"
-    // pill itself, force center mode so the pill always wins regardless of
-    // a mini-dock underneath. The pill is a deliberate target — once the
-    // user lands on it, that's their intent.
-    const pillRect = pillRef.current?.getBoundingClientRect()
-    const overPill = !!pillRect &&
-      clientX >= pillRect.left && clientX <= pillRect.right &&
-      clientY >= pillRect.top && clientY <= pillRect.bottom
-    // Also yield to any registered mini-dock drop zone the cursor is sitting
-    // over — those are canvas-node mini-docks layered above the canvas, and
-    // we want their tab/split indicators to win over "Drop into canvas".
-    // Main-window dock zones (left/right/bottom) sit outside this overlay's
-    // rect so they're handled implicitly by onPointerLeave.
-    const overMiniDock = !overPill && getDropZoneEntries().some((entry) => {
-      if (!entry.dockStoreApi) return false
-      const r = entry.getRect()
-      if (!r) return false
-      return clientX >= r.left && clientX <= r.right && clientY >= r.top && clientY <= r.bottom
-    })
-    const center = overPill || (!inEdgeStrip && !overMiniDock)
+    const inOverlay = x >= 0 && y >= 0 && x <= rect.width && y <= rect.height
+    // Yield to the dock-zone drop indicators (left/right/bottom edges of the
+    // window) when the cursor sits in the outer edge strip. Without this,
+    // CanvasDropZone claims the whole canvas area and the underlying dock
+    // indicators never fire — so the user can't dock a panel into a hidden
+    // side zone by dragging to the edge anymore.
+    const inEdgeStrip = inOverlay && (
+      x < EDGE_STRIP ||
+      y < EDGE_STRIP ||
+      x > rect.width - EDGE_STRIP ||
+      y > rect.height - EDGE_STRIP
+    )
+    const center = inOverlay && !inEdgeStrip
     setCursor({ x, y })
     setInCenter(center)
     inCenterRef.current = center
-    // The source's mousemove handler checks this flag to decide whether to
-    // run its own hit-test. Only claim the cursor when we're in the center —
-    // otherwise let the dock's split-edge / mini-dock indicators fire.
     canvasDropZoneHovered = center
     if (center) {
       useDockDragStore.getState().setDropTarget(null)
@@ -191,16 +204,66 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
         // mouseup handler bails out instead of duplicating the drop.
         useDockDragStore.getState().markCanvasDropConsumed()
 
+        // Canvas-node mini-dock source — the user dragged the (only) tab of
+        // a canvas node back onto the same canvas. Treat as a reposition of
+        // the existing node instead of undock+add, which would leave an empty
+        // canvas node behind and spawn a duplicate.
+        if (dragSource?.type === 'dock' && sourceDockStoreApi) {
+          const ownedNodeId = findNodeIdForDockStore(sourceDockStoreApi)
+          if (ownedNodeId && canvasStoreApi.getState().nodes[ownedNodeId]) {
+            const sourceCs = canvasStoreApi.getState()
+            const localX = e.clientX - rect.left
+            const localY = e.clientY - rect.top
+            const zoom = sourceCs.zoomLevel
+            const vp = sourceCs.viewportOffset
+            const canvasX = (localX - vp.x) / zoom
+            const canvasY = (localY - vp.y) / zoom
+            const ownedNode = sourceCs.nodes[ownedNodeId]
+            // Map grab offset (screen-px inside the source dock rect) into
+            // canvas-space inside this node so the cursor lands at the same
+            // relative point of the node after the move.
+            let ox = ownedNode.size.width / 2
+            let oy = ownedNode.size.height / 2
+            if (grabOffsetCanvas && dockSourceSize) {
+              ox = (grabOffsetCanvas.x / dockSourceSize.width) * ownedNode.size.width
+              oy = (grabOffsetCanvas.y / dockSourceSize.height) * ownedNode.size.height
+            }
+            sourceCs.moveNode(ownedNodeId, { x: canvasX - ox, y: canvasY - oy })
+            snapToGridIfEnabled(canvasStoreApi, ownedNodeId)
+            useDockDragStore.getState().endDrag()
+            document.body.classList.remove('canvas-interacting')
+            setCursor(null)
+            setInCenter(false)
+            return
+          }
+        }
+
         // --- Remove from source -----------------------------------------
         if (dragSource?.type === 'dock') {
           const sourceStore = sourceDockStoreApi ?? useDockStore
           sourceStore.getState().undockPanel(draggedPanelId)
         } else if (dragSource?.type === 'canvas') {
-          // Self-drop guard: dropping back onto the same canvas → no-op move
-          // (the canvas-node body drag's regular path already moved it).
-          if (canvasStoreApi.getState().nodes[dragSource.nodeId]) {
+          // Self-drop onto the same canvas — reposition the existing node
+          // at the cursor instead of bailing. The body-drag path moves the
+          // node in real time, but a tab-initiated dock-drag never engages
+          // useNodeDrag, so without this the node stayed in place even though
+          // the user clearly meant to drop it at the cursor position.
+          const sourceCs = canvasStoreApi.getState()
+          if (sourceCs.nodes[dragSource.nodeId]) {
+            const localX = e.clientX - rect.left
+            const localY = e.clientY - rect.top
+            const zoom = sourceCs.zoomLevel
+            const vp = sourceCs.viewportOffset
+            const canvasX = (localX - vp.x) / zoom
+            const canvasY = (localY - vp.y) / zoom
+            const ox = grabOffsetCanvas?.x ?? sourceCs.nodes[dragSource.nodeId].size.width / 2
+            const oy = grabOffsetCanvas?.y ?? sourceCs.nodes[dragSource.nodeId].size.height / 2
+            sourceCs.moveNode(dragSource.nodeId, { x: canvasX - ox, y: canvasY - oy })
+            snapToGridIfEnabled(canvasStoreApi, dragSource.nodeId)
             useDockDragStore.getState().endDrag()
             document.body.classList.remove('canvas-interacting')
+            setCursor(null)
+            setInCenter(false)
             return
           }
           const sourceCanvas = findCanvasStoreForNode(dragSource.nodeId)
@@ -217,21 +280,17 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
         const vp = cs.viewportOffset
         const canvasX = (localX - vp.x) / zoom
         const canvasY = (localY - vp.y) / zoom
-        // Place the node's top-left so it matches the ghost preview. For
-        // canvas sources the grab offset is already in canvas-space. For
-        // dock sources it's in screen pixels and must be divided by zoom.
-        // The dropped node uses `sourceSize` (canvas default), but we want
-        // its top-left to match where the ghost was, which for dock is the
-        // grab offset centered on the real rect → we recenter inside the
-        // smaller canvas-default window to keep the cursor inside it.
+        // Place the node's top-left so the cursor lands at the same relative
+        // point inside the new node that the user grabbed in the source. For
+        // canvas sources the grab offset is already in canvas-space; for dock
+        // sources it's screen-px relative to the source rect and we rescale
+        // proportionally to the new node's canvas-space size.
         let offsetX: number
         let offsetY: number
         if (dragSource?.type === 'canvas' && grabOffsetCanvas) {
           offsetX = grabOffsetCanvas.x
           offsetY = grabOffsetCanvas.y
         } else if (dragSource?.type === 'dock' && dockSourceSize && grabOffsetCanvas) {
-          // Proportional offset inside the new (canvas-default) node so the
-          // cursor lands at the same relative position the user grabbed.
           offsetX = (grabOffsetCanvas.x / dockSourceSize.width) * sourceSize.width
           offsetY = (grabOffsetCanvas.y / dockSourceSize.height) * sourceSize.height
         } else {
@@ -254,6 +313,7 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
         // Focus the new node but DON'T pan the viewport — the user explicitly
         // dropped at this cursor position and expects it to stay there.
         canvasStoreApi.getState().focusNode(newNodeId)
+        snapToGridIfEnabled(canvasStoreApi, newNodeId)
 
         useDockDragStore.getState().endDrag()
         document.body.classList.remove('canvas-interacting')
@@ -336,13 +396,27 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
       </div>
 
       {/* Window-shaped ghost following the cursor — previews where the new
-          node will land. Centered on the cursor. */}
-      {cursor && (
+          node will land. Snaps to grid during drag when the setting is on,
+          mirroring the body-drag behavior. */}
+      {cursor && (() => {
+        // Unsnapped screen-space ghost top-left (cursor minus grab offset).
+        let ghostLeft = cursor.x - ghostOffset.x
+        let ghostTop = cursor.y - ghostOffset.y
+        if (snapEnabled && gridSpacing > 0) {
+          // Convert to canvas-space, snap, then back to screen-space.
+          const canvasX = (ghostLeft - viewportOffset.x) / targetZoom
+          const canvasY = (ghostTop - viewportOffset.y) / targetZoom
+          const snapX = Math.round(canvasX / gridSpacing) * gridSpacing
+          const snapY = Math.round(canvasY / gridSpacing) * gridSpacing
+          ghostLeft = snapX * targetZoom + viewportOffset.x
+          ghostTop = snapY * targetZoom + viewportOffset.y
+        }
+        return (
         <div
           style={{
             position: 'absolute',
-            left: cursor.x - ghostOffset.x,
-            top: cursor.y - ghostOffset.y,
+            left: ghostLeft,
+            top: ghostTop,
             width: defaults.width,
             height: defaults.height,
             borderRadius: 8,
@@ -389,7 +463,8 @@ function CanvasDropZoneInner({ canvasStoreApi }: CanvasDropZoneProps) {
             Drop to place here
           </div>
         </div>
-      )}
+        )
+      })()}
     </div>
   )
 }

--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -17,6 +17,8 @@ import { useAppStore } from '../stores/appStore'
 import { X, Columns, Plus, Terminal as TerminalIcon, Globe, FileText, GitBranch, TreeStructure, SquaresFour, List } from '@phosphor-icons/react'
 import DropZoneOverlay from './DropZoneOverlay'
 import { canvasDropZoneHovered } from './CanvasDropZone'
+import { findNodeIdForDockStore } from '../panels/CanvasPanel'
+import { findCanvasStoreForNode } from '../stores/canvasStore'
 
 // Human-readable labels for each panel type, used in tooltips and the split menu.
 const PANEL_TYPE_LABELS: Record<PanelType, string> = {
@@ -366,6 +368,26 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
           const sourceSize = stackRect
             ? { width: stackRect.width, height: stackRect.height }
             : null
+          // If this dock is a canvas-node mini-dock, capture the node's own
+          // canvas-space size so CanvasDropZone can preview + place at 1:1
+          // with the existing node instead of falling back to a default.
+          let sourceNodeSize: { width: number; height: number } | null = null
+          const ownedNodeId = findNodeIdForDockStore(dockStoreApi)
+          if (ownedNodeId) {
+            const cs = findCanvasStoreForNode(ownedNodeId)
+            const n = cs?.getState().nodes[ownedNodeId]
+            if (n) {
+              // If the node is maximized at drag-start, spring-load will
+              // un-maximize it shortly after, restoring node.size to its
+              // pre-maximize size. Use preMaximizeSize as the ghost size so
+              // the preview matches the final dropped/moved node, not the
+              // huge maximized rect that's about to shrink away.
+              const usePre = n.preMaximizeSize != null
+              const w = usePre ? n.preMaximizeSize!.width : n.size.width
+              const h = usePre ? n.preMaximizeSize!.height : n.size.height
+              sourceNodeSize = { width: w, height: h }
+            }
+          }
           useDockDragStore.getState().startDrag(
             panelId,
             panel.type,
@@ -374,6 +396,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
             dockStoreApi,
             grabOffset,
             sourceSize,
+            sourceNodeSize,
           )
         }
 
@@ -679,6 +702,11 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
     (activeDropTarget.type === 'tab' || activeDropTarget.type === 'split') &&
     'stackId' in activeDropTarget &&
     activeDropTarget.stackId === stack.id
+  // Show an inline "new tab" placeholder at the end of the existing tabs
+  // when a tab drop is active for this stack — gives the user a precise
+  // visual anchor for where the dropped panel will land, in place of the
+  // floating chip portal which can never quite sit beside the real tabs.
+  const showTabPlaceholder = isOver && activeDropTarget?.type === 'tab'
 
   return (
     <div ref={stackRef} className="flex flex-col h-full min-h-0 relative">
@@ -737,9 +765,15 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
                   if (isActive) return
                   if (!useDockDragStore.getState().isDragging) return
                   if (springLoadTimer.current) window.clearTimeout(springLoadTimer.current)
+                  // Canvas tabs spring-load faster (250ms) — the user is
+                  // explicitly trying to reveal the canvas to drop a tab on
+                  // it, and a 600ms wait felt unresponsive. Non-canvas tabs
+                  // keep the normal 600ms to avoid accidental activation
+                  // when the cursor merely traverses the tab strip.
+                  const delay = panelType === 'canvas' ? 250 : 600
                   springLoadTimer.current = window.setTimeout(() => {
                     setActiveTab(stack.id, i)
-                  }, 600)
+                  }, delay)
                 }}
                 onPointerLeave={() => {
                   if (springLoadTimer.current) {
@@ -812,6 +846,21 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
               </div>
             )
           })}
+          {showTabPlaceholder && (
+            <div
+              aria-hidden
+              className={`flex items-center justify-center whitespace-nowrap select-none border-r border-white/5 ${compact ? 'px-2 text-[11px]' : 'px-3 text-xs'}`}
+              style={{
+                minWidth: 100,
+                color: 'var(--focus-blue, #3b82f6)',
+                backgroundColor: 'color-mix(in srgb, var(--focus-blue, #3b82f6) 18%, transparent)',
+                border: '1px dashed color-mix(in srgb, var(--focus-blue, #3b82f6) 70%, transparent)',
+                borderRadius: 4,
+              }}
+            >
+              + new tab
+            </div>
+          )}
           {/* Draggable spacer that fills the rest of the row. In a detached
               dock window this is the macOS title-bar drag region. In a
               canvas-node mini-dock (onTabBarMouseDown set) it's instead a

--- a/src/renderer/docking/DropZoneOverlay.tsx
+++ b/src/renderer/docking/DropZoneOverlay.tsx
@@ -128,7 +128,10 @@ function DropPreview({ position }: { position: 'top' | 'bottom' | 'left' | 'righ
       case 'right':
         return { ...base, top: pad, right: pad, bottom: pad, width: `calc(50% - ${pad}px)` }
       case 'center':
-        return { ...base, top: pad, left: pad, right: pad, bottom: pad }
+        // 'center' / tab targets render an inline placeholder chip in the
+        // tab list (see DockTabStack), not a full-area overlay. We hide the
+        // portal preview for tab drops to avoid the duplicate blue box.
+        return { ...base, display: 'none' }
     }
   }, [position])
 

--- a/src/renderer/hooks/useCanvasInteraction.ts
+++ b/src/renderer/hooks/useCanvasInteraction.ts
@@ -8,6 +8,7 @@ import type { StoreApi } from 'zustand'
 import type { CanvasStore } from '../stores/canvasStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStore } from '../stores/uiStore'
+import { useDockDragStore } from './useDockDrag'
 import { viewToCanvas } from '../lib/coordinates'
 import { ZOOM_MIN, ZOOM_MAX } from '../../shared/types'
 import type { Point } from '../../shared/types'
@@ -77,33 +78,57 @@ export function useCanvasInteraction(
     setCanvasContextMenu(null)
   }, [])
 
+  // Helper — fully stop any in-flight zoom/pan animations and reset interaction
+  // refs. Called on unmount AND when a dock-drag begins, so canvas state can't
+  // continue mutating while the user is repositioning a panel via docking.
+  const cancelAllAnimations = useCallback(() => {
+    if (cancelInertia.current) {
+      cancelInertia.current()
+      cancelInertia.current = null
+    }
+    if (zoomRafId.current) {
+      cancelAnimationFrame(zoomRafId.current)
+      zoomRafId.current = 0
+    }
+    targetZoom.current = null
+    if (panRafId.current) {
+      cancelAnimationFrame(panRafId.current)
+      panRafId.current = 0
+    }
+    pendingPanDelta.current = { x: 0, y: 0 }
+    if (wheelPanEndTimer.current) {
+      clearTimeout(wheelPanEndTimer.current)
+      wheelPanEndTimer.current = null
+    }
+    if (wheelPanActive.current) {
+      document.body.classList.remove('canvas-interacting')
+      wheelPanActive.current = false
+    }
+    // Also stop the canvas store's own animateZoomTo rAF — it lives in a
+    // module-level variable inside canvasStore.ts (not in this hook's refs),
+    // so cancelling our local zoom rAF doesn't reach it. If a toolbar zoom or
+    // keyboard shortcut kicked it off and a dock-drag begins mid-flight,
+    // the world transform would keep scaling and the dimmed source would
+    // appear to "scale with movement" even though nothing's resizing it.
+    canvasStoreApi.getState().cancelZoomAnimation()
+  }, [canvasStoreApi])
+
   // Cancel animations on unmount to avoid memory leaks
   useEffect(() => {
-    return () => {
-      if (cancelInertia.current) {
-        cancelInertia.current()
-        cancelInertia.current = null
-      }
-      if (zoomRafId.current) {
-        cancelAnimationFrame(zoomRafId.current)
-        zoomRafId.current = 0
-      }
-      // Reset zoom target so a remount doesn't fire a stale animation
-      targetZoom.current = null
-      if (panRafId.current) {
-        cancelAnimationFrame(panRafId.current)
-        panRafId.current = 0
-      }
-      if (wheelPanEndTimer.current) {
-        clearTimeout(wheelPanEndTimer.current)
-        wheelPanEndTimer.current = null
-      }
-      if (wheelPanActive.current) {
-        document.body.classList.remove('canvas-interacting')
-        wheelPanActive.current = false
-      }
-    }
-  }, [])
+    return cancelAllAnimations
+  }, [cancelAllAnimations])
+
+  // When a dock-aware drag begins, immediately stop any zoom/pan momentum so
+  // the canvas isn't simultaneously moving + the user is dragging a tab.
+  // Subscribed on the store so the rAF/timer state is killed at the moment
+  // `isDragging` transitions to true, not on a re-render.
+  useEffect(() => {
+    let prev = useDockDragStore.getState().isDragging
+    return useDockDragStore.subscribe((s) => {
+      if (s.isDragging && !prev) cancelAllAnimations()
+      prev = s.isDragging
+    })
+  }, [cancelAllAnimations])
 
   // ---------------------------------------------------------------------------
   // Smooth zoom animation — interpolates zoomLevel toward targetZoom each frame
@@ -146,6 +171,14 @@ export function useCanvasInteraction(
 
   const handleWheel = useCallback(
     (e: React.WheelEvent<HTMLDivElement>) => {
+      // When a dock-drag is active, swallow wheel input. Trackpad gestures
+      // commonly fire alongside a mouse drag and would otherwise zoom/pan the
+      // canvas mid-drag, causing the ghost to misalign and the drop to land
+      // far from the cursor.
+      if (useDockDragStore.getState().isDragging) {
+        e.preventDefault()
+        return
+      }
       // If the scroll originated inside a focused panel's content area,
       // let the panel handle it — but only if the panel can scroll in that direction.
       // Horizontal swipes should pan the canvas when the panel has no horizontal scroll.

--- a/src/renderer/hooks/useDockDrag.ts
+++ b/src/renderer/hooks/useDockDrag.ts
@@ -49,6 +49,11 @@ export interface DockDragState {
    *  CanvasDropZone to render the ghost 1:1 with the real window. Null when
    *  unknown (e.g. canvas-source drags provide size via canvas node). */
   dragSourceSize: { width: number; height: number } | null
+  /** Canvas-space size of the source node when the drag originated inside a
+   *  canvas-node mini-dock (or from a canvas node body). Lets CanvasDropZone
+   *  preview AND place the dropped node at the existing node's actual size
+   *  instead of falling back to PANEL_DEFAULT_SIZES. Null otherwise. */
+  dragSourceNodeSize: { width: number; height: number } | null
 }
 
 interface DockDragActions {
@@ -61,6 +66,7 @@ interface DockDragActions {
     sourceDockStoreApi?: StoreApi<DockStore> | null,
     grabOffset?: Point | null,
     sourceSize?: { width: number; height: number } | null,
+    sourceNodeSize?: { width: number; height: number } | null,
   ) => void
   /** Update cursor position during drag */
   updateCursor: (position: Point) => void
@@ -89,8 +95,9 @@ export const useDockDragStore = create<DockDragState & DockDragActions>((set) =>
   canvasDropConsumed: false,
   dragGrabOffset: null,
   dragSourceSize: null,
+  dragSourceNodeSize: null,
 
-  startDrag(panelId, panelType, panelTitle, source, sourceDockStoreApi = null, grabOffset = null, sourceSize = null) {
+  startDrag(panelId, panelType, panelTitle, source, sourceDockStoreApi = null, grabOffset = null, sourceSize = null, sourceNodeSize = null) {
     set({
       isDragging: true,
       draggedPanelId: panelId,
@@ -103,6 +110,7 @@ export const useDockDragStore = create<DockDragState & DockDragActions>((set) =>
       canvasDropConsumed: false,
       dragGrabOffset: grabOffset,
       dragSourceSize: sourceSize,
+      dragSourceNodeSize: sourceNodeSize,
     })
   },
 
@@ -131,6 +139,7 @@ export const useDockDragStore = create<DockDragState & DockDragActions>((set) =>
       canvasDropConsumed: false,
       dragGrabOffset: null,
       dragSourceSize: null,
+      dragSourceNodeSize: null,
     })
   },
 }))
@@ -178,35 +187,45 @@ export function getDropZoneEntries(): readonly DropZoneEntry[] {
 const TAB_BAR_DROP_HINT = 38
 
 /** Resolve which of the 5 drop zones (top/bottom/left/right/center) the cursor
- *  is in relative to a container rect. Returns the edge or 'center'. */
+ *  is in relative to a container rect. Returns the edge, 'center' (only when
+ *  the cursor is over the tab strip), or null when the cursor is in the
+ *  body's safe zone — letting the drag pass through without activating any
+ *  drop target. This avoids the prior eager behavior where the entire panel
+ *  body lit up with a full-screen blue tab indicator the moment the cursor
+ *  passed over it. */
 export function resolveDropEdge(
   cursorX: number,
   cursorY: number,
   rect: DOMRect,
-): 'top' | 'bottom' | 'left' | 'right' | 'center' {
+): 'top' | 'bottom' | 'left' | 'right' | 'center' | null {
   const relX = cursorX - rect.left
   const relY = cursorY - rect.top
   const w = rect.width
   const h = rect.height
 
-  // Tab-bar zone: cursor over the tab strip → always a tab drop, never split.
-  // This makes "drag onto the header" land as a sibling tab rather than as
-  // a split-top, and prevents the drop indicator from overlapping the tab bar.
+  // Tab-bar zone: cursor over the tab strip → tab drop ("add as new tab").
+  // Anywhere else in the body returns null unless the cursor is genuinely
+  // on an edge, so docking only triggers when the user means it.
   if (relY >= 0 && relY < TAB_BAR_DROP_HINT) return 'center'
 
-  // Edge zones: 25% strip along each edge
-  const edgeFraction = 0.25
-  const leftEdge = w * edgeFraction
-  const rightEdge = w * (1 - edgeFraction)
-  const topEdge = h * edgeFraction
-  const bottomEdge = h * (1 - edgeFraction)
+  // Edge zones: a narrow ~12% strip (capped at 60px) along each edge.
+  // Previously 25%, which meant a quarter of every panel was a split zone
+  // and you couldn't drag a tab across the canvas without triggering one.
+  const edgeFraction = 0.12
+  const EDGE_MAX_PX = 60
+  const leftEdge = Math.min(w * edgeFraction, EDGE_MAX_PX)
+  const rightEdgeStart = w - leftEdge
+  const topEdge = Math.min(h * edgeFraction, EDGE_MAX_PX)
+  const bottomEdgeStart = h - topEdge
 
-  // Check edges in priority order
+  // Check edges in priority order — diagonal regions resolve to the nearer
+  // edge so a corner doesn't flicker between two split targets.
   if (relY < topEdge && relY < relX && relY < (w - relX)) return 'top'
-  if (relY > bottomEdge && (h - relY) < relX && (h - relY) < (w - relX)) return 'bottom'
+  if (relY > bottomEdgeStart && (h - relY) < relX && (h - relY) < (w - relX)) return 'bottom'
   if (relX < leftEdge) return 'left'
-  if (relX > rightEdge) return 'right'
-  return 'center'
+  if (relX > rightEdgeStart) return 'right'
+  // Body — no drop target, let the drag pass through.
+  return null
 }
 
 /** Full hit test that also returns the matched entry's owning DockStore (if any).
@@ -272,6 +291,11 @@ function hitTestInternal(
 
   if (best.entry.stackId) {
     const edge = resolveDropEdge(cursorX, cursorY, best.rect)
+    if (edge === null) {
+      // Body safe zone — no drop. Let the drag pass through (e.g. to the
+      // canvas) instead of hijacking it with a full-panel tab indicator.
+      return null
+    }
     if (edge === 'center') {
       return { target: { type: 'tab', stackId: best.entry.stackId }, entry: best.entry }
     }

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -39,6 +39,20 @@ export function findNodeDockStore(nodeId: string): StoreApi<DockStore> | null {
   return null
 }
 
+/** Reverse lookup — given a DockStore, return the canvas-node id it backs
+ *  (or null if the store isn't a per-canvas-node mini-dock). Lets drop handlers
+ *  recognise drags that originated inside a canvas node and treat them as a
+ *  node move instead of an undock + add. */
+export function findNodeIdForDockStore(store: StoreApi<DockStore>): string | null {
+  for (const [key, s] of nodeStoreMap.entries()) {
+    if (s === store) {
+      const idx = key.indexOf(':')
+      return idx >= 0 ? key.slice(idx + 1) : null
+    }
+  }
+  return null
+}
+
 // ---------------------------------------------------------------------------
 // Helper — walk a DockLayoutNode tree and collect panel locations
 // ---------------------------------------------------------------------------
@@ -139,6 +153,34 @@ const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, zoomLevel, render
       nodeStoreMap.delete(storeKey)
     }
   }, [storeKey])
+
+  // ------------------------------------------------------------------
+  // Sweep orphan panel IDs from this mini-dock's layout — IDs that don't
+  // exist in ws.panels (e.g. session-restore mismatch, panel cleanup that
+  // missed canvas-node layouts). These render as a generic "Panel" tab
+  // with the editor icon because the panel record can't be resolved.
+  // Watch the workspace's panels record reactively so a panel that's
+  // added later (e.g. async restore) doesn't get pruned by an early run.
+  // ------------------------------------------------------------------
+  const workspacePanels = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === useAppStore.getState().selectedWorkspaceId)?.panels,
+  )
+  useEffect(() => {
+    if (!workspacePanels) return
+    const layout = dockStoreApi.getState().zones.center.layout
+    if (!layout) return
+    const collectOrphans = (n: DockLayoutNode): string[] => {
+      if (n.type === 'tabs') return n.panelIds.filter((id) => !workspacePanels[id])
+      const out: string[] = []
+      for (const c of n.children) out.push(...collectOrphans(c))
+      return out
+    }
+    const orphans = collectOrphans(layout)
+    if (orphans.length === 0) return
+    for (const id of orphans) {
+      try { dockStoreApi.getState().undockPanel(id) } catch { /* ignore */ }
+    }
+  }, [workspacePanels, dockStoreApi])
 
   const renderPanel = useCallback(
     (panelId: string) => renderPanelContent?.(panelId, nodeId, zoomLevel) ?? null,

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -12,7 +12,10 @@ export const ProjectList: React.FC = () => {
   const removeWorkspace = useAppStore((s) => s.removeWorkspace)
 
   const handleNewWorkspace = useCallback(() => {
-    const wsId = addWorkspace()
+    // If there's already an uninitialized workspace (no folder picked yet),
+    // reuse it instead of stacking another empty "Add Workspace" row.
+    const existing = useAppStore.getState().workspaces.find((w) => !w.rootPath)
+    const wsId = existing ? existing.id : addWorkspace()
     selectWorkspace(wsId)
   }, [addWorkspace, selectWorkspace])
 

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -385,13 +385,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         <span className="flex-1 min-w-0 text-[14px] truncate italic">
           {workspace.isRootPathPending ? 'Connecting…' : 'Add Workspace'}
         </span>
-        <button
-          className="flex-shrink-0 opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity"
-          onClick={(e) => { e.stopPropagation(); onClose() }}
-          title="Close Workspace"
-        >
-          <DotsThree size={14} />
-        </button>
       </div>
     )
   }

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -400,8 +400,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // Snapshot current canvas state back into the outgoing workspace
     get().syncCanvasToWorkspace(state.selectedWorkspaceId)
 
+    // Discard outgoing workspace if it was never initialized (no folder
+    // picked, not currently picking one). Keeps stray "Add Workspace" rows
+    // from accumulating in the sidebar.
+    const outgoing = state.workspaces.find((w) => w.id === state.selectedWorkspaceId)
+    const shouldDropOutgoing =
+      !!outgoing && !outgoing.rootPath && !outgoing.isRootPathPending && outgoing.id !== id
+
     // Switch selection
     set({ selectedWorkspaceId: id })
+
+    if (shouldDropOutgoing && outgoing) {
+      get().removeWorkspace(outgoing.id)
+    }
 
     // Load the new workspace's canvas state into the canvas store
     const ws = get().workspaces.find((w) => w.id === id)
@@ -500,6 +511,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
           return { ...w, panels }
         }),
       }))
+    }
+
+    // Sweep orphaned dock tabs (in some dock zone but not in ws.panels). These
+    // appear after a panel state was dropped without the dock layout being
+    // updated — e.g. closeAllPanels wiping ws.panels, or a stale snapshot
+    // restore — and render as a generic "Panel" tab with the editor icon.
+    const orphanedDockIds = Array.from(allDockPanelIds).filter((id) => !ws.panels[id])
+    if (orphanedDockIds.length > 0) {
+      for (const id of orphanedDockIds) {
+        try { useDockStore.getState().undockPanel(id) } catch { /* ignore */ }
+      }
     }
 
     // Check if the center zone now contains a canvas-type panel
@@ -1190,6 +1212,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // Clear the canvas store if this is the active workspace
     if (wsId === get().selectedWorkspaceId) {
       canvasOps?.clearAllNodes()
+      // Reset the dock to a clean state so the just-cleared panel IDs don't
+      // linger in dock zones as orphan tabs (which render as a generic
+      // "Panel" tab with an editor icon).
+      useDockStore.getState().restoreSnapshot({
+        zones: {
+          left:   { position: 'left',   visible: false, size: 260, layout: null },
+          right:  { position: 'right',  visible: false, size: 260, layout: null },
+          bottom: { position: 'bottom', visible: false, size: 240, layout: null },
+          center: { position: 'center', visible: true,  size: 0,   layout: null },
+        },
+        locations: {},
+      })
+      get().ensureCenterCanvas(wsId)
     }
   },
 


### PR DESCRIPTION
## Summary
- Docking-mode drag-and-drop: drop anywhere on canvas (60px edge strip reserved for dock indicators), ghost matches dropped node size (with grid-snap during drag), source hidden during drag so it no longer appears to scale.
- Stops canvas zoom/pan animations and swallows wheel input while a dock-drag is active — zoom and drag can't happen simultaneously.
- Spring-load: maximized canvas nodes un-maximize after 200ms into a drag; canvas tabs spring-activate at 250ms.
- Tab title/icon resolution hardened (fallback to fresh appStore read + panel-type label); orphan panelIds swept from canvas-node mini-dock layouts.
- Update & restart now actually relaunches: `quitAndInstall(false, true)` + `will-quit` defers its `reallyExit(0)` shortcut while an install is in flight.
- Version bumped to 0.4.4 to trigger CD.

## Test plan
- [ ] In docking mode, drag a canvas-node tab → ghost matches node size, drops at cursor; source hidden during drag, restored at new position.
- [ ] Drag from main dock onto canvas → ghost at default size; snaps to grid both during drag and on drop.
- [ ] Drag toward window edges → left/right/bottom dock indicators show and accept the drop.
- [ ] While dragging a tab, try to trackpad-pinch or two-finger-pan → canvas does not zoom/pan.
- [ ] Maximize a canvas terminal node → drag any tab; node un-maximizes within ~200ms revealing the canvas.
- [ ] Inactive Canvas tab in a dock zone → drag a tab over it → canvas activates in ~250ms.
- [ ] Run installed v0.4.4, install next release → app actually relaunches after "Update & Restart".