### PR TITLE
test(drag): clear body classes in afterEach to isolate scenarios

### DIFF
--- a/src/renderer/drag/__tests__/scenarios.test.tsx
+++ b/src/renderer/drag/__tests__/scenarios.test.tsx
@@ -28,6 +28,7 @@ let scene: SceneApi | null = null
 afterEach(() => {
   scene?.unmount()
   scene = null
+  document.body.classList.remove('canvas-interacting', 'canvas-dragging')
 })
 
 describe('drag integration — canvas-node scenarios', () => {


### PR DESCRIPTION
## Summary
CI on main failed after #50: 5 `scenarios.test.tsx` tests broke because test 5 arms a drag without `mouseup`, leaving `canvas-interacting` on `document.body`. The first-gesture-wins guard added to `useDragOp` (`if (document.body.classList.contains('canvas-interacting')) return`) then short-circuits the next test's mousedown.

Fix: clean `canvas-interacting` / `canvas-dragging` body classes in `afterEach` so the harness restores DOM state between tests. Production behavior unchanged.

## Test plan
- [x] `npx vitest run src/renderer/drag/__tests__/scenarios.test.tsx` — 12 pass, 3 skipped
- [x] `npx vitest run` — 251 pass, 3 skipped