### PR TITLE
docs(readme): bump current source version to v0.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.3.3
+  <strong>Current source version:</strong> v0.4.5
 </p>
 
 <p align="center">
@@ -50,7 +50,7 @@ Cate replaces that pile of windows with **one persistent canvas per project**. T
 
 ## Install
 
-If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v0.3.3**.
+If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v0.4.5**.
 
 | Platform | Formats | Link |
 |----------|---------|------|


### PR DESCRIPTION
README referenced v0.3.3; package.json is at 0.4.5. Sync README to match.