### PR TITLE
refactor(panels): introduce panel-type registry

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { saveCrashReport, checkPendingCrashReport } from './crashReporter'
 import { beginTerminalTransfer, acknowledgeTerminalTransfer, handleCrossWindowDropTerminalTransfer } from './ipc/terminal'
 import type { CateWindowParams, DockWindowInitPayload, PanelState, PanelTransferSnapshot, WindowDockState } from '../shared/types'
 import { disableRendererSandbox, disableTrustScoping } from './featureFlags'
+import { getSharedPanelDef } from '../shared/panels'
 import { installWebContentsSecurity } from './webSecurity'
 import {
   startCrossWindowDrag,
@@ -307,17 +308,8 @@ function createDragGhostWindow(
   // Ignore mouse events so the ghost doesn't interfere with drop targets
   dragGhostWin.setIgnoreMouseEvents(true)
 
-  const iconMap: Record<string, string> = {
-    terminal: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(77,217,100)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>',
-    browser: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(74,158,255)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>',
-    editor: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(255,159,10)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>',
-    git: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(255,59,48)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>',
-    fileExplorer: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(90,200,250)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>',
-    projectList: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(255,214,10)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>',
-    canvas: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgb(191,90,242)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>',
-  }
   const escapeHtml = (s: string) => s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]!))
