### PR TITLE
fix(agent): disable asar to fix child process module resolution

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,8 +2,7 @@ appId: com.cate.app
 productName: Cate
 directories:
   output: release
-asarUnpack:
-  - "node_modules/**"
+asar: false
 extraResources:
   # Ship bundled pi extensions (e.g. cate-plan-mode) into the packaged app so
   # installPlanModeExtension can copy them into ~/.pi/agent/extensions/ on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -41,11 +41,10 @@ import { AGENT_EVENT } from '../../shared/ipc-channels'
 import { installSubagentExtension } from './installSubagents'
 import { installPlanModeExtension } from './installPlanMode'
 import type { AuthManager } from './authManager'
-import { unpackedAppPath } from './paths'
 
 function resolvePiCliPath(): string {
   return path.join(
-    unpackedAppPath(),
+    app.getAppPath(),
     'node_modules',
     '@earendil-works',
     'pi-coding-agent',

--- a/src/agent/main/installSubagents.ts
+++ b/src/agent/main/installSubagents.ts
@@ -20,14 +20,13 @@ import path from 'path'
 import { app } from 'electron'
 import log from '../../main/logger'
 import { addAllowedRoot } from '../../main/ipc/pathValidation'
-import { unpackedAppPath } from './paths'
 
 function agentDir(): string {
   return path.join(os.homedir(), '.pi', 'agent')
 }
 
 function piPackageDir(): string {
-  return path.join(unpackedAppPath(), 'node_modules', '@earendil-works', 'pi-coding-agent')
+  return path.join(app.getAppPath(), 'node_modules', '@earendil-works', 'pi-coding-agent')
 }
 
 async function copyIfMissing(src: string, dest: string): Promise<void> {

--- a/src/agent/main/marketplace.ts
+++ b/src/agent/main/marketplace.ts
@@ -19,7 +19,6 @@ import path from 'path'
 import { spawn } from 'child_process'
 import { app } from 'electron'
 import log from '../../main/logger'
-import { unpackedAppPath } from './paths'
 
 export interface MarketplaceEntry {
   name: string
@@ -57,7 +56,7 @@ function settingsPath(): string {
 
 function piBinaryPath(): string {
   const binName = process.platform === 'win32' ? 'pi.cmd' : 'pi'
-  return path.join(unpackedAppPath(), 'node_modules', '.bin', binName)
+  return path.join(app.getAppPath(), 'node_modules', '.bin', binName)
 }
 
 /** Heuristic: pi extensions that call ctx.ui.custom(...) need a real terminal

--- a/src/agent/main/paths.ts
+++ b/src/agent/main/paths.ts
@@ -1,9 +1,0 @@
-import { app } from 'electron'
-
-// In production the asar archive can't be used to spawn child processes, so
-// electron-builder unpacks @earendil-works/** via asarUnpack. The unpacked
-// files live at app.asar.unpacked/ next to app.asar.
-export function unpackedAppPath(): string {
-  const p = app.getAppPath()
-  return p.includes('app.asar') ? p.replace('app.asar', 'app.asar.unpacked') : p
-}


### PR DESCRIPTION
## Summary
- Disable asar packaging entirely (`asar: false`) — pi-coding-agent is spawned as a child process and needs the full dependency tree accessible on disk
- Remove `unpackedAppPath()` helper and revert path resolution to `app.getAppPath()` since there's no asar to unpack from
- Previous approach of unpacking all node_modules hit EMFILE (too many open files) in CI
- Bump version to 0.4.10