### PR TITLE
fix(windows): use cmd wrapper instead of symlink for node shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.4.5
+  <strong>Current source version:</strong> v1.0.0
 </p>
 
 <p align="center">
@@ -88,7 +88,7 @@ Cate replaces that pile of windows with **one persistent canvas per project**. T
 
 ## Install
 
-If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v0.4.5**.
+If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v1.0.0**.
 
 | Platform | Formats | Link |
 |----------|---------|------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.13",
+  "version": "1.0.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -18,6 +18,7 @@ import { app, type WebContents } from 'electron'
 import { RpcClient } from '@earendil-works/pi-coding-agent'
 import log from '../../main/logger'
 import { getShellEnv } from '../../main/shellEnv'
+import { createNodeShim } from './nodeShim'
 
 // Structural alias for pi-ai's ImageContent — pi-ai doesn't expose a `.` export
 // so we duplicate the minimal shape here. Pi reads `{type, data, mimeType}`.
@@ -79,22 +80,8 @@ function nodeExistsOnPath(env: Record<string, string>): boolean {
 function ensureElectronNodeShim(): string {
   if (fallbackNodeDir) return fallbackNodeDir
   const dir = path.join(app.getPath('temp'), 'cate-node-shim')
-  fs.mkdirSync(dir, { recursive: true })
-
-  if (process.platform === 'win32') {
-    // Windows: symlinks require Developer Mode or admin privileges (EPERM).
-    // Use a cmd wrapper that launches the Electron exe with ELECTRON_RUN_AS_NODE=1.
-    const cmdPath = path.join(dir, 'node.cmd')
-    const script = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`
-    fs.writeFileSync(cmdPath, script)
-    log.info('[agentManager] created node.cmd shim at %s', cmdPath)
-  } else {
-    const linkPath = path.join(dir, 'node')
-    try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }
-    fs.symlinkSync(process.execPath, linkPath)
-    log.info('[agentManager] created node symlink at %s -> %s', linkPath, process.execPath)
-  }
-
+  createNodeShim(dir, process.execPath)
+  log.info('[agentManager] created node shim in %s (platform=%s)', dir, process.platform)
   fallbackNodeDir = dir
   return dir
 }

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -80,11 +80,22 @@ function ensureElectronNodeShim(): string {
   if (fallbackNodeDir) return fallbackNodeDir
   const dir = path.join(app.getPath('temp'), 'cate-node-shim')
   fs.mkdirSync(dir, { recursive: true })
-  const linkPath = path.join(dir, 'node')
-  try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }
-  fs.symlinkSync(process.execPath, linkPath)
+
+  if (process.platform === 'win32') {
+    // Windows: symlinks require Developer Mode or admin privileges (EPERM).
+    // Use a cmd wrapper that launches the Electron exe with ELECTRON_RUN_AS_NODE=1.
+    const cmdPath = path.join(dir, 'node.cmd')
+    const script = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`
+    fs.writeFileSync(cmdPath, script)
+    log.info('[agentManager] created node.cmd shim at %s', cmdPath)
+  } else {
+    const linkPath = path.join(dir, 'node')
+    try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }
+    fs.symlinkSync(process.execPath, linkPath)
+    log.info('[agentManager] created node symlink at %s -> %s', linkPath, process.execPath)
+  }
+
   fallbackNodeDir = dir
-  log.info('[agentManager] created node shim at %s -> %s', linkPath, process.execPath)
   return dir
 }
 

