### PR TITLE
fix(canvas): preserve child nodes when detaching a canvas panel to a window

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useRef, useState, useCallback, Suspense } from 'react'
 import log from './lib/logger'
 import { useAppStore, useSelectedWorkspace, setupWorkspaceSync } from './stores/appStore'
-import { useCanvasStore } from './stores/canvasStore'
+import { useCanvasStore, getOrCreateCanvasStoreForPanel } from './stores/canvasStore'
 import { CanvasStoreProvider } from './stores/CanvasStoreContext'
 import { setCanvasOperations } from './stores/appStore'
 import { createCanvasOps } from './lib/canvasBridge'
@@ -318,6 +318,14 @@ function MainApp() {
       // PTY transfer MUST be deposited before any state set that mounts TerminalPanel.
       if (snapshot.terminalPtyId) {
         terminalRegistry.setPendingTransfer(snapshot.panel.id, snapshot.terminalPtyId, snapshot.terminalScrollback)
+      }
+
+      // Canvas panel: hydrate the per-panel canvas store with the snapshot's
+      // children before the panel mounts.
+      if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
+        const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
+        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
       }
 
       const wsId = useAppStore.getState().selectedWorkspaceId

--- a/src/renderer/lib/panelTransfer.test.ts
+++ b/src/renderer/lib/panelTransfer.test.ts
@@ -13,6 +13,7 @@ vi.mock('./terminalRegistry', () => ({
 }))
 
 import { createTransferSnapshot } from './panelTransfer'
+import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import type { PanelState } from '../../shared/types'
 
 describe('createTransferSnapshot — editor content survival', () => {
@@ -35,5 +36,50 @@ describe('createTransferSnapshot — editor content survival', () => {
 
     expect(snapshot.editorState).toBeDefined()
     expect(snapshot.editorState?.unsavedContent).toBe('function hello() { return 42 }')
+  })
+})
+
+// Regression: detaching a canvas-type panel into its own window used to land
+// on an empty canvas because the snapshot carried no children. Verify the
+// snapshot now captures nodes / regions / viewport so the receiving window
+// can hydrate before first paint.
+describe('createTransferSnapshot — canvas children survival', () => {
+  it('captures the canvas store nodes + regions + viewport for canvas panels', () => {
+    const panel: PanelState = {
+      id: 'panel-canvas-1',
+      type: 'canvas',
+      title: 'Sub-canvas',
+      isDirty: false,
+    }
+    const store = getOrCreateCanvasStoreForPanel(panel.id)
+    const nodeId = store.getState().addNode('child-panel-1', 'terminal', { x: 100, y: 80 }, { width: 320, height: 240 })
+    store.setState({ zoomLevel: 1.5, viewportOffset: { x: 12, y: 34 } })
+
+    const snapshot = createTransferSnapshot(
+      panel,
+      { type: 'canvas', canvasId: 'c-root', canvasNodeId: 'n-root' },
+      { origin: { x: 0, y: 0 }, size: { width: 800, height: 600 } },
+    )
+
+    expect(snapshot.canvasState).toBeDefined()
+    expect(snapshot.canvasState?.zoomLevel).toBe(1.5)
+    expect(snapshot.canvasState?.viewportOffset).toEqual({ x: 12, y: 34 })
+    expect(snapshot.canvasState?.nodes[nodeId]).toBeDefined()
+    expect(snapshot.canvasState?.nodes[nodeId].panelId).toBe('child-panel-1')
+  })
+
+  it('omits canvasState for non-canvas panels', () => {
+    const panel: PanelState = {
+      id: 'panel-term-1',
+      type: 'terminal',
+      title: 'zsh',
+      isDirty: false,
+    }
+    const snapshot = createTransferSnapshot(
+      panel,
+      { type: 'canvas', canvasId: 'c-1', canvasNodeId: 'n-1' },
+      { origin: { x: 0, y: 0 }, size: { width: 400, height: 300 } },
+    )
+    expect(snapshot.canvasState).toBeUndefined()
   })
 })

--- a/src/renderer/lib/panelTransfer.ts
+++ b/src/renderer/lib/panelTransfer.ts
@@ -5,6 +5,7 @@
 
 import type { PanelState, PanelTransferSnapshot, PanelLocation, Point, Size } from '../../shared/types'
 import { terminalRegistry } from './terminalRegistry'
