### PR TITLE
fix(canvas): closing a canvas node now disposes its panels

### DIFF
--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -303,10 +303,14 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   )
 
   const handleClose = useCallback(async () => {
-    const ok = await confirmCloseForPanels(collectPanelIds(layout))
+    const panelIds = collectPanelIds(layout)
+    const ok = await confirmCloseForPanels(panelIds)
     if (!ok) return
+    for (const panelId of panelIds) {
+      useAppStore.getState().closePanel(wsId, panelId)
+    }
     removeNode(nodeId)
-  }, [removeNode, nodeId, layout, collectPanelIds, confirmCloseForPanels])
+  }, [removeNode, nodeId, layout, collectPanelIds, confirmCloseForPanels, wsId])
 
   const handleToggleMaximize = useCallback(() => {
     setIsAnimatingLayout(true)


### PR DESCRIPTION
## Summary
- Closing a canvas node via its X button now calls `closePanel` for every
  panel in the node's dock layout, then removes the node — instead of only
  removing the node wrapper.

## Why
`CanvasNode.handleClose` was only calling `removeNode(nodeId)`, which tears
down the canvas wrapper but leaves every panel inside it in
`workspaces[].panels`. As a result:
- Terminal PTYs kept running in the background (no `terminalRegistry.dispose`).
- Sidebar workspace tree kept showing the "closed" terminals and browsers.
- The only way to clean them up was "Close all panels", which also closes
  unrelated active terminals.

`closePanel` already does the right thing per panel: PTY teardown, dock
unregistration, canvas store cleanup, and removal from the workspace.
Calling it for each panel collected from the node's dock layout before
removing the node fully releases the resources.

Fixes #84