### PR TITLE
fix(agent): unpack pi-coding-agent from asar for production builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,6 +2,10 @@ appId: com.cate.app
 productName: Cate
 directories:
   output: release
+asarUnpack:
+  - "node_modules/@earendil-works/**"
+  - "node_modules/.bin/pi"
+  - "node_modules/.bin/pi.cmd"
 extraResources:
   # Ship bundled pi extensions (e.g. cate-plan-mode) into the packaged app so
   # installPlanModeExtension can copy them into ~/.pi/agent/extensions/ on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -41,14 +41,11 @@ import { AGENT_EVENT } from '../../shared/ipc-channels'
 import { installSubagentExtension } from './installSubagents'
 import { installPlanModeExtension } from './installPlanMode'
 import type { AuthManager } from './authManager'
+import { unpackedAppPath } from './paths'
 
-// `RpcClient` spawns `node <cliPath> --mode rpc`. Pi's package only exports
-// the `.` subpath, so we can't `require.resolve('.../dist/cli.js')` — instead
-// we anchor on the app root. Once packaged we'll need to ship cli.js via
-// electron-builder's `extraResources` and read from `process.resourcesPath`.
 function resolvePiCliPath(): string {
   return path.join(
-    app.getAppPath(),
+    unpackedAppPath(),
     'node_modules',
     '@earendil-works',
     'pi-coding-agent',

--- a/src/agent/main/installSubagents.ts
+++ b/src/agent/main/installSubagents.ts
@@ -20,15 +20,14 @@ import path from 'path'
 import { app } from 'electron'
 import log from '../../main/logger'
 import { addAllowedRoot } from '../../main/ipc/pathValidation'
+import { unpackedAppPath } from './paths'
 
 function agentDir(): string {
   return path.join(os.homedir(), '.pi', 'agent')
 }
 
 function piPackageDir(): string {
-  // Pi only exports `.` and `./hooks`, so we can't resolve via package.json.
-  // Anchor on the app root instead.
-  return path.join(app.getAppPath(), 'node_modules', '@earendil-works', 'pi-coding-agent')
+  return path.join(unpackedAppPath(), 'node_modules', '@earendil-works', 'pi-coding-agent')
 }
 
 async function copyIfMissing(src: string, dest: string): Promise<void> {

--- a/src/agent/main/marketplace.ts
+++ b/src/agent/main/marketplace.ts
@@ -19,6 +19,7 @@ import path from 'path'
 import { spawn } from 'child_process'
 import { app } from 'electron'
 import log from '../../main/logger'
+import { unpackedAppPath } from './paths'
 
 export interface MarketplaceEntry {
   name: string
@@ -55,11 +56,8 @@ function settingsPath(): string {
 }
 
 function piBinaryPath(): string {
-  // node_modules/.bin/pi exists in dev. Once packaged, electron-builder needs
-  // to ship the pi CLI similarly; we anchor on app.getAppPath() the same way
-  // installSubagents.ts and agentManager.ts do.
   const binName = process.platform === 'win32' ? 'pi.cmd' : 'pi'
-  return path.join(app.getAppPath(), 'node_modules', '.bin', binName)
+  return path.join(unpackedAppPath(), 'node_modules', '.bin', binName)
 }
 
 /** Heuristic: pi extensions that call ctx.ui.custom(...) need a real terminal

--- a/src/agent/main/paths.ts
+++ b/src/agent/main/paths.ts
@@ -1,0 +1,9 @@
+import { app } from 'electron'
+
+// In production the asar archive can't be used to spawn child processes, so
+// electron-builder unpacks @earendil-works/** via asarUnpack. The unpacked
+// files live at app.asar.unpacked/ next to app.asar.
+export function unpackedAppPath(): string {
+  const p = app.getAppPath()
+  return p.includes('app.asar') ? p.replace('app.asar', 'app.asar.unpacked') : p
+}


### PR DESCRIPTION
## Summary
- Add `asarUnpack` to electron-builder.yml for `@earendil-works/pi-coding-agent` and `.bin/pi`
- Resolve CLI/binary paths to `app.asar.unpacked/` in production via shared `unpackedAppPath()` helper
- Fixes MODULE_NOT_FOUND error when spawning the agent panel in release builds
- Bump version to 0.4.8