### PR TITLE
Replace hardcoded violet classes with semantic agent color tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <a href="https://www.producthunt.com/products/cate?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-cate" target="_blank" rel="noopener noreferrer"><img alt="CATE - Figma like open canvas for development | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1150094&theme=neutral&t=1779630669260"></a>
+</p>
+
+<p align="center">
   <img src="assets/cate-logo.svg" alt="Cate" width="240" />
 </p>
 

--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -871,7 +871,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
                 onClick={() => setModelPickerOpen((v) => !v)}
                 className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] text-primary hover:bg-white/5"
               >
-                <Sparkle size={12} weight="fill" className="text-violet-400" />
+                <Sparkle size={12} weight="fill" className="text-agent-light" />
                 <span className="truncate max-w-[220px]">
                   {selectedModel ? selectedModel.model : 'Pick a model'}
                 </span>
@@ -907,13 +907,13 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
         ) : (
           <div className="relative flex-1 flex flex-col min-h-0">
             {selectedModel && !selectedProviderConnected && (
-              <div className="px-3 py-2 bg-violet-500/10 border-b border-violet-500/30 flex items-center gap-2 text-[12px] text-primary">
+              <div className="px-3 py-2 bg-agent/10 border-b border-agent/30 flex items-center gap-2 text-[12px] text-primary">
                 <span className="flex-1 truncate">
                   Connect <strong>{selectedModel.provider}</strong> to start.
                 </span>
                 <button
                   onClick={() => openSettings(selectedModel.provider)}
-                  className="px-2 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[11px] font-medium shrink-0"
+                  className="px-2 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[11px] font-medium shrink-0"
                 >
                   Connect
                 </button>
@@ -927,8 +927,8 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
             {messages.length === 0 ? (
               <div className="flex-1 overflow-y-auto flex flex-col items-center justify-center px-6 py-8 min-h-0">
                 <div className="w-full max-w-[520px] flex flex-col items-center">
-                  <div className="w-12 h-12 rounded-2xl bg-violet-500/15 flex items-center justify-center mb-4">
-                    <Sparkle size={22} weight="fill" className="text-violet-400" />
+                  <div className="w-12 h-12 rounded-2xl bg-agent/15 flex items-center justify-center mb-4">
+                    <Sparkle size={22} weight="fill" className="text-agent-light" />
                   </div>
                   <div className="text-[16px] font-medium text-primary mb-3 text-center">
                     What should we work on?
@@ -1089,7 +1089,7 @@ function AgentSidebar({
         <div className="flex-1" />
         <button
           onClick={onNewChat}
-          className="p-1.5 rounded-md text-violet-300 hover:text-violet-100 hover:bg-violet-500/20"
+          className="p-1.5 rounded-md text-agent-light hover:text-primary hover:bg-agent/20"
           title="New chat"
         >
           <Plus size={14} />
@@ -1182,11 +1182,11 @@ function ChatRow({
         className="flex-1 min-w-0 flex items-center gap-1.5 px-1 py-1 text-left"
         title={`${chat.title}\n${chat.messageCount} messages · ${new Date(chat.updatedAt).toLocaleString()}${open ? '\nRunning in background' : ''}`}
       >
-        <ChatCircleDots size={11} className={chat.named ? 'text-violet-300 shrink-0' : 'text-muted shrink-0'} />
+        <ChatCircleDots size={11} className={chat.named ? 'text-agent-light shrink-0' : 'text-muted shrink-0'} />
         <span className="truncate text-[11.5px] text-primary">{chat.title}</span>
         {open && !active && (
           <span
-            className="w-1.5 h-1.5 rounded-full bg-violet-400 shrink-0"
+            className="w-1.5 h-1.5 rounded-full bg-agent-light shrink-0"
             aria-label="Open in background"
           />
         )}
@@ -1364,8 +1364,8 @@ function ChatInput({
         }}
         className={`relative rounded-2xl border bg-surface-3 transition-colors ${
           dragOver
-            ? 'border-violet-400 ring-2 ring-violet-400/40'
-            : 'border-white/10 focus-within:border-violet-500/50'
+            ? 'border-agent-light ring-2 ring-agent-light/40'
+            : 'border-white/10 focus-within:border-agent/50'
         }`}
       >
         {popupOpen && (
@@ -1430,7 +1430,7 @@ function ChatInput({
             onClick={onTogglePlanMode}
             className={`p-1.5 rounded-md ${
               planModeActive
-                ? 'bg-violet-500/25 text-violet-100'
+                ? 'bg-agent/25 text-primary'
                 : 'text-primary/80 hover:bg-white/5'
             }`}
             title="Plan mode — agent investigates with parallel scouts, proposes a plan, then waits for your approval."
@@ -1455,7 +1455,7 @@ function ChatInput({
           <div className="flex-1" />
           {compactionActive ? (
             <div
-              className="p-1.5 rounded-full bg-violet-500/40 text-white"
+              className="p-1.5 rounded-full bg-agent/40 text-white"
               title="Compacting context…"
             >
               <Spinner size={12} weight="bold" className="animate-spin" />
@@ -1464,7 +1464,7 @@ function ChatInput({
             canSend ? (
               <button
                 onClick={onSubmit}
-                className="p-1.5 rounded-full bg-violet-500 hover:bg-violet-400 text-white"
+                className="p-1.5 rounded-full bg-agent hover:bg-agent-light text-white"
                 title="Steer"
               >
                 <PaperPlaneRight size={12} weight="fill" />
@@ -1472,7 +1472,7 @@ function ChatInput({
             ) : (
               <button
                 onClick={onStop}
-                className="p-1.5 rounded-full bg-violet-500 hover:bg-violet-400 text-white"
+                className="p-1.5 rounded-full bg-agent hover:bg-agent-light text-white"
                 title="Stop"
               >
                 <Stop size={12} weight="fill" />
@@ -1482,7 +1482,7 @@ function ChatInput({
             <button
               onClick={onSubmit}
               disabled={!canSend}
-              className="p-1.5 rounded-full bg-violet-500 hover:bg-violet-400 disabled:bg-white/10 disabled:text-muted text-white"
+              className="p-1.5 rounded-full bg-agent hover:bg-agent-light disabled:bg-white/10 disabled:text-muted text-white"
               title="Send"
             >
               <PaperPlaneRight size={12} weight="fill" />
@@ -1604,7 +1604,7 @@ const SOURCE_LABEL: Record<AgentSlashCommand['source'], string> = {
 }
 
 const SOURCE_COLOR: Record<AgentSlashCommand['source'], string> = {
-  skill: 'text-violet-300 bg-violet-500/10',
+  skill: 'text-agent-light bg-agent/10',
   prompt: 'text-muted bg-white/5',
   extension: 'text-muted bg-white/5',
 }
@@ -1618,7 +1618,7 @@ const TAB_BADGE: Record<'agents' | 'prompts' | 'skills', string> = {
 const TAB_BADGE_COLOR: Record<'agents' | 'prompts' | 'skills', string> = {
   agents: 'text-muted bg-white/5',
   prompts: 'text-muted bg-white/5',
-  skills: 'text-violet-300 bg-violet-500/10',
+  skills: 'text-agent-light bg-agent/10',
 }
 
 function SlashPopup({
@@ -1788,7 +1788,7 @@ function SettingsView({
           {!creating && (
             <button
               onClick={() => { setCreating(true); setError(null) }}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-violet-500/20 hover:bg-violet-500/30 text-violet-100 text-[12px]"
+              className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-agent/20 hover:bg-agent/30 text-primary text-[12px]"
             >
               <Plus size={11} /> New {tab.slice(0, -1)}
             </button>
@@ -1813,12 +1813,12 @@ function SettingsView({
                 if (e.key === 'Escape') { setCreating(false); setNewName(''); setError(null) }
               }}
               placeholder={`${tab.slice(0, -1)} name`}
-              className="flex-1 bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-violet-500/60 font-mono"
+              className="flex-1 bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 font-mono"
             />
             <button
               onClick={handleCreate}
               disabled={!newName.trim()}
-              className="px-2.5 py-1 rounded-md bg-violet-500 hover:bg-violet-400 disabled:opacity-40 text-white text-[12px]"
+              className="px-2.5 py-1 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px]"
             >
               Create
             </button>
@@ -2061,7 +2061,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
             {browseLoading && (
               <span
                 aria-label="Loading"
-                className="inline-block h-2.5 w-2.5 rounded-full border border-violet-400/40 border-t-violet-300 animate-spin"
+                className="inline-block h-2.5 w-2.5 rounded-full border border-agent-light/40 border-t-agent-light animate-spin"
               />
             )}
           </div>
@@ -2072,7 +2072,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
                 setSort(e.target.value as MarketplaceSortValue)
                 setPage(1)
               }}
-              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-violet-500/60"
+              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
             >
               <option value="downloads">Most downloads</option>
               <option value="recent">Recently published</option>
@@ -2082,7 +2082,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
               value={queryInput}
               onChange={(e) => setQueryInput(e.target.value)}
               placeholder="Search..."
-              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-violet-500/60 w-[180px]"
+              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 w-[180px]"
             />
           </div>
         </div>
@@ -2120,7 +2120,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={browseLoading || page <= 1}
-              className="px-2 py-1 rounded-md bg-white/5 hover:bg-violet-500/20 hover:text-violet-100 disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
+              className="px-2 py-1 rounded-md bg-white/5 hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
             >
               « Prev
             </button>
@@ -2130,7 +2130,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={browseLoading || page >= totalPages}
-              className="px-2 py-1 rounded-md bg-white/5 hover:bg-violet-500/20 hover:text-violet-100 disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
+              className="px-2 py-1 rounded-md bg-white/5 hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
             >
               Next »
             </button>
@@ -2166,7 +2166,7 @@ function ExtensionRow({
 }) {
   const toneClass =
     actionTone === 'primary'
-      ? 'bg-violet-500 hover:bg-violet-400 text-white'
+      ? 'bg-agent hover:bg-agent-light text-white'
       : actionTone === 'danger'
       ? 'bg-white/5 hover:bg-rose-500/30 text-rose-100'
       : 'bg-white/5 text-muted'
@@ -2178,7 +2178,7 @@ function ExtensionRow({
           {requiresTerminal && (
             <span
               title={TERMINAL_TOOLTIP}
-              className="shrink-0 px-1.5 py-[1px] rounded text-[9px] uppercase tracking-wider font-semibold text-violet-200 bg-violet-500/15"
+              className="shrink-0 px-1.5 py-[1px] rounded text-[9px] uppercase tracking-wider font-semibold text-agent-light bg-agent/15"
             >
               Terminal required
             </span>
@@ -2383,7 +2383,7 @@ function ModelPicker({
                     }`}
                   >
                     <span className="truncate flex-1">{m.label ?? m.model}</span>
-                    {isSelected && <CheckCircle size={10} weight="fill" className="text-violet-300" />}
+                    {isSelected && <CheckCircle size={10} weight="fill" className="text-agent-light" />}
                   </button>
                 )
               })}
@@ -2395,7 +2395,7 @@ function ModelPicker({
       <div className="border-t border-white/10 shrink-0">
         <button
           onClick={onManage}
-          className="w-full text-left px-3 py-1.5 text-[12px] text-violet-300 hover:bg-white/5"
+          className="w-full text-left px-3 py-1.5 text-[12px] text-agent-light hover:bg-white/5"
         >
           Manage providers…
         </button>

--- a/src/agent/renderer/AgentPanelChrome.tsx
+++ b/src/agent/renderer/AgentPanelChrome.tsx
@@ -93,7 +93,7 @@ export function CompactionBanner({ state }: { state: CompactionState }) {
         : 'Auto-compacting context…'
     return (
       <BannerRow tone="info">
-        <Spinner size={11} className="text-violet-300 animate-spin shrink-0" />
+        <Spinner size={11} className="text-agent-light animate-spin shrink-0" />
         <span>{label}</span>
       </BannerRow>
     )
@@ -169,7 +169,7 @@ function BannerRow({
 }) {
   const toneClass =
     tone === 'info'
-      ? 'bg-violet-500/10 text-violet-100 border-violet-500/30'
+      ? 'bg-agent/10 text-primary border-agent/30'
       : tone === 'warning'
       ? 'bg-amber-500/10 text-amber-100 border-amber-500/30'
       : tone === 'error'
@@ -200,7 +200,7 @@ export function QueueBadges({
         <span
           key={`s${i}`}
           title={s}
-          className="px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-200 max-w-[200px] truncate"
+          className="px-1.5 py-0.5 rounded bg-agent/15 text-agent-light max-w-[200px] truncate"
         >
           steer: {s}
         </span>
@@ -349,7 +349,7 @@ export function ExtensionDialog({
             <button
               key={opt}
               onClick={() => onRespond({ id: request.id, value: opt })}
-              className="w-full text-left px-3 py-1.5 rounded-md bg-white/5 hover:bg-violet-500/30 text-primary text-[12px]"
+              className="w-full text-left px-3 py-1.5 rounded-md bg-white/5 hover:bg-agent/30 text-primary text-[12px]"
             >
               {opt}
             </button>
@@ -371,7 +371,7 @@ export function ExtensionDialog({
           </button>
           <button
             onClick={() => onRespond({ id: request.id, confirmed: true })}
-            className="px-2.5 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[12px] font-medium"
+            className="px-2.5 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[12px] font-medium"
           >
             Yes
           </button>
@@ -395,7 +395,7 @@ export function ExtensionDialog({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={String(request.placeholder ?? '')}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-violet-500/60"
+            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex items-center gap-2 justify-end">
             <button
@@ -407,7 +407,7 @@ export function ExtensionDialog({
             </button>
             <button
               type="submit"
-              className="px-2.5 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[12px] font-medium"
+              className="px-2.5 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[12px] font-medium"
             >
               Submit
             </button>
@@ -425,7 +425,7 @@ export function ExtensionDialog({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           rows={8}
-          className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-2 text-[12px] text-primary outline-none focus:border-violet-500/60 font-mono resize-y"
+          className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-2 text-[12px] text-primary outline-none focus:border-agent/60 font-mono resize-y"
         />
         <div className="flex items-center gap-2 justify-end mt-2">
           <button
@@ -436,7 +436,7 @@ export function ExtensionDialog({
           </button>
           <button
             onClick={() => onRespond({ id: request.id, value })}
-            className="px-2.5 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[12px] font-medium"
+            className="px-2.5 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[12px] font-medium"
           >
             Save
           </button>
@@ -460,7 +460,7 @@ function DialogShell({
   onCancel: () => void
 }) {
   return (
-    <div className="rounded-lg border border-violet-500/30 bg-surface-3/90 backdrop-blur px-3 py-3 space-y-2">
+    <div className="rounded-lg border border-agent/30 bg-surface-3/90 backdrop-blur px-3 py-3 space-y-2">
       <div className="flex items-start gap-2">
         <div className="flex-1 min-w-0">
           {title && <div className="text-[12.5px] text-primary font-medium">{title}</div>}
@@ -496,7 +496,7 @@ export function ImageChips({
       {images.map((img, i) => (
         <div
           key={i}
-          className="flex items-center gap-1 pl-1 pr-1.5 py-0.5 rounded-md bg-violet-500/15 text-violet-100 text-[10px]"
+          className="flex items-center gap-1 pl-1 pr-1.5 py-0.5 rounded-md bg-agent/15 text-primary text-[10px]"
         >
           <img
             src={`data:${img.mimeType};base64,${img.data}`}

--- a/src/agent/renderer/ChatThread.tsx
+++ b/src/agent/renderer/ChatThread.tsx
@@ -113,9 +113,9 @@ export function ChatThread({ messages, pendingApprovals, onApproval, running, fo
 function ThinkingDots() {
   return (
     <div className="flex items-center gap-1 py-1" aria-label="Agent is thinking">
-      <span className="w-1.5 h-1.5 rounded-full bg-violet-300/80 animate-thinking-dot [animation-delay:0ms]" />
-      <span className="w-1.5 h-1.5 rounded-full bg-violet-300/80 animate-thinking-dot [animation-delay:160ms]" />
-      <span className="w-1.5 h-1.5 rounded-full bg-violet-300/80 animate-thinking-dot [animation-delay:320ms]" />
+      <span className="w-1.5 h-1.5 rounded-full bg-agent-light/80 animate-thinking-dot [animation-delay:0ms]" />
+      <span className="w-1.5 h-1.5 rounded-full bg-agent-light/80 animate-thinking-dot [animation-delay:160ms]" />
+      <span className="w-1.5 h-1.5 rounded-full bg-agent-light/80 animate-thinking-dot [animation-delay:320ms]" />
     </div>
   )
 }
@@ -146,7 +146,7 @@ function MessageRow({
   if (msg.type === 'user') {
     return (
       <div className="flex flex-col items-end gap-1">
-        <div className="max-w-[85%] px-3.5 py-2 rounded-2xl rounded-br-md bg-violet-500/85 text-white text-[13px] whitespace-pre-wrap break-words shadow-sm">
+        <div className="max-w-[85%] px-3.5 py-2 rounded-2xl rounded-br-md bg-agent/85 text-white text-[13px] whitespace-pre-wrap break-words shadow-sm">
           {msg.text}
         </div>
         <div className="flex items-center gap-0.5 text-muted">
@@ -238,9 +238,9 @@ function ThinkingBlock({ text, streaming }: { text: string; streaming: boolean }
         {expanded
           ? <CaretDown size={9} className="shrink-0" />
           : <CaretRight size={9} className="shrink-0" />}
-        <Brain size={11} className="text-violet-300/80 shrink-0" />
+        <Brain size={11} className="text-agent-light/80 shrink-0" />
         <span>Reasoning</span>
-        {streaming && <Spinner size={10} className="text-violet-300 animate-spin" />}
+        {streaming && <Spinner size={10} className="text-agent-light animate-spin" />}
       </button>
       {expanded && (
         <pre className="mt-1 pl-5 text-[11px] text-primary/70 whitespace-pre-wrap break-words font-mono leading-relaxed max-h-[260px] overflow-auto">
@@ -270,12 +270,12 @@ function Markdown({ text }: { text: string }) {
           li: ({ children }) => <li className="leading-relaxed">{children}</li>,
           a: ({ href, children }) => (
             <a href={href} target="_blank" rel="noreferrer"
-               className="text-violet-300 underline decoration-violet-400/30 hover:decoration-violet-300">
+               className="text-agent-light underline decoration-agent-light/30 hover:decoration-agent-light">
               {children}
             </a>
           ),
           blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-violet-400/40 pl-3 text-primary/80 italic">
+            <blockquote className="border-l-2 border-agent-light/40 pl-3 text-primary/80 italic">
               {children}
             </blockquote>
           ),
@@ -292,7 +292,7 @@ function Markdown({ text }: { text: string }) {
               )
             }
             return (
-              <code className="font-mono text-[11.5px] px-1 py-[1px] rounded bg-black/30 text-violet-200" {...props}>
+              <code className="font-mono text-[11.5px] px-1 py-[1px] rounded bg-black/30 text-agent-light" {...props}>
                 {children}
               </code>
             )
@@ -576,25 +576,25 @@ function SubagentCard({ msg }: { msg: ToolMessage }) {
   })()
 
   return (
-    <div className="rounded-lg border border-violet-500/20 bg-violet-500/[0.04] overflow-hidden text-[12px]">
+    <div className="rounded-lg border border-agent/20 bg-agent/[0.04] overflow-hidden text-[12px]">
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-2 px-2.5 py-1.5 hover:bg-violet-500/[0.08] text-left"
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 hover:bg-agent/[0.08] text-left"
       >
         {expanded
           ? <CaretDown size={10} className="text-muted shrink-0" />
           : <CaretRight size={10} className="text-muted shrink-0" />}
-        <Sparkle size={13} weight="duotone" className="text-violet-300 shrink-0" />
+        <Sparkle size={13} weight="duotone" className="text-agent-light shrink-0" />
         <span className="text-primary/90 font-medium shrink-0">Subagent</span>
         <span className="flex-1 text-muted text-[11px] truncate text-right">{headerStatus}</span>
         {running
-          ? <Spinner size={11} className="text-violet-300 animate-spin shrink-0" />
+          ? <Spinner size={11} className="text-agent-light animate-spin shrink-0" />
           : msg.status === 'error'
           ? <XCircle size={12} weight="fill" className="text-rose-400 shrink-0" />
-          : <CheckCircle size={12} weight="fill" className="text-violet-300 shrink-0" />}
+          : <CheckCircle size={12} weight="fill" className="text-agent-light shrink-0" />}
       </button>
       {expanded && (
-        <div className="border-t border-violet-500/15 px-2 py-2 space-y-1.5">
+        <div className="border-t border-agent/15 px-2 py-2 space-y-1.5">
           {results.length === 0 ? (
             <div className="text-[11px] text-muted italic px-1 py-1">Waiting for subagent to start…</div>
           ) : (
@@ -646,16 +646,16 @@ function SubagentResultRow({
       >
         <div className="shrink-0 mt-[2px]">
           {isRunning
-            ? <Spinner size={11} className="text-violet-300 animate-spin" />
+            ? <Spinner size={11} className="text-agent-light animate-spin" />
             : isError
             ? <XCircle size={11} weight="fill" className="text-rose-400" />
             : result.exitCode === 0
-            ? <CheckCircle size={11} weight="fill" className="text-violet-300" />
+            ? <CheckCircle size={11} weight="fill" className="text-agent-light" />
             : <Spinner size={11} className="text-muted" />}
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap">
-            <span className="font-mono text-[11.5px] text-violet-200 shrink-0">{result.agent}</span>
+            <span className="font-mono text-[11.5px] text-agent-light shrink-0">{result.agent}</span>
             {result.step != null && (
               <span className="text-[10px] text-muted shrink-0">#{result.step}</span>
             )}
@@ -838,9 +838,9 @@ function PlanReadyCard({
   }
 
   return (
-    <div className={`rounded-lg border border-violet-500/40 bg-violet-500/10 overflow-hidden text-[12px] ${effectiveLocked ? 'opacity-60' : ''}`}>
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-violet-500/20">
-        <ClipboardText size={13} weight="duotone" className="text-violet-300 shrink-0" />
+    <div className={`rounded-lg border border-agent/40 bg-agent/10 overflow-hidden text-[12px] ${effectiveLocked ? 'opacity-60' : ''}`}>
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-agent/20">
+        <ClipboardText size={13} weight="duotone" className="text-agent-light shrink-0" />
         <span className="text-primary font-medium">Plan ready</span>
       </div>
       <div className="px-3 py-3 space-y-3">
@@ -853,7 +853,7 @@ function PlanReadyCard({
           <ol className="space-y-2">
             {steps.map((s, i) => (
               <li key={i} className="flex gap-2.5">
-                <span className="shrink-0 text-violet-300 font-mono text-[12px] mt-[1px]">
+                <span className="shrink-0 text-agent-light font-mono text-[12px] mt-[1px]">
                   {i + 1}.
                 </span>
                 <div className="flex-1 min-w-0">
@@ -876,20 +876,20 @@ function PlanReadyCard({
           disabled={!!effectiveLocked}
           rows={2}
           placeholder="Refine: type the changes you want…"
-          className="w-full rounded-md bg-black/20 border border-violet-500/20 focus:border-violet-400/60 outline-none px-2.5 py-2 text-[12px] text-primary placeholder:text-muted resize-none disabled:opacity-50"
+          className="w-full rounded-md bg-black/20 border border-agent/20 focus:border-agent-light/60 outline-none px-2.5 py-2 text-[12px] text-primary placeholder:text-muted resize-none disabled:opacity-50"
         />
         <div className="flex items-center gap-2 flex-wrap">
           <button
             onClick={handleRefine}
             disabled={!!effectiveLocked || refineText.trim().length === 0}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-violet-500/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
+            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
           >
             {lockLabel('Refine plan', 'refine')}
           </button>
           <button
             onClick={handleClear}
             disabled={!!effectiveLocked}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-violet-500/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
+            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
           >
             {lockLabel('Clear context & implement', 'clear')}
           </button>
@@ -897,7 +897,7 @@ function PlanReadyCard({
           <button
             onClick={handleImplement}
             disabled={!!effectiveLocked}
-            className="px-3 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-violet-500"
+            className="px-3 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-agent"
           >
             {lockLabel('Implement', 'implement')}
           </button>
@@ -911,9 +911,9 @@ function StatusIcon({ status }: { status: ToolMessage['status'] }) {
   switch (status) {
     case 'pending':
     case 'running':
-      return <Spinner size={11} className="text-violet-300 animate-spin shrink-0" />
+      return <Spinner size={11} className="text-agent-light animate-spin shrink-0" />
     case 'success':
-      return <CheckCircle size={11} weight="fill" className="text-violet-300 shrink-0" />
+      return <CheckCircle size={11} weight="fill" className="text-agent-light shrink-0" />
     case 'error':
     case 'denied':
       return <XCircle size={11} weight="fill" className="text-muted shrink-0" />
@@ -1002,7 +1002,7 @@ function DiffView({ diff }: { diff: DiffInfo }) {
           key={i}
           className={
             l.kind === 'add'
-              ? 'text-violet-200'
+              ? 'text-agent-light'
               : l.kind === 'del'
               ? 'text-rose-300/80 line-through decoration-rose-400/30'
               : 'text-muted'
@@ -1030,9 +1030,9 @@ function ApprovalCard({
   onDecide: (decision: 'allow' | 'deny') => void
 }) {
   return (
-    <div className="rounded-lg border border-violet-500/40 bg-violet-500/10 px-3 py-2 space-y-2">
+    <div className="rounded-lg border border-agent/40 bg-agent/10 px-3 py-2 space-y-2">
       <div className="flex items-center gap-2 text-[12px] text-primary">
-        <Wrench size={12} className="text-violet-300" />
+        <Wrench size={12} className="text-agent-light" />
         <span>
           Allow <strong className="font-mono">{req.toolName}</strong>?
         </span>
@@ -1043,7 +1043,7 @@ function ApprovalCard({
       <div className="flex items-center gap-2">
         <button
           onClick={() => onDecide('allow')}
-          className="px-2.5 py-1 rounded-md bg-violet-500 hover:bg-violet-400 text-white text-[11px] font-medium"
+          className="px-2.5 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[11px] font-medium"
         >
           Allow
         </button>

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -183,7 +183,7 @@ function ProviderListRow({
     >
       <span className="flex-1 truncate text-[12.5px] text-primary">{name}</span>
       {connected ? (
-        <span className="inline-flex items-center gap-1 text-[10px] text-violet-300/90">
+        <span className="inline-flex items-center gap-1 text-[10px] text-agent-light/90">
           <CheckCircle size={10} weight="fill" /> Connected
         </span>
       ) : (
@@ -197,7 +197,7 @@ function ProviderListRow({
 function StatusPill({ status }: { status?: AuthProviderStatus }) {
   if (status?.connected) {
     return (
-      <span className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full bg-violet-500/15 text-violet-300">
+      <span className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full bg-agent/15 text-agent-light">
         <CheckCircle size={10} weight="fill" />
         Connected
       </span>
@@ -311,7 +311,7 @@ function OAuthForm({
         <div className="space-y-3">
           <button
             onClick={handleStart}
-            className="w-full px-3 py-2.5 rounded-lg bg-violet-500 hover:bg-violet-400 text-white text-[13px] font-medium"
+            className="w-full px-3 py-2.5 rounded-lg bg-agent hover:bg-agent-light text-white text-[13px] font-medium"
           >
             Sign in with {provider.name}
           </button>
@@ -334,7 +334,7 @@ function OAuthForm({
         <div className="space-y-3 rounded-lg border border-white/10 bg-black/10 p-3">
           <div className="text-[12px] text-primary">
             Enter this code in your browser at{' '}
-            <a href={phase.verificationUri} target="_blank" rel="noreferrer" className="underline text-violet-300">
+            <a href={phase.verificationUri} target="_blank" rel="noreferrer" className="underline text-agent-light">
               {phase.verificationUri}
             </a>
             :
@@ -376,13 +376,13 @@ function OAuthForm({
             onChange={(e) => setPromptValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handlePromptSubmit(phase.promptId, promptValue) }}
             placeholder={phase.placeholder ?? ''}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-violet-500/60"
+            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex justify-end">
             <button
               disabled={submitting || (!phase.allowEmpty && !promptValue.trim())}
               onClick={() => handlePromptSubmit(phase.promptId, promptValue)}
-              className="px-3 py-1.5 rounded-md bg-violet-500 hover:bg-violet-400 disabled:opacity-40 text-white text-[12px] font-medium"
+              className="px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
             >
               Submit
             </button>
@@ -419,13 +419,13 @@ function OAuthForm({
             value={promptValue}
             onChange={(e) => setPromptValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handlePromptSubmit(phase.promptId, promptValue) }}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-violet-500/60"
+            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex justify-end">
             <button
               disabled={submitting || !promptValue.trim()}
               onClick={() => handlePromptSubmit(phase.promptId, promptValue)}
-              className="px-3 py-1.5 rounded-md bg-violet-500 hover:bg-violet-400 disabled:opacity-40 text-white text-[12px] font-medium"
+              className="px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
             >
               Submit
             </button>
@@ -434,7 +434,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'done' && (
-        <div className="flex items-center gap-2 text-[12px] text-violet-300">
+        <div className="flex items-center gap-2 text-[12px] text-agent-light">
           <CheckCircle size={14} weight="fill" /> Connected.
         </div>
       )}
@@ -458,7 +458,7 @@ function AuthUrlCard({ url, instructions }: { url: string; instructions?: string
   return (
     <div className="space-y-3 rounded-lg border border-white/10 bg-black/10 p-3">
       <div className="flex items-center gap-2 text-[12px] text-primary">
-        <CloudArrowUp size={14} className="text-violet-300" />
+        <CloudArrowUp size={14} className="text-agent-light" />
         Browser opened for sign in.
       </div>
       {instructions && (
@@ -543,7 +543,7 @@ function ApiKeyForm({
             autoComplete="off"
             spellCheck={false}
             placeholder={status?.connected ? '••••••••••••' : `Paste your ${provider.name} key`}
-            className="flex-1 min-w-0 bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-violet-500/60 font-mono"
+            className="flex-1 min-w-0 bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
           />
           <button
             type="button"
@@ -558,7 +558,7 @@ function ApiKeyForm({
 
       {error && <div className="text-[12px] text-primary">{error}</div>}
       {savedAt && !error && (
-        <div className="text-[12px] text-violet-300 flex items-center gap-1">
+        <div className="text-[12px] text-agent-light flex items-center gap-1">
           <CheckCircle size={12} weight="fill" /> Saved.
         </div>
       )}
@@ -567,7 +567,7 @@ function ApiKeyForm({
         <button
           disabled={saving || !value.trim()}
           onClick={handleSave}
-          className="px-3 py-1.5 rounded-md bg-violet-500 hover:bg-violet-400 disabled:opacity-40 text-white text-[12px] font-medium"
+          className="px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
@@ -634,7 +634,7 @@ function DefaultModelSection({ statuses }: { statuses: AuthProviderStatus[] }) {
       <select
         value={selectedKey}
         onChange={(e) => handleChange(e.target.value)}
-        className="w-full bg-white/[0.04] border border-white/10 rounded-md px-2 py-1.5 text-[12.5px] text-primary focus:outline-none focus:border-violet-400/50"
+        className="w-full bg-white/[0.04] border border-white/10 rounded-md px-2 py-1.5 text-[12.5px] text-primary focus:outline-none focus:border-agent-light/50"
       >
       <option value="">No default — first available</option>
       {currentMissing && current && (

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -56,6 +56,9 @@
   --panel-fileExplorer: #4a8fb0;
   --panel-projectList: #b09640;
   --panel-canvas: #8857b0;
+  /* Agent accent — RGB channels for Tailwind alpha modifier support. */
+  --agent-rgb: 74 158 255;
+  --agent-light-rgb: 147 197 255;
 }
 
 [data-theme="dark-warm"] {
@@ -102,6 +105,8 @@
   --panel-fileExplorer: #4a8fb0;
   --panel-projectList: #b09640;
   --panel-canvas: #8857b0;
+  --agent-rgb: 74 158 255;
+  --agent-light-rgb: 147 197 255;
 }
 
 [data-theme="light-subtle"] {
@@ -152,6 +157,8 @@
   --panel-fileExplorer: #2e8fbf;
   --panel-projectList: #a07a00;
   --panel-canvas: #7d3ab8;
+  --agent-rgb: 60 126 240;
+  --agent-light-rgb: 30 80 180;
 }
 
 [data-theme="dark-cold"] {
@@ -199,6 +206,8 @@
   --panel-fileExplorer: #4aa0c7;
   --panel-projectList: #a08840;
   --panel-canvas: #7a5cc7;
+  --agent-rgb: 10 132 255;
+  --agent-light-rgb: 120 180 255;
 }
 
 /* Semantic utility classes. Declared directly (not via Tailwind colors) so

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -363,7 +363,7 @@ export const CommandPalette: React.FC = () => {
               setSearchText(e.target.value)
               setSelectedIndex(0)
             }}
-            placeholder="Search everything — files, terminals, commands…"
+            placeholder="Search across files, terminals, commands and more..."
             className="flex-1 bg-transparent text-primary text-base font-medium outline-none placeholder:text-muted placeholder:font-normal"
           />
         </div>
@@ -383,7 +383,7 @@ export const CommandPalette: React.FC = () => {
                   {recommendedPanels.map((panel, i) => {
                     const isSelected = i === selectedIndex
                     const iconForType = panel.type === 'terminal' ? <TerminalIcon /> : panel.type === 'browser' ? <GlobeIcon /> : panel.type === 'agent' ? <AgentIcon /> : <FileTextIcon />
-                    const colorForType = panel.type === 'terminal' ? 'bg-green-500/15 text-green-400' : panel.type === 'browser' ? 'bg-cyan-500/15 text-cyan-400' : panel.type === 'agent' ? 'bg-purple-500/15 text-purple-400' : 'bg-amber-500/15 text-amber-400'
+                    const colorForType = panel.type === 'terminal' ? 'bg-green-500/15 text-green-400' : panel.type === 'browser' ? 'bg-cyan-500/15 text-cyan-400' : panel.type === 'agent' ? 'bg-blue-500/15 text-blue-400' : 'bg-amber-500/15 text-amber-400'
                     return (
                       <div
                         key={panel.id}

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -132,13 +132,13 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
   agent: {
     type: 'agent',
     label: 'Agent',
-    brandColor: '#A78BFA',
-    switcherColor: '#A78BFA',
-    mutedColor: '#7a6aa0',
-    tintClass: 'text-violet-400',
+    brandColor: '#4A9EFF',
+    switcherColor: '#4A9EFF',
+    mutedColor: '#3a7acc',
+    tintClass: 'text-blue-400',
     defaultSize: { width: 760, height: 480 },
     minimumSize: { width: 360, height: 320 },
-    ghostSvg: ghost('rgb(167,139,250)', '<path d="M12 3l1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8L12 3z"/><path d="M19 14l.9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9L19 14z"/>'),
+    ghostSvg: ghost('rgb(74,158,255)', '<path d="M12 3l1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8L12 3z"/><path d="M19 14l.9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9L19 14z"/>'),
     canLiveOnCanvas: true,
   },
   canvas: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,8 @@ export default {
         'surface-5': 'var(--surface-5)',
         'surface-6': 'var(--surface-6)',
         'surface-border': 'var(--border-subtle)',
+        'agent': 'rgb(var(--agent-rgb) / <alpha-value>)',
+        'agent-light': 'rgb(var(--agent-light-rgb) / <alpha-value>)',
       },
       animation: {
         'pulse-activity': 'pulseActivity 1s ease-in-out infinite alternate',


### PR DESCRIPTION
## Summary
- Introduces `agent` and `agent-light` Tailwind color tokens in `tailwind.config.ts` and `globals.css`, replacing ~80 hardcoded `violet-*` class references across agent panel components
- Centralizes the agent accent color so it can be changed in one place
- Adds Product Hunt badge to README

## Test plan
- [ ] Run `npm run dev` and verify agent panel renders with correct purple accent
- [ ] Check chat bubbles, buttons, spinners, subagent cards, plan cards, and approval cards all use the new tokens
- [ ] Confirm no visual regressions in the agent panel UI