### PR TITLE
fix(dock-window): scope titlebar 78px padding to top-level tab bar only

### DIFF
--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -329,13 +329,17 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       <div className="dock-window-root h-screen w-screen flex flex-col bg-surface-4 overflow-hidden">
         {/* Make the top tab bar act as the macOS titlebar drag region, with
             left padding reserved for the traffic lights. Children remain
-            interactive via no-drag. */}
+            interactive via no-drag. The `:not(...)` scope is critical so
+            nested mini-dock tab bars inside canvas-nodes don't also get the
+            78px indent (regression seen when a canvas panel is detached). */}
         <style>{`
-          .dock-window-root .dock-tab-bar {
+          .dock-window-root .dock-tab-bar:not(.dock-tab-bar .dock-tab-bar) {
             padding-left: 78px;
             -webkit-app-region: drag;
           }
-          .dock-window-root .dock-tab-bar > * { -webkit-app-region: no-drag; }
+          .dock-window-root .dock-tab-bar:not(.dock-tab-bar .dock-tab-bar) > * {
+            -webkit-app-region: no-drag;
+          }
         `}</style>
         {/* Full content area — center zone only */}
         <div className="flex-1 min-h-0 min-w-0 relative overflow-hidden">


### PR DESCRIPTION
## Summary
After detaching a canvas with child nodes, every canvas-node inside the new window had its tab pill shoved 78px to the right.

Root cause in \`DockWindowShell.tsx\`: the runtime \`<style>\` that reserves space for the macOS traffic lights used the selector \`.dock-window-root .dock-tab-bar\`, which matched **every** \`.dock-tab-bar\` — including the nested mini-dock tab bars rendered by canvas-nodes inside the window's canvas.

Fix: scope the rule with \`:not(.dock-tab-bar .dock-tab-bar)\` so it only applies to a top-level dock tab bar (one that isn't itself nested inside another).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: detach a canvas with terminal/editor nodes → child node titles align flush with their panel body, not indented 78px