--- a/src/agent/main/nodeShim.test.ts
+++ b/src/agent/main/nodeShim.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { createNodeShim } from './nodeShim'
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'cate-shim-test-'))
+}
+
+function cleanup(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true })
+}
+
+describe('createNodeShim', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const d of dirs) cleanup(d)
+    dirs.length = 0
+  })
+
+  test('creates node.cmd batch wrapper on win32', () => {
+    const dir = makeTmpDir()
+    dirs.push(dir)
+    const fakeExe = 'C:\\Program Files\\Cate\\Cate.exe'
+
+    createNodeShim(dir, fakeExe, 'win32')
+
+    const cmdPath = path.join(dir, 'node.cmd')
+    expect(fs.existsSync(cmdPath)).toBe(true)
+
+    const content = fs.readFileSync(cmdPath, 'utf-8')
+    expect(content).toContain('@echo off')
+    expect(content).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(content).toContain(`"${fakeExe}" %*`)
+  })
+
+  test('creates node symlink on non-win32', () => {
+    if (process.platform === 'win32') return
+
+    const dir = makeTmpDir()
+    dirs.push(dir)
+    const fakeExe = '/usr/local/bin/electron'
+
+    createNodeShim(dir, fakeExe, 'linux')
+
+    const linkPath = path.join(dir, 'node')
+    const stat = fs.lstatSync(linkPath)
+    expect(stat.isSymbolicLink()).toBe(true)
+    expect(fs.readlinkSync(linkPath)).toBe(fakeExe)
+  })
+
+  test('win32 shim is executable via cmd (integration)', () => {
+    if (process.platform !== 'win32') return
+
+    const dir = makeTmpDir()
+    dirs.push(dir)
+
+    createNodeShim(dir, process.execPath, 'win32')
+
+    const { execSync } = require('child_process')
+    const result = execSync(`"${path.join(dir, 'node.cmd')}" -e "process.stdout.write('ok')"`, {
+      encoding: 'utf-8',
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    })
+    expect(result).toBe('ok')
+  })
+
+  test('creates directory if it does not exist', () => {
+    const base = makeTmpDir()
+    dirs.push(base)
+    const nested = path.join(base, 'sub', 'dir')
+
+    createNodeShim(nested, '/fake/exe', 'win32')
+
+    expect(fs.existsSync(path.join(nested, 'node.cmd'))).toBe(true)
+  })
+
+  test('overwrites existing shim without error', () => {
+    const dir = makeTmpDir()
+    dirs.push(dir)
+
+    createNodeShim(dir, '/first/exe', 'win32')
+    createNodeShim(dir, '/second/exe', 'win32')
+
+    const content = fs.readFileSync(path.join(dir, 'node.cmd'), 'utf-8')
+    expect(content).toContain('/second/exe')
+  })
+})

--- a/src/agent/main/nodeShim.ts
+++ b/src/agent/main/nodeShim.ts
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Create a shim so that `node` on PATH resolves to the Electron binary
+ * running with ELECTRON_RUN_AS_NODE=1.
+ *
+ * On macOS/Linux this is a symlink.  On Windows, symlinks require Developer
+ * Mode or admin privileges — so we write a lightweight `node.cmd` batch
+ * wrapper instead.
+ */
+export function createNodeShim(
+  dir: string,
+  execPath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  fs.mkdirSync(dir, { recursive: true })
+
+  if (platform === 'win32') {
+    const cmdPath = path.join(dir, 'node.cmd')
+    const script = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${execPath}" %*\r\n`
+    fs.writeFileSync(cmdPath, script)
+  } else {
+    const linkPath = path.join(dir, 'node')
+    try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }
+    fs.symlinkSync(execPath, linkPath)
+  }
+}


### PR DESCRIPTION
## Summary

- On Windows, `fs.symlinkSync` requires Developer Mode or admin privileges — most users have neither, causing `EPERM` when the agent starts
- Replaces the symlink approach with a `node.cmd` batch wrapper on Windows that sets `ELECTRON_RUN_AS_NODE=1` and forwards all arguments to the Electron executable
- macOS/Linux behavior unchanged (still uses symlink)

Fixes #77

## Test plan

- [ ] Verify agent starts on Windows without Developer Mode enabled
- [ ] Verify agent still starts on macOS/Linux
- [ ] Verify extension installation works after the shim fix