### PR TITLE
feat(worktree): tint terminal icons by worktree in sidebar + tabs

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -447,7 +447,18 @@ export function registerHandlers(): void {
 
   ipcMain.handle(GIT_WORKTREE_STATUS, async (_event, worktreePath: string) => {
     try {
+      // After a worktree is removed (or its directory deleted out-of-band),
+      // a stale status request may still arrive before the renderer refreshes
+      // its list. Treat "path missing" / "not a repo" as a soft no-op so we
+      // don't spam the log with confusing GitErrors.
+      try {
+        const stat = await fs.stat(worktreePath)
+        if (!stat.isDirectory()) return null
+      } catch {
+        return null
+      }
       const git = simpleGit(validateCwd(worktreePath))
+      if (!(await git.checkIsRepo())) return null
       const status = await git.status()
       let ahead = 0
       let behind = 0

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -372,7 +372,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     staged: number
     unstaged: number
     untracked: number
-  }> {
+  } | null> {
     return ipcRenderer.invoke(GIT_WORKTREE_STATUS, worktreePath)
   },
 

--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -6,10 +6,32 @@
 // =============================================================================
 
 import React from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import type { PanelState, PanelType, DockTabStack as DockTabStackType } from '../../shared/types'
 import { X } from '@phosphor-icons/react'
 import { useDragStore, useTabSourceVisibility } from '../drag'
 import { PANEL_REGISTRY, getPanelDef } from '../panels/registry'
+import { useAppStore } from '../stores/appStore'
+
+// Lookup: panelId → worktree color. Only returns a color when the panel's
+// workspace has 2+ worktrees (matches WorktreePill's visibility rule, so the
+// tab tint and the title-bar pill appear together or not at all).
+function useWorktreeColorByPanel(): Record<string, string> {
+  return useAppStore(useShallow((s) => {
+    const out: Record<string, string> = {}
+    for (const ws of s.workspaces) {
+      const worktrees = ws.worktrees ?? []
+      if (worktrees.length < 2) continue
+      const primary = worktrees.find((w) => w.isPrimary)
+      for (const panel of Object.values(ws.panels)) {
+        if (panel.type !== 'terminal' && panel.type !== 'agent') continue
+        const wt = worktrees.find((w) => w.id === panel.worktreeId) ?? primary
+        if (wt?.color) out[panel.id] = wt.color
+      }
+    }
+    return out
+  }))
+}
 
 // Type → icon/tint mirrors the Spotlight overlay so tabs, search results, and
 // the command palette speak the same visual language.
@@ -80,6 +102,8 @@ export function DockTabBar(props: DockTabBarProps) {
     onEmptyMouseDown, onEmptyContextMenu,
     showTabPlaceholder, selfTabDrag, onTabBarMouseDown,
   } = props
+
+  const worktreeColorByPanel = useWorktreeColorByPanel()
 
   // Build the visible tab list (skip the in-flight tab when source === this
   // stack) and choose where to slot the placeholder. Clamp to >=1 so a
@@ -168,7 +192,10 @@ export function DockTabBar(props: DockTabBarProps) {
                 style={{ backgroundColor: 'var(--node-chrome-accent, #3b82f6)' }}
               />
             )}
-            <span className={`shrink-0 ${isActive ? PANEL_TYPE_TINT[panelType] : 'text-muted'}`}>
+            <span
+              className={`shrink-0 ${worktreeColorByPanel[panelId] ? '' : isActive ? PANEL_TYPE_TINT[panelType] : 'text-muted'}`}
+              style={worktreeColorByPanel[panelId] ? { color: worktreeColorByPanel[panelId] } : undefined}
+            >
               <TabIcon type={panelType} size={compact ? 11 : 13} />
             </span>
             {renameId === panelId ? (

--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -319,6 +319,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
         list.map(async (g) => {
           try {
             const s = await window.electronAPI.gitWorktreeStatus(g.path)
+            if (!s) return null
             return [g.path, s] as const
           } catch {
             return null
@@ -442,7 +443,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       if (!target && primary?.path) {
         try {
           const s = await window.electronAPI.gitWorktreeStatus(primary.path)
-          target = s.branch
+          if (s) target = s.branch
         } catch { /* ignore */ }
       }
       if (!wt.branch || !target) {

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -126,12 +126,13 @@ export interface TerminalPanelRowProps {
   indent: boolean
   agentState: AgentState | undefined
   hasPorts: boolean
+  worktreeColor?: string
   onClick: (e: React.MouseEvent) => void
 }
 
 const AWAIT_COLOR = '#c08a5a'
 
-export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, agentState, hasPorts, onClick }) => {
+export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, agentState, hasPorts, worktreeColor, onClick }) => {
   const Icon = PANEL_ICONS[panel.type] ?? TerminalIcon
   const label = panel.title || panel.filePath?.split('/').pop() || panel.url || panel.type
 
@@ -146,7 +147,11 @@ export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, inden
       onClick={onClick}
       title={panel.filePath || panel.url || label}
     >
-      <Icon size={11} className="flex-shrink-0 opacity-60" />
+      <Icon
+        size={11}
+        className="flex-shrink-0"
+        style={worktreeColor ? { color: worktreeColor, opacity: 0.95 } : { opacity: 0.6 }}
+      />
       <span className={`truncate min-w-0 flex-1 ${isRunning ? 'cate-notif-pulse' : ''}`}>
         {label}
       </span>
@@ -207,6 +212,14 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const panels = useAppStore(useShallow((s) => {
     const ws = s.workspaces.find((w) => w.id === workspace.id)
     return ws?.panels ?? workspace.panels
+  }))
+
+  // worktrees ignored by useWorkspaceList's equality fn → workspace.worktrees
+  // is stale. Subscribe directly so the per-row accent updates as worktrees
+  // are added/recolored.
+  const worktrees = useAppStore(useShallow((s) => {
+    const ws = s.workspaces.find((w) => w.id === workspace.id)
+    return ws?.worktrees ?? workspace.worktrees ?? []
   }))
 
   // Set of panel ids living on this workspace's canvases. Union of:
@@ -434,6 +447,17 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     }
   }
 
+  // Worktree color resolver: only meaningful when the workspace has 2+
+  // worktrees (matches WorktreePill's visibility rule — single-branch
+  // workspaces would just get noisy with monochrome dots).
+  const showWorktreeAccent = worktrees.length >= 2
+  const worktreeColorFor = (panelId: string): string | undefined => {
+    if (!showWorktreeAccent) return undefined
+    const wtId = panels[panelId]?.worktreeId
+    const wt = worktrees.find((w) => w.id === wtId) ?? worktrees.find((w) => w.isPrimary)
+    return wt?.color
+  }
+
   const renderPanelRow = (p: typeof panelList[number], indent = false) => {
     if (p.type === 'terminal' || p.type === 'agent') {
       const resolvedState = agentStateByPanel[p.id]
@@ -447,6 +471,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
           indent={indent}
           agentState={resolvedState}
           hasPorts={(portsByPanel[p.id]?.length ?? 0) > 0}
+          worktreeColor={worktreeColorFor(p.id)}
           onClick={(e) => handlePanelClick(e, p.id)}
         />
       )

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -152,7 +152,7 @@ export interface ElectronAPI {
     staged: number
     unstaged: number
     untracked: number
-  }>
+  } | null>
 
   /** Fetch + checkout `toBranch` + merge `fromBranch` into it. Returns
    *  `{ ok: false, conflict }` on merge failure so the renderer can show a


### PR DESCRIPTION
## Summary
- Workspace overview sidebar tints terminal/agent panel icons with their worktree color
- Dock tab bar tints terminal/agent tab icons with the worktree color (matches the title-bar `WorktreePill`)
- Only applied when the workspace has 2+ worktrees, same visibility rule as the pill
- `gitWorktreeStatus` IPC handler soft-fails (returns `null`) when the path is gone or not a repo — fixes the noisy `fatal: not a git repository` log after deleting a worktree

## Test plan
- [ ] Workspace with 2+ worktrees: terminal icons in the sidebar and dock tabs take the worktree color
- [ ] Single-worktree workspace: original muted/tinted icon (no regression)
- [ ] Switch a terminal's worktree via the pill — sidebar and tab icons update
- [ ] Delete a worktree — no `git:worktreeStatus` error in the main log