### PR TITLE
fix(canvas-detach): ship child PanelStates; spawn fresh canvas when last detached

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,7 @@ import DockWindowShell from './shells/DockWindowShell'
 import { WindowTypeContext } from './stores/WindowTypeContext'
 import { setupCrossWindowDragListeners } from './drag'
 import { terminalRegistry } from './lib/terminalRegistry'
+import { applyCanvasChildPanels } from './lib/applyCanvasChildPanels'
 import { applyTheme } from './lib/themeManager'
 import { confirmCloseDirtyPanels } from './lib/confirmCloseDirty'
 import { confirmCloseCanvas } from './lib/confirmCloseCanvas'
@@ -324,15 +325,17 @@ function MainApp() {
         terminalRegistry.setPendingTransfer(snapshot.panel.id, snapshot.terminalPtyId, snapshot.terminalScrollback)
       }
 
+      const wsId = useAppStore.getState().selectedWorkspaceId
+
       // Canvas panel: hydrate the per-panel canvas store with the snapshot's
-      // children before the panel mounts.
+      // children + child PanelState records before the panel mounts.
       if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
         const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
-        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        const { nodes, regions, viewportOffset, zoomLevel, childPanels } = snapshot.canvasState
         store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
+        applyCanvasChildPanels(wsId, childPanels ?? {})
       }
 
-      const wsId = useAppStore.getState().selectedWorkspaceId
       useAppStore.getState().addPanel(wsId, snapshot.panel)
 
       if (target.kind === 'dock') {

--- a/src/renderer/drag/useDragOp.ts
+++ b/src/renderer/drag/useDragOp.ts
@@ -245,6 +245,14 @@ function buildSnapshotFor(spec: DragOpSourceSpec): PanelTransferSnapshot | null 
   // dock window.
   const panel = spec.panel
 
+  // For canvas-type panels, the snapshot needs each child's PanelState so the
+  // receiving window can render real child panels instead of "Panel" stubs.
+  const resolveChildPanel = (childId: string) => {
+    const app = useAppStore.getState()
+    const ws = app.workspaces.find((w) => w.id === app.selectedWorkspaceId)
+    return ws?.panels[childId]
+  }
+
   if (spec.kind === 'canvas-node') {
     const node = spec.canvasStoreApi.getState().nodes[spec.nodeId]
     if (!node) return null
@@ -252,6 +260,7 @@ function buildSnapshotFor(spec: DragOpSourceSpec): PanelTransferSnapshot | null 
       panel,
       { type: 'canvas', canvasId: '', canvasNodeId: spec.nodeId },
       { origin: node.origin, size: node.size },
+      { resolveChildPanel },
     )
   }
 
@@ -264,6 +273,7 @@ function buildSnapshotFor(spec: DragOpSourceSpec): PanelTransferSnapshot | null 
       panel,
       { type: 'detached', windowId: 0 },
       { origin: { x: 0, y: 0 }, size },
+      { resolveChildPanel },
     )
   }
 
@@ -273,6 +283,7 @@ function buildSnapshotFor(spec: DragOpSourceSpec): PanelTransferSnapshot | null 
     panel,
     { type: 'dock', zone: spec.zone, stackId: spec.stackId },
     { origin: { x: 0, y: 0 }, size },
+    { resolveChildPanel },
   )
 }
 