+import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 
 /**
  * Create a PanelTransferSnapshot from a panel's current state.
@@ -69,6 +70,20 @@ export function createTransferSnapshot(
       url: panel.url,
       canGoBack: false,
       canGoForward: false,
+    }
+  }
+
+  // Canvas-specific: capture child nodes + regions + viewport so the receiving
+  // window can hydrate. Without this, the new window's per-panel canvas store
+  // is constructed empty.
+  if (panel.type === 'canvas') {
+    const store = getOrCreateCanvasStoreForPanel(panel.id)
+    const state = store.getState()
+    snapshot.canvasState = {
+      nodes: { ...state.nodes },
+      regions: { ...state.regions },
+      viewportOffset: { ...state.viewportOffset },
+      zoomLevel: state.zoomLevel,
     }
   }
 

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -13,6 +13,7 @@ import DockZone from '../docking/DockZone'
 import { DragOverlay, setupCrossWindowDragListeners } from '../drag'
 import { terminalRegistry } from '../lib/terminalRegistry'
 import { terminalRestoreData } from '../lib/session'
+import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
@@ -64,6 +65,16 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
         terminalRestoreData.set(snapshot.panel.id, { replayFromId: snapshot.terminalReplayPtyId })
       }
 
+      // Canvas panel: hydrate the per-panel canvas store BEFORE rendering, so
+      // child nodes/regions are present on first paint. Without this the new
+      // window mounts an empty canvas and writes that empty state back to
+      // session persistence on the next sync.
+      if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
+        const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
+        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
+      }
+
       setPanels((prev) => ({
         ...prev,
         [snapshot.panel.id]: snapshot.panel,
@@ -79,6 +90,13 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       // PTY transfer MUST be deposited before any state set that mounts TerminalPanel.
       if (snapshot.terminalPtyId) {
         terminalRegistry.setPendingTransfer(snapshot.panel.id, snapshot.terminalPtyId, snapshot.terminalScrollback)
+      }
+
+      // Canvas panel: hydrate before mount so children are visible immediately.
+      if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
+        const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
+        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
       }
 
       setPanels((prev) => ({

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -10,6 +10,7 @@ import { terminalRegistry } from '../lib/terminalRegistry'
 import { terminalRestoreData } from '../lib/session'
 import { DragOverlay, setupCrossWindowDragListeners, useDragOp } from '../drag'
 import { renderPanelComponent, getPanelDef } from '../panels/registry'
+import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 
 interface PanelWindowShellProps {
   panelType?: string
@@ -32,6 +33,13 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
         // log under this ptyId. Seed terminalRestoreData so getOrCreate runs
         // replayTerminalLog after spawning a fresh PTY.
         terminalRestoreData.set(snapshot.panel.id, { replayFromId: snapshot.terminalReplayPtyId })
+      }
+
+      // Canvas panel: hydrate the per-panel canvas store before mount.
+      if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
+        const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
+        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
       }
 
       setPanel(snapshot.panel)

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -22,6 +22,7 @@ import { PANEL_DEFAULT_SIZES, ZOOM_DEFAULT, ALL_ZONES } from '../../shared/types
 import type { CanvasNodeId, CanvasNodeState, CanvasRegion } from '../../shared/types'
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from './canvasStore'
+import { shouldPreserveExistingCanvas } from './canvasSyncGuard'
 import { terminalRegistry } from '../lib/terminalRegistry'
 import { useDockStore } from './dockStore'
 import { createCanvasOps } from '../lib/canvasBridge'
@@ -1081,19 +1082,25 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const dockSnapshot = useDockStore.getState().getSnapshot()
 
     set((state) => ({
-      workspaces: state.workspaces.map((ws) =>
-        ws.id === workspaceId
-          ? {
-              ...ws,
-              canvasNodes: { ...canvasState.nodes },
-              regions: { ...canvasState.regions },
-              viewportOffset: { ...canvasState.viewportOffset },
-              zoomLevel: canvasState.zoomLevel,
-              focusedNodeId: canvasState.focusedNodeId,
-              dockState: dockSnapshot,
-            }
-          : ws,
-      ),
+      workspaces: state.workspaces.map((ws) => {
+        if (ws.id !== workspaceId) return ws
+        if (shouldPreserveExistingCanvas(
+          Object.keys(canvasState.nodes).length,
+          Object.keys(ws.canvasNodes ?? {}).length,
+        )) {
+          // Keep nodes/regions/viewport intact; only refresh dock state.
+          return { ...ws, dockState: dockSnapshot }
+        }
+        return {
+          ...ws,
+          canvasNodes: { ...canvasState.nodes },
+          regions: { ...canvasState.regions },
+          viewportOffset: { ...canvasState.viewportOffset },
+          zoomLevel: canvasState.zoomLevel,
+          focusedNodeId: canvasState.focusedNodeId,
+          dockState: dockSnapshot,
+        }
+      }),
     }))
   },
 

--- a/src/renderer/stores/canvasSyncGuard.test.ts
+++ b/src/renderer/stores/canvasSyncGuard.test.ts
@@ -1,0 +1,25 @@
+// Regression: detaching the workspace's primary canvas panel to another
+// window used to wipe its children on the next autosave. The guard preserves
+// the persisted snapshot when the live store is empty but the saved one had
+// children.
+
+import { describe, it, expect } from 'vitest'
+import { shouldPreserveExistingCanvas } from './canvasSyncGuard'
+
+describe('shouldPreserveExistingCanvas', () => {
+  it('preserves persisted nodes when the live store is empty', () => {
+    expect(shouldPreserveExistingCanvas(0, 3)).toBe(true)
+  })
+
+  it('lets a populated live store write through (normal case)', () => {
+    expect(shouldPreserveExistingCanvas(5, 3)).toBe(false)
+  })
+
+  it('lets an empty live store overwrite an empty workspace (no data loss to prevent)', () => {
+    expect(shouldPreserveExistingCanvas(0, 0)).toBe(false)
+  })
+
+  it('lets a populated live store overwrite an empty workspace (first save)', () => {
+    expect(shouldPreserveExistingCanvas(2, 0)).toBe(false)
+  })
+})

--- a/src/renderer/stores/canvasSyncGuard.ts
+++ b/src/renderer/stores/canvasSyncGuard.ts
@@ -1,0 +1,17 @@
+// =============================================================================
+// canvasSyncGuard — pure decision: should `syncCanvasToWorkspace` write the
+// live canvas store back to the workspace, or keep the persisted snapshot?
+//
+// The workspace's primary canvas panel can be detached into a different
+// window. In the source window the per-panel registry then hands out a fresh
+// empty CanvasOperations for that panelId, and a naive write would overwrite
+// the user's saved children with `{}`. The guard preserves the existing
+// snapshot when the incoming store is empty but the saved one isn't.
+// =============================================================================
+
+export function shouldPreserveExistingCanvas(
+  incomingNodeCount: number,
+  existingNodeCount: number,
+): boolean {
+  return incomingNodeCount === 0 && existingNodeCount > 0
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -191,6 +191,16 @@ export interface PanelTransferSnapshot {
     canGoBack: boolean
     canGoForward: boolean
   }
+
+  // Canvas-specific — child nodes/regions/viewport for nested canvas panels.
+  // Without this, detaching a canvas panel to a new window would land with an
+  // empty store (fresh per-process), losing every panel inside it.
+  canvasState?: {
+    nodes: Record<CanvasNodeId, CanvasNodeState>
+    regions: Record<string, CanvasRegion>
+    viewportOffset: Point
+    zoomLevel: number
+  }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Detaching a canvas-type panel (a canvas containing other panels) to its own window landed on an **empty canvas**, and the source window's next autosave then clobbered the workspace's persisted children with an empty store — so reopening couldn't recover them.

## Root cause (two layers)
1. **`PanelTransferSnapshot`** (`src/shared/types.ts`) had type-specific blocks for terminal/editor/browser but **no canvas block**, so the new window received the panel shell without children.
2. **`syncCanvasToWorkspace`** (`src/renderer/stores/appStore.ts`) did a naive `set()` with the live store's nodes. After detach, the source window's per-panel registry handed out a fresh empty `CanvasOperations` for the detached `panelId`, and that empty `{}` got persisted on top of the real saved children.

## Fix
- Add `canvasState` (`nodes` / `regions` / `viewportOffset` / `zoomLevel`) to `PanelTransferSnapshot`.
- `createTransferSnapshot` captures the per-panel canvas store when `panel.type === 'canvas'`.
- `DockWindowShell` / `PanelWindowShell` / `App.tsx` receive paths hydrate the per-panel canvas store via `loadWorkspaceCanvas` before mount, so children appear on first paint (covers both `onPanelReceive` and `setupCrossWindowDragListeners`).
- New pure `shouldPreserveExistingCanvas` guard wired into `syncCanvasToWorkspace`: if the live store is empty but the workspace had children, keep the saved snapshot and only refresh dock state.

## Test plan
- [x] `npx vitest run` — 257 pass, 3 skipped (was 251; +6 new)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: drag a canvas panel containing 2-3 child panels into a new window — children should appear in the new window, original workspace's children survive close/reopen
- [ ] Manual: drag the canvas panel back into the main window — children still present