### PR TITLE
fix(agent): use Electron-as-node for asar module resolution

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,7 +2,10 @@ appId: com.cate.app
 productName: Cate
 directories:
   output: release
-asar: false
+asarUnpack:
+  - "node_modules/@earendil-works/**"
+  - "node_modules/.bin/pi"
+  - "node_modules/.bin/pi.cmd"
 extraResources:
   # Ship bundled pi extensions (e.g. cate-plan-mode) into the packaged app so
   # installPlanModeExtension can copy them into ~/.pi/agent/extensions/ on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -54,10 +54,11 @@ function resolvePiCliPath(): string {
 }
 
 // RpcClient hardcodes `spawn("node", ...)`, so `node` must be on PATH.
-// When launched from Finder/Dock the inherited PATH is minimal and may not
-// include node. Even with the resolved shell env, the user may not have a
-// standalone node install (e.g. only Electron is present). In that case we
-// create a `node` symlink to process.execPath + ELECTRON_RUN_AS_NODE=1.
+//
+// In production we MUST use Electron's own binary (with ELECTRON_RUN_AS_NODE=1)
+// because it has built-in asar support — a regular system `node` can't resolve
+// modules from inside the asar archive. In dev we fall back to the system node
+// only if one exists; otherwise we shim Electron the same way.
 let fallbackNodeDir: string | null = null
 
 function nodeExistsOnPath(env: Record<string, string>): boolean {
@@ -75,7 +76,7 @@ function nodeExistsOnPath(env: Record<string, string>): boolean {
   return false
 }
 
-function ensureFallbackNode(): string {
+function ensureElectronNodeShim(): string {
   if (fallbackNodeDir) return fallbackNodeDir
   const dir = path.join(app.getPath('temp'), 'cate-node-shim')
   fs.mkdirSync(dir, { recursive: true })
@@ -89,12 +90,13 @@ function ensureFallbackNode(): string {
 
 function buildAgentEnv(): Record<string, string> {
   const env = { ...getShellEnv() }
-  if (!nodeExistsOnPath(env)) {
-    const shimDir = ensureFallbackNode()
+  const needsShim = app.isPackaged || !nodeExistsOnPath(env)
+  if (needsShim) {
+    const shimDir = ensureElectronNodeShim()
     const sep = process.platform === 'win32' ? ';' : ':'
     env.PATH = shimDir + sep + (env.PATH || '')
     env.ELECTRON_RUN_AS_NODE = '1'
-    log.info('[agentManager] node not found on PATH, using Electron shim')
+    log.info('[agentManager] using Electron as node (packaged=%s)', app.isPackaged)
   }
   return env
 }

--- a/src/agent/main/installSubagents.ts
+++ b/src/agent/main/installSubagents.ts
@@ -26,7 +26,9 @@ function agentDir(): string {
 }
 
 function piPackageDir(): string {
-  return path.join(app.getAppPath(), 'node_modules', '@earendil-works', 'pi-coding-agent')
+  const base = app.getAppPath()
+  const root = base.includes('app.asar') ? base.replace('app.asar', 'app.asar.unpacked') : base
+  return path.join(root, 'node_modules', '@earendil-works', 'pi-coding-agent')
 }
 
 async function copyIfMissing(src: string, dest: string): Promise<void> {

--- a/src/agent/main/marketplace.ts
+++ b/src/agent/main/marketplace.ts
@@ -56,7 +56,9 @@ function settingsPath(): string {
 
 function piBinaryPath(): string {
   const binName = process.platform === 'win32' ? 'pi.cmd' : 'pi'
-  return path.join(app.getAppPath(), 'node_modules', '.bin', binName)
+  const base = app.getAppPath()
+  const root = base.includes('app.asar') ? base.replace('app.asar', 'app.asar.unpacked') : base
+  return path.join(root, 'node_modules', '.bin', binName)
 }
 
 /** Heuristic: pi extensions that call ctx.ui.custom(...) need a real terminal


### PR DESCRIPTION
## Summary
- In production, always spawn the pi agent child process using Electron's binary (`ELECTRON_RUN_AS_NODE=1`) so it inherits asar support and can resolve transitive deps (e.g. `undici`) from inside the archive
- Only unpack `@earendil-works/**` and `.bin/pi` — marketplace binary spawning and installSubagents file copying need real files on disk
- Previous approaches failed: unpacking all `node_modules/**` hit EMFILE limits in CI; `asar: false` hit the same EMFILE during code signing
- Bump version to 0.4.11