@@ -320,6 +331,22 @@ function runEffects(prevActive: ActiveDispatch, next: RuntimeState) {
           workspaceId: useAppStore.getState().selectedWorkspaceId,
           onRemovedFromCanvas: (panelId, panelType) => {
             if (panelType === 'terminal') terminalRegistry.release(panelId)
+            // If the user just detached the workspace's only canvas, spawn a
+            // fresh empty one so they don't end up staring at an empty dock.
+            // The detached window keeps the contents that were carried via
+            // PanelTransferSnapshot.canvasState.
+            if (panelType === 'canvas') {
+              const app = useAppStore.getState()
+              const ws = app.workspaces.find((w) => w.id === app.selectedWorkspaceId)
+              if (ws) {
+                const remainingCanvases = Object.values(ws.panels).filter(
+                  (p) => p.type === 'canvas' && p.id !== panelId,
+                )
+                if (remainingCanvases.length === 0) {
+                  app.createCanvas(app.selectedWorkspaceId)
+                }
+              }
+            }
           },
           prepareLocalRemount: (panelId, panelType) => {
             prepareTerminalRemount(panelId, panelType, terminalRegistry)

--- a/src/renderer/lib/applyCanvasChildPanels.ts
+++ b/src/renderer/lib/applyCanvasChildPanels.ts
@@ -1,0 +1,52 @@
+// =============================================================================
+// applyCanvasChildPanels — receive-side helper for canvas panel transfers.
+//
+// When a canvas panel is detached into a new window, the snapshot carries
+// PanelState records for each child. Without merging them into the receiving
+// window's useAppStore, `resolvePanel` falls back to a generic "Panel" stub
+// (no type, no title), because detached windows never bootstrap workspaces.
+// =============================================================================
+
+import type { PanelState } from '../../shared/types'
+import { useAppStore } from '../stores/appStore'
+
+export function applyCanvasChildPanels(
+  workspaceId: string,
+  childPanels: Record<string, PanelState>,
+): void {
+  if (!workspaceId || Object.keys(childPanels).length === 0) return
+  useAppStore.setState((state) => {
+    const existing = state.workspaces.find((w) => w.id === workspaceId)
+    if (existing) {
+      return {
+        workspaces: state.workspaces.map((w) =>
+          w.id === workspaceId
+            ? { ...w, panels: { ...w.panels, ...childPanels } }
+            : w,
+        ),
+      }
+    }
+    // Minimal workspace stub so resolvePanel can find the children. The full
+    // workspace record will arrive via session restore / main-window sync.
+    return {
+      workspaces: [
+        ...state.workspaces,
+        {
+          id: workspaceId,
+          name: 'Workspace',
+          color: '',
+          rootPath: '',
+          rootPathError: null,
+          isRootPathPending: false,
+          panels: { ...childPanels },
+          canvasNodes: {},
+          regions: {},
+          zoomLevel: 1,
+          viewportOffset: { x: 0, y: 0 },
+          focusedNodeId: null,
+        } as any,
+      ],
+      selectedWorkspaceId: state.selectedWorkspaceId || workspaceId,
+    }
+  })
+}

--- a/src/renderer/lib/panelTransfer.test.ts
+++ b/src/renderer/lib/panelTransfer.test.ts
@@ -55,10 +55,17 @@ describe('createTransferSnapshot — canvas children survival', () => {
     const nodeId = store.getState().addNode('child-panel-1', 'terminal', { x: 100, y: 80 }, { width: 320, height: 240 })
     store.setState({ zoomLevel: 1.5, viewportOffset: { x: 12, y: 34 } })
 
+    const childPanel: PanelState = {
+      id: 'child-panel-1',
+      type: 'terminal',
+      title: 'zsh',
+      isDirty: false,
+    }
     const snapshot = createTransferSnapshot(
       panel,
       { type: 'canvas', canvasId: 'c-root', canvasNodeId: 'n-root' },
       { origin: { x: 0, y: 0 }, size: { width: 800, height: 600 } },
+      { resolveChildPanel: (id) => (id === childPanel.id ? childPanel : undefined) },
     )
 
     expect(snapshot.canvasState).toBeDefined()
@@ -66,6 +73,7 @@ describe('createTransferSnapshot — canvas children survival', () => {
     expect(snapshot.canvasState?.viewportOffset).toEqual({ x: 12, y: 34 })
     expect(snapshot.canvasState?.nodes[nodeId]).toBeDefined()
     expect(snapshot.canvasState?.nodes[nodeId].panelId).toBe('child-panel-1')
+    expect(snapshot.canvasState?.childPanels['child-panel-1']).toEqual(childPanel)
   })
 
   it('omits canvasState for non-canvas panels', () => {

--- a/src/renderer/lib/panelTransfer.ts
+++ b/src/renderer/lib/panelTransfer.ts
@@ -18,6 +18,7 @@ export function createTransferSnapshot(
   panel: PanelState,
   sourceLocation: PanelLocation,
   geometry: { origin: Point; size: Size },
+  options: { resolveChildPanel?: (panelId: string) => PanelState | undefined } = {},
 ): PanelTransferSnapshot {
   const snapshot: PanelTransferSnapshot = {
     panel: { ...panel },
@@ -73,17 +74,25 @@ export function createTransferSnapshot(
     }
   }
 
-  // Canvas-specific: capture child nodes + regions + viewport so the receiving
-  // window can hydrate. Without this, the new window's per-panel canvas store
-  // is constructed empty.
+  // Canvas-specific: capture child nodes + regions + viewport AND the PanelState
+  // record for each child panel. Without the PanelStates the receiving window
+  // can't resolve child panel types/titles and renders generic "Panel" stubs.
   if (panel.type === 'canvas') {
     const store = getOrCreateCanvasStoreForPanel(panel.id)
     const state = store.getState()
+    const childPanels: Record<string, PanelState> = {}
+    if (options.resolveChildPanel) {
+      for (const node of Object.values(state.nodes)) {
+        const childPanel = options.resolveChildPanel(node.panelId)
+        if (childPanel) childPanels[node.panelId] = { ...childPanel }
+      }
+    }
     snapshot.canvasState = {
       nodes: { ...state.nodes },
       regions: { ...state.regions },
       viewportOffset: { ...state.viewportOffset },
       zoomLevel: state.zoomLevel,
+      childPanels,
     }
   }
 
@@ -99,3 +108,4 @@ export async function acknowledgeTransfer(snapshot: PanelTransferSnapshot): Prom
     await window.electronAPI.panelTransferAck(snapshot.terminalPtyId)
   }
 }
+

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -14,6 +14,7 @@ import { DragOverlay, setupCrossWindowDragListeners } from '../drag'
 import { terminalRegistry } from '../lib/terminalRegistry'
 import { terminalRestoreData } from '../lib/session'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
+import { applyCanvasChildPanels } from '../lib/applyCanvasChildPanels'
 import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
@@ -81,11 +82,17 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       // Canvas panel: hydrate the per-panel canvas store BEFORE rendering, so
       // child nodes/regions are present on first paint. Without this the new
       // window mounts an empty canvas and writes that empty state back to
-      // session persistence on the next sync.
+      // session persistence on the next sync. Also seed both local `panels`
+      // and useAppStore with the child PanelState records so the canvas's
+      // child nodes resolve to their real types/titles instead of "Panel".
       if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
         const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
-        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        const { nodes, regions, viewportOffset, zoomLevel, childPanels } = snapshot.canvasState
         store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
+        applyCanvasChildPanels(wsId, childPanels ?? {})
+        if (childPanels) {
+          setPanels((prev) => ({ ...prev, ...childPanels }))
+        }
       }
 
       setPanels((prev) => ({
@@ -95,7 +102,7 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
     })
 
     return cleanup
-  }, [])
+  }, [wsId])
 
   // Set up cross-window drag listeners
   useEffect(() => {
@@ -112,8 +119,12 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       // Canvas panel: hydrate before mount so children are visible immediately.
       if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
         const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
-        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        const { nodes, regions, viewportOffset, zoomLevel, childPanels } = snapshot.canvasState
         store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
+        applyCanvasChildPanels(wsId, childPanels ?? {})
+        if (childPanels) {
+          setPanels((prev) => ({ ...prev, ...childPanels }))
+        }
       }
 
       setPanels((prev) => ({

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -13,6 +13,7 @@ import { renderPanelComponent, getPanelDef } from '../panels/registry'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import { applyTheme } from '../lib/themeManager'
+import { applyCanvasChildPanels } from '../lib/applyCanvasChildPanels'
 
 interface PanelWindowShellProps {
   panelType?: string
@@ -47,11 +48,12 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
         terminalRestoreData.set(snapshot.panel.id, { replayFromId: snapshot.terminalReplayPtyId })
       }
 
-      // Canvas panel: hydrate the per-panel canvas store before mount.
+      // Canvas panel: hydrate the per-panel canvas store + child PanelStates.
       if (snapshot.panel.type === 'canvas' && snapshot.canvasState) {
         const store = getOrCreateCanvasStoreForPanel(snapshot.panel.id)
-        const { nodes, regions, viewportOffset, zoomLevel } = snapshot.canvasState
+        const { nodes, regions, viewportOffset, zoomLevel, childPanels } = snapshot.canvasState
         store.getState().loadWorkspaceCanvas(nodes, viewportOffset, zoomLevel, null, regions)
+        applyCanvasChildPanels(workspaceId ?? '', childPanels ?? {})
       }
 
       setPanel(snapshot.panel)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -195,11 +195,16 @@ export interface PanelTransferSnapshot {
   // Canvas-specific — child nodes/regions/viewport for nested canvas panels.
   // Without this, detaching a canvas panel to a new window would land with an
   // empty store (fresh per-process), losing every panel inside it.
+  //
+  // `childPanels` carries the PanelState records for every panel referenced
+  // by the canvas's nodes. Without these the receiving window can't resolve
+  // child panel types/titles and falls back to a generic "Panel" stub.
   canvasState?: {
     nodes: Record<CanvasNodeId, CanvasNodeState>
     regions: Record<string, CanvasRegion>
     viewportOffset: Point
     zoomLevel: number
+    childPanels: Record<string, PanelState>
   }
 }
 


### PR DESCRIPTION
## Summary
Two follow-ups to the canvas-detach work merged in #54.

### 1. Detached canvas rendered children as generic 'Panel' stubs
The transfer snapshot carried \`CanvasNodeState\` entries but no \`PanelState\` records for those children, so the receiving window's \`resolvePanel\` returned undefined and the CanvasNode chrome fell back to a 'Panel' default (no type, no title).

**Fix**
- Add \`canvasState.childPanels: Record<string, PanelState>\` to \`PanelTransferSnapshot\`.
- \`createTransferSnapshot\` accepts an optional \`resolveChildPanel\` lookup; \`useDragOp.buildSnapshotFor\` wires it to the source workspace's panels record.
- New \`applyCanvasChildPanels\` helper merges those records into the receiving window's \`useAppStore\` (creating a stub workspace if missing) so \`resolvePanel\` finds them. Called from \`App.tsx\`, \`DockWindowShell\`, \`PanelWindowShell\` receive paths. \`DockWindowShell\` also merges into its local \`panels\` state for \`renderPanelContent\`.
- \`panelTransfer.ts\` no longer imports \`useAppStore\` (it dragged in heavy side-effects under jsdom and hung the test runner). The appStore-touching helper lives in its own file.

### 2. Detaching the workspace's only canvas left the source canvas-less
\`useDragOp.onRemovedFromCanvas\` now checks: if the panel just removed was a canvas AND no canvas remains in the source workspace, call \`createCanvas()\` to spawn a fresh empty one in its place. The detached window keeps the contents (carried by the snapshot).

## Test plan
- [x] \`npx vitest run\` — 258 pass, 3 skipped (was 257; +1 new)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: detach a canvas tab with terminal/editor children → new window shows real panels with correct titles
- [ ] Manual: workspace with only one canvas → detach it → source spawns a fresh empty canvas; detached keeps content