### PR TITLE
feat(titlebar): themed drag strip on macOS when native tabs off

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -103,6 +103,12 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   const snapGeom = bootSnap?.geometry
   const snapBg = bootSnap?.backgroundColor
 
+  // Snapshot native-tabs state at window creation. The renderer reads this via
+  // the URL query so that the React TitlebarStrip matches the actual
+  // titleBarStyle — toggling the setting at runtime only takes effect on the
+  // next launch.
+  const nativeTabsActive = process.platform === 'darwin' && windowType === 'main' && getSettingSync('nativeTabs')
+
   const win = new BrowserWindow({
     width: snapGeom?.width ?? (isDock ? 700 : isPanel ? 700 : 1200),
     height: snapGeom?.height ?? (isDock ? 500 : isPanel ? 500 : 800),
@@ -116,20 +122,21 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
     // suppresses the tab bar entirely. When native tabs are enabled for main
     // windows we fall back to the default title bar so the tab strip (app
     // name tab + "+" button) can render.
-    titleBarStyle: isPanel
-      ? 'hidden'
-      : (process.platform === 'darwin' && windowType === 'main' && getSettingSync('nativeTabs'))
-        ? 'default'
-        : 'hiddenInset',
-    trafficLightPosition: isDock ? { x: 12, y: 11 } : undefined,
+    titleBarStyle: isPanel ? 'hidden' : nativeTabsActive ? 'default' : 'hiddenInset',
+    // Align traffic lights with our 28px themed TitlebarStrip on macOS. Apple's
+    // standard NSWindow title bar is ~28pt with lights at y≈7; matching that
+    // here makes the themed bar visually identical to a native title bar.
+    trafficLightPosition: isDock
+      ? { x: 12, y: 11 }
+      : (process.platform === 'darwin' && windowType === 'main' && !nativeTabsActive)
+        ? { x: 10, y: 6 }
+        : undefined,
     frame: !(isPanel || isDock),
     // macOS native window tabs — only on main windows. Setting tabbingIdentifier
     // makes new windows in this group join as native tabs in the title bar
     // (subject to System Settings → Desktop & Dock → "Prefer tabs"). Panel and
     // dock windows are excluded so they stay free-floating.
-    ...(process.platform === 'darwin' && windowType === 'main' && getSettingSync('nativeTabs')
-      ? { tabbingIdentifier: 'cate-main' }
-      : {}),
+    ...(nativeTabsActive ? { tabbingIdentifier: 'cate-main' } : {}),
     backgroundColor: snapBg ?? '#1f1e1c',
     icon: nativeImage.createFromPath(iconPath),
     webPreferences: {
@@ -252,6 +259,7 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   // Build query string from params
   const queryParts: string[] = []
   queryParts.push(`type=${encodeURIComponent(windowType)}`)
+  if (nativeTabsActive) queryParts.push('nativeTabsBoot=1')
   if (params?.panelType) queryParts.push(`panelType=${encodeURIComponent(params.panelType)}`)
   if (params?.panelId) queryParts.push(`panelId=${encodeURIComponent(params.panelId)}`)
   if (params?.workspaceId) queryParts.push(`workspaceId=${encodeURIComponent(params.workspaceId)}`)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -789,6 +789,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => { ipcRenderer.removeListener(DRAG_END, listener) }
   },
 
+  /** Subscribe to native-fullscreen state changes. Fires with the new boolean
+   *  whenever any Cate window enters or leaves macOS native fullscreen. */
+  onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, value: boolean): void => {
+      callback(Boolean(value))
+    }
+    ipcRenderer.on(WINDOW_FULLSCREEN_STATE, listener)
+    return () => { ipcRenderer.removeListener(WINDOW_FULLSCREEN_STATE, listener) }
+  },
+
   // ---------------------------------------------------------------------------
   // Dock window management
   // ---------------------------------------------------------------------------

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -36,6 +36,7 @@ import { useDockStore } from './stores/dockStore'
 import MainWindowShell from './shells/MainWindowShell'
 import PanelWindowShell from './shells/PanelWindowShell'
 import DockWindowShell from './shells/DockWindowShell'
+import TitlebarStrip from './shells/TitlebarStrip'
 import { WindowTypeContext } from './stores/WindowTypeContext'
 import { setupCrossWindowDragListeners } from './drag'
 import { terminalRegistry } from './lib/terminalRegistry'
@@ -461,10 +462,12 @@ function MainApp() {
   return (
     <CanvasStoreProvider store={useCanvasStore}>
     <div
-      className="h-screen w-screen relative bg-canvas-bg"
+      className="h-screen w-screen flex flex-col bg-canvas-bg"
       onDragOver={handleFileDragOver}
       onDrop={handleFileDrop}
     >
+      <TitlebarStrip />
+      <div className="relative flex-1 min-h-0 min-w-0">
       {/* Main window shell fills the viewport so the canvas extends edge to
           edge under the translucent sidebars. The top-level dock tab bar
           insets itself via CSS vars (--cate-left/right-sidebar-width) so the
@@ -504,6 +507,7 @@ function MainApp() {
           <div className="mt-3 text-[11px] text-muted tracking-wide">v{pkg.version}</div>
         </div>
       )}
+      </div>
     </div>
     </CanvasStoreProvider>
   )

--- a/src/renderer/settings/GeneralSettings.tsx
+++ b/src/renderer/settings/GeneralSettings.tsx
@@ -1,8 +1,12 @@
+import { InfoIcon, WarningIcon } from '@phosphor-icons/react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { SettingRow, Toggle, TextInput } from './SettingsComponents'
 
+const NATIVE_TABS_BOOT = new URLSearchParams(window.location.search).get('nativeTabsBoot') === '1'
+
 export function GeneralSettings() {
   const store = useSettingsStore()
+  const nativeTabsPending = store.nativeTabs !== NATIVE_TABS_BOOT
 
   return (
     <div className="flex flex-col gap-1">
@@ -15,7 +19,23 @@ export function GeneralSettings() {
       {navigator.userAgent.includes('Mac') && (
         <SettingRow
           label="Native macOS window tabs"
-          description="Group main windows as native tabs in the title bar. Restart required."
+          description="Group main windows as native tabs in the title bar."
+          hint={(NATIVE_TABS_BOOT || nativeTabsPending) ? (
+            <>
+              {NATIVE_TABS_BOOT && (
+                <p className="flex items-center gap-1 text-xs text-muted">
+                  <InfoIcon size={12} />
+                  Title bar follows macOS appearance and ignores the app theme while tabs are enabled.
+                </p>
+              )}
+              {nativeTabsPending && (
+                <p className="flex items-center gap-1 text-xs text-amber-500 mt-1">
+                  <WarningIcon size={12} />
+                  Restart required for this change to take effect.
+                </p>
+              )}
+            </>
+          ) : undefined}
         >
           <Toggle checked={store.nativeTabs} onChange={(v) => store.setSetting('nativeTabs', v)} />
         </SettingRow>

--- a/src/renderer/settings/SettingsComponents.tsx
+++ b/src/renderer/settings/SettingsComponents.tsx
@@ -11,15 +11,18 @@ import type { ReactNode } from 'react'
 interface SettingRowProps {
   label: string
   description?: string
+  /** Optional node rendered below the description, still above the row border. */
+  hint?: ReactNode
   children: ReactNode
 }
 
-export function SettingRow({ label, description, children }: SettingRowProps) {
+export function SettingRow({ label, description, hint, children }: SettingRowProps) {
   return (
     <div className="flex items-center justify-between py-2.5 border-b border-subtle">
-      <div className="flex flex-col">
+      <div className="flex flex-col min-w-0">
         <span className="text-sm text-primary">{label}</span>
         {description && <span className="text-xs text-muted mt-0.5">{description}</span>}
+        {hint && <div className="mt-1">{hint}</div>}
       </div>
       <div className="flex-shrink-0 ml-4">{children}</div>
     </div>

--- a/src/renderer/shells/TitlebarStrip.tsx
+++ b/src/renderer/shells/TitlebarStrip.tsx
@@ -1,0 +1,39 @@
+// =============================================================================
+// TitlebarStrip — themed drag region rendered at the top of the main window
+// when macOS native tabs are disabled (titleBarStyle: 'hiddenInset'). Reserves
+// space for the traffic lights and gives the window a drag region matched to
+// the app theme.
+//
+// Reads the boot-time nativeTabs value from the URL (set by main on window
+// create) instead of the live setting, so the strip always matches the actual
+// window chrome. Toggling the setting at runtime has no effect until restart.
+//
+// In native macOS fullscreen the traffic lights are hidden by the OS, so the
+// strip would otherwise show as a 28px dead zone at the top — subscribe to
+// fullscreen state and collapse while fullscreen is active.
+// =============================================================================
+
+import { useEffect, useState } from 'react'
+
+const IS_MAC = navigator.userAgent.includes('Mac')
+const NATIVE_TABS_BOOT = new URLSearchParams(window.location.search).get('nativeTabsBoot') === '1'
+
+export default function TitlebarStrip() {
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(
+    () => window.electronAPI.isMainWindowFullscreen?.() ?? false,
+  )
+
+  useEffect(() => {
+    if (!IS_MAC || NATIVE_TABS_BOOT) return
+    return window.electronAPI.onFullscreenChange?.((value) => setIsFullscreen(value))
+  }, [])
+
+  if (!IS_MAC || NATIVE_TABS_BOOT || isFullscreen) return null
+
+  return (
+    <div
+      className="titlebar-drag shrink-0 bg-titlebar-bg select-none"
+      style={{ paddingLeft: 80, height: 28 }}
+    />
+  )
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -434,6 +434,10 @@ export interface ElectronAPI {
   /** Subscribe to drag end events (main -> renderer). */
   onDragEnd(callback: () => void): () => void
 
+  /** Subscribe to native-fullscreen state changes. Fires with the new boolean
+   *  whenever any Cate window enters or leaves macOS native fullscreen. */
+  onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void
+
   // ---------------------------------------------------------------------------
   // Dock window management
   // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -766,7 +766,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // where it commonly isn't installed.
   defaultShellPath: '',
   warnBeforeQuit: false,
-  nativeTabs: true,
+  nativeTabs: false,
 
   // Appearance
   appearanceMode: 'system',


### PR DESCRIPTION

<img width="333" height="203" alt="titlebar" src="https://github.com/user-attachments/assets/5eca904e-8fc5-4cda-900a-af26d7b54807" />


## Summary

- New themed `TitlebarStrip` rendered above the canvas on macOS when native window tabs are disabled. The chrome now follows the app theme instead of breaking on dark/light backgrounds.
- `nativeTabs` default flipped to `false` so first-launch users see the themed bar rather than the un-themable native tab bar.
- `trafficLightPosition` set to `{x: 10, y: 6}` to align the OS-rendered traffic lights with the 28px strip.
- Settings: inline "Restart required" warning when the toggle diverges from the boot value; the existing macOS-appearance hint moved into a new `SettingRow.hint` slot so it sits above the row border instead of bleeding into the next row.

## Why "restart required" instead of auto-relaunch?

`titleBarStyle` and `tabbingIdentifier` are immutable after `BrowserWindow` creation. Three options were considered:

1. **Boot snapshot** *(chosen)* — main passes the boot-time `nativeTabs` to the renderer via the URL query. `TitlebarStrip` reads that boot value, not the live setting, so the React chrome always matches the actual window. Toggling the setting persists, but only takes effect on the next launch — exactly what the inline warning communicates.
2. **Auto-relaunch on toggle** — quit + respawn. Rejected: kills terminal/browser/agent state and breaks the user's flow for a cosmetic preference.
3. **In-place window recreate** — spawn a new BrowserWindow with the desired style and migrate renderer state. Rejected as overkill; session-restore would have to be flawless on every toggle.

Option 1 keeps a **single source of truth** (the actual window state at boot), avoids data loss, and is small.

## Fullscreen

In macOS native fullscreen the OS hides the traffic lights, which would leave the strip as a 28px dead zone. `TitlebarStrip` subscribes to `WINDOW_FULLSCREEN_STATE` (newly exposed via `onFullscreenChange`) and collapses while fullscreen is active.