### PR TITLE
fix(macos): grant microphone entitlement for in-app terminal tools

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,8 @@ mac:
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   notarize: true
+  extendInfo:
+    NSMicrophoneUsageDescription: Cate needs microphone access so terminal-based tools (like Claude Code) can record audio for voice input.
   target:
     - target: dmg
       arch:


### PR DESCRIPTION
## Summary
- Add `com.apple.security.device.audio-input` to the macOS entitlements.
- Add `NSMicrophoneUsageDescription` via `electron-builder.yml` → `mac.extendInfo`.

## Why
Cate ships with `hardenedRuntime: true` but no microphone entitlement and no
`NSMicrophoneUsageDescription`. Tools launched inside a Cate terminal panel
(e.g. Claude Code's voice input, `ffmpeg`, `sox`) inherit Cate's TCC
"responsible process" identity. Without the entitlement and usage string,
macOS silently denies CoreAudio access — no prompt is shown — and the child
process reports something like `no audio detected from microphone`.

With this change, the system displays the standard microphone permission
prompt on first use, and child processes can record audio normally.