### PR TITLE
feat: minimap expand animation, browser stability, workspace multi-select

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1097,7 +1097,7 @@ app.whenReady().then(async () => {
         responseHeaders: {
           ...details.responseHeaders,
           'Content-Security-Policy': [
-            `default-src 'self'; script-src 'self'${process.env.ELECTRON_RENDERER_URL ? " 'unsafe-inline' 'unsafe-eval'" : ''}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: file:; connect-src 'self' https: ws: wss:; font-src 'self' data:; base-uri 'self'`,
+            `default-src 'self'; script-src 'self'${process.env.ELECTRON_RENDERER_URL ? " 'unsafe-inline' 'unsafe-eval'" : ''}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: file:; connect-src 'self' https: ws: wss: sentry-ipc:; font-src 'self' data:; base-uri 'self'`,
           ],
         },
       })

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -290,7 +290,11 @@ function createTerminal(
         if (dataBuffer) {
           const windowId = terminalOwners.get(id)
           if (windowId != null) {
-            sendToWindow(windowId, TERMINAL_DATA, id, dataBuffer)
+            try {
+              sendToWindow(windowId, TERMINAL_DATA, id, dataBuffer)
+            } catch {
+              // Window destroyed between buffer and flush
+            }
           }
         }
         dataBuffer = ''
@@ -318,7 +322,11 @@ function writeTerminal(id: string, data: string): void {
     // shell wouldn't run until the next SIGCONT.
     const state = idleState.get(id)
     if (state?.suspended) resumeTerminal(id)
-    pty.write(data)
+    try {
+      pty.write(data)
+    } catch {
+      // PTY fd already closed (race between shell exit and incoming write)
+    }
   }
 }
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -18,6 +18,10 @@ log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
 // launched from Finder have no attached stdout/stderr, so writes throw EIO.
 log.transports.console.level = process.env.NODE_ENV === 'development' ? 'debug' : false
 
+// Guard against EIO on broken stderr even in dev (parent terminal closed).
+process.stderr?.on?.('error', () => {})
+process.stdout?.on?.('error', () => {})
+
 // Catch uncaughtException + unhandledRejection globally
 log.errorHandler.startCatching()
 

--- a/src/renderer/canvas/CanvasToolbar.test.ts
+++ b/src/renderer/canvas/CanvasToolbar.test.ts
@@ -3,10 +3,8 @@
 //
 // These are source-level assertions rather than full React renders — the
 // toolbar pulls in heavy renderer modules (xterm, electron-log, the canvas
-// store context tree) that aren't worth wiring up just to verify two
-// structural invariants. Both bugs being pinned here were silent regressions
-// in the source, so reading the source is the cheapest way to catch them
-// coming back.
+// store context tree) that aren't worth wiring up just to verify structural
+// invariants.
 // =============================================================================
 
 import { readFileSync } from 'node:fs'
@@ -19,49 +17,22 @@ const SOURCE = readFileSync(
 )
 
 describe('CanvasToolbar — minimap section', () => {
-  it('does not force a hard-coded theme on the minimap popover (must inherit the active app theme)', () => {
-    // Bug: the popover wrapper used to set data-theme="dark-warm", which
-    // pinned the surface tokens to the warm palette regardless of the user's
-    // selected theme (cool dark, light, etc).
+  it('does not force a hard-coded theme on the minimap container (must inherit the active app theme)', () => {
     const minimapStart = SOURCE.indexOf('<Minimap mode="popover"')
     expect(minimapStart).toBeGreaterThan(-1)
 
-    // Look at the ~600 chars preceding the Minimap usage — that's its wrapping
-    // chain inside the toolbar. None of them should pin the theme.
     const wrapperBlock = SOURCE.slice(Math.max(0, minimapStart - 600), minimapStart)
     expect(wrapperBlock).not.toMatch(/data-theme=/)
   })
 
-  it('renders both the minimap button and popover only when the showMinimap setting is true', () => {
-    // The button used to render unconditionally; toggling the setting only
-    // hid the popover, leaving an orphaned button behind. The entire minimap
-    // sub-tree must now be gated on `showMinimap`.
-    const minimapStart = SOURCE.indexOf('<Minimap mode="popover"')
-    const buttonStart = SOURCE.indexOf('<MapTrifold')
-    expect(minimapStart).toBeGreaterThan(-1)
-    expect(buttonStart).toBeGreaterThan(-1)
-
-    // Find the nearest enclosing `{showMinimap && (` opener before each.
-    const gateRegex = /\{showMinimap && \(/g
-    const gates: number[] = []
-    let m: RegExpExecArray | null
-    while ((m = gateRegex.exec(SOURCE)) !== null) gates.push(m.index)
-    expect(gates.length).toBeGreaterThan(0)
-
-    const nearestGateBefore = (idx: number) =>
-      gates.filter((g) => g < idx).pop() ?? -1
-
-    expect(nearestGateBefore(buttonStart)).toBeGreaterThan(-1)
-    expect(nearestGateBefore(minimapStart)).toBeGreaterThan(-1)
-  })
-
-  it('drives the popover open/close from the transient uiStore, not from the persisted setting', () => {
-    // The click handler used to flip the `showMinimap` setting itself, which
-    // conflated "feature available" with "popover open" — toggling the
-    // setting then made the button vanish too. The button must instead drive
-    // a transient uiStore flag.
+  it('drives the popover open/close from the transient uiStore, not from a persisted setting', () => {
     expect(SOURCE).toMatch(/toggleMinimapOpen/)
     expect(SOURCE).not.toMatch(/saveSetting\(['"]showMinimap['"]/)
     expect(SOURCE).not.toMatch(/setSetting\(['"]showMinimap['"]/)
+  })
+
+  it('always renders the minimap button (not gated by a setting)', () => {
+    expect(SOURCE).toContain('<MapTrifold')
+    expect(SOURCE).not.toMatch(/\{showMinimap && \(/)
   })
 })

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -16,10 +16,10 @@ import {
   DotsThree,
   SquaresFour,
   MapTrifold,
+  X,
 } from '@phosphor-icons/react'
 import Minimap from './Minimap'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
-import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStore } from '../stores/uiStore'
 import { UpdateButton } from './UpdateButton'
 
@@ -89,7 +89,6 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   onZoomOut,
 }) => {
   const canvasApi = useCanvasStoreApi()
-  const showMinimap = useSettingsStore((s) => s.showMinimap)
   const minimapOpen = useUIStore((s) => s.minimapOpen)
   const toggleMinimapOpen = useUIStore((s) => s.toggleMinimapOpen)
   const zoomText = `${Math.round(zoom * 100)}%`
@@ -207,80 +206,44 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
 
     </div>
 
-    {/* Minimap — standalone pill button anchored to the bottom-right corner.
-        The right offset includes the right sidebar width so the button stays
-        visible when the overlay sidebar is expanded. The entire minimap UI
-        (button + popover) is gated by the `showMinimap` setting. */}
+    {/* Minimap — pill button anchored to bottom-right that grows upward-left
+        to reveal the map. The button stays at the bottom-right corner so open
+        and close feel like the same gesture. */}
     <div
-      className="absolute bottom-4 z-50 flex items-center gap-2"
+      className="absolute bottom-4 z-50 flex items-end gap-2"
       style={{ right: 'calc(1rem + var(--cate-right-sidebar-width, 0px))' }}
     >
       <UpdateButton />
-      {showMinimap && (
-        <div className="relative" data-testid="minimap-toggle">
-          <div className="rounded-full border border-strong bg-surface-6 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
-            <div className="flex items-center p-1.5">
-              <ToolbarButton
-                onClick={toggleMinimapOpen}
-                title={minimapOpen ? 'Hide minimap' : 'Show minimap'}
-                size="panel"
-                active={minimapOpen}
-              >
-                <MapTrifold size={14} />
-              </ToolbarButton>
-            </div>
+      <div
+        data-testid="minimap-toggle"
+        className="relative overflow-hidden border border-strong shadow-[0_8px_24px_-6px_var(--shadow-node)]"
+        style={{
+          borderRadius: 20,
+          transition: 'width 300ms cubic-bezier(0.16,1,0.3,1), height 300ms cubic-bezier(0.16,1,0.3,1), background 200ms ease, backdrop-filter 200ms ease',
+          width: minimapOpen ? 220 : 36,
+          height: minimapOpen ? 160 : 36,
+          background: minimapOpen
+            ? 'color-mix(in srgb, var(--surface-2) 45%, transparent)'
+            : 'var(--surface-6)',
+          backdropFilter: minimapOpen ? 'blur(24px) saturate(1.5)' : 'none',
+          WebkitBackdropFilter: minimapOpen ? 'blur(24px) saturate(1.5)' : 'none',
+        }}
+      >
+        {minimapOpen && (
+          <div className="absolute inset-0">
+            <Minimap mode="popover" />
           </div>
-          {minimapOpen && (
-            <div
-              className="absolute right-0 bottom-full mb-2 rounded-lg overflow-hidden shadow-[0_18px_40px_-12px_var(--shadow-node)]"
-            >
-              <Minimap mode="popover" />
-            </div>
-          )}
-          {minimapOpen && (
-            <>
-              {/* Border triangle (slightly larger, underneath) */}
-              <div
-                aria-hidden
-                className="absolute left-1/2 -translate-x-1/2 bottom-full"
-                style={{
-                  marginBottom: 1,
-                  width: 0,
-                  height: 0,
-                  borderLeft: '7px solid transparent',
-                  borderRight: '7px solid transparent',
-                  borderTop: '7px solid var(--border-subtle)',
-                }}
-              />
-              {/* Fill triangle (on top, 1px inset) */}
-              <div
-                aria-hidden
-                className="absolute left-1/2 -translate-x-1/2 bottom-full"
-                style={{
-                  marginBottom: 2,
-                  width: 0,
-                  height: 0,
-                  borderLeft: '6px solid transparent',
-                  borderRight: '6px solid transparent',
-                  borderTop: '6px solid var(--surface-2)',
-                }}
-              />
-              {/* Notch — covers the 1px popover border across the tail's width so
-                  the tail visually connects to the popover without a seam line. */}
-              <div
-                aria-hidden
-                className="absolute left-1/2 -translate-x-1/2 bottom-full"
-                style={{
-                  marginBottom: 8,
-                  width: 12,
-                  height: 1,
-                  background: 'var(--surface-2)',
-                }}
-              />
-            </>
-          )}
-        </div>
-      )}
+        )}
+        <button
+          type="button"
+          onClick={toggleMinimapOpen}
+          title={minimapOpen ? 'Hide minimap' : 'Show minimap'}
+          style={{ WebkitTapHighlightColor: 'transparent' }}
+          className="absolute -bottom-[1px] -right-[1px] w-[36px] h-[36px] flex items-center justify-center text-primary hover:text-primary/80 active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100 z-10"
+        >
+          {minimapOpen ? <X size={12} weight="bold" /> : <MapTrifold size={14} />}
+        </button>
+      </div>
     </div>
     </>
   )

--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -78,8 +78,8 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
   })
   const [corner, setCorner] = useState<Corner>(loadCorner)
   const [size, setSize] = useState<{ w: number; h: number }>(loadSize)
-  const MINIMAP_WIDTH = mode === 'popover' ? 220 : size.w
-  const MINIMAP_HEIGHT = mode === 'popover' ? 160 : size.h
+  const MINIMAP_WIDTH = mode === 'popover' ? 218 : size.w
+  const MINIMAP_HEIGHT = mode === 'popover' ? 158 : size.h
 
   const sizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cornerDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -257,19 +257,19 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
       ref={minimapRef}
       style={{
         ...(isPopover
-          ? { position: 'relative' as const }
+          ? { position: 'relative' as const, width: '100%', height: '100%' }
           : {
               position: 'absolute' as const,
               ...(corner.startsWith('bottom') ? { bottom: MINIMAP_GAP } : { top: MINIMAP_GAP }),
               ...(corner.endsWith('right') ? { right: MINIMAP_GAP } : { left: MINIMAP_GAP }),
               opacity: 0.7,
               zIndex: 20,
+              width: MINIMAP_WIDTH,
+              height: MINIMAP_HEIGHT,
             }),
-        width: MINIMAP_WIDTH,
-        height: MINIMAP_HEIGHT,
-        backgroundColor: 'var(--surface-2)',
-        borderRadius: 8,
-        border: `1px solid var(--border-subtle)`,
+        backgroundColor: isPopover ? 'transparent' : 'var(--surface-2)',
+        borderRadius: isPopover ? 6 : 8,
+        border: isPopover ? 'none' : `1px solid var(--border-subtle)`,
         overflow: 'hidden',
         cursor: 'crosshair',
       }}

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -7,7 +7,6 @@ import { useEffect } from 'react'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useAppStore } from '../stores/appStore'
-import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStore } from '../stores/uiStore'
 import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
@@ -100,12 +99,7 @@ export function useShortcuts(): void {
           break
         }
         case 'toggleMinimap':
-          // Only toggles the popover when the minimap feature is enabled in
-          // settings; if disabled, the shortcut is a no-op (matches the
-          // hidden-button state).
-          if (useSettingsStore.getState().showMinimap) {
-            useUIStore.getState().toggleMinimapOpen()
-          }
+          useUIStore.getState().toggleMinimapOpen()
           break
         case 'nodeSwitcher':
           useUIStore.getState().setShowNodeSwitcher(true)

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -95,6 +95,10 @@ export default function BrowserPanel({
   const rawInitialUrl = url || browserHomepage || 'https://www.google.com'
   const initialUrl = rawInitialUrl.startsWith('about:') ? rawInitialUrl : normalizeUrl(rawInitialUrl)
 
+  // Stable src for the <webview> element — computed once at mount so React
+  // never updates the attribute on re-render (which would re-navigate).
+  const [webviewSrc] = useState(() => initialUrl)
+
   const webviewRef = useRef<WebviewElement | null>(null)
   const [currentUrl, setCurrentUrl] = useState(initialUrl)
   const [inputUrl, setInputUrl] = useState(initialUrl)
@@ -222,6 +226,10 @@ export default function BrowserPanel({
 
     const onDidNavigate = (event: any) => {
       const url = event.url ?? webview.getURL()
+      // Skip about:blank — it fires transiently when the webview guest
+      // process spins up or during teardown. Persisting it would clobber
+      // the real URL and break session restore / visibility-cull remount.
+      if (url === 'about:blank') return
       setCurrentUrl(url)
       setInputUrl(url)
       setCanGoBack(webview.canGoBack())
@@ -233,6 +241,7 @@ export default function BrowserPanel({
 
     const onDidNavigateInPage = (event: any) => {
       const url = event.url ?? webview.getURL()
+      if (url === 'about:blank') return
       setCurrentUrl(url)
       setInputUrl(url)
       setCanGoBack(webview.canGoBack())
@@ -303,10 +312,6 @@ export default function BrowserPanel({
     webview.addEventListener('new-window', onNewWindow)
 
     return () => {
-      // IMPORTANT: remove navigation listeners BEFORE kicking off any
-      // teardown navigation. Otherwise the late-firing did-navigate from
-      // loadURL('about:blank') below would overwrite panel.url with
-      // 'about:blank' in the store, and the URL would be lost on restart.
       try { portalRegistry.unregister(panelId) } catch { /* ignore */ }
       webview.removeEventListener('dom-ready', onDomReady)
       webview.removeEventListener('did-navigate', onDidNavigate)
@@ -317,12 +322,6 @@ export default function BrowserPanel({
       webview.removeEventListener('did-stop-loading', onDidStopLoading)
       webview.removeEventListener('will-navigate', onWillNavigate)
       webview.removeEventListener('new-window', onNewWindow)
-      try {
-        // May throw if webview was never attached / dom-ready before unmount
-        webview.loadURL('about:blank')
-      } catch {
-        // ignore — webview is being torn down anyway
-      }
     }
   }, [panelId, workspaceId, updatePanelTitle, updatePanelUrl])
 
@@ -406,7 +405,7 @@ export default function BrowserPanel({
         {/* Webview */}
         <webview
           ref={webviewRef as any}
-          src={initialUrl}
+          src={webviewSrc}
           className={`w-full h-full ${loadError ? 'hidden' : ''}`}
           partition={`persist:browser-${panelId}`}
         />

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -312,19 +312,21 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
           ))}
         </Canvas>
 
-        <CanvasToolbar
-          zoom={zoomLevel}
-          onNewTerminal={onNewTerminal}
-          onNewBrowser={onNewBrowser}
-          onNewEditor={onNewEditor}
-          onNewAgent={onNewAgent}
-          onNewCanvas={onNewCanvas}
-          onNewRegion={onNewRegion}
-          onAutoLayout={onAutoLayout}
-          onZoomToFit={onZoomToFit}
-          onZoomIn={onZoomIn}
-          onZoomOut={onZoomOut}
-        />
+        {(nodeIds.length > 0 || workspaceRootPath) && (
+          <CanvasToolbar
+            zoom={zoomLevel}
+            onNewTerminal={onNewTerminal}
+            onNewBrowser={onNewBrowser}
+            onNewEditor={onNewEditor}
+            onNewAgent={onNewAgent}
+            onNewCanvas={onNewCanvas}
+            onNewRegion={onNewRegion}
+            onAutoLayout={onAutoLayout}
+            onZoomToFit={onZoomToFit}
+            onZoomIn={onZoomIn}
+            onZoomOut={onZoomOut}
+          />
+        )}
 
         <ShortcutHintOverlay />
       </div>

--- a/src/renderer/settings/CanvasSettings.tsx
+++ b/src/renderer/settings/CanvasSettings.tsx
@@ -30,12 +30,6 @@ export function CanvasSettings() {
           ]}
         />
       </SettingRow>
-      <SettingRow
-        label="Show minimap"
-        description="Show the minimap button in the bottom-right corner of the canvas."
-      >
-        <Toggle checked={store.showMinimap} onChange={(v) => store.setSetting('showMinimap', v)} />
-      </SettingRow>
       <SettingRow label="Default panel width">
         <NumberInput value={store.defaultPanelWidth} onChange={(v) => store.setSetting('defaultPanelWidth', v)} min={300} max={1200} step={50} />
       </SettingRow>

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useRef, useEffect } from 'react'
 import { Plus } from '@phosphor-icons/react'
 import { useAppStore, useWorkspaceList } from '../stores/appStore'
 import { WorkspaceTab } from './WorkspaceTab'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
+import type { NativeContextMenuItem } from '../../shared/electron-api.d'
 
 export const ProjectList: React.FC = () => {
   const workspaces = useWorkspaceList()
@@ -11,12 +12,79 @@ export const ProjectList: React.FC = () => {
   const selectWorkspace = useAppStore((s) => s.selectWorkspace)
   const removeWorkspace = useAppStore((s) => s.removeWorkspace)
 
+  const [multiSelected, setMultiSelected] = useState<Set<string>>(new Set())
+  const lastClickedIndexRef = useRef<number | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Clear multi-selection when workspaces change (e.g. after deletion)
+  useEffect(() => {
+    setMultiSelected((prev) => {
+      const wsIds = new Set(workspaces.map((w) => w.id))
+      const filtered = new Set([...prev].filter((id) => wsIds.has(id)))
+      if (filtered.size === prev.size) return prev
+      return filtered
+    })
+  }, [workspaces])
+
+  const handleWorkspaceClick = useCallback((index: number, wsId: string, e?: React.MouseEvent) => {
+    if (e?.shiftKey && lastClickedIndexRef.current !== null) {
+      const start = Math.min(lastClickedIndexRef.current, index)
+      const end = Math.max(lastClickedIndexRef.current, index)
+      const rangeIds = new Set<string>()
+      for (let i = start; i <= end; i++) {
+        rangeIds.add(workspaces[i].id)
+      }
+      setMultiSelected(rangeIds)
+      return
+    }
+
+    setMultiSelected(new Set())
+    lastClickedIndexRef.current = index
+    selectWorkspace(wsId)
+  }, [workspaces, selectWorkspace])
+
+  const handleBulkDelete = useCallback(() => {
+    if (multiSelected.size === 0) return
+    const idsToRemove = [...multiSelected]
+    setMultiSelected(new Set())
+    lastClickedIndexRef.current = null
+    for (const id of idsToRemove) {
+      useAppStore.getState().removeWorkspace(id)
+    }
+  }, [multiSelected])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.key === 'Delete' || e.key === 'Backspace') && multiSelected.size > 0) {
+      e.preventDefault()
+      handleBulkDelete()
+    }
+    if (e.key === 'Escape' && multiSelected.size > 0) {
+      e.preventDefault()
+      setMultiSelected(new Set())
+    }
+  }, [multiSelected, handleBulkDelete])
+
+  const handleBulkContextMenu = useCallback(async (e: React.MouseEvent, wsId: string) => {
+    if (multiSelected.size < 2) return false
+    if (!multiSelected.has(wsId)) return false
+    e.preventDefault()
+    e.stopPropagation()
+    if (!window.electronAPI) return true
+    const items: NativeContextMenuItem[] = [
+      { id: 'delete-selected', label: `Close ${multiSelected.size} Workspaces` },
+    ]
+    const id = await window.electronAPI.showContextMenu(items)
+    if (id === 'delete-selected') {
+      handleBulkDelete()
+    }
+    return true
+  }, [multiSelected, handleBulkDelete])
+
   const handleNewWorkspace = useCallback(() => {
-    // If there's already an uninitialized workspace (no folder picked yet),
-    // reuse it instead of stacking another empty "Add Workspace" row.
     const existing = useAppStore.getState().workspaces.find((w) => !w.rootPath)
     const wsId = existing ? existing.id : addWorkspace()
     selectWorkspace(wsId)
+    setMultiSelected(new Set())
   }, [addWorkspace, selectWorkspace])
 
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
@@ -24,7 +92,12 @@ export const ProjectList: React.FC = () => {
   const displayWorkspaces = workspaces
 
   return (
-    <div className="flex flex-col h-full">
+    <div
+      className="flex flex-col h-full"
+      ref={containerRef}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+    >
       <SidebarSectionHeader
         title="Workspace"
         actions={
@@ -40,7 +113,7 @@ export const ProjectList: React.FC = () => {
           {displayWorkspaces.map((ws, index) => (
             <div
               key={ws.id}
-              draggable
+              draggable={multiSelected.size === 0}
               onDragStart={(e) => {
                 e.dataTransfer.setData('text/plain', String(index))
                 e.dataTransfer.effectAllowed = 'move'
@@ -67,8 +140,10 @@ export const ProjectList: React.FC = () => {
               <WorkspaceTab
                 workspace={ws}
                 isSelected={ws.id === selectedWorkspaceId}
-                onClick={() => selectWorkspace(ws.id)}
+                isMultiSelected={multiSelected.has(ws.id)}
+                onClick={(e) => handleWorkspaceClick(index, ws.id, e)}
                 onClose={() => removeWorkspace(ws.id)}
+                onBulkContextMenu={(e) => handleBulkContextMenu(e, ws.id)}
               />
             </div>
           ))}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -183,15 +183,19 @@ const COLOR_NAMES: Record<string, string> = {
 interface WorkspaceTabProps {
   workspace: WorkspaceState
   isSelected: boolean
-  onClick: () => void
+  isMultiSelected?: boolean
+  onClick: (e?: React.MouseEvent) => void
   onClose: () => void
+  onBulkContextMenu?: (e: React.MouseEvent) => Promise<boolean>
 }
 
 export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   workspace,
   isSelected,
+  isMultiSelected = false,
   onClick,
   onClose,
+  onBulkContextMenu,
 }) => {
   // Single store read for all workspace status data
   const wsStatus = useStatusStore(useShallow((s) => {
@@ -275,6 +279,10 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const renameInputRef = useRef<HTMLInputElement>(null)
 
   const handleContextMenu = useCallback(async (e: React.MouseEvent) => {
+    if (onBulkContextMenu) {
+      const handled = await onBulkContextMenu(e)
+      if (handled) return
+    }
     e.preventDefault()
     e.stopPropagation()
     if (!window.electronAPI) return
@@ -339,7 +347,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       case 'close-panels': app.closeAllPanels(workspace.id); break
       case 'remove': app.removeWorkspace(workspace.id); break
     }
-  }, [workspace.id, workspace.name, workspace.rootPath, workspace.color, workspace.panels, isSelected])
+  }, [workspace.id, workspace.name, workspace.rootPath, workspace.color, workspace.panels, isSelected, onBulkContextMenu])
 
   useEffect(() => {
     if (isRenaming && renameInputRef.current) {
@@ -504,14 +512,16 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         className={`group flex items-center gap-1 h-8 px-1.5 rounded-md cursor-pointer transition-colors outline-none ${
           isContextActive ? 'ring-1 ring-strong' : ''
         } ${
-          isSelected
+          isMultiSelected
+            ? 'bg-surface-3 text-primary ring-1 ring-strong'
+            : isSelected
             ? 'bg-surface-3 text-primary'
             : 'text-secondary hover:text-primary hover:bg-hover'
         }`}
         style={hasColor ? {
           backgroundColor: isSelected ? `${accent}26` : `${accent}14`,
         } : undefined}
-        onClick={onClick}
+        onClick={(e) => onClick(e)}
       >
         {/* Chevron / expand toggle */}
         <button

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -53,9 +53,7 @@ interface UIStoreState {
   showPanelSwitcher: boolean
   showGlobalSearch: boolean
   showLayoutsDialog: boolean
-  /** Whether the minimap popover is currently open. Distinct from the
-   *  `showMinimap` setting which controls whether the minimap feature
-   *  (button + popover) is available at all. */
+  /** Whether the minimap is currently expanded. */
   minimapOpen: boolean
   showSettings: boolean
   /** Optional initial settings tab to open when showSettings flips to true. */

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+*:focus {
+  outline: none;
+}
+
 /* =============================================================================
    Theme tokens — defined per [data-theme] attribute on <html>.
    :root provides a safe fallback (dark-warm values) for any un-themed render.


### PR DESCRIPTION
## Summary
- **Minimap redesign**: replaced the popover + floating button with an animated pill that expands in-place (smooth width/height transition with backdrop blur). Removed the `showMinimap` setting — the button is always visible. Shortcut toggle works unconditionally.
- **BrowserPanel stability**: stabilized `<webview>` src to prevent re-navigation on re-render, ignore transient `about:blank` navigations that were clobbering session-restore URLs, removed teardown `loadURL('about:blank')`.
- **Workspace multi-select**: shift-click range selection in the sidebar workspace list, with bulk-delete via right-click context menu or Delete/Backspace keys. Visual ring indicator on multi-selected items.
- **Robustness**: guard PTY write-after-close and `sendToWindow` on destroyed windows, handle EIO on broken stderr/stdout in logger, add `sentry-ipc:` to CSP `connect-src`.
- **Polish**: remove global focus outlines, hide toolbar on empty canvas, streamline minimap test assertions.

## Test plan
- [ ] Open app, verify minimap button visible in bottom-right — click to expand/collapse with smooth animation
- [ ] Toggle minimap via keyboard shortcut
- [ ] Open a browser panel, navigate somewhere, close and reopen — URL should persist
- [ ] Shift-click multiple workspaces in sidebar — verify highlight ring, right-click bulk delete
- [ ] Verify no focus outline rings appear on click throughout the app