### PR TITLE
fix: enable Ctrl+V paste in terminal panels on Windows/Linux

### DIFF
--- a/src/renderer/lib/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminalRegistry.test.ts
@@ -119,6 +119,35 @@ beforeEach(() => {
   })
 })
 
+describe('isTerminalPasteChord', () => {
+  const kd = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init)
+
+  it('matches Ctrl+V and Ctrl+Shift+V on non-mac', async () => {
+    const { isTerminalPasteChord } = await import('./terminalRegistry')
+    expect(isTerminalPasteChord(kd({ ctrlKey: true, key: 'v' }), false)).toBe(true)
+    expect(isTerminalPasteChord(kd({ ctrlKey: true, shiftKey: true, key: 'V' }), false)).toBe(true)
+  })
+
+  it('ignores Ctrl+V on macOS (it is the terminal "literal next" key there)', async () => {
+    const { isTerminalPasteChord } = await import('./terminalRegistry')
+    expect(isTerminalPasteChord(kd({ ctrlKey: true, key: 'v' }), true)).toBe(false)
+  })
+
+  it('does not match when alt or meta is also held, or without ctrl', async () => {
+    const { isTerminalPasteChord } = await import('./terminalRegistry')
+    expect(isTerminalPasteChord(kd({ ctrlKey: true, altKey: true, key: 'v' }), false)).toBe(false)
+    expect(isTerminalPasteChord(kd({ metaKey: true, key: 'v' }), false)).toBe(false)
+    expect(isTerminalPasteChord(kd({ key: 'v' }), false)).toBe(false)
+    expect(isTerminalPasteChord(kd({ ctrlKey: true, key: 'c' }), false)).toBe(false)
+  })
+
+  it('only matches keydown, not keyup', async () => {
+    const { isTerminalPasteChord } = await import('./terminalRegistry')
+    const up = new KeyboardEvent('keyup', { ctrlKey: true, key: 'v' })
+    expect(isTerminalPasteChord(up, false)).toBe(false)
+  })
+})
+
 describe('terminalRegistry pending-transfer cleanup invariant', () => {
   // Establish a baseline: a fresh getOrCreate with a pending transfer reconnects.
   // The panelTransferAck is deferred to attach() now — see the

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -25,6 +25,24 @@ function getScrollback(): number {
   return Math.max(100, Math.min(raw, 10000))
 }
 
+const isMacPlatform =
+  typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform || navigator.userAgent)
+
+/**
+ * True for the Windows/Linux paste chord (Ctrl+V or Ctrl+Shift+V). xterm.js has
+ * no built-in Ctrl+V binding, so it would otherwise encode a literal ^V (0x16)
+ * to the PTY. The caller returns false for this chord, which makes xterm skip
+ * the key WITHOUT calling preventDefault — so the browser still fires its native
+ * paste event into xterm's textarea and xterm performs the paste exactly once
+ * (honouring bracketed-paste mode). macOS keeps Ctrl+V as the terminal "literal
+ * next" key and pastes with Cmd+V instead.
+ */
+function isTerminalPasteChord(event: KeyboardEvent): boolean {
+  if (isMacPlatform) return false
+  if (event.type !== 'keydown' || !event.ctrlKey || event.altKey || event.metaKey) return false
+  return event.key === 'v' || event.key === 'V'
+}
+
 // ---------------------------------------------------------------------------
 // Themes — three palettes for dark-warm, light-subtle, dark-cold
 // ---------------------------------------------------------------------------
@@ -464,6 +482,12 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
     terminal.attachCustomKeyEventHandler((event) => {
       if (event.type !== 'keydown') return true
 
+      // Returning false makes xterm skip this key (no literal ^V) without
+      // calling preventDefault, so the browser still fires its paste event into
+      // xterm's textarea and xterm performs the paste once. Do NOT preventDefault
+      // here — that would also cancel the paste event and nothing would paste.
+      if (isTerminalPasteChord(event)) return false
+
       const keyCode = CSI_U_KEYS[event.key]
       if (keyCode === undefined) return true // let xterm handle all other keys
 
@@ -620,6 +644,7 @@ async function reconnectTerminal(
   }
   terminal.attachCustomKeyEventHandler((event) => {
     if (event.type !== 'keydown') return true
+    if (isTerminalPasteChord(event)) return false
     const keyCode = CSI_U_KEYS[event.key]
     if (keyCode === undefined) return true
     let mod = 1

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -37,8 +37,8 @@ const isMacPlatform =
  * (honouring bracketed-paste mode). macOS keeps Ctrl+V as the terminal "literal
  * next" key and pastes with Cmd+V instead.
  */
-function isTerminalPasteChord(event: KeyboardEvent): boolean {
-  if (isMacPlatform) return false
+export function isTerminalPasteChord(event: KeyboardEvent, isMac = isMacPlatform): boolean {
+  if (isMac) return false
   if (event.type !== 'keydown' || !event.ctrlKey || event.altKey || event.metaKey) return false
   return event.key === 'v' || event.key === 'V'
 }


### PR DESCRIPTION
## Summary

Fixes #94.

Pressing **Ctrl+V** in a terminal panel did not paste on Windows/Linux — instead xterm sent a literal `^V` (0x16) to the PTY. xterm.js has no built-in Ctrl+V binding (it treats it as a control keystroke), and the app's Edit-menu paste accelerator wasn't reaching the terminal.

## Fix

`src/renderer/lib/terminalRegistry.ts`: the terminal's custom key handler now returns `false` for the Ctrl+V / Ctrl+Shift+V chord on non-macOS. Returning `false` makes xterm **skip** the key *without* calling `preventDefault`, so the browser still fires its native `paste` event into xterm's textarea and xterm performs the paste exactly once (respecting bracketed-paste mode).

Key detail: we must **not** call `event.preventDefault()` here — doing so also cancels the subsequent `paste` event, and nothing pastes (tested). macOS is unchanged: Ctrl+V stays the terminal "literal next" key and paste happens via Cmd+V.

Applied to both terminal key-handler sites (`getOrCreate` and `reconnectTerminal`).

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] Manual (Windows, canvas terminal): single-line Ctrl+V pastes once, no `^V`.
- [x] Manual: multi-line Ctrl+V pastes once, not duplicated (each line still executes on its newline in cmd.exe — normal shell behavior).
- [ ] macOS regression check: Cmd+V still pastes; Ctrl+V remains literal-next.
