### PR TITLE
fix: resolve Windows agent launch crash (spawn node ENOENT)

### DIFF
--- a/src/agent/main/nodeShim.test.ts
+++ b/src/agent/main/nodeShim.test.ts
@@ -9,7 +9,18 @@ function makeTmpDir(): string {
 }
 
 function cleanup(dir: string) {
-  fs.rmSync(dir, { recursive: true, force: true })
+  // Best-effort: a node.exe hardlinked to the running binary can stay briefly
+  // locked on Windows (EPERM). Leaving the temp dir behind is harmless.
+  try {
+    fs.rmSync(dir, { recursive: true, force: true })
+  } catch { /* temp dir — let the OS reclaim it */ }
+}
+
+/** Write a fake executable file (the shim's link/copy target) and return its path. */
+function makeFakeExe(dir: string, name: string, contents: string): string {
+  const exe = path.join(dir, name)
+  fs.writeFileSync(exe, contents)
+  return exe
 }
 
 describe('createNodeShim', () => {
@@ -20,20 +31,20 @@ describe('createNodeShim', () => {
     dirs.length = 0
   })
 
-  test('creates node.cmd batch wrapper on win32', () => {
+  test('creates a real node.exe on win32 (resolvable by shell-less spawn)', () => {
     const dir = makeTmpDir()
     dirs.push(dir)
-    const fakeExe = 'C:\\Program Files\\Cate\\Cate.exe'
+    // Source exe must be a real file on the same volume so the hardlink succeeds.
+    const fakeExe = makeFakeExe(dir, 'source.exe', 'fake-electron-binary')
 
     createNodeShim(dir, fakeExe, 'win32')
 
-    const cmdPath = path.join(dir, 'node.cmd')
-    expect(fs.existsSync(cmdPath)).toBe(true)
-
-    const content = fs.readFileSync(cmdPath, 'utf-8')
-    expect(content).toContain('@echo off')
-    expect(content).toContain('ELECTRON_RUN_AS_NODE=1')
-    expect(content).toContain(`"${fakeExe}" %*`)
+    const exePath = path.join(dir, 'node.exe')
+    expect(fs.existsSync(exePath)).toBe(true)
+    // No .cmd wrapper — CreateProcess won't resolve it for a shell-less spawn.
+    expect(fs.existsSync(path.join(dir, 'node.cmd'))).toBe(false)
+    // Contents mirror the source binary (hardlink or copy).
+    expect(fs.readFileSync(exePath, 'utf-8')).toBe('fake-electron-binary')
   })
 
   test('creates node symlink on non-win32', () => {
@@ -51,7 +62,7 @@ describe('createNodeShim', () => {
     expect(fs.readlinkSync(linkPath)).toBe(fakeExe)
   })
 
-  test('win32 shim is executable via cmd (integration)', () => {
+  test('win32 shim runs as node (integration)', () => {
     if (process.platform !== 'win32') return
 
     const dir = makeTmpDir()
@@ -59,8 +70,9 @@ describe('createNodeShim', () => {
 
     createNodeShim(dir, process.execPath, 'win32')
 
-    const { execSync } = require('child_process')
-    const result = execSync(`"${path.join(dir, 'node.cmd')}" -e "process.stdout.write('ok')"`, {
+    const { execFileSync } = require('child_process')
+    // Invoke the shim directly (no shell) to mirror pi's spawn("node", ...).
+    const result = execFileSync(path.join(dir, 'node.exe'), ['-e', "process.stdout.write('ok')"], {
       encoding: 'utf-8',
       env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
     })
@@ -70,21 +82,23 @@ describe('createNodeShim', () => {
   test('creates directory if it does not exist', () => {
     const base = makeTmpDir()
     dirs.push(base)
+    const fakeExe = makeFakeExe(base, 'source.exe', 'x')
     const nested = path.join(base, 'sub', 'dir')
 
-    createNodeShim(nested, '/fake/exe', 'win32')
+    createNodeShim(nested, fakeExe, 'win32')
 
-    expect(fs.existsSync(path.join(nested, 'node.cmd'))).toBe(true)
+    expect(fs.existsSync(path.join(nested, 'node.exe'))).toBe(true)
   })
 
   test('overwrites existing shim without error', () => {
     const dir = makeTmpDir()
     dirs.push(dir)
+    const first = makeFakeExe(dir, 'first.exe', 'first-binary')
+    const second = makeFakeExe(dir, 'second.exe', 'second-binary')
 
-    createNodeShim(dir, '/first/exe', 'win32')
-    createNodeShim(dir, '/second/exe', 'win32')
+    createNodeShim(dir, first, 'win32')
+    createNodeShim(dir, second, 'win32')
 
-    const content = fs.readFileSync(path.join(dir, 'node.cmd'), 'utf-8')
-    expect(content).toContain('/second/exe')
+    expect(fs.readFileSync(path.join(dir, 'node.exe'), 'utf-8')).toBe('second-binary')
   })
 })

--- a/src/agent/main/nodeShim.test.ts
+++ b/src/agent/main/nodeShim.test.ts
@@ -79,6 +79,27 @@ describe('createNodeShim', () => {
     expect(result).toBe('ok')
   })
 
+  test('shell-less spawn("node") resolves shim on PATH (#92)', async () => {
+    const dir = makeTmpDir()
+    dirs.push(dir)
+
+    createNodeShim(dir, process.execPath)
+
+    const { spawn } = require('child_process')
+    const result = await new Promise<string>((resolve, reject) => {
+      const child = spawn('node', ['-e', 'process.stdout.write("ok")'], {
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', PATH: dir },
+        shell: false,
+      })
+      let out = ''
+      child.stdout.on('data', (d: Buffer) => { out += d })
+      child.on('close', (code: number) => code === 0 ? resolve(out) : reject(new Error(`exit ${code}`)))
+      child.on('error', reject)
+    })
+
+    expect(result).toBe('ok')
+  })
+
   test('creates directory if it does not exist', () => {
     const base = makeTmpDir()
     dirs.push(base)

--- a/src/agent/main/nodeShim.ts
+++ b/src/agent/main/nodeShim.ts
@@ -3,11 +3,15 @@ import path from 'path'
 
 /**
  * Create a shim so that `node` on PATH resolves to the Electron binary
- * running with ELECTRON_RUN_AS_NODE=1.
+ * (which behaves as Node when ELECTRON_RUN_AS_NODE=1 is set in the env).
  *
- * On macOS/Linux this is a symlink.  On Windows, symlinks require Developer
- * Mode or admin privileges — so we write a lightweight `node.cmd` batch
- * wrapper instead.
+ * On macOS/Linux this is a symlink. On Windows it must be a real `node.exe`:
+ * pi's RpcClient launches the agent via a shell-less `spawn("node", ...)`,
+ * and CreateProcess only resolves `node`/`node.exe` on PATH — never `.cmd`.
+ * A `node.cmd` wrapper is therefore invisible to that spawn and yields
+ * `spawn node ENOENT`. We hardlink `node.exe` to the Electron binary (cheap,
+ * no Developer Mode/admin needed on the same volume) and fall back to a copy
+ * when a hardlink isn't possible (e.g. shim dir on a different volume).
  */
 export function createNodeShim(
   dir: string,
@@ -17,9 +21,13 @@ export function createNodeShim(
   fs.mkdirSync(dir, { recursive: true })
 
   if (platform === 'win32') {
-    const cmdPath = path.join(dir, 'node.cmd')
-    const script = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${execPath}" %*\r\n`
-    fs.writeFileSync(cmdPath, script)
+    const exePath = path.join(dir, 'node.exe')
+    try { fs.unlinkSync(exePath) } catch { /* didn't exist */ }
+    try {
+      fs.linkSync(execPath, exePath)
+    } catch {
+      fs.copyFileSync(execPath, exePath)
+    }
   } else {
     const linkPath = path.join(dir, 'node')
     try { fs.unlinkSync(linkPath) } catch { /* didn't exist */ }


### PR DESCRIPTION
## Summary

Fixes #92.

On Windows, launching the agent crashed the app with a native Electron dialog: `Error: spawn node ENOENT`.

pi's `RpcClient` launches the agent via a shell-less `spawn("node", [cliPath, ...])`. On Windows, `CreateProcess` only resolves `node` / `node.exe` on `PATH` — it never resolves a `.cmd` file (those require a shell). The previous shim wrote a `node.cmd` wrapper, which was therefore invisible to that spawn, producing `spawn node ENOENT` and crashing the main process.

## Fix

`src/agent/main/nodeShim.ts`: on Windows, create a real `node.exe` in the shim directory instead of `node.cmd`:

- Hardlink `node.exe` to the Electron binary (`process.execPath`) — cheap and needs no Developer Mode/admin when the shim dir and binary are on the same volume.
- Fall back to a copy (`fs.copyFileSync`) when a hardlink isn't possible (e.g. different volumes).

`ELECTRON_RUN_AS_NODE=1` is already set in the spawned env by `buildAgentEnv()`, so the Electron binary behaves as Node. macOS/Linux behavior (symlink) is unchanged.

## Test plan

- [x] `src/agent/main/nodeShim.test.ts` updated and passing, including a Windows integration test that shell-less-spawns the `node.exe` shim (`execFileSync`) and asserts it runs as Node (prints `ok`).
- [x] `npm run build` passes.
- [ ] Manual: on a packaged Windows build, launch an agent / pick a model — no `spawn node ENOENT`, agent starts.

## Notes

- Best-effort temp-dir cleanup was added in the test because a `node.exe` hardlinked to the running binary can be briefly locked by Windows (EPERM) after the spawned child exits; leaving the temp dir is harmless.
