### PR TITLE
fix(browser): support file:// URLs and absolute local paths (#106)

### DIFF
--- a/src/main/webSecurity.ts
+++ b/src/main/webSecurity.ts
@@ -35,7 +35,10 @@ export function isAllowedGuestUrl(url: string): boolean {
   if (url === 'about:blank') return true
   try {
     const parsed = new URL(url)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    // Allow file: so the browser panel can render local HTML files explicitly
+    // requested by the user via the address bar. Cross-origin reads from a
+    // remote page into file:// are blocked by the same-origin policy.
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'file:'
   } catch {
     return false
   }

--- a/src/renderer/panels/BrowserPanel.test.ts
+++ b/src/renderer/panels/BrowserPanel.test.ts
@@ -1,0 +1,87 @@
+// =============================================================================
+// URL helpers used by BrowserPanel address bar.
+//
+// Regression: prior versions hard-coded an http(s)-only protocol prefix, which
+// rewrote `file:///path/to/index.html` into `https://file:///...` and made
+// local HTML files unreachable from the browser panel (issue #106).
+// =============================================================================
+
+import { describe, it, expect } from 'vitest'
+import { isUrl, normalizeUrl } from './browserUrl'
+
+describe('isUrl', () => {
+  it('recognises absolute http(s) URLs', () => {
+    expect(isUrl('http://example.com')).toBe(true)
+    expect(isUrl('https://example.com/path')).toBe(true)
+  })
+
+  it('recognises file:// URLs', () => {
+    expect(isUrl('file:///Users/foo/index.html')).toBe(true)
+  })
+
+  it('recognises POSIX absolute paths', () => {
+    expect(isUrl('/Users/foo/index.html')).toBe(true)
+    expect(isUrl('/etc/hosts')).toBe(true)
+  })
+
+  it('recognises Windows absolute paths', () => {
+    expect(isUrl('C:\\Users\\foo\\index.html')).toBe(true)
+    expect(isUrl('C:/Users/foo/index.html')).toBe(true)
+  })
+
+  it('recognises domains and localhost', () => {
+    expect(isUrl('example.com')).toBe(true)
+    expect(isUrl('localhost:3000')).toBe(true)
+    expect(isUrl('myhost:8080/path')).toBe(true)
+  })
+
+  it('treats spaces as a search query', () => {
+    expect(isUrl('how to use file://')).toBe(false)
+  })
+
+  it('treats single bare words as search queries', () => {
+    expect(isUrl('react')).toBe(false)
+  })
+})
+
+describe('normalizeUrl', () => {
+  it('passes http(s) and about: through unchanged', () => {
+    expect(normalizeUrl('http://example.com')).toBe('http://example.com')
+    expect(normalizeUrl('https://example.com')).toBe('https://example.com')
+    expect(normalizeUrl('about:blank')).toBe('about:blank')
+  })
+
+  it('passes file:// URLs through unchanged', () => {
+    expect(normalizeUrl('file:///Users/foo/index.html')).toBe('file:///Users/foo/index.html')
+  })
+
+  it('prepends file:// to POSIX absolute paths', () => {
+    expect(normalizeUrl('/Users/foo/index.html')).toBe('file:///Users/foo/index.html')
+  })
+
+  it('escapes #, ?, and % in POSIX paths so they are not parsed as URL syntax', () => {
+    expect(normalizeUrl('/tmp/a#b.html')).toBe('file:///tmp/a%23b.html')
+    expect(normalizeUrl('/tmp/a?b.html')).toBe('file:///tmp/a%3Fb.html')
+    expect(normalizeUrl('/tmp/100%done.html')).toBe('file:///tmp/100%25done.html')
+  })
+
+  it('converts Windows absolute paths to file:// URLs with forward slashes', () => {
+    expect(normalizeUrl('C:\\Users\\foo\\index.html')).toBe('file:///C:/Users/foo/index.html')
+    expect(normalizeUrl('C:/Users/foo/index.html')).toBe('file:///C:/Users/foo/index.html')
+  })
+
+  it('escapes URL syntax characters in Windows paths', () => {
+    expect(normalizeUrl('C:\\tmp\\a#b.html')).toBe('file:///C:/tmp/a%23b.html')
+  })
+
+  it('prepends http:// for localhost variants', () => {
+    expect(normalizeUrl('localhost')).toBe('http://localhost')
+    expect(normalizeUrl('localhost:3000')).toBe('http://localhost:3000')
+    expect(normalizeUrl('127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+  })
+
+  it('prepends https:// for bare domains', () => {
+    expect(normalizeUrl('example.com')).toBe('https://example.com')
+    expect(normalizeUrl('example.com/path')).toBe('https://example.com/path')
+  })
+})

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -12,6 +12,7 @@ import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { SEARCH_ENGINE_URLS } from '../../shared/types'
 import type { BrowserPanelProps } from './types'
 import { portalRegistry } from '../lib/portalRegistry'
+import { isUrl, normalizeUrl } from './browserUrl'
 
 // -----------------------------------------------------------------------------
 // Type declarations for Electron's <webview> element
@@ -31,47 +32,6 @@ interface WebviewElement extends HTMLElement {
   getWebContentsId(): number
   addEventListener(type: string, listener: (event: any) => void): void
   removeEventListener(type: string, listener: (event: any) => void): void
-}
-
-// -----------------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------------
-
-/** Check if input looks like a URL rather than a search query. */
-function isUrl(input: string): boolean {
-  const trimmed = input.trim()
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    return true
-  }
-  // Has spaces — definitely a search query
-  if (trimmed.includes(' ')) {
-    return false
-  }
-  // Contains a dot — likely a domain (e.g. "example.com", "192.168.1.1")
-  if (trimmed.includes('.')) {
-    return true
-  }
-  // "localhost" or "localhost:port"
-  if (/^localhost(:\d+)?(\/.*)?$/.test(trimmed)) {
-    return true
-  }
-  // Explicit port on any host (e.g. "myhost:3000")
-  if (/^[\w-]+(:\d+)(\/.*)?$/.test(trimmed)) {
-    return true
-  }
-  return false
-}
-
-/** Normalize a URL string, prepending a protocol if none present.
- *  Uses http:// for localhost/127.0.0.1/[::1], https:// for everything else. */
-function normalizeUrl(input: string): string {
-  const trimmed = input.trim()
-  if (trimmed.startsWith('about:')) return trimmed
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-    return trimmed
-  }
-  const isLocal = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/.test(trimmed)
-  return `${isLocal ? 'http' : 'https'}://${trimmed}`
 }
 
 // -----------------------------------------------------------------------------
@@ -276,9 +236,9 @@ export default function BrowserPanel({
     const onWillNavigate = (event: any) => {
       try {
         const { protocol } = new URL(event.url)
-        if (protocol !== 'http:' && protocol !== 'https:') {
+        if (protocol !== 'http:' && protocol !== 'https:' && protocol !== 'file:') {
           event.preventDefault()
-          console.warn('[BrowserPanel] Blocked navigation to non-http(s) URL:', event.url)
+          console.warn('[BrowserPanel] Blocked navigation to non-http(s)/file URL:', event.url)
         }
       } catch {
         event.preventDefault()

--- a/src/renderer/panels/browserUrl.ts
+++ b/src/renderer/panels/browserUrl.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// URL helpers for the BrowserPanel address bar.
+//
+// Lives outside the React component so unit tests can import them without
+// dragging the rest of the component (and Electron/React) into the test
+// environment.
+// =============================================================================
+
+/** Check if input looks like a URL rather than a search query. */
+export function isUrl(input: string): boolean {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return true
+  }
+  // Local file URL or absolute filesystem path (POSIX `/Users/...` or Windows `C:\...`).
+  if (trimmed.startsWith('file://') || trimmed.startsWith('/') || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return true
+  }
+  // Has spaces — definitely a search query
+  if (trimmed.includes(' ')) {
+    return false
+  }
+  // Contains a dot — likely a domain (e.g. "example.com", "192.168.1.1")
+  if (trimmed.includes('.')) {
+    return true
+  }
+  // "localhost" or "localhost:port"
+  if (/^localhost(:\d+)?(\/.*)?$/.test(trimmed)) {
+    return true
+  }
+  // Explicit port on any host (e.g. "myhost:3000")
+  if (/^[\w-]+(:\d+)(\/.*)?$/.test(trimmed)) {
+    return true
+  }
+  return false
+}
+
+/** Percent-encode the characters in a filesystem path that would otherwise be
+ *  interpreted as URL syntax: `%` (must be escaped first so we don't double-
+ *  encode the others), `#` (fragment), and `?` (query). Other characters in
+ *  paths — including `/`, `:`, `@`, spaces, unicode — are allowed in a file
+ *  URL path without escaping (browsers tolerate them) and we leave them
+ *  alone so the URL stays human-readable in the address bar. */
+function escapeFilePath(path: string): string {
+  return path
+    .replace(/%/g, '%25')
+    .replace(/#/g, '%23')
+    .replace(/\?/g, '%3F')
+}
+
+/** Normalize a URL string, prepending a protocol if none present.
+ *  Uses http:// for localhost/127.0.0.1/[::1], file:// for absolute local
+ *  paths, and https:// for everything else. */
+export function normalizeUrl(input: string): string {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('about:')) return trimmed
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed
+  }
+  if (trimmed.startsWith('file://')) return trimmed
+  // Absolute POSIX path → file URL
+  if (trimmed.startsWith('/')) return `file://${escapeFilePath(trimmed)}`
+  // Absolute Windows path (e.g. C:\foo or C:/foo) → file URL with forward slashes
+  if (/^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return `file:///${escapeFilePath(trimmed.replace(/\\/g, '/'))}`
+  }
+  const isLocal = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/.test(trimmed)
+  return `${isLocal ? 'http' : 'https'}://${trimmed}`
+}


### PR DESCRIPTION
Closes #106.

## Summary
- Browser panel address bar accepts `file:///Users/foo/index.html` and absolute local paths (`/Users/foo/index.html`, Windows `C:\Users\foo\index.html`); the prior normalizer rewrote them to `https://file:///...` and `https:///Users/...`.
- `onWillNavigate` (renderer) now permits `file:` in addition to `http(s)`.
- `isAllowedGuestUrl` in `src/main/webSecurity.ts` permits `file:` so packaged builds don't cancel the navigation at the `will-attach-webview` / `onBeforeRequest` layer.
- Extract URL helpers to `browserUrl.ts` so they can be unit-tested without pulling Electron/React into the test env.
- Percent-encode `#`, `?`, `%` in paths before forming the file URL (e.g. `/tmp/a#b.html` → `file:///tmp/a%23b.html`) — without this the URL parser would split the path on `#` as a fragment.

## Security notes
Allowing `file:` in the webview policy lets the user load arbitrary local files into a guest webview. Threat model: this is a desktop developer tool; the user types or restores the URL themselves. Cross-origin reads from a remote (http) page into `file://` are still blocked by the same-origin policy. `setWindowOpenHandler` still denies all new-window requests so a remote page can't pop a `file://` window.

## Windows behaviour — please review
- Drive-letter paths work: `C:\Users\foo\index.html` and `C:/Users/foo/index.html` → `file:///C:/Users/foo/index.html`. Backslashes are converted to forward slashes; `#`/`?`/`%` are escaped.
- **UNC paths (`\\server\share\file.html`) are NOT recognised** — they don't match `^[A-Za-z]:[\\/]` and don't start with `/`, so they fall through to the search engine. Pre-existing behaviour; not a regression of this PR, but a known gap if you want UNC support filed as a follow-up.
- Tested manually only on macOS. Windows behaviour is covered by unit tests but has not been exercised on a Windows runtime.

## Test plan
- [x] `npx vitest run src/renderer/panels/BrowserPanel.test.ts` — 15 pass (POSIX, Windows, file://, http(s), localhost, hash/query/percent escaping)
- [x] Manual: `file:///tmp/cate-test.html` loads in browser panel
- [x] Manual: `/tmp/cate-test.html` (no protocol) loads via auto-prepended `file://`
- [x] Manual: `/tmp/a#b.html` (filename contains `#`) loads — fragment-vs-path bug avoided
- [x] Manual: `https://example.com` and search queries still work (no regression)
- [ ] Manual on Windows — not performed