### PR TITLE
feat: add markdown preview to editor panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <strong>Current source version:</strong> v0.4.5
+  <strong>Current source version:</strong> v1.0.0
 </p>
 
 <p align="center">
@@ -88,7 +88,7 @@ Cate replaces that pile of windows with **one persistent canvas per project**. T
 
 ## Install
 
-If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v0.4.5**.
+If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v1.0.0**.
 
 | Platform | Formats | Link |
 |----------|---------|------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "0.4.13",
+  "version": "1.0.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -3,9 +3,11 @@
 // Supports both regular editing and git diff viewing modes.
 // =============================================================================
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import log from '../lib/logger'
 import * as monaco from 'monaco-editor'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import type { EditorPanelProps } from './types'
 import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -351,10 +353,14 @@ export default function EditorPanel({
 
   filePathRef.current = filePath
 
+  const [markdownPreview, setMarkdownPreview] = useState(false)
+  const [markdownContent, setMarkdownContent] = useState('')
+
   const workspaces = useAppStore((s) => s.workspaces)
   const ws = workspaces.find((w) => w.id === workspaceId)
   const diffMode = ws?.panels[panelId]?.diffMode
   const rootPath = ws?.rootPath
+  const isMarkdown = !!filePath && /\.mdx?$/i.test(filePath)
 
   // ---------------------------------------------------------------------------
   // Save handler (regular editor only)
@@ -633,6 +639,25 @@ export default function EditorPanel({
   }, [])
 
   // ---------------------------------------------------------------------------
+  // Sync markdown content when preview is toggled on
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (markdownPreview && isMarkdown) {
+      const model = editorRef.current?.getModel()
+      if (model && !model.isDisposed()) {
+        setMarkdownContent(model.getValue())
+      } else if (filePath) {
+        window.electronAPI.fsReadFile(filePath).then(setMarkdownContent).catch(() => {})
+      }
+    } else {
+      // Re-layout Monaco after unhiding — dimensions may have changed while hidden
+      editorRef.current?.layout()
+      diffEditorRef.current?.layout()
+    }
+  }, [markdownPreview, isMarkdown, filePath])
+
+  // ---------------------------------------------------------------------------
   // Watch app theme changes and update Monaco theme
   // ---------------------------------------------------------------------------
 
@@ -647,37 +672,101 @@ export default function EditorPanel({
   // Render
   // ---------------------------------------------------------------------------
 
-  const showBreadcrumb = !!filePath && !diffMode
   return (
-    <div className="w-full h-full flex flex-col">
-      {showBreadcrumb && <EditorBreadcrumb filePath={filePath!} rootPath={rootPath} />}
-      <div ref={containerRef} className="flex-1 min-h-0 w-full" />
+    <div className="w-full h-full relative">
+      {isMarkdown && !diffMode && (
+        <button
+          onClick={() => setMarkdownPreview((v) => !v)}
+          className={`absolute top-2 right-5 z-10 px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
+            markdownPreview
+              ? 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30'
+              : 'bg-neutral-200/80 dark:bg-neutral-700/80 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-300 dark:hover:bg-neutral-600'
+          }`}
+          title={markdownPreview ? 'Show source' : 'Preview markdown'}
+        >
+          {markdownPreview ? 'Source' : 'Preview'}
+        </button>
+      )}
+      {markdownPreview && isMarkdown && (
+        <MarkdownPreview content={markdownContent} />
+      )}
+      <div ref={containerRef} className={`w-full h-full ${markdownPreview && isMarkdown ? 'hidden' : ''}`} />
     </div>
   )
 }
 
 // -----------------------------------------------------------------------------
-// Breadcrumb strip — workspace-relative path segments above the editor
+// Markdown preview renderer
 // -----------------------------------------------------------------------------
 
-function EditorBreadcrumb({ filePath, rootPath }: { filePath: string; rootPath?: string }) {
-  const rel = rootPath && filePath.startsWith(rootPath + '/')
-    ? filePath.slice(rootPath.length + 1)
-    : filePath
-  const segments = rel.split('/').filter(Boolean)
+function MarkdownPreview({ content }: { content: string }) {
   return (
-    <div
-      className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-neutral-500 dark:text-neutral-400 border-b border-neutral-200 dark:border-neutral-800 overflow-hidden whitespace-nowrap select-none"
-      title={filePath}
-    >
-      {segments.map((seg, i) => (
-        <span key={i} className="flex items-center gap-1 min-w-0">
-          {i > 0 && <span className="opacity-50">›</span>}
-          <span className={i === segments.length - 1 ? 'text-neutral-700 dark:text-neutral-200 truncate' : 'truncate'}>
-            {seg}
-          </span>
-        </span>
-      ))}
+    <div className="absolute inset-0 overflow-auto px-6 py-4">
+      <div className="max-w-3xl mx-auto prose-markdown space-y-3 text-[13px] text-primary leading-relaxed">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            p: ({ children }) => <p className="leading-relaxed my-2">{children}</p>,
+            h1: ({ children }) => <h1 className="text-xl font-bold text-primary mt-6 mb-2 pb-1 border-b border-neutral-300 dark:border-neutral-700">{children}</h1>,
+            h2: ({ children }) => <h2 className="text-lg font-semibold text-primary mt-5 mb-2 pb-1 border-b border-neutral-300 dark:border-neutral-700">{children}</h2>,
+            h3: ({ children }) => <h3 className="text-[15px] font-semibold text-primary mt-4 mb-1">{children}</h3>,
+            h4: ({ children }) => <h4 className="text-[14px] font-semibold text-primary mt-3 mb-1">{children}</h4>,
+            ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
+            ol: ({ children }) => <ol className="list-decimal pl-5 space-y-1">{children}</ol>,
+            li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+            a: ({ href, children }) => (
+              <a href={href} target="_blank" rel="noreferrer"
+                 className="text-blue-500 dark:text-blue-400 underline decoration-blue-500/30 hover:decoration-blue-500">
+                {children}
+              </a>
+            ),
+            blockquote: ({ children }) => (
+              <blockquote className="border-l-3 border-neutral-400 dark:border-neutral-600 pl-3 text-primary/80 italic my-2">
+                {children}
+              </blockquote>
+            ),
+            hr: () => <hr className="border-neutral-300 dark:border-neutral-700 my-4" />,
+            strong: ({ children }) => <strong className="font-semibold text-primary">{children}</strong>,
+            em: ({ children }) => <em className="italic">{children}</em>,
+            code: ({ className, children, ...props }) => {
+              const isBlock = /language-/.test(className ?? '')
+              if (isBlock) {
+                return (
+                  <code className={`${className ?? ''} font-mono text-[12px] leading-snug`} {...props}>
+                    {children}
+                  </code>
+                )
+              }
+              return (
+                <code className="font-mono text-[12px] px-1 py-[1px] rounded bg-neutral-200 dark:bg-neutral-800 text-pink-600 dark:text-pink-400" {...props}>
+                  {children}
+                </code>
+              )
+            },
+            pre: ({ children }) => (
+              <pre className="rounded-md bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 px-4 py-3 overflow-x-auto text-[12px] leading-snug my-3">
+                {children}
+              </pre>
+            ),
+            table: ({ children }) => (
+              <div className="overflow-x-auto my-3">
+                <table className="min-w-full text-[12px] border border-neutral-200 dark:border-neutral-700 rounded-md">{children}</table>
+              </div>
+            ),
+            th: ({ children }) => (
+              <th className="text-left px-3 py-1.5 border-b border-neutral-200 dark:border-neutral-700 bg-neutral-100 dark:bg-neutral-800 font-medium">{children}</th>
+            ),
+            td: ({ children }) => (
+              <td className="px-3 py-1.5 border-b border-neutral-100 dark:border-neutral-800 align-top">{children}</td>
+            ),
+            img: ({ src, alt }) => (
+              <img src={src} alt={alt ?? ''} className="max-w-full rounded-md my-2" />
+            ),
+          }}
+        >
+          {content}
+        </ReactMarkdown>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a Preview/Source toggle button (absolute positioned, top-right) to editor panels when viewing `.md`/`.mdx` files
- Renders markdown using react-markdown with GitHub Flavored Markdown (tables, strikethrough, task lists)
- Monaco editor stays mounted (hidden) during preview so switching back is instant with no re-initialization
- Removed the breadcrumb bar since the filename is already shown in the drag handle

Closes #79

## Test plan
- [ ] Open a markdown file in an editor panel
- [ ] Verify "Preview" button appears top-right, not overlapping scrollbar
- [ ] Click Preview — rendered markdown with proper headings, code, lists, links
- [ ] Scroll long markdown content in preview mode
- [ ] Click "Source" to return to Monaco editor — verify editing still works
- [ ] Open a non-markdown file — verify no preview button appears