### PR TITLE
fix(dock-window): override 78px tab-bar padding inside canvas-nodes

### DIFF
--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -327,17 +327,18 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   return (
     <DockStoreProvider store={dockStore}>
       <div className="dock-window-root h-screen w-screen flex flex-col bg-surface-4 overflow-hidden">
-        {/* Make the top tab bar act as the macOS titlebar drag region, with
-            left padding reserved for the traffic lights. Children remain
-            interactive via no-drag. The `:not(...)` scope is critical so
-            nested mini-dock tab bars inside canvas-nodes don't also get the
-            78px indent (regression seen when a canvas panel is detached). */}
+        {/* Reserve 78px on the left of the top tab bar for the macOS traffic
+            lights and make it the window drag region. Override inside any
+            canvas-node ([data-node-id]) so nested mini-dock tab bars don't
+            inherit the indent or become drag handles. */}
         <style>{`
-          .dock-window-root .dock-tab-bar:not(.dock-tab-bar .dock-tab-bar) {
+          .dock-window-root .dock-tab-bar {
             padding-left: 78px;
             -webkit-app-region: drag;
           }
-          .dock-window-root .dock-tab-bar:not(.dock-tab-bar .dock-tab-bar) > * {
+          .dock-window-root .dock-tab-bar > * { -webkit-app-region: no-drag; }
+          .dock-window-root [data-node-id] .dock-tab-bar {
+            padding-left: 0;
             -webkit-app-region: no-drag;
           }
         `}</style>


### PR DESCRIPTION
Follow-up to #58. The `:not(.dock-tab-bar .dock-tab-bar)` selector didn't actually exclude nested mini-dock tab bars at runtime, so child canvas-node titles in detached canvases were still indented 78px.

Switch to an explicit override pattern: keep the base `.dock-tab-bar` rule (78px padding + drag region) for the top zone, then add a higher-specificity reset inside `[data-node-id]` (CanvasNode's root) that zeros out the padding and webkit-app-region for nested tab bars.

## Test plan
- [x] tsc clean
- [ ] Manual: detached canvas with terminal nodes — title pills align flush with their panel body