### PR TITLE
fix(session): persist agent nodes across app restarts

### DIFF
--- a/src/renderer/lib/session.ts
+++ b/src/renderer/lib/session.ts
@@ -458,6 +458,23 @@ export async function restoreSession(snapshot: SessionSnapshot, canvasStoreApi?:
         }
         break
       }
+      case 'agent': {
+        const panelId = appStore.createAgent(wsId, position)
+        if (nodeSnap.title) appStore.updatePanelTitle(wsId, panelId, nodeSnap.title)
+        const canvasState = getCanvasState()
+        if (canvasState) {
+          const newNodeId = canvasState.nodeForPanel(panelId)
+          if (newNodeId) {
+            canvasState.moveNode(newNodeId, position)
+            canvasState.resizeNode(newNodeId, size)
+            if (nodeSnap.regionId) {
+              const mappedRegionId = regionIdMap.get(nodeSnap.regionId)
+              if (mappedRegionId) canvasState.setNodeRegion(newNodeId, mappedRegionId)
+            }
+          }
+        }
+        break
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Agent panels were serialized on save but silently dropped during restore because `restoreSession()` had no `case 'agent'` in its switch statement
- Added agent restoration handler that recreates agent panels with their title, position, size, and region assignment

## Test plan
- [ ] Open Cate, create agent panels on the canvas
- [ ] Close and reopen — agent panels should reappear in the same position with their titles preserved