### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.4.5
+  <strong>Current source version:</strong> v1.0.0
 </p>
 
 <p align="center">
@@ -88,7 +88,7 @@ Cate replaces that pile of windows with **one persistent canvas per project**. T
 
 ## Install
 
-If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v0.4.5**.
+If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v1.0.0**.
 
 | Platform | Formats | Link |
 |----------|---------|------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.13",
+  "version": "1.0.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps package.json version from 0.4.13 to 1.0.0
- Updates README version references to v1.0.0