### PR TITLE
fix(ci): increase Node.js heap size for build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Typecheck
         run: npm run typecheck


### PR DESCRIPTION
## Summary
- Adds `NODE_OPTIONS: --max-old-space-size=4096` to the CI build step
- Fixes macOS OOM crashes (`exit code 134`) caused by the Vite build running out of heap memory after the pdfjs-dist dependency was added in #96

## Test plan
- [ ] macOS CI build passes without OOM