### PR TITLE
fix(ci): set NODE_OPTIONS heap size in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Build app
         run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Package (macOS)
         if: matrix.platform == 'mac'


### PR DESCRIPTION
## Summary
- Add `NODE_OPTIONS: --max-old-space-size=4096` to the release workflow's Build step
- Matches the fix from #98 that was applied to ci.yml but missed in release.yml
- Without this, the macOS release build OOMs during electron-vite bundling (v1.0.1 release failed)

## Test plan
- [ ] CI passes
- [ ] After merge, delete and re-push v1.0.1 tag to re-trigger release