-  const icon = iconMap[panelType] || iconMap['editor']
+  const icon = getSharedPanelDef(panelType).ghostSvg
   const safeTitle = escapeHtml(panelTitle.slice(0, 40))
   const html = `data:text/html;charset=utf-8,<!DOCTYPE html>
 <html><head><style>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,22 +22,8 @@ import {
 } from './lib/agentScreenDetector'
 import type { AgentState } from '../shared/types'
 import { Sidebar, RightSidebar } from './sidebar/Sidebar'
-// Kick off the dynamic imports immediately so the panel chunks download in
-// parallel with settings/session load, instead of waiting for first render.
-const terminalPanelImport = import('./panels/TerminalPanel')
-const editorPanelImport = import('./panels/EditorPanel')
-const browserPanelImport = import('./panels/BrowserPanel')
-const gitPanelImport = import('./panels/GitPanel')
-const fileExplorerPanelImport = import('./panels/FileExplorerPanel')
-const projectListPanelImport = import('./panels/ProjectListPanel')
-const canvasPanelImport = import('./panels/CanvasPanel')
-const TerminalPanel = React.lazy(() => terminalPanelImport)
-const EditorPanel = React.lazy(() => editorPanelImport)
-const BrowserPanel = React.lazy(() => browserPanelImport)
-const GitPanel = React.lazy(() => gitPanelImport)
-const FileExplorerPanel = React.lazy(() => fileExplorerPanelImport)
-const ProjectListPanel = React.lazy(() => projectListPanelImport)
-const CanvasPanel = React.lazy(() => canvasPanelImport)
+import { renderPanelComponent, PANEL_REGISTRY } from './panels/registry'
+const CanvasPanel = PANEL_REGISTRY.canvas.Component
 import { NodeSwitcher } from './ui/NodeSwitcher'
 import { PanelSwitcher } from './ui/PanelSwitcher'
 import { CommandPalette } from './ui/CommandPalette'
@@ -416,32 +402,11 @@ function MainApp() {
       const panel = currentWorkspace.panels[panelId]
       if (!panel) return null
 
-      let content: React.ReactNode = null
-      switch (panel.type) {
-        case 'terminal':
-          content = <TerminalPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} />
-          break
-        case 'editor':
-          content = <EditorPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} filePath={panel.filePath} />
-          break
-        case 'browser':
-          content = <BrowserPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} url={panel.url} zoomLevel={zoom} />
-          break
-        case 'git':
-          content = <GitPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} />
-          break
-        case 'fileExplorer':
-          content = <FileExplorerPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} />
-          break
-        case 'projectList':
-          content = <ProjectListPanel panelId={panelId} workspaceId={selectedWorkspaceId} nodeId={nodeId} />
-          break
-        case 'canvas':
-          // Canvas panels should not be nested on another canvas — they only live in dock zones
-          return null
-        default:
-          return null
-      }
+      // Canvas panels should not be nested on another canvas — they only live in dock zones
+      if (panel.type === 'canvas') return null
+
+      const content = renderPanelComponent(panel, { workspaceId: selectedWorkspaceId, nodeId, zoomLevel: zoom })
+      if (!content) return null
 
       return (
         <Suspense fallback={<div className="w-full h-full bg-surface-4 flex items-center justify-center text-muted text-sm">Loading...</div>}>

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -25,6 +25,7 @@ import { saveEditor } from '../lib/editorSaveRegistry'
 import { ArrowsOutSimple, ArrowsInSimple, X, Lock, LockOpen } from '@phosphor-icons/react'
 import { resolveTerminalPreset } from '../lib/terminalRegistry'
 import { useSettingsStore } from '../stores/settingsStore'
+import { PANEL_DEFINITIONS } from '../../shared/panels'
 
 // -----------------------------------------------------------------------------
 // Props
@@ -246,13 +247,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     (panelId: string) => {
       const p = resolvePanel(panelId)
       if (p?.title) return p.title
-      if (p?.type) {
-        const labels: Record<PanelType, string> = {
-          terminal: 'Terminal', browser: 'Browser', editor: 'Editor',
-          git: 'Git', fileExplorer: 'File Explorer', projectList: 'Projects', canvas: 'Canvas',
-        }
-        return labels[p.type] ?? 'Panel'
-      }
+      if (p?.type) return PANEL_DEFINITIONS[p.type]?.label ?? 'Panel'
       return 'Panel'
     },
     [resolvePanel],

--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -6,6 +6,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useCanvasStoreContext, useCanvasStoreApi, shallow } from '../stores/CanvasStoreContext'
 import { useWorkspacePanels } from '../stores/appStore'
 import { panelColor as brandPanelColor } from '../panels/types'
+import { PANEL_REGISTRY } from '../panels/registry'
+import type { PanelType } from '../../shared/types'
 
 const MINIMAP_DEFAULT_WIDTH = 200
 const MINIMAP_DEFAULT_HEIGHT = 150
@@ -35,12 +37,8 @@ const loadSize = (): { w: number; h: number } => {
 }
 
 function mutedPanelColor(panelType: string): string {
-  switch (panelType) {
-    case 'terminal': return '#4a9960'
-    case 'editor': return '#b07440'
-    case 'browser': return '#4a7ab0'
-    default: return '#888'
-  }
+  const def = PANEL_REGISTRY[panelType as PanelType]
+  return def?.mutedColor ?? '#888'
 }
 
 interface MinimapProps {

--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -7,31 +7,19 @@
 
 import React from 'react'
 import type { PanelState, PanelType, DockTabStack as DockTabStackType } from '../../shared/types'
-import { X, Terminal as TerminalIcon, Globe, FileText, GitBranch, TreeStructure, SquaresFour, List } from '@phosphor-icons/react'
+import { X } from '@phosphor-icons/react'
 import { useDragStore, useTabSourceVisibility } from '../drag'
+import { PANEL_REGISTRY, getPanelDef } from '../panels/registry'
 
 // Type → icon/tint mirrors the Spotlight overlay so tabs, search results, and
 // the command palette speak the same visual language.
-export const PANEL_TYPE_TINT: Record<PanelType, string> = {
-  terminal: 'text-emerald-400',
-  browser: 'text-sky-400',
-  editor: 'text-orange-400',
-  git: 'text-red-400',
-  fileExplorer: 'text-cyan-400',
-  projectList: 'text-yellow-400',
-  canvas: 'text-violet-400',
-}
+export const PANEL_TYPE_TINT: Record<PanelType, string> = Object.fromEntries(
+  (Object.keys(PANEL_REGISTRY) as PanelType[]).map((t) => [t, PANEL_REGISTRY[t].tintClass]),
+) as Record<PanelType, string>
 
 export function TabIcon({ type, size }: { type: PanelType; size: number }) {
-  switch (type) {
-    case 'terminal':     return <TerminalIcon size={size} />
-    case 'browser':      return <Globe size={size} />
-    case 'editor':       return <FileText size={size} />
-    case 'git':          return <GitBranch size={size} />
-    case 'fileExplorer': return <TreeStructure size={size} />
-    case 'projectList':  return <List size={size} />
-    case 'canvas':       return <SquaresFour size={size} />
-  }
+  const Icon = getPanelDef(type).icon
+  return <Icon size={size} />
 }
 
 /** Thin wrapper around the tab-pill DOM that calls useTabSourceVisibility(panelId)

--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -14,17 +14,12 @@ import { DockTabContextMenu, SPLIT_MENU_ITEMS } from './DockTabContextMenu'
 import type { SplitMenuItem } from './DockTabContextMenu'
 import { useDockTabActions, useAcceptsPanelType } from './useDockTabActions'
 import { useDockTabDrag } from './useDockTabDrag'
+import { PANEL_DEFINITIONS } from '../../shared/panels'
 
 // Human-readable labels for each panel type, used in tooltips and the split menu.
-const PANEL_TYPE_LABELS: Record<PanelType, string> = {
-  editor: 'Editor',
-  terminal: 'Terminal',
-  browser: 'Browser',
-  git: 'Git',
-  fileExplorer: 'File Explorer',
-  projectList: 'Projects',
-  canvas: 'Canvas',
-}
+const PANEL_TYPE_LABELS: Record<PanelType, string> = Object.fromEntries(
+  (Object.keys(PANEL_DEFINITIONS) as PanelType[]).map((t) => [t, PANEL_DEFINITIONS[t].label]),
+) as Record<PanelType, string>
 
 interface DockTabStackProps {
   stack: DockTabStackType

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -13,6 +13,7 @@ import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStore } from '../stores/uiStore'
 import type { DockStore } from '../stores/dockStore'
+import { getPanelDef } from '../panels/registry'
 
 export interface DockTabActionsParams {
   stack: DockTabStackType
@@ -96,28 +97,9 @@ export function useDockTabActions(params: DockTabActionsParams) {
       const placement: import('../stores/appStore').PanelPlacement = localOnly
         ? { target: 'none' }
         : { target: 'dock', zone }
-      const app = useAppStore.getState()
-      switch (type) {
-        case 'editor': {
-          const filePath =
-            activePanel?.type === 'editor' && !activePanel.diffMode ? activePanel.filePath : undefined
-          return app.createEditor(wsId, filePath, undefined, placement) || null
-        }
-        case 'terminal':
-          return app.createTerminal(wsId, undefined, undefined, placement) || null
-        case 'browser':
-          return app.createBrowser(wsId, undefined, undefined, placement) || null
-        case 'git':
-          return app.createGit(wsId, undefined, placement) || null
-        case 'fileExplorer':
-          return app.createFileExplorer(wsId, undefined, placement) || null
-        case 'projectList':
-          return app.createProjectList(wsId, undefined, placement) || null
-        case 'canvas':
-          return app.createCanvas(wsId, undefined, placement) || null
-        default:
-          return null
-      }
+      const filePath =
+        activePanel?.type === 'editor' && !activePanel.diffMode ? activePanel.filePath : undefined
+      return getPanelDef(type).create({ workspaceId: wsId, placement, filePath })
     },
     [activePanel, workspaceId, zone, localOnly],
   )

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -27,6 +27,7 @@ import {
   findNodeDockStore,
   findNodeIdForDockStore,
 } from './nodeDockRegistry'
+import { getPanelDef } from '../panels/registry'
 
 // Re-export the lookup helpers so existing callers (drag dispatcher, drop
 // resolver) keep working through the same import path. New code should import
@@ -224,32 +225,7 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
 
   const onCreateAtPoint = useCallback(
     (type: PanelType, canvasPoint: Point) => {
-      if (type === 'canvas') {
-        // Canvas panels don't go on canvases — create via appStore which routes to center zone
-        useAppStore.getState().createCanvas(workspaceId)
-        return
-      }
-      const appStore = useAppStore.getState()
-      switch (type) {
-        case 'terminal':
-          appStore.createTerminal(workspaceId, undefined, canvasPoint)
-          break
-        case 'browser':
-          appStore.createBrowser(workspaceId, undefined, canvasPoint)
-          break
-        case 'editor':
-          appStore.createEditor(workspaceId, undefined, canvasPoint)
-          break
-        case 'git':
-          appStore.createGit(workspaceId, canvasPoint)
-          break
-        case 'fileExplorer':
-          appStore.createFileExplorer(workspaceId, canvasPoint)
-          break
-        case 'projectList':
-          appStore.createProjectList(workspaceId, canvasPoint)
-          break
-      }
+      getPanelDef(type).create({ workspaceId, canvasPoint })
     },
     [workspaceId],
   )

--- a/src/renderer/panels/registry.ts
+++ b/src/renderer/panels/registry.ts
@@ -1,0 +1,168 @@
+// =============================================================================
+// Panel registry (renderer side)
+//
+// Extends the shared per-type data in `src/shared/panels.ts` with renderer-only
+// concerns: the Phosphor icon component, the lazy panel component, and a
+// factory that maps to the right `appStore.createXxx()` call.
+//
+// Every place that used to switch on `panel.type` should read from
+// PANEL_REGISTRY here instead. Adding a new panel type is a two-touch change:
+//   1. add a SharedPanelDefinition in src/shared/panels.ts
+//   2. add a RendererPanelDefinition entry here
+// Nothing else in the renderer or main process needs to know about it.
+// =============================================================================
+
+import React, { type LazyExoticComponent, type ComponentType } from 'react'
+import {
+  Terminal,
+  Globe,
+  FileText,
+  GitBranch,
+  TreeStructure,
+  SquaresFour,
+  List,
+  type Icon as PhosphorIcon,
+} from '@phosphor-icons/react'
+import type { PanelType, Point } from '../../shared/types'
+import type { PanelPlacement } from '../stores/appStore'
+import { useAppStore } from '../stores/appStore'
+import { PANEL_DEFINITIONS, type SharedPanelDefinition } from '../../shared/panels'
+import type { PanelProps } from './types'
+
+// -----------------------------------------------------------------------------
+// Lazy-loaded panel components. The `import(...)` expression on the right-hand
+// side is what splits each panel into its own chunk, so this file is the only
+// place that knows the per-type chunk boundary.
+// -----------------------------------------------------------------------------
+
+const TerminalPanel = React.lazy(() => import('./TerminalPanel'))
+const EditorPanel = React.lazy(() => import('./EditorPanel'))
+const BrowserPanel = React.lazy(() => import('./BrowserPanel'))
+const GitPanel = React.lazy(() => import('./GitPanel'))
+const FileExplorerPanel = React.lazy(() => import('./FileExplorerPanel'))
+const ProjectListPanel = React.lazy(() => import('./ProjectListPanel'))
+const CanvasPanel = React.lazy(() => import('./CanvasPanel'))
+
+// -----------------------------------------------------------------------------
+// Renderer definition
+// -----------------------------------------------------------------------------
+
+/** Arguments accepted by panel factories. Each factory ignores fields it
+ *  doesn't understand — e.g. the git factory ignores `filePath`. */
+export interface PanelCreateArgs {
+  workspaceId: string
+  canvasPoint?: Point
+  placement?: PanelPlacement
+  /** Editor only. */
+  filePath?: string
+  /** Browser only. */
+  url?: string
+  /** Terminal only. */
+  initialInput?: string
+}
+
+export interface RendererPanelDefinition extends SharedPanelDefinition {
+  icon: PhosphorIcon
+  /** React.lazy() wrapped panel component. Accepts the standard PanelProps
+   *  plus optional per-type extras (filePath/url/zoomLevel) — the dispatcher
+   *  reads those off the PanelState. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Component: LazyExoticComponent<ComponentType<any>>
+  /** Spawn a fresh panel of this type into the workspace. Returns the new
+   *  panelId or null if creation failed. */
+  create: (args: PanelCreateArgs) => string | null
+}
+
+// -----------------------------------------------------------------------------
+// Registry
+// -----------------------------------------------------------------------------
+
+export const PANEL_REGISTRY: Record<PanelType, RendererPanelDefinition> = {
+  terminal: {
+    ...PANEL_DEFINITIONS.terminal,
+    icon: Terminal,
+    Component: TerminalPanel,
+    create: ({ workspaceId, canvasPoint, placement, initialInput }) =>
+      useAppStore.getState().createTerminal(workspaceId, initialInput, canvasPoint, placement) || null,
+  },
+  browser: {
+    ...PANEL_DEFINITIONS.browser,
+    icon: Globe,
+    Component: BrowserPanel,
+    create: ({ workspaceId, canvasPoint, placement, url }) =>
+      useAppStore.getState().createBrowser(workspaceId, url, canvasPoint, placement) || null,
+  },
+  editor: {
+    ...PANEL_DEFINITIONS.editor,
+    icon: FileText,
+    Component: EditorPanel,
+    create: ({ workspaceId, canvasPoint, placement, filePath }) =>
+      useAppStore.getState().createEditor(workspaceId, filePath, canvasPoint, placement) || null,
+  },
+  git: {
+    ...PANEL_DEFINITIONS.git,
+    icon: GitBranch,
+    Component: GitPanel,
+    create: ({ workspaceId, canvasPoint, placement }) =>
+      useAppStore.getState().createGit(workspaceId, canvasPoint, placement) || null,
+  },
+  fileExplorer: {
+    ...PANEL_DEFINITIONS.fileExplorer,
+    icon: TreeStructure,
+    Component: FileExplorerPanel,
+    create: ({ workspaceId, canvasPoint, placement }) =>
+      useAppStore.getState().createFileExplorer(workspaceId, canvasPoint, placement) || null,
+  },
+  projectList: {
+    ...PANEL_DEFINITIONS.projectList,
+    icon: List,
+    Component: ProjectListPanel,
+    create: ({ workspaceId, canvasPoint, placement }) =>
+      useAppStore.getState().createProjectList(workspaceId, canvasPoint, placement) || null,
+  },
+  canvas: {
+    ...PANEL_DEFINITIONS.canvas,
+    icon: SquaresFour,
+    Component: CanvasPanel,
+    create: ({ workspaceId, canvasPoint, placement }) =>
+      useAppStore.getState().createCanvas(workspaceId, canvasPoint, placement) || null,
+  },
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/** Lookup the renderer definition for a panel type. Falls back to the editor
+ *  definition for unknown values so the UI degrades to a sensible default
+ *  rather than blowing up. */
+export function getPanelDef(type: PanelType | string): RendererPanelDefinition {
+  return PANEL_REGISTRY[type as PanelType] ?? PANEL_REGISTRY.editor
+}
+
+/** Render the component for a panel. Reads the panel's per-type extras off
+ *  the panel state itself, so callers don't need to know which extras any
+ *  given type expects. Caller wraps in <Suspense> at the boundary it wants. */
+export function renderPanelComponent(
+  panel: { type: PanelType; id: string; filePath?: string; url?: string },
+  ctx: { workspaceId: string; nodeId: string; zoomLevel?: number },
+): React.ReactElement | null {
+  const def = PANEL_REGISTRY[panel.type]
+  if (!def) return null
+  const { Component } = def
+  // Per-type extras are passed through; components that don't accept them
+  // simply ignore the extra props.
+  const extras: Record<string, unknown> = {}
+  if (panel.type === 'editor') extras.filePath = panel.filePath
+  if (panel.type === 'browser') {
+    extras.url = panel.url
+    extras.zoomLevel = ctx.zoomLevel ?? 1
+  }
+  const props: PanelProps & Record<string, unknown> = {
+    panelId: panel.id,
+    workspaceId: ctx.workspaceId,
+    nodeId: ctx.nodeId,
+    ...extras,
+  }
+  return React.createElement(Component, props)
+}

--- a/src/renderer/panels/types.ts
+++ b/src/renderer/panels/types.ts
@@ -3,6 +3,7 @@
 // =============================================================================
 
 import type { PanelType } from '../../shared/types'
+import { PANEL_DEFINITIONS } from '../../shared/panels'
 
 // -----------------------------------------------------------------------------
 // Base panel props
@@ -35,42 +36,7 @@ export interface BrowserPanelProps extends PanelProps {
 // Panel display helpers
 // -----------------------------------------------------------------------------
 
-/** Returns a Lucide icon name for the given panel type. */
-export function panelIcon(type: PanelType): string {
-  switch (type) {
-    case 'terminal':
-      return 'Terminal'
-    case 'browser':
-      return 'Globe'
-    case 'editor':
-      return 'FileText'
-    case 'git':
-      return 'GitBranch'
-    case 'fileExplorer':
-      return 'FolderOpen'
-    case 'projectList':
-      return 'Layers'
-    case 'canvas':
-      return 'Layout'
-  }
-}
-
 /** Returns a brand color hex string for the given panel type. */
 export function panelColor(type: PanelType): string {
-  switch (type) {
-    case 'terminal':
-      return '#4DD964' // green
-    case 'browser':
-      return '#4A9EFF' // blue
-    case 'editor':
-      return '#FF9F0A' // orange
-    case 'git':
-      return '#FF3B30' // red
-    case 'fileExplorer':
-      return '#5AC8FA' // teal
-    case 'projectList':
-      return '#FFD60A' // yellow
-    case 'canvas':
-      return '#BF5AF2' // purple
-  }
+  return PANEL_DEFINITIONS[type].brandColor
 }

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -17,13 +17,8 @@ import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
 
-const TerminalPanel = React.lazy(() => import('../panels/TerminalPanel'))
-const EditorPanel = React.lazy(() => import('../panels/EditorPanel'))
-const BrowserPanel = React.lazy(() => import('../panels/BrowserPanel'))
-const GitPanel = React.lazy(() => import('../panels/GitPanel'))
-const FileExplorerPanel = React.lazy(() => import('../panels/FileExplorerPanel'))
-const ProjectListPanel = React.lazy(() => import('../panels/ProjectListPanel'))
-const CanvasPanel = React.lazy(() => import('../panels/CanvasPanel'))
+import { renderPanelComponent, PANEL_REGISTRY } from '../panels/registry'
+const CanvasPanel = PANEL_REGISTRY.canvas.Component
 
 interface DockWindowShellProps {
   workspaceId?: string
@@ -179,29 +174,8 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       const panel = panels[panelId]
       if (!panel) return null
 
-      let content: React.ReactNode = null
-      switch (panel.type) {
-        case 'terminal':
-          content = <TerminalPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} />
-          break
-        case 'editor':
-          content = <EditorPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} filePath={panel.filePath} />
-          break
-        case 'browser':
-          content = <BrowserPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} url={panel.url} zoomLevel={zoom} />
-          break
-        case 'git':
-          content = <GitPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} />
-          break
-        case 'fileExplorer':
-          content = <FileExplorerPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} />
-          break
-        case 'projectList':
-          content = <ProjectListPanel panelId={panelId} workspaceId={wsId} nodeId={nodeId} />
-          break
-        default:
-          return null
-      }
+      const content = renderPanelComponent(panel, { workspaceId: wsId, nodeId, zoomLevel: zoom })
+      if (!content) return null
 
       return (
         <Suspense fallback={<div className="w-full h-full bg-surface-4 flex items-center justify-center text-muted text-sm">Loading...</div>}>

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -4,18 +4,12 @@
 // =============================================================================
 
 import React, { useEffect, useState, useCallback, Suspense } from 'react'
-import { X, Terminal, FileText, Globe, Square } from '@phosphor-icons/react'
+import { X } from '@phosphor-icons/react'
 import type { PanelState, PanelTransferSnapshot } from '../../shared/types'
 import { terminalRegistry } from '../lib/terminalRegistry'
 import { terminalRestoreData } from '../lib/session'
 import { DragOverlay, setupCrossWindowDragListeners, useDragOp } from '../drag'
-
-const TerminalPanel = React.lazy(() => import('../panels/TerminalPanel'))
-const EditorPanel = React.lazy(() => import('../panels/EditorPanel'))
-const BrowserPanel = React.lazy(() => import('../panels/BrowserPanel'))
-const GitPanel = React.lazy(() => import('../panels/GitPanel'))
-const FileExplorerPanel = React.lazy(() => import('../panels/FileExplorerPanel'))
-const ProjectListPanel = React.lazy(() => import('../panels/ProjectListPanel'))
+import { renderPanelComponent, getPanelDef } from '../panels/registry'
 
 interface PanelWindowShellProps {
   panelType?: string
@@ -184,22 +178,9 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
 // -----------------------------------------------------------------------------
 
 function PanelContent({ panel, workspaceId }: { panel: PanelState; workspaceId: string }) {
-  switch (panel.type) {
-    case 'terminal':
-      return <TerminalPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" />
-    case 'editor':
-      return <EditorPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" filePath={panel.filePath} />
-    case 'browser':
-      return <BrowserPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" url={panel.url} zoomLevel={1} />
-    case 'git':
-      return <GitPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" />
-    case 'fileExplorer':
-      return <FileExplorerPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" />
-    case 'projectList':
-      return <ProjectListPanel panelId={panel.id} workspaceId={workspaceId} nodeId="" />
-    default:
-      return <div className="w-full h-full flex items-center justify-center text-muted">Unknown panel type</div>
-  }
+  const content = renderPanelComponent(panel, { workspaceId, nodeId: '' })
+  if (!content) return <div className="w-full h-full flex items-center justify-center text-muted">Unknown panel type</div>
+  return content
 }
 
 // -----------------------------------------------------------------------------
@@ -207,16 +188,6 @@ function PanelContent({ panel, workspaceId }: { panel: PanelState; workspaceId: 
 // -----------------------------------------------------------------------------
 
 function PanelTypeIcon({ type }: { type: string }) {
-  const iconClass = "text-muted"
-  const props = { size: 14, className: iconClass }
-  switch (type) {
-    case 'terminal':
-      return <Terminal {...props} />
-    case 'editor':
-      return <FileText {...props} />
-    case 'browser':
-      return <Globe {...props} />
-    default:
-      return <Square {...props} />
-  }
+  const Icon = getPanelDef(type).icon
+  return <Icon size={14} className="text-muted" />
 }

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
-import { CaretRight, Terminal as TerminalIcon, Globe, FileCode, GitBranch, Folder, FolderPlus, SquaresFour, List, DotsThree } from '@phosphor-icons/react'
+import { CaretRight, Terminal as TerminalIcon, Folder, FolderPlus, SquaresFour, DotsThree, type Icon as PhosphorIcon } from '@phosphor-icons/react'
 import type { WorkspaceState, PanelType, PanelLocation, DockLayoutNode } from '../../shared/types'
 import { ALL_ZONES } from '../../shared/types'
 import { useStatusStore } from '../stores/statusStore'
@@ -11,6 +11,7 @@ import { findTabStack, findStackContainingPanel } from '../stores/dockTreeUtils'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import type { AgentState } from '../../shared/types'
 import { terminalRegistry } from '../lib/terminalRegistry'
+import { PANEL_REGISTRY } from '../panels/registry'
 
 // -----------------------------------------------------------------------------
 // Panel jump helper — focus a panel inside a workspace, switching workspace
@@ -161,15 +162,9 @@ const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, agen
   )
 }
 
-const PANEL_ICONS: Record<PanelType, typeof TerminalIcon> = {
-  terminal: TerminalIcon,
-  browser: Globe,
-  editor: FileCode,
-  git: GitBranch,
-  fileExplorer: Folder,
-  projectList: List,
-  canvas: SquaresFour,
-}
+const PANEL_ICONS: Record<PanelType, PhosphorIcon> = Object.fromEntries(
+  (Object.keys(PANEL_REGISTRY) as PanelType[]).map((t) => [t, PANEL_REGISTRY[t].icon]),
+) as Record<PanelType, PhosphorIcon>
 
 const COLOR_NAMES: Record<string, string> = {
   '#6b8fb0': 'Slate Blue',

--- a/src/renderer/ui/NodeSwitcher.tsx
+++ b/src/renderer/ui/NodeSwitcher.tsx
@@ -4,10 +4,10 @@
 // =============================================================================
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Terminal, Globe, FileText } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useAppStore } from '../stores/appStore'
+import { getPanelDef } from '../panels/registry'
 import type { PanelType, CanvasNodeId } from '../../shared/types'
 
 // -----------------------------------------------------------------------------
@@ -15,15 +15,9 @@ import type { PanelType, CanvasNodeId } from '../../shared/types'
 // -----------------------------------------------------------------------------
 
 function PanelIcon({ type }: { type: PanelType }) {
-  const size = 20
-  switch (type) {
-    case 'terminal':
-      return <Terminal size={size} color="#34C759" />
-    case 'browser':
-      return <Globe size={size} color="#007AFF" />
-    case 'editor':
-      return <FileText size={size} color="#FF9500" />
-  }
+  const def = getPanelDef(type)
+  const Icon = def.icon
+  return <Icon size={20} color={def.switcherColor} />
 }
 
 // -----------------------------------------------------------------------------

--- a/src/renderer/ui/PanelSwitcher.tsx
+++ b/src/renderer/ui/PanelSwitcher.tsx
@@ -1,36 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Terminal, Globe, FileText, GitBranch, TreeStructure, SquaresFour, List } from '@phosphor-icons/react'
 import { useUIStore } from '../stores/uiStore'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useSelectedWorkspace } from '../stores/appStore'
 import { useDockStore } from '../stores/dockStore'
 import { findTabStack } from '../stores/dockTreeUtils'
+import { getPanelDef } from '../panels/registry'
 import type { PanelType } from '../../shared/types'
-
-function panelColor(type: PanelType): string {
-  switch (type) {
-    case 'terminal': return '#34C759'
-    case 'browser': return '#007AFF'
-    case 'editor': return '#FF9500'
-    case 'git': return '#FF3B30'
-    case 'fileExplorer': return '#5AC8FA'
-    case 'projectList': return '#FFD60A'
-    case 'canvas': return '#BF5AF2'
-  }
-}
-
-function PlaceholderIcon({ type, color }: { type: PanelType; color: string }) {
-  const size = 44
-  switch (type) {
-    case 'terminal':     return <Terminal size={size} color={color} weight="light" />
-    case 'browser':      return <Globe size={size} color={color} weight="light" />
-    case 'editor':       return <FileText size={size} color={color} weight="light" />
-    case 'git':          return <GitBranch size={size} color={color} weight="light" />
-    case 'fileExplorer': return <TreeStructure size={size} color={color} weight="light" />
-    case 'projectList':  return <List size={size} color={color} weight="light" />
-    case 'canvas':       return <SquaresFour size={size} color={color} weight="light" />
-  }
-}
 
 /**
  * Crop panel regions from a pre-captured page screenshot.
@@ -274,7 +249,7 @@ export function PanelSwitcher() {
             const type = item.type
             const title = item.title
             const isSelected = i === selectedIndex
-            const color = panelColor(type)
+            const color = getPanelDef(type).switcherColor
             const thumb = item.kind === 'canvas' ? thumbnails[item.nodeId] : undefined
 
             // Canvas items use the node's real aspect; dock items get a
@@ -328,9 +303,12 @@ export function PanelSwitcher() {
                         background: `linear-gradient(135deg, ${color}12 0%, transparent 70%)`,
                       }}
                     >
-                      <PlaceholderIcon type={type} color={color} />
+                      {(() => {
+                        const Icon = getPanelDef(type).icon
+                        return <Icon size={44} color={color} weight="light" />
+                      })()}
                       <span style={{ fontSize: 10, color: 'var(--text-muted)', textTransform: 'capitalize' }}>
-                        {type === 'fileExplorer' ? 'File Explorer' : type === 'projectList' ? 'Projects' : type}
+                        {getPanelDef(type).label}
                       </span>
                     </div>
                   )}

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -1,0 +1,153 @@
+// =============================================================================
+// Panel definitions — per-type data shared between main and renderer.
+//
+// This module holds everything that:
+//   1. doesn't depend on React, Phosphor, or other renderer-only libraries, AND
+//   2. is needed in more than one place (drag ghost in main, sizes everywhere,
+//      labels/colors in many renderer files).
+//
+// Renderer-only fields (icon component, lazy component, factory) live in
+// `src/renderer/panels/registry.ts`, which extends this with the renderer
+// concerns and re-exports the unified definition.
+//
+// Adding a new panel type means adding one entry here + one entry in
+// `registry.ts`. The PanelType union in `./types.ts` keeps everyone honest.
+// =============================================================================
+
+import type { PanelType, Size } from './types'
+
+// -----------------------------------------------------------------------------
+// Definition shape
+// -----------------------------------------------------------------------------
+
+export interface SharedPanelDefinition {
+  type: PanelType
+  /** Human-readable label, e.g. "File Explorer". Used in tooltips, split menus,
+   *  fallback titles. */
+  label: string
+  /** Brand color used in panel chrome and the drag ghost window. */
+  brandColor: string
+  /** More saturated variant used in the full-screen panel switcher overlay. */
+  switcherColor: string
+  /** Dim variant used in the minimap dot. */
+  mutedColor: string
+  /** Tailwind class for tab-bar tint when the tab is active. */
+  tintClass: string
+  defaultSize: Size
+  minimumSize: Size
+  /** Inline SVG (12×12) used by the drag-ghost window rendered in the main
+   *  process. Lives here so main and renderer agree on the same icon set. */
+  ghostSvg: string
+  /** Whether a panel of this type can be placed as a canvas node. Canvas
+   *  panels themselves live only in dock zones. */
+  canLiveOnCanvas: boolean
+}
+
+// -----------------------------------------------------------------------------
+// Ghost SVG helpers — keep stroke colors in one place so the brand color
+// drives the ghost icon automatically.
+// -----------------------------------------------------------------------------
+
+function ghost(stroke: string, body: string): string {
+  return `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="${stroke}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${body}</svg>`
+}
+
+// -----------------------------------------------------------------------------
+// Definitions
+// -----------------------------------------------------------------------------
+
+export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
+  terminal: {
+    type: 'terminal',
+    label: 'Terminal',
+    brandColor: '#4DD964',
+    switcherColor: '#34C759',
+    mutedColor: '#4a9960',
+    tintClass: 'text-emerald-400',
+    defaultSize: { width: 640, height: 400 },
+    minimumSize: { width: 320, height: 200 },
+    ghostSvg: ghost('rgb(77,217,100)', '<polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>'),
+    canLiveOnCanvas: true,
+  },
+  browser: {
+    type: 'browser',
+    label: 'Browser',
+    brandColor: '#4A9EFF',
+    switcherColor: '#007AFF',
+    mutedColor: '#4a7ab0',
+    tintClass: 'text-sky-400',
+    defaultSize: { width: 800, height: 600 },
+    minimumSize: { width: 400, height: 300 },
+    ghostSvg: ghost('rgb(74,158,255)', '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>'),
+    canLiveOnCanvas: true,
+  },
+  editor: {
+    type: 'editor',
+    label: 'Editor',
+    brandColor: '#FF9F0A',
+    switcherColor: '#FF9500',
+    mutedColor: '#b07440',
+    tintClass: 'text-orange-400',
+    defaultSize: { width: 600, height: 500 },
+    minimumSize: { width: 300, height: 250 },
+    ghostSvg: ghost('rgb(255,159,10)', '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>'),
+    canLiveOnCanvas: true,
+  },
+  git: {
+    type: 'git',
+    label: 'Git',
+    brandColor: '#FF3B30',
+    switcherColor: '#FF3B30',
+    mutedColor: '#8a3a35',
+    tintClass: 'text-red-400',
+    defaultSize: { width: 500, height: 600 },
+    minimumSize: { width: 350, height: 300 },
+    ghostSvg: ghost('rgb(255,59,48)', '<line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>'),
+    canLiveOnCanvas: true,
+  },
+  fileExplorer: {
+    type: 'fileExplorer',
+    label: 'File Explorer',
+    brandColor: '#5AC8FA',
+    switcherColor: '#5AC8FA',
+    mutedColor: '#4a8aa5',
+    tintClass: 'text-cyan-400',
+    defaultSize: { width: 300, height: 500 },
+    minimumSize: { width: 180, height: 200 },
+    ghostSvg: ghost('rgb(90,200,250)', '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>'),
+    canLiveOnCanvas: true,
+  },
+  projectList: {
+    type: 'projectList',
+    label: 'Projects',
+    brandColor: '#FFD60A',
+    switcherColor: '#FFD60A',
+    mutedColor: '#a89030',
+    tintClass: 'text-yellow-400',
+    defaultSize: { width: 300, height: 400 },
+    minimumSize: { width: 180, height: 200 },
+    ghostSvg: ghost('rgb(255,214,10)', '<rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>'),
+    canLiveOnCanvas: true,
+  },
+  canvas: {
+    type: 'canvas',
+    label: 'Canvas',
+    brandColor: '#BF5AF2',
+    switcherColor: '#BF5AF2',
+    mutedColor: '#7a4a9a',
+    tintClass: 'text-violet-400',
+    defaultSize: { width: 800, height: 600 },
+    minimumSize: { width: 400, height: 300 },
+    ghostSvg: ghost('rgb(191,90,242)', '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/>'),
+    canLiveOnCanvas: false,
+  },
+}
+
+/** Ordered list of every known panel type. */
+export const PANEL_TYPES: PanelType[] = Object.keys(PANEL_DEFINITIONS) as PanelType[]
+
+/** Lookup helper. Falls back to the editor definition (matches the previous
+ *  drag-ghost behaviour). */
+export function getSharedPanelDef(type: PanelType | string): SharedPanelDefinition {
+  return PANEL_DEFINITIONS[type as PanelType] ?? PANEL_DEFINITIONS.editor
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -749,28 +749,20 @@ export const DEFAULT_SETTINGS: AppSettings = {
 }
 
 // -----------------------------------------------------------------------------
-// Panel size constants — from CanvasLayoutEngine.swift
+// Panel size constants — derived from the panel registry so the sizes for a
+// new panel type are declared in one place. Kept as named exports so existing
+// call sites can keep importing them.
 // -----------------------------------------------------------------------------
 
-export const PANEL_DEFAULT_SIZES: Record<PanelType, Size> = {
-  terminal: { width: 640, height: 400 },
-  browser: { width: 800, height: 600 },
-  editor: { width: 600, height: 500 },
-  git: { width: 500, height: 600 },
-  fileExplorer: { width: 300, height: 500 },
-  projectList: { width: 300, height: 400 },
-  canvas: { width: 800, height: 600 },
-}
+import { PANEL_DEFINITIONS } from './panels'
 
-export const PANEL_MINIMUM_SIZES: Record<PanelType, Size> = {
-  terminal: { width: 320, height: 200 },
-  browser: { width: 400, height: 300 },
-  editor: { width: 300, height: 250 },
-  git: { width: 350, height: 300 },
-  fileExplorer: { width: 180, height: 200 },
-  projectList: { width: 180, height: 200 },
-  canvas: { width: 400, height: 300 },
-}
+export const PANEL_DEFAULT_SIZES: Record<PanelType, Size> = Object.fromEntries(
+  (Object.keys(PANEL_DEFINITIONS) as PanelType[]).map((t) => [t, PANEL_DEFINITIONS[t].defaultSize]),
+) as Record<PanelType, Size>
+
+export const PANEL_MINIMUM_SIZES: Record<PanelType, Size> = Object.fromEntries(
+  (Object.keys(PANEL_DEFINITIONS) as PanelType[]).map((t) => [t, PANEL_DEFINITIONS[t].minimumSize]),
+) as Record<PanelType, Size>
 
 // -----------------------------------------------------------------------------
 // Zoom constants — from CanvasState.swift


### PR DESCRIPTION
## Summary
- Adds `src/shared/panels.ts` (label, colors, sizes, drag-ghost SVG, canLiveOnCanvas — usable from main and renderer) and `src/renderer/panels/registry.ts` (Phosphor icon, lazy component, unified `create(args)` factory).
- Migrates every consumer that used to `switch (panel.type)` — App.tsx, both window shells, CanvasPanel, useDockTabActions, PanelSwitcher, DockTabBar/Stack, NodeSwitcher, Minimap, WorkspaceTab, CanvasNode, panels/types.ts, and the main-process drag ghost — to read from the registry.
- Net −239 LOC, ~12 switches eliminated. `PANEL_DEFAULT_SIZES`/`PANEL_MINIMUM_SIZES` are now derived from the registry but kept as named exports so existing call sites still compile.
- Adding a new panel type is now a two-touch change: one entry in `PANEL_DEFINITIONS`, one in `PANEL_REGISTRY`. Nothing else in the renderer or main process needs to know.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — per-panel code-splitting preserved (TerminalPanel, BrowserPanel, GitPanel, CanvasPanel, EditorPanel still emit as separate chunks)
- [ ] Manual smoke: drag-ghost icons render correctly for each panel type
- [ ] Manual smoke: spawn each panel type from canvas right-click + dock + button
- [ ] Manual smoke: panel switcher overlay shows correct icons/colors per type
- [ ] Manual smoke: tab bar tint + minimap dot color unchanged