### PR TITLE
fix(canvas): block canvas-on-canvas; detached windows apply theme + settings

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -315,6 +315,10 @@ function MainApp() {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     return setupCrossWindowDragListeners((snapshot, target) => {
+      // Canvas-on-canvas is unsupported: refuse cross-window drops of a
+      // canvas panel onto a canvas target. The source window stays as-is.
+      if (snapshot.panel.type === 'canvas' && target.kind !== 'dock') return
+
       // PTY transfer MUST be deposited before any state set that mounts TerminalPanel.
       if (snapshot.terminalPtyId) {
         terminalRegistry.setPendingTransfer(snapshot.panel.id, snapshot.terminalPtyId, snapshot.terminalScrollback)

--- a/src/renderer/drag/commit.ts
+++ b/src/renderer/drag/commit.ts
@@ -48,6 +48,9 @@ export async function commitDrop(
     }
 
     case 'canvas-add': {
+      // Canvas-on-canvas is unsupported — refuse the drop instead of removing
+      // the panel from its source (which would silently delete a canvas tab).
+      if (panel.type === 'canvas') return
       ctx.prepareLocalRemount?.(source.panelId, panel.type)
       // Remove the panel from its current location first so addNode doesn't
       // race with a stale duplicate (terminal PTY, xterm DOM, etc.).

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -17,6 +17,8 @@ import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
+import { useSettingsStore } from '../stores/settingsStore'
+import { applyTheme } from '../lib/themeManager'
 
 import { renderPanelComponent, PANEL_REGISTRY } from '../panels/registry'
 const CanvasPanel = PANEL_REGISTRY.canvas.Component
@@ -32,6 +34,17 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   const dockStore = useMemo(() => createDockStore(), [])
   const syncTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const hadPanelsRef = useRef(false)
+
+  // Hydrate settings + apply theme so the detached window mirrors the main
+  // app's appearance (theme, minimap, canvas grid, etc.). Without this the
+  // window renders with default settings and ignores the user's preferences.
+  useEffect(() => {
+    useSettingsStore.getState().loadSettings()
+  }, [])
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode)
+  useEffect(() => {
+    applyTheme(appearanceMode)
+  }, [appearanceMode])
 
   // Listen for DOCK_WINDOW_INIT from main process
   useEffect(() => {
@@ -87,6 +100,10 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   // Set up cross-window drag listeners
   useEffect(() => {
     return setupCrossWindowDragListeners((snapshot, target) => {
+      // Canvas-on-canvas is unsupported: refuse cross-window drops of a
+      // canvas panel onto a canvas target.
+      if (snapshot.panel.type === 'canvas' && target.kind !== 'dock') return
+
       // PTY transfer MUST be deposited before any state set that mounts TerminalPanel.
       if (snapshot.terminalPtyId) {
         terminalRegistry.setPendingTransfer(snapshot.panel.id, snapshot.terminalPtyId, snapshot.terminalScrollback)

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -11,6 +11,8 @@ import { terminalRestoreData } from '../lib/session'
 import { DragOverlay, setupCrossWindowDragListeners, useDragOp } from '../drag'
 import { renderPanelComponent, getPanelDef } from '../panels/registry'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { applyTheme } from '../lib/themeManager'
 
 interface PanelWindowShellProps {
   panelType?: string
@@ -21,6 +23,16 @@ interface PanelWindowShellProps {
 export default function PanelWindowShell({ panelType, panelId, workspaceId }: PanelWindowShellProps) {
   const [panel, setPanel] = useState<PanelState | null>(null)
   const [receivedSnapshot, setReceivedSnapshot] = useState<PanelTransferSnapshot | null>(null)
+
+  // Hydrate settings + apply theme so this window mirrors the main app's
+  // appearance and settings (theme, minimap, canvas grid, etc.).
+  useEffect(() => {
+    useSettingsStore.getState().loadSettings()
+  }, [])
+  const appearanceMode = useSettingsStore((s) => s.appearanceMode)
+  useEffect(() => {
+    applyTheme(appearanceMode)
+  }, [appearanceMode])
 
   // Listen for incoming panel transfers from the main process
   useEffect(() => {

--- a/src/renderer/stores/canvasStore.test.ts
+++ b/src/renderer/stores/canvasStore.test.ts
@@ -65,3 +65,16 @@ describe('canvasStore.addNode panelId dedup invariant', () => {
     expect(nodes.some((n) => n.panelId === 'panel-B')).toBe(true)
   })
 })
+
+// Regression: a canvas tab dragged onto a canvas viewport (or any other path
+// that reached addNode with panelType==='canvas') used to create a nested
+// canvas — broken interaction (ambiguous drag targets, duplicate stores keyed
+// by the same id, nested zoom). Block at the data layer.
+describe('canvasStore.addNode — canvas-on-canvas is rejected', () => {
+  it('returns empty string and does not add the node', () => {
+    const store = createCanvasStore()
+    const result = store.getState().addNode('panel-canvas-1', 'canvas', { x: 10, y: 10 }, { width: 400, height: 300 })
+    expect(result).toBe('')
+    expect(Object.keys(store.getState().nodes)).toHaveLength(0)
+  })
+})

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -369,6 +369,12 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
   },
 
   addNode(panelId, panelType, position?, size?) {
+    // Canvas-on-canvas is unsupported and produces broken interaction (nested
+    // zoom, ambiguous drag targets, duplicate stores keyed by the same id).
+    // Refuse at the data layer regardless of which UI path tried it.
+    if (panelType === 'canvas') {
+      return ''
+    }
     get().pushHistory()
     const state = get()
     const defaultSize = size ?? PANEL_DEFAULT_SIZES[panelType]


### PR DESCRIPTION
## Summary
Two distinct issues fixed together.

### 1. Canvas-on-canvas must be blocked
Dropping a canvas onto another canvas produced broken interaction (nested zoom, ambiguous drag targets, duplicate stores keyed by the same \`panelId\`). Refused at three layers for defense-in-depth:

- \`canvasStore.addNode\` returns \`''\` when \`panelType === 'canvas'\` — primary data-layer guard.
- \`commit.ts\` \`canvas-add\` branch returns early for canvas-type instead of running \`removeFromSource\` first (which would silently delete the source tab).
- \`App.tsx\` + \`DockWindowShell\` cross-window receive paths refuse when the drop target is canvas and \`panel.type === 'canvas'\`.

Top-level canvas creation (via toolbar / command palette / new-workspace bootstrap) still works — those paths route to the dock center via \`placePanel\`, not as canvas-nodes.

### 2. Detached windows now apply theme + settings
\`DockWindowShell\` and \`PanelWindowShell\` never hydrated \`useSettingsStore\` or called \`applyTheme\`, so detached windows ignored the user's theme, minimap, and canvas-grid preferences. Fix:

- Call \`useSettingsStore.getState().loadSettings()\` on mount.
- Subscribe to \`appearanceMode\` and call \`applyTheme(...)\` on change.

(Live cross-window settings sync is a follow-up — settings still hydrate from disk on each window mount.)

## Test plan
- [x] \`npx vitest run\` — 258 pass, 3 skipped (was 257; +1 new)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: try dragging a canvas onto another canvas → no drop, source tab intact
- [ ] Manual: detach a panel/dock → theme + minimap + grid match the main window