### PR TITLE
fix(agent): unpack all node_modules from asar for child process

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -3,9 +3,7 @@ productName: Cate
 directories:
   output: release
 asarUnpack:
-  - "node_modules/@earendil-works/**"
-  - "node_modules/.bin/pi"
-  - "node_modules/.bin/pi.cmd"
+  - "node_modules/**"
 extraResources:
   # Ship bundled pi extensions (e.g. cate-plan-mode) into the packaged app so
   # installPlanModeExtension can copy them into ~/.pi/agent/extensions/ on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Widen `asarUnpack` from `@earendil-works/**` to `node_modules/**` so transitive dependencies (e.g. `undici`) are also available to the spawned pi child process
- Bump version to 0.4.9