### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -12,10 +12,12 @@
 // =============================================================================
 
 import os from 'os'
+import fs from 'fs'
 import path from 'path'
 import { app, type WebContents } from 'electron'
 import { RpcClient } from '@earendil-works/pi-coding-agent'
 import log from '../../main/logger'
+import { getShellEnv } from '../../main/shellEnv'
 
 // Structural alias for pi-ai's ImageContent — pi-ai doesn't expose a `.` export
 // so we duplicate the minimal shape here. Pi reads `{type, data, mimeType}`.
@@ -53,6 +55,52 @@ function resolvePiCliPath(): string {
     'dist',
     'cli.js',
   )
+}
+
+// RpcClient hardcodes `spawn("node", ...)`, so `node` must be on PATH.
+// When launched from Finder/Dock the inherited PATH is minimal and may not
+// include node. Even with the resolved shell env, the user may not have a
+// standalone node install (e.g. only Electron is present). In that case we
+// create a `node` symlink to process.execPath + ELECTRON_RUN_AS_NODE=1.
+let fallbackNodeDir: string | null = null
+
+function nodeExistsOnPath(env: Record<string, string>): boolean {
+  const pathVar = env.PATH || env.Path || ''
+  if (!pathVar) return false
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const name = process.platform === 'win32' ? 'node.exe' : 'node'
+  for (const dir of pathVar.split(sep)) {
+    if (!dir) continue
+    try {
+      fs.accessSync(path.join(dir, name), fs.constants.X_OK)
+      return true
+    } catch { /* not here */ }
+  }
+  return false
+}
+
+function ensureFallbackNode(): string {
+  if (fallbackNodeDir) return fallbackNodeDir
+  const dir = path.join(app.getPath('temp'), 'cate-node-shim')
+  fs.mkdirSync(dir, { recursive: true })
+  const linkPath = path.join(dir, 'node')
+  try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }
+  fs.symlinkSync(process.execPath, linkPath)
+  fallbackNodeDir = dir
+  log.info('[agentManager] created node shim at %s -> %s', linkPath, process.execPath)
+  return dir
+}
+
+function buildAgentEnv(): Record<string, string> {
+  const env = { ...getShellEnv() }
+  if (!nodeExistsOnPath(env)) {
+    const shimDir = ensureFallbackNode()
+    const sep = process.platform === 'win32' ? ';' : ':'
+    env.PATH = shimDir + sep + (env.PATH || '')
+    env.ELECTRON_RUN_AS_NODE = '1'
+    log.info('[agentManager] node not found on PATH, using Electron shim')
+  }
+  return env
 }
 
 interface AgentSession {
@@ -125,6 +173,7 @@ export class AgentManager {
         provider: opts.model?.provider,
         model: opts.model?.model,
         args: extraArgs.length > 0 ? extraArgs : undefined,
+        env: buildAgentEnv(),
       })
 
       try {

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -25,7 +25,7 @@ import log from './logger'
 import { getSettingSync } from './store'
 import { getCommonContext } from './appContext'
 import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, appendLine, removeFile } from './jsonFileStore'
-import { ANALYTICS_FEEDBACK_PROMPT, ANALYTICS_FEEDBACK_SUBMIT, ANALYTICS_FEEDBACK_DISMISS } from '../shared/ipc-channels'
+import { ANALYTICS_FEEDBACK_PROMPT, ANALYTICS_FEEDBACK_SUBMIT, ANALYTICS_FEEDBACK_DISMISS, ANALYTICS_FEEDBACK_GET_PENDING } from '../shared/ipc-channels'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -241,6 +241,17 @@ export function initAnalytics(): void {
       from_version: state.pendingFeedbackFromVersion ?? null,
     })
     updateState({ pendingFeedbackForVersion: undefined, pendingFeedbackFromVersion: undefined })
+  })
+
+  ipcMain.handle(ANALYTICS_FEEDBACK_GET_PENDING, (): { fromVersion: string; toVersion: string } | null => {
+    const state = readState()
+    if (state.pendingFeedbackForVersion) {
+      return {
+        fromVersion: state.pendingFeedbackFromVersion ?? '',
+        toVersion: state.pendingFeedbackForVersion,
+      }
+    }
+    return null
   })
 
   // Best-effort flush of anything left from a previous session.

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -34,7 +34,7 @@ const GITHUB_REPO = 'cate'
 const API_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`
 
 autoUpdater.autoDownload = false
-autoUpdater.autoInstallOnAppQuit = true
+autoUpdater.autoInstallOnAppQuit = false
 
 /** True after the user clicked "Update & Restart". The will-quit handler in
  *  src/main/index.ts reads this to skip its `process.reallyExit(0)` fallback —
@@ -297,7 +297,7 @@ export function initAutoUpdater(): void {
     })
   }, 5000)
 
-  // Check every hour
+  // Check every 15 minutes
   setInterval(
     () => {
       autoUpdater.checkForUpdates().catch((err) => {
@@ -305,7 +305,7 @@ export function initAutoUpdater(): void {
         fallbackCheckForUpdate(false)
       })
     },
-    60 * 60 * 1000,
+    15 * 60 * 1000,
   )
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,7 +36,7 @@ import { addAllowedRoot, clearScopedWriteAllowancesForWindow, validatePath } fro
 import { buildApplicationMenu, rebuildApplicationMenu, setNewMainWindowFn } from './menu'
 import { initShellEnv } from './shellEnv'
 import { initAutoUpdater, isInstallingUpdate } from './auto-updater'
-import { initSentry, captureMainException } from './sentry'
+import { initSentry, captureMainException, flushSentry } from './sentry'
 import { initAnalytics, trackAppStart, checkAndReportUpdate } from './analytics'
 import { beginTerminalTransfer, acknowledgeTerminalTransfer, handleCrossWindowDropTerminalTransfer } from './ipc/terminal'
 import type { CateWindowParams, DockWindowInitPayload, PanelState, PanelTransferSnapshot, WindowDockState } from '../shared/types'
@@ -1052,10 +1052,11 @@ process.on('uncaughtException', (err) => {
   log.error('uncaughtException: %O', err)
   captureMainException(err)
   emergencyKillPTYs()
-  process.exit(1)
+  flushSentry().finally(() => process.exit(1))
 })
 process.on('unhandledRejection', (reason) => {
   log.error('unhandledRejection: %O', reason)
+  captureMainException(reason)
 })
 
 process.on('SIGTERM', () => {

--- a/src/main/sentry.ts
+++ b/src/main/sentry.ts
@@ -119,6 +119,17 @@ export function captureMainException(err: unknown): void {
   }
 }
 
+/** Flush buffered Sentry events before exiting. Returns a promise that
+ *  resolves once flushed or after a 2-second timeout. */
+export async function flushSentry(): Promise<void> {
+  if (!initialized) return
+  try {
+    await Sentry.flush(2000)
+  } catch {
+    /* best-effort */
+  }
+}
+
 /** Strip the user's home directory from any string field that might carry it. */
 function scrubPath(s: string): string {
   const home = app.getPath('home')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -119,6 +119,7 @@ import {
   ANALYTICS_FEEDBACK_PROMPT,
   ANALYTICS_FEEDBACK_SUBMIT,
   ANALYTICS_FEEDBACK_DISMISS,
+  ANALYTICS_FEEDBACK_GET_PENDING,
   AGENT_CREATE,
   AGENT_PROMPT,
   AGENT_INTERRUPT,
@@ -921,6 +922,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   dismissFeedback(): void {
     ipcRenderer.send(ANALYTICS_FEEDBACK_DISMISS)
+  },
+
+  getPendingFeedback(): Promise<{ fromVersion: string; toVersion: string } | null> {
+    return ipcRenderer.invoke(ANALYTICS_FEEDBACK_GET_PENDING)
   },
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/dialogs/PostUpdateFeedbackDialog.tsx
+++ b/src/renderer/dialogs/PostUpdateFeedbackDialog.tsx
@@ -18,15 +18,29 @@ export function PostUpdateFeedbackDialog() {
   const [resultMessage, setResultMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    const unsubscribe = window.electronAPI.onFeedbackPrompt((p) => {
+    let dismissed = false
+    const show = (p: Payload): void => {
+      if (dismissed) return
       setPayload(p)
       setRating(0)
       setHover(0)
       setComment('')
       setSending(false)
       setResultMessage(null)
-    })
-    return unsubscribe
+    }
+    const unsubscribe = window.electronAPI.onFeedbackPrompt(show)
+    const pull = (): void => {
+      window.electronAPI.getPendingFeedback().then((p) => { if (p) show(p) }).catch(() => {})
+    }
+    pull()
+    const t1 = setTimeout(pull, 4000)
+    const t2 = setTimeout(pull, 8000)
+    return () => {
+      dismissed = true
+      unsubscribe()
+      clearTimeout(t1)
+      clearTimeout(t2)
+    }
   }, [])
 
   const close = useCallback(() => {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -537,6 +537,8 @@ export interface ElectronAPI {
   submitFeedback(payload: { rating: number; comment?: string }): Promise<{ ok: boolean; buffered?: boolean }>
   /** Mark the feedback prompt as dismissed without submitting. */
   dismissFeedback(): void
+  /** Pull-based check for pending feedback (renderer calls on mount). */
+  getPendingFeedback(): Promise<{ fromVersion: string; toVersion: string } | null>
 
   // ---------------------------------------------------------------------------
   // Pi agent

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -108,6 +108,8 @@ export const ANALYTICS_FEEDBACK_PROMPT = 'analytics:feedbackPrompt'
 export const ANALYTICS_FEEDBACK_SUBMIT = 'analytics:feedbackSubmit'
 // Renderer -> main: user dismissed the modal without submitting.
 export const ANALYTICS_FEEDBACK_DISMISS = 'analytics:feedbackDismiss'
+// Renderer -> main: pull-based check for pending feedback (returns payload or null).
+export const ANALYTICS_FEEDBACK_GET_PENDING = 'analytics:feedbackGetPending'
 
 
 // Menu actions (main -> renderer)


### PR DESCRIPTION
## Summary
- **Update checks every 15 min** instead of 60 min
- **No auto-restart on quit** — user must click "Restart" button to install downloaded updates
- **Feedback dialog guaranteed to show** — added pull-based `getPendingFeedback` IPC with retries at 0s/4s/8s after mount, eliminating the race condition where the push IPC arrived before the React listener was registered
- **Fix "spawn node ENOENT"** crash in agent manager when node isn't on PATH (creates a shim symlink)
- **Sentry flush on crash** — ensures uncaughtException reports are sent before exit

## Test plan
- [ ] Build and install v0.4.7 over v0.4.6 — feedback dialog must appear
- [ ] Dismiss feedback dialog — verify it doesn't reappear on next launch
- [ ] Download an update, quit app — should NOT auto-install
- [ ] Download an update, click Restart — should install and relaunch
- [ ] Verify update check runs every 15 min (check logs)