### PR TITLE
feat(analytics): track update actions and feedback dismissals

### DIFF
--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -3,10 +3,14 @@
 // /api/app-events endpoint. Strictly opt-in via `usageAnalyticsEnabled`.
 //
 // What we send:
-//   - app_start       : version, platform, arch, locale, electron version
-//   - app_install     : first launch of this install
-//   - app_updated     : from_version → to_version (detected via lastSeenVersion)
-//   - feedback_submitted : 1-5 rating + optional free-text comment, post-update
+//   - app_start                : version, platform, arch, locale, electron version
+//   - app_install              : first launch of this install
+//   - app_updated              : from_version → to_version (detected via lastSeenVersion)
+//   - update_download_clicked  : user clicked "Download" on the update button
+//   - update_install_clicked   : user clicked "Restart" to install
+//   - update_manual_open_clicked : user clicked through to GitHub release page
+//   - feedback_submitted       : 1-5 rating + optional free-text comment, post-update
+//   - feedback_dismissed       : user skipped/closed the post-update feedback dialog
 //
 // What we deliberately do NOT send: file paths, project names, workspace
 // contents, hostname, IP-derived identifiers, user account info.
@@ -210,6 +214,8 @@ export function sanitizeFeedbackPayload(payload: unknown): { rating: number; com
 // Public API
 // ---------------------------------------------------------------------------
 
+export { sendEvent }
+
 export function initAnalytics(): void {
   // Renderer submits feedback. Returns an ack so the modal can show success /
   // failure rather than blindly claiming success.
@@ -229,6 +235,11 @@ export function initAnalytics(): void {
   })
 
   ipcMain.on(ANALYTICS_FEEDBACK_DISMISS, () => {
+    const state = readState()
+    void sendEvent('feedback_dismissed', {
+      to_version: state.pendingFeedbackForVersion ?? null,
+      from_version: state.pendingFeedbackFromVersion ?? null,
+    })
     updateState({ pendingFeedbackForVersion: undefined, pendingFeedbackFromVersion: undefined })
   })
 

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -23,6 +23,7 @@ import {
   UPDATE_OPEN_RELEASE,
 } from '../shared/ipc-channels'
 import { getWindowType } from './windowRegistry'
+import { sendEvent } from './analytics'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -197,6 +198,8 @@ export function initAutoUpdater(): void {
   ipcMain.on(UPDATE_DOWNLOAD, () => {
     if (!app.isPackaged) return
     log.info('[auto-updater] Renderer requested download')
+    const version = currentStatus.state === 'available' ? currentStatus.version : undefined
+    void sendEvent('update_download_clicked', { version: version ?? null })
     autoUpdater.downloadUpdate().catch((err) => {
       log.error('[auto-updater] downloadUpdate failed:', err)
       broadcastStatus({ state: 'error', message: err?.message || 'Download failed' })
@@ -206,6 +209,8 @@ export function initAutoUpdater(): void {
   ipcMain.on(UPDATE_INSTALL, async () => {
     if (!app.isPackaged) return
     log.info('[auto-updater] Renderer requested install')
+    const version = currentStatus.state === 'downloaded' ? currentStatus.version : undefined
+    void sendEvent('update_install_clicked', { version: version ?? null })
     updateInstalling = true
     await flushSessionBeforeUpdate()
     // (isSilent=false, isForceRunAfter=true) — force relaunch after install
@@ -216,7 +221,11 @@ export function initAutoUpdater(): void {
 
   ipcMain.on(UPDATE_OPEN_RELEASE, (_e, url?: string) => {
     const target = url || latestReleaseUrl
-    if (target) shell.openExternal(target)
+    if (target) {
+      const version = currentStatus.state === 'manual' ? currentStatus.version : undefined
+      void sendEvent('update_manual_open_clicked', { version: version ?? null })
+      shell.openExternal(target)
+    }
   })
 
   ipcMain.handle('update:getStatus', () => currentStatus)


### PR DESCRIPTION
## Summary
- Track `update_download_clicked`, `update_install_clicked`, `update_manual_open_clicked` in auto-updater
- Track `feedback_dismissed` when user skips/closes the post-update feedback dialog
- Lets us see how many users interact with the update prompt vs ignore it

## Test plan
- [ ] Trigger an update notification, click download — verify event logged
- [ ] Click restart after download — verify event logged
- [ ] Skip the feedback dialog — verify `feedback_dismissed` event logged