### PR TITLE
chore(release): v0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.4.5

Patch release covering the refactor/cleanup work merged since v0.4.4:
- Unified drag system, drop annotations/drawings, split DockTabStack (#44)
- Remove unused files / dead code / stale .claude artifacts (#46)
- Remove website, docs, stale resources/test-results dirs (#45)
- Simplify surface area: notifications, grid snap, URL prompt, IPC (#43)

## Test plan
- [ ] CI green
- [ ] After merge, tag `v0.4.5` on the merge commit to trigger the release workflow