### PR TITLE
feat(minimap): click node to focus and center

### DIFF
--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -341,6 +341,11 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
         return (
           <div
             key={node.id}
+            onMouseDown={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              canvasApi.getState().focusAndCenter(node.id)
+            }}
             style={{
               position: 'absolute',
               left: toMiniX(node.origin.x),
@@ -350,6 +355,7 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
               backgroundColor: themedPanelColor(type),
               borderRadius: 1,
               opacity: 1,
+              cursor: 'pointer',
             }}
           />
         )

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -17,7 +17,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import type { TerminalPanelProps } from './types'
 import { terminalRegistry } from '../lib/terminalRegistry'
 import { useAppStore } from '../stores/appStore'
-import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
+import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { TerminalUrlPrompt } from './TerminalUrlPrompt'
 
 // ---------------------------------------------------------------------------
@@ -104,6 +104,7 @@ export default function TerminalPanel({
   rootPathRef.current = rootPath
 
   const isFocused = useCanvasStoreContext((s) => s.focusedNodeId === nodeId)
+  const canvasApi = useCanvasStoreApi()
   const zoomLevel = useCanvasStoreContext((s) => s.zoomLevel)
 
   // -------------------------------------------------------------------------
@@ -342,23 +343,62 @@ export default function TerminalPanel({
   // -------------------------------------------------------------------------
 
   useEffect(() => {
-    if (!isFocused) return
-    const entry = terminalRegistry.getEntry(panelId)
-    if (!entry) return
+    let cancelled = false
 
-    const textarea = entry.terminal.element?.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
-    if (textarea) {
-      textarea.focus({ preventScroll: true })
-    } else {
-      entry.terminal.focus()
+    const runFocus = () => {
+      let waitAttempts = 0
+      let recheckAttempts = 0
+      let scrollRestored = false
+      let myCancelled = false
+      const tick = () => {
+        if (cancelled || myCancelled) return
+        const entry = terminalRegistry.getEntry(panelId)
+        const el = entry?.terminal.element
+        // Skip when xterm DOM is not attached: IntersectionObserver can briefly
+        // detach the element during mount on a virtualized panel just brought
+        // into view via the minimap.
+        if (!entry || !el || !el.isConnected) {
+          if (waitAttempts++ < 80) setTimeout(tick, 25)
+          return
+        }
+        const textarea = el.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+        const target: HTMLElement = textarea ?? el
+        if (document.activeElement !== target) {
+          if (textarea) textarea.focus({ preventScroll: true })
+          else entry.terminal.focus()
+        }
+        if (!scrollRestored) {
+          scrollRestored = true
+          terminalRegistry.restoreScroll(panelId)
+          requestAnimationFrame(() => terminalRegistry.restoreScroll(panelId))
+        }
+        // Re-check for ~500ms after first success to survive a detach/reattach
+        // race from the IntersectionObserver right after mount.
+        if (recheckAttempts++ < 20) setTimeout(tick, 25)
+      }
+      tick()
+      return () => { myCancelled = true }
     }
 
-    // Restore scroll position from the continuously-tracked value in the
-    // registry. This survives any scroll resets that may have happened
-    // between losing and regaining focus.
-    terminalRegistry.restoreScroll(panelId)
-    requestAnimationFrame(() => terminalRegistry.restoreScroll(panelId))
-  }, [isFocused, panelId])
+    // Initial focus when this panel becomes the focused node.
+    let stopRun: (() => void) | undefined
+    if (isFocused) stopRun = runFocus()
+
+    // Imperative subscription to focusEpoch — re-runs focus when the same node
+    // is re-focused (no React re-render of this panel on unrelated focus actions).
+    const unsubscribe = canvasApi.subscribe((s, prev) => {
+      if (s.focusEpoch === prev.focusEpoch) return
+      if (s.focusedNodeId !== nodeId) return
+      stopRun?.()
+      stopRun = runFocus()
+    })
+
+    return () => {
+      cancelled = true
+      stopRun?.()
+      unsubscribe()
+    }
+  }, [isFocused, panelId, nodeId, canvasApi])
 
   // -------------------------------------------------------------------------
   // Crisp rendering at high canvas zoom

--- a/src/renderer/stores/canvasStore.test.ts
+++ b/src/renderer/stores/canvasStore.test.ts
@@ -78,3 +78,69 @@ describe('canvasStore.addNode — canvas-on-canvas is rejected', () => {
     expect(Object.keys(store.getState().nodes)).toHaveLength(0)
   })
 })
+
+// focusEpoch is the signal panels watch to re-fire focus side effects when the
+// same node is re-focused (e.g. minimap click on the already-focused node).
+// Without it, useEffect deps on `isFocused` alone would not re-run.
+describe('canvasStore — focusEpoch bumps on focus actions', () => {
+  it('starts at 0', () => {
+    const store = createCanvasStore()
+    expect(store.getState().focusEpoch).toBe(0)
+  })
+
+  it('focusNode increments focusEpoch each call, even for the already-focused node', () => {
+    const store = createCanvasStore()
+    const id = store.getState().addNode('p1', 'terminal', { x: 0, y: 0 }, { width: 100, height: 80 })
+
+    const before = store.getState().focusEpoch
+    store.getState().focusNode(id)
+    const afterFirst = store.getState().focusEpoch
+    store.getState().focusNode(id)
+    const afterSecond = store.getState().focusEpoch
+
+    expect(afterFirst).toBe(before + 1)
+    expect(afterSecond).toBe(before + 2)
+    expect(store.getState().focusedNodeId).toBe(id)
+  })
+
+  it('focusAndCenter increments focusEpoch', () => {
+    const store = createCanvasStore()
+    const id = store.getState().addNode('p1', 'terminal', { x: 0, y: 0 }, { width: 100, height: 80 })
+    store.getState().setContainerSize({ width: 800, height: 600 })
+
+    const before = store.getState().focusEpoch
+    store.getState().focusAndCenter(id)
+    expect(store.getState().focusEpoch).toBe(before + 1)
+    expect(store.getState().focusedNodeId).toBe(id)
+  })
+
+  it('focusAndCenter bumps focusEpoch even when called twice on the same node', () => {
+    const store = createCanvasStore()
+    const id = store.getState().addNode('p1', 'terminal', { x: 0, y: 0 }, { width: 100, height: 80 })
+    store.getState().setContainerSize({ width: 800, height: 600 })
+
+    store.getState().focusAndCenter(id)
+    const after1 = store.getState().focusEpoch
+    store.getState().focusAndCenter(id)
+    const after2 = store.getState().focusEpoch
+
+    expect(after2).toBe(after1 + 1)
+  })
+
+  it('focusNode on a missing nodeId does not bump focusEpoch', () => {
+    const store = createCanvasStore()
+    const before = store.getState().focusEpoch
+    store.getState().focusNode('does-not-exist')
+    expect(store.getState().focusEpoch).toBe(before)
+  })
+
+  it('toggleMaximize bumps focusEpoch', () => {
+    const store = createCanvasStore()
+    const id = store.getState().addNode('p1', 'terminal', { x: 0, y: 0 }, { width: 100, height: 80 })
+    store.getState().setContainerSize({ width: 800, height: 600 })
+
+    const before = store.getState().focusEpoch
+    store.getState().toggleMaximize(id, { width: 800, height: 600 })
+    expect(store.getState().focusEpoch).toBe(before + 1)
+  })
+})

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -37,6 +37,8 @@ export interface CanvasStoreState {
   viewportOffset: Point
   zoomLevel: number
   focusedNodeId: CanvasNodeId | null
+  /** Increments on every focus action — lets panels re-run focus side effects even when focusedNodeId doesn't change. */
+  focusEpoch: number
   nextZOrder: number
   nextCreationIndex: number
   containerSize: Size
@@ -300,6 +302,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
   viewportOffset: { x: 0, y: 0 },
   zoomLevel: ZOOM_DEFAULT,
   focusedNodeId: null,
+  focusEpoch: 0,
   nextZOrder: 0,
   nextCreationIndex: 0,
   containerSize: { width: 0, height: 0 },
@@ -497,6 +500,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
         },
         nextZOrder: state.nextZOrder + 1,
         focusedNodeId: id,
+        focusEpoch: state.focusEpoch + 1,
       }
     })
   },
@@ -554,6 +558,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
       nodes: { ...state.nodes, [id]: updated },
       nextZOrder: state.nextZOrder + 1,
       focusedNodeId: id,
+      focusEpoch: state.focusEpoch + 1,
     })
   },
 
@@ -739,6 +744,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
       nodes: { ...state.nodes, [nodeId]: updated },
       nextZOrder: state.nextZOrder + 1,
       focusedNodeId: nodeId,
+      focusEpoch: state.focusEpoch + 1,
     }
     if (cs.width > 0 && cs.height > 0) {
       newState.viewportOffset = {


### PR DESCRIPTION
## Summary
- Clicking a node rect in the minimap now focuses + centers the viewport on that panel — no second click on the panel needed to start typing.
- New `focusEpoch` counter in canvasStore bumps on every focus action (`focusNode`, `focusAndCenter`, `toggleMaximize`), so panels can re-run focus side effects when the same node is re-focused.
- TerminalPanel subscribes imperatively (`canvasApi.subscribe`) → no React re-renders of every TerminalPanel on unrelated focus actions.
- TerminalPanel focus effect polls `terminalRegistry` for up to 2s while the entry is async-created, then re-checks for 500ms after first focus to survive a detach/reattach race from the IntersectionObserver on virtualized panels just brought into view.

## Trade-offs
- `stopPropagation` on the node-rect mousedown means a pan-drag started directly on a node pixel in the minimap is suppressed (user gets focusAndCenter instead). Pan still works when starting on empty minimap area. Acceptable given how small node rects are.

## Test plan
- [x] Click a node rect for a near (already-mounted) terminal → instantly typeable
- [x] Click a node rect for a far (virtualized, not mounted) terminal → mounts, centers, typeable on first click
- [x] Repeatedly click the already-focused terminal in the minimap → focus re-asserts (no-op visually, but keyboard focus restored if drifted)
- [x] Click empty minimap area → still pans viewport to that point
- [x] Resize / drag minimap → still works
- [x] `npx vitest run src/renderer/stores/canvasStore.test.ts` — 11 pass