### PR TITLE
chore: bump version to 0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump package.json version from 0.4.5 → 0.4.6 for release

## Post-merge
Tag `v0.4.6` will be pushed after merge to trigger the release workflow.