### PR TITLE
fix: allow creating files/folders in an empty explorer folder

### DIFF
--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -476,10 +476,13 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
         <div className="flex items-center justify-center flex-1 text-xs text-muted">
           Loading...
         </div>
-      ) : nodes.length === 0 ? (
-        <div className="flex flex-col items-center justify-center flex-1 text-muted text-xs gap-2 p-4">
-          <span className="text-2xl">&#128193;</span>
-          <span>No files found</span>
+      ) : nodes.length === 0 && !rootCreating ? (
+        <div
+          className="flex flex-col items-center justify-center flex-1 text-muted text-xs gap-2 p-4"
+          onContextMenu={handleRootContextMenu}
+        >
+          <span className="text-2xl pointer-events-none">&#128193;</span>
+          <span className="pointer-events-none">No files found</span>
         </div>
       ) : (
         <div


### PR DESCRIPTION
## Summary

Fixes #90.

In the File Explorer, **New File** / **New Folder** did nothing when the target folder was completely empty. The inline name-entry input for root-level creation was only rendered inside the file-tree branch, so when `nodes.length === 0` the component rendered the "No files found" empty state instead — leaving nowhere to type the name. As soon as the folder had one item, the tree branch rendered and creation worked, which matched the reported symptom.

## Changes

- `src/renderer/sidebar/FileExplorer.tsx`: render the create branch when `rootCreating` is active even if the tree is empty (guarded the empty-state branch with `!rootCreating`).
- Added a right-click context menu to the "No files found" empty state, with `pointer-events-none` on the inner spans so the context-menu handler's target guard passes.

Not platform-specific — reproduces on any OS; it was reported on Windows.

## Test plan

- [ ] `npm run build` passes (verified locally).
- [ ] Open a workspace with an empty root folder, click New File, inline input appears, type name + Enter, file is created.
- [ ] Same for New Folder.
- [ ] Right-click the empty area: New File… / New Folder… work.
- [ ] Non-empty folders behave as before.

## Screenshots

UI change — screenshots to be added (no running build captured in this environment).
