### PR TITLE
feat(editor): Save-As for untitled buffers + clearer close-confirm dialog

### DIFF
--- a/src/main/grantedPathStore.ts
+++ b/src/main/grantedPathStore.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// grantedPathStore — main-owned persistence for file paths the user has
+// explicitly approved via a native dialog (currently the Save-As picker for
+// untitled editors).
+//
+// The list lives in a JSON file under userData and is loaded on first use.
+// Crucially, paths can only be ADDED from inside the main process — there is
+// no IPC handler that lets a renderer enrol arbitrary paths. The renderer
+// never sees this store directly; main grants per-window read+write access
+// to each persisted path when a window is created, and the window-scoped
+// grant evaporates on window close.
+// =============================================================================
+
+import path from 'path'
+import { app } from 'electron'
+import fs from 'fs/promises'
+import log from './logger'
+
+const STORE_FILENAME = 'granted-paths.json'
+
+function storePath(): string {
+  return path.join(app.getPath('userData'), STORE_FILENAME)
+}
+
+let cache: Set<string> | null = null
+
+async function load(): Promise<Set<string>> {
+  if (cache) return cache
+  try {
+    const raw = await fs.readFile(storePath(), 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      cache = new Set(parsed.filter((x): x is string => typeof x === 'string'))
+      return cache
+    }
+  } catch {
+    // File missing or unreadable — treat as empty.
+  }
+  cache = new Set()
+  return cache
+}
+
+async function flush(): Promise<void> {
+  if (!cache) return
+  try {
+    await fs.writeFile(storePath(), JSON.stringify(Array.from(cache)), 'utf-8')
+  } catch (err) {
+    log.warn('[grantedPathStore] Failed to persist:', err)
+  }
+}
+
+/** Record `filePath` as a persistently approved location. Idempotent. The
+ *  on-disk file is flushed before this promise resolves so an immediate
+ *  app quit after a Save-As does not lose the freshly recorded grant. */
+export async function recordPersistentGrant(filePath: string): Promise<void> {
+  const set = await load()
+  if (set.has(filePath)) return
+  set.add(filePath)
+  await flush()
+}
+
+/** Return a snapshot of all currently persisted paths. */
+export async function listPersistentGrants(): Promise<string[]> {
+  return Array.from(await load())
+}
+
+/** Drop a persisted entry — used to prune paths that no longer exist on disk.
+ *  Flushed synchronously for the same reason as {@link recordPersistentGrant}. */
+export async function removePersistentGrant(filePath: string): Promise<void> {
+  const set = await load()
+  if (!set.delete(filePath)) return
+  await flush()
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,11 +2,11 @@ import log from './logger'
 import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session } from 'electron'
 import fs from 'fs'
 import path from 'path'
-import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, APP_OPEN_PATH } from '../shared/ipc-channels'
+import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, APP_OPEN_PATH } from '../shared/ipc-channels'
 import {
   WINDOW_SET_TITLE,
   PANEL_TRANSFER, PANEL_RECEIVE, PANEL_TRANSFER_ACK,
-  PANEL_WINDOWS_LIST, PANEL_WINDOW_DOCK_BACK, PANEL_WINDOW_SYNC_PTY,
+  PANEL_WINDOWS_LIST, PANEL_WINDOW_DOCK_BACK, PANEL_WINDOW_SYNC_PTY, PANEL_WINDOW_SYNC_META,
   DRAG_START, DRAG_DETACH, DRAG_END,
   WINDOW_FULLSCREEN_STATE,
   DOCK_WINDOW_INIT, DOCK_WINDOW_SYNC_STATE, DOCK_WINDOWS_LIST,
@@ -32,7 +32,8 @@ const agentManager = new AgentManager(authManager)
 import { writeDragTempFile, cleanupDragTempFile, createDragGhostImage } from './ipc/drag'
 import { registerWindow, getWindowType, sendToWindow, broadcastToAll, broadcastToAllExcept, setPanelWindowMeta, setPanelWindowTerminalPtyId, listPanelWindows, getWindow, setDockWindowState, listDockWindows } from './windowRegistry'
 import { registerWorkspaceHandlers } from './workspaceManager'
-import { addAllowedRoot, clearScopedWriteAllowancesForWindow, validatePath } from './ipc/pathValidation'
+import { addAllowedRoot, clearFileGrantsForWindow, clearScopedWriteAllowancesForWindow, grantFileAccess, validatePath } from './ipc/pathValidation'
+import { listPersistentGrants, recordPersistentGrant } from './grantedPathStore'
 import { buildApplicationMenu, rebuildApplicationMenu, setNewMainWindowFn } from './menu'
 import { initShellEnv } from './shellEnv'
 import { initAutoUpdater, isInstallingUpdate } from './auto-updater'
@@ -178,6 +179,33 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   const windowId = win.id
   log.info('Creating window type=%s id=%d', windowType, windowId)
 
+  // Re-arm grants for every persisted Save-As path so editors restored in
+  // this window (any window type — main, panel, dock) can read+save their
+  // out-of-workspace files. We check the file still exists; missing entries
+  // are pruned so the store doesn't grow unbounded with stale paths. The
+  // returned promise gates loadURL below so the renderer's session-restore
+  // pass cannot mount an out-of-workspace editor before its grant lands.
+  const grantsReady = (async () => {
+    try {
+      const paths = await listPersistentGrants()
+      for (const filePath of paths) {
+        // Note: we do NOT prune missing files here. If the user deletes or
+        // moves the file off-disk between sessions, the grant must survive
+        // so that the editor restored with `filePath = …/missing.txt` can
+        // still receive a Cmd+S that recreates the file at the previously
+        // approved location. The grant only writes/reads to/from that
+        // exact path; it does not widen access elsewhere.
+        try {
+          await grantFileAccess(windowId, filePath)
+        } catch (err) {
+          log.warn('[grants] Failed to grant %s to window %d: %s', filePath, windowId, err)
+        }
+      }
+    } catch (err) {
+      log.warn('[grants] Failed to apply persisted grants:', err)
+    }
+  })()
+
   // When the main window is closed, also close any detached panel/dock
   // windows so the app actually quits (otherwise they keep the process
   // alive and `window-all-closed` never fires).
@@ -204,6 +232,7 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
     unregisterTerminalsForWindow(windowId)
     stopMonitorsForWindow(windowId)
     clearScopedWriteAllowancesForWindow(windowId)
+    clearFileGrantsForWindow(windowId)
     // Rebuild menu to update panel/dock window list
     if (isPanel || isDock) rebuildApplicationMenu()
     // Trigger immediate session save from main window when a child window closes
@@ -265,13 +294,21 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   if (params?.workspaceId) queryParts.push(`workspaceId=${encodeURIComponent(params.workspaceId)}`)
   const query = queryParts.length > 0 ? `?${queryParts.join('&')}` : ''
 
-  if (process.env.ELECTRON_RENDERER_URL) {
-    win.loadURL(`${process.env.ELECTRON_RENDERER_URL}${query}`)
-  } else {
-    win.loadFile(path.join(__dirname, '../renderer/index.html'), {
-      search: query ? query.slice(1) : undefined,
-    })
-  }
+  // Defer loadURL until persisted grants are applied. Without this, the
+  // renderer can begin session restore and mount an editor pointing at an
+  // out-of-workspace path before grantFileAccess has populated the window's
+  // grant set, causing fsReadFile to be rejected and the editor to mount
+  // empty for a file we should have been able to read.
+  void grantsReady.finally(() => {
+    if (win.isDestroyed()) return
+    if (process.env.ELECTRON_RENDERER_URL) {
+      win.loadURL(`${process.env.ELECTRON_RENDERER_URL}${query}`)
+    } else {
+      win.loadFile(path.join(__dirname, '../renderer/index.html'), {
+        search: query ? query.slice(1) : undefined,
+      })
+    }
+  })
 
   return win
 }
@@ -442,24 +479,88 @@ function registerWindowAndDialogHandlers(): void {
     return result.filePaths[0]
   })
 
-  // Native unsaved-changes confirmation. Returns 'save' | 'discard' | 'cancel'.
-  ipcMain.handle(DIALOG_CONFIRM_UNSAVED, async (event, payload: { fileName?: string; multiple?: boolean }) => {
+  // Native Save-As dialog for untitled editor buffers.
+  ipcMain.handle(DIALOG_SAVE_FILE, async (event, payload: { defaultName?: string; defaultPath?: string }) => {
     const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
-    const name = payload?.fileName ?? 'this file'
-    const message = payload?.multiple
-      ? `Do you want to save the changes you made to ${payload?.fileName ?? 'these files'}?`
-      : `Do you want to save the changes you made to ${name}?`
-    const result = await dialog.showMessageBox(win!, {
-      type: 'warning',
-      message,
-      detail: "Your changes will be lost if you don't save them.",
-      buttons: ['Save', "Don't Save", 'Cancel'],
-      defaultId: 0,
-      cancelId: 2,
-      noLink: true,
+    const result = await dialog.showSaveDialog(win!, {
+      title: 'Save File',
+      defaultPath: payload?.defaultPath || payload?.defaultName || 'Untitled.txt',
     })
-    return result.response === 0 ? 'save' : result.response === 1 ? 'discard' : 'cancel'
+    if (result.canceled || !result.filePath) return null
+    // The picked location is almost always outside the workspace allowed
+    // roots (Desktop, Documents, …). Grant the calling window persistent
+    // read+write access to the exact file so the initial fsWriteFile AND
+    // every subsequent reload / Cmd+S on this editor succeed for the
+    // lifetime of the window. The grant is dropped on window close.
+    // Return the canonical safe path (realpath-of-parent + basename) so the
+    // renderer stores the same string the grant set keys on — otherwise a
+    // symlinked parent would yield a stored alias that later fails the
+    // lexical validatePath check before realpath has a chance to run.
+    if (win) {
+      try {
+        const safePath = await grantFileAccess(win.id, result.filePath)
+        // Persist the approval so future windows (and future app launches)
+        // can read+write this file via createWindow's grantsReady pass.
+        // Critically there is NO renderer-facing IPC to add paths here —
+        // only paths the user just confirmed in a native dialog land in
+        // the store.
+        try {
+          await recordPersistentGrant(safePath)
+        } catch (err) {
+          log.warn('[DIALOG_SAVE_FILE] Failed to persist grant:', err)
+        }
+        // Grant the path to every currently-open window too. Without this,
+        // a panel transferred to a window that existed BEFORE the Save-As
+        // would lose access (createWindow's grantsReady only runs at the
+        // owning window's creation — older sibling windows never see the
+        // newly approved path otherwise).
+        for (const other of BrowserWindow.getAllWindows()) {
+          if (other.id === win.id || other.isDestroyed()) continue
+          try {
+            await grantFileAccess(other.id, safePath)
+          } catch (err) {
+            log.warn('[DIALOG_SAVE_FILE] Failed to grant to window %d: %s', other.id, err)
+          }
+        }
+        return safePath
+      } catch (err) {
+        log.warn('[DIALOG_SAVE_FILE] Failed to grant file access:', err)
+      }
+    }
+    return result.filePath
   })
+
+  // Native unsaved-changes confirmation. Returns 'save' | 'discard' | 'cancel'.
+  ipcMain.handle(
+    DIALOG_CONFIRM_UNSAVED,
+    async (event, payload: { fileName?: string; multiple?: boolean; filePath?: string }) => {
+      const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
+      const name = payload?.fileName ?? 'this file'
+      const message = payload?.multiple
+        ? `Do you want to save the changes you made to ${payload?.fileName ?? 'these files'}?`
+        : `Do you want to save the changes you made to ${name}?`
+      // For a single dirty file, show the on-disk location so the user knows
+      // exactly which file the "Save" button is going to overwrite. Untitled
+      // buffers (no filePath) fall back to a hint that a Save-As picker will
+      // appear after confirming.
+      const baseDetail = "Your changes will be lost if you don't save them."
+      const detail = payload?.multiple
+        ? baseDetail
+        : payload?.filePath
+          ? `${payload.filePath}\n\n${baseDetail}`
+          : `This file has not been saved yet. Save will prompt for a location.\n\n${baseDetail}`
+      const result = await dialog.showMessageBox(win!, {
+        type: 'warning',
+        message,
+        detail,
+        buttons: ['Save', "Don't Save", 'Cancel'],
+        defaultId: 0,
+        cancelId: 2,
+        noLink: true,
+      })
+      return result.response === 0 ? 'save' : result.response === 1 ? 'discard' : 'cancel'
+    },
+  )
 
   // Confirm close of a canvas panel. When the workspace has other canvases and
   // the closing canvas contains panels, the user is offered three choices:
@@ -656,6 +757,16 @@ function registerWindowAndDialogHandlers(): void {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win) return
     setPanelWindowTerminalPtyId(win.id, ptyId)
+  })
+
+  // Renderer pushes an updated PanelState — used after Save-As inside a
+  // detached panel window so the windowRegistry meta (the source for
+  // session persistence + the panel-window list) reflects the new
+  // filePath/title/clean state instead of the at-transfer-time snapshot.
+  ipcMain.handle(PANEL_WINDOW_SYNC_META, async (event, payload: { panel: PanelState; workspaceId?: string }) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || !payload?.panel) return
+    setPanelWindowMeta(win.id, payload.panel, payload.workspaceId)
   })
 
   // Double-click panel window title bar → close the panel window and signal main window to dock

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -478,18 +478,20 @@ export function stopWatchersForWindow(windowId: number): void {
 }
 
 export function registerHandlers(): void {
-  ipcMain.handle(FS_READ_FILE, async (_event, filePath: string) => {
+  ipcMain.handle(FS_READ_FILE, async (event, filePath: string) => {
     try {
-      return await readFile(await validatePathStrict(filePath))
+      const win = windowFromEvent(event)
+      return await readFile(await validatePathStrict(filePath, win?.id))
     } catch (error) {
       log.error(`[${FS_READ_FILE}]`, error)
       throw error instanceof Error ? error : new Error(String(error))
     }
   })
 
-  ipcMain.handle(FS_READ_BINARY, async (_event, filePath: string) => {
+  ipcMain.handle(FS_READ_BINARY, async (event, filePath: string) => {
     try {
-      const safePath = await validatePathStrict(filePath)
+      const win = windowFromEvent(event)
+      const safePath = await validatePathStrict(filePath, win?.id)
       return await fs.readFile(safePath)
     } catch (error) {
       log.error(`[${FS_READ_BINARY}]`, error)

--- a/src/main/ipc/pathValidation.test.ts
+++ b/src/main/ipc/pathValidation.test.ts
@@ -3,12 +3,16 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   addAllowedRoot,
+  clearFileGrantsForWindow,
   clearScopedWriteAllowancesForWindow,
   consumeScopedWriteAllowance,
   getAllowedRoots,
+  grantFileAccess,
   registerScopedWriteAllowance,
   removeAllowedRoot,
+  validatePath,
   validatePathForCreation,
+  validatePathStrict,
 } from './pathValidation'
 
 describe('pathValidation', () => {
@@ -25,6 +29,8 @@ describe('pathValidation', () => {
     for (const root of Array.from(getAllowedRoots())) removeAllowedRoot(root)
     clearScopedWriteAllowancesForWindow(1)
     clearScopedWriteAllowancesForWindow(2)
+    clearFileGrantsForWindow(1)
+    clearFileGrantsForWindow(2)
     await fs.rm(rootDir, { recursive: true, force: true })
     await fs.rm(outsideDir, { recursive: true, force: true })
     vi.useRealTimers()
@@ -59,5 +65,42 @@ describe('pathValidation', () => {
     await registerScopedWriteAllowance(2, targetPath, 1_000)
     clearScopedWriteAllowancesForWindow(2)
     await expect(validatePathForCreation(targetPath, 2)).rejects.toThrow(/outside allowed directories/)
+  })
+
+  test('grantFileAccess allows reads and repeated writes outside trusted roots', async () => {
+    const targetPath = path.join(outsideDir, 'saved.txt')
+    await fs.writeFile(targetPath, 'hello')
+
+    // Without a grant the lexical and strict validators both reject.
+    expect(() => validatePath(targetPath, 1)).toThrow(/outside allowed directories/)
+    await expect(validatePathStrict(targetPath, 1)).rejects.toThrow(/outside allowed directories/)
+    await expect(validatePathForCreation(targetPath, 1)).rejects.toThrow(/outside allowed directories/)
+
+    await grantFileAccess(1, targetPath)
+
+    // After granting, all three validators accept the path.
+    expect(validatePath(targetPath, 1)).toBe(path.resolve(targetPath))
+    await expect(validatePathStrict(targetPath, 1)).resolves.toBe(path.resolve(targetPath))
+    await expect(validatePathForCreation(targetPath, 1)).resolves.toBe(path.resolve(targetPath))
+
+    // Grant is not consumed; it survives many uses.
+    await expect(validatePathForCreation(targetPath, 1)).resolves.toBe(path.resolve(targetPath))
+    await expect(validatePathStrict(targetPath, 1)).resolves.toBe(path.resolve(targetPath))
+  })
+
+  test('grantFileAccess is scoped per window and cleared on window close', async () => {
+    const targetPath = path.join(outsideDir, 'window-scoped.txt')
+    await fs.writeFile(targetPath, 'data')
+    await grantFileAccess(1, targetPath)
+
+    // Window 1 sees the grant.
+    await expect(validatePathStrict(targetPath, 1)).resolves.toBe(path.resolve(targetPath))
+    // Window 2 does not.
+    await expect(validatePathStrict(targetPath, 2)).rejects.toThrow(/outside allowed directories/)
+    // Untagged calls (no window id) are rejected.
+    await expect(validatePathStrict(targetPath)).rejects.toThrow(/outside allowed directories/)
+
+    clearFileGrantsForWindow(1)
+    await expect(validatePathStrict(targetPath, 1)).rejects.toThrow(/outside allowed directories/)
   })
 })

--- a/src/main/ipc/pathValidation.ts
+++ b/src/main/ipc/pathValidation.ts
@@ -11,6 +11,17 @@ const allowedRoots = new Set<string>()
 const scopedWriteAllowances = new Map<number, Map<string, ReturnType<typeof setTimeout>>>()
 const DEFAULT_WRITE_ALLOWANCE_TTL_MS = 60_000
 
+// Persistent per-window grants for files the user explicitly chose outside
+// the workspace roots (e.g. via the native Save-As dialog). Unlike scoped
+// write allowances, these:
+//   - cover both read AND write
+//   - have no TTL (live until the window closes)
+//   - are not consumed on use
+// They are stored by the resolved real-path-of-parent + basename so that a
+// symlink shenanigan inside an allowed root can't laundry a sensitive
+// location into the grant set.
+const persistentFileGrants = new Map<number, Set<string>>()
+
 export function addAllowedRoot(root: string): void {
   allowedRoots.add(path.resolve(root))
 }
@@ -99,16 +110,44 @@ export function clearScopedWriteAllowancesForWindow(windowId: number): void {
 }
 
 /**
- * Validates that a file path is within an allowed root directory.
- * Returns the normalized absolute path if valid, throws if not.
+ * Persistently grant a window read+write access to a single file path. Used
+ * by the Save-As / Open-File dialogs so the file the user explicitly picked
+ * stays accessible for the rest of the window's lifetime even when it sits
+ * outside any workspace root. Returns the resolved safe path (realpath of
+ * parent + basename).
  */
-export function validatePath(filePath: string): string {
+export async function grantFileAccess(windowId: number, filePath: string): Promise<string> {
+  const safePath = await normalizeCreationTarget(filePath)
+  const set = persistentFileGrants.get(windowId) ?? new Set<string>()
+  set.add(safePath)
+  persistentFileGrants.set(windowId, set)
+  return safePath
+}
+
+function hasGrantedFile(windowId: number | undefined, normalized: string): boolean {
+  if (windowId == null) return false
+  return persistentFileGrants.get(windowId)?.has(normalized) ?? false
+}
+
+export function clearFileGrantsForWindow(windowId: number): void {
+  persistentFileGrants.delete(windowId)
+}
+
+/**
+ * Validates that a file path is within an allowed root directory or
+ * persistently granted to the calling window. Returns the normalized
+ * absolute path if valid, throws if not.
+ */
+export function validatePath(filePath: string, ownerWindowId?: number): string {
   if (!filePath || typeof filePath !== 'string') {
     throw new Error('Access denied: invalid path')
   }
 
   const normalized = path.resolve(filePath)
   if (isWithinAllowedRoots(normalized)) {
+    return normalized
+  }
+  if (hasGrantedFile(ownerWindowId, normalized)) {
     return normalized
   }
 
@@ -119,13 +158,14 @@ export function validatePath(filePath: string): string {
  * Validates that a file path is within an allowed root directory AND that its
  * fully-resolved (symlink-free) real path is also within an allowed root.
  * This prevents TOCTOU attacks where a symlink inside a workspace root points
- * to a sensitive path outside it (e.g. /etc/passwd).
+ * to a sensitive path outside it (e.g. /etc/passwd). A persistent per-window
+ * grant on either the lexical or the realpath form also satisfies the check.
  *
  * Returns the real absolute path if valid, throws if not.
  */
-export async function validatePathStrict(filePath: string): Promise<string> {
+export async function validatePathStrict(filePath: string, ownerWindowId?: number): Promise<string> {
   // First do the cheap lexical check so we fail fast on obviously bad input.
-  validatePath(filePath)
+  validatePath(filePath, ownerWindowId)
 
   let real: string
   try {
@@ -135,6 +175,9 @@ export async function validatePathStrict(filePath: string): Promise<string> {
   }
 
   if (isWithinAllowedRoots(real)) {
+    return real
+  }
+  if (hasGrantedFile(ownerWindowId, real)) {
     return real
   }
 
@@ -155,6 +198,9 @@ export async function validatePathForCreation(filePath: string, ownerWindowId?: 
   if (isWithinAllowedRoots(normalized) || isWithinAllowedRoots(safeTarget)) {
     return safeTarget
   }
+  if (hasGrantedFile(ownerWindowId, safeTarget)) {
+    return safeTarget
+  }
   if (hasScopedWriteAllowance(ownerWindowId, safeTarget)) {
     return safeTarget
   }
@@ -165,6 +211,6 @@ export async function validatePathForCreation(filePath: string, ownerWindowId?: 
  * Validates a directory path for git/shell operations.
  * Same as validatePath but specifically for cwd parameters.
  */
-export function validateCwd(cwd: string): string {
-  return validatePath(cwd)
+export function validateCwd(cwd: string, ownerWindowId?: number): string {
+  return validatePath(cwd, ownerWindowId)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,6 +70,7 @@ import {
   MENU_TRIGGER_ACTION,
   MENU_SHOW_CONTEXT,
   DIALOG_OPEN_FOLDER,
+  DIALOG_SAVE_FILE,
   DIALOG_CONFIRM_UNSAVED,
   DIALOG_CONFIRM_CLOSE_CANVAS,
   DIALOG_CONFIRM_DELETE_REGION,
@@ -94,6 +95,7 @@ import {
   PANEL_WINDOWS_LIST,
   PANEL_WINDOW_DOCK_BACK,
   PANEL_WINDOW_SYNC_PTY,
+  PANEL_WINDOW_SYNC_META,
   DRAG_START,
   DRAG_DETACH,
   WINDOW_FULLSCREEN_STATE,
@@ -618,7 +620,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(DIALOG_OPEN_FOLDER)
   },
 
-  confirmUnsavedChanges(payload: { fileName?: string; multiple?: boolean }): Promise<'save' | 'discard' | 'cancel'> {
+  saveFileDialog(payload?: { defaultName?: string; defaultPath?: string }): Promise<string | null> {
+    return ipcRenderer.invoke(DIALOG_SAVE_FILE, payload ?? {})
+  },
+
+  confirmUnsavedChanges(payload: { fileName?: string; multiple?: boolean; filePath?: string }): Promise<'save' | 'discard' | 'cancel'> {
     return ipcRenderer.invoke(DIALOG_CONFIRM_UNSAVED, payload)
   },
 
@@ -748,6 +754,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   panelWindowSyncPty(ptyId: string): Promise<void> {
     return ipcRenderer.invoke(PANEL_WINDOW_SYNC_PTY, ptyId)
+  },
+
+  panelWindowSyncMeta(payload: { panel: unknown; workspaceId?: string }): Promise<void> {
+    return ipcRenderer.invoke(PANEL_WINDOW_SYNC_META, payload)
   },
 
   panelWindowDockBack(): Promise<void> {

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -277,14 +277,23 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
         dirty.length === 1
           ? dirty[0].title.replace(/\s•\s*$/, '').trim()
           : `${dirty.length} files`
+      const filePath = dirty.length === 1 ? dirty[0].filePath : undefined
       const choice = await window.electronAPI.confirmUnsavedChanges({
         fileName,
         multiple: dirty.length > 1,
+        filePath,
       })
       if (choice === 'cancel') return false
       if (choice === 'save') {
         for (const p of dirty) {
-          try { await saveEditor(p.id) } catch { /* swallow — user can retry */ }
+          let result: Awaited<ReturnType<typeof saveEditor>> = 'no-handler'
+          try { result = await saveEditor(p.id) } catch { /* treat as no-handler */ }
+          // Only an explicit Save-As cancellation aborts the close. A
+          // `no-handler` result means this panel isn't mounted (typically an
+          // inactive tab in a dock stack); aborting would leave the user
+          // unable to close. Pre-existing limitation: that tab's unsaved
+          // content is lost.
+          if (result === 'cancelled') return false
         }
       }
       return true

--- a/src/renderer/lib/confirmCloseDirty.ts
+++ b/src/renderer/lib/confirmCloseDirty.ts
@@ -21,14 +21,24 @@ export async function confirmCloseDirtyPanels(
       ? dirty[0].title.replace(/\s•\s*$/, '').trim()
       : `${dirty.length} files`
 
+  const filePath = dirty.length === 1 ? dirty[0].filePath : undefined
+
   const choice = await window.electronAPI.confirmUnsavedChanges({
     fileName,
     multiple: dirty.length > 1,
+    filePath,
   })
   if (choice === 'cancel') return false
   if (choice === 'save') {
     for (const p of dirty) {
-      try { await saveEditor(p.id) } catch { /* swallow — user can retry */ }
+      let result: Awaited<ReturnType<typeof saveEditor>> = 'no-handler'
+      try { result = await saveEditor(p.id) } catch { /* treat as no-handler */ }
+      // Only an explicit Save-As cancellation aborts the close. `no-handler`
+      // means the panel isn't currently mounted (e.g. an inactive tab in a
+      // dock stack) — we can't save it from here, but aborting would leave
+      // the user with no way to proceed. Pre-existing limitation: that
+      // tab's content is lost if the user picks "Save".
+      if (result === 'cancelled') return false
     }
   }
   return true

--- a/src/renderer/lib/editorSaveRegistry.ts
+++ b/src/renderer/lib/editorSaveRegistry.ts
@@ -4,7 +4,22 @@
 // the user chooses "Save" in the unsaved-changes dialog.
 // =============================================================================
 
-type SaveFn = () => Promise<void>
+/** Internal save function — true on successful write, false when the user
+ *  cancelled the Save-As picker (or the write failed). */
+type SaveFn = () => Promise<boolean>
+
+/** Result of {@link saveEditor}:
+ *  - `saved`        — write completed
+ *  - `cancelled`    — the user dismissed the Save-As picker for an untitled
+ *                     buffer (the only case where close-confirm should abort)
+ *  - `no-handler`   — no editor is registered for this panel (e.g. dirty
+ *                     inactive tab in a dock stack that isn't mounted). The
+ *                     caller cannot recover the buffer from here, so it must
+ *                     decide whether to proceed without saving or surface
+ *                     the situation; aborting the close would strand the
+ *                     user without a path forward.
+ */
+export type SaveResult = 'saved' | 'cancelled' | 'no-handler'
 
 const registry = new Map<string, SaveFn>()
 
@@ -16,7 +31,28 @@ export function unregisterEditorSave(panelId: string): void {
   registry.delete(panelId)
 }
 
-export async function saveEditor(panelId: string): Promise<void> {
+export async function saveEditor(panelId: string): Promise<SaveResult> {
   const fn = registry.get(panelId)
-  if (fn) await fn()
+  if (!fn) return 'no-handler'
+  const ok = await fn()
+  return ok ? 'saved' : 'cancelled'
+}
+
+// Tracks which editor most recently held keyboard focus on its Monaco
+// textarea. The window-level Cmd+S / Ctrl+S `save-file` event routes to
+// THIS panel, not whichever editor happens to hold `hasTextFocus()` at the
+// instant the key fires — so clicking the markdown preview toggle or any
+// other panel chrome doesn't leave the user without a save target.
+let activeEditorPanelId: string | null = null
+
+export function markEditorActive(panelId: string): void {
+  activeEditorPanelId = panelId
+}
+
+export function clearEditorActive(panelId: string): void {
+  if (activeEditorPanelId === panelId) activeEditorPanelId = null
+}
+
+export function getActiveEditorPanelId(): string | null {
+  return activeEditorPanelId
 }

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -11,7 +11,13 @@ import remarkGfm from 'remark-gfm'
 import type { EditorPanelProps } from './types'
 import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { registerEditorSave, unregisterEditorSave } from '../lib/editorSaveRegistry'
+import {
+  registerEditorSave,
+  unregisterEditorSave,
+  markEditorActive,
+  clearEditorActive,
+  getActiveEditorPanelId,
+} from '../lib/editorSaveRegistry'
 import { getResolvedTheme, subscribeTheme } from '../lib/themeManager'
 
 // -----------------------------------------------------------------------------
@@ -351,7 +357,13 @@ export default function EditorPanel({
   const isDirtyRef = useRef(false)
   const filePathRef = useRef(filePath)
 
-  filePathRef.current = filePath
+  // Only overwrite the ref from the prop when the prop is itself defined.
+  // In detached/dock windows the shell keeps its own local `panels` state
+  // and doesn't observe the global appStore update we issue after a
+  // Save-As, so the `filePath` prop stays undefined for the lifetime of
+  // this mount. Without this guard, every re-render would wipe out the
+  // path we just learned and the next Cmd+S would re-open Save-As.
+  if (filePath !== undefined) filePathRef.current = filePath
 
   const [markdownPreview, setMarkdownPreview] = useState(false)
   const [markdownContent, setMarkdownContent] = useState('')
@@ -366,25 +378,75 @@ export default function EditorPanel({
   // Save handler (regular editor only)
   // ---------------------------------------------------------------------------
 
-  const save = useCallback(async () => {
+  const save = useCallback(async (): Promise<boolean> => {
     const editor = editorRef.current
-    if (!editor || !filePathRef.current || diffMode) return
+    if (!editor || diffMode) return false
 
     const content = editor.getValue()
 
+    // Untitled buffer (no filePath): prompt the user for a destination via the
+    // native Save-As dialog. Once a path is chosen, persist it on the panel
+    // state so future saves (Cmd+S, close-confirm) write to the same file.
+    let targetPath = filePathRef.current
+    let isInitialSave = false
+    if (!targetPath) {
+      const currentPanel = useAppStore
+        .getState()
+        .workspaces.find((w) => w.id === workspaceId)?.panels[panelId]
+      const cleanTitle = currentPanel?.title?.replace(/\s•\s*$/, '').trim()
+      const defaultName = cleanTitle && cleanTitle !== 'Untitled' ? cleanTitle : 'Untitled.txt'
+      // Pick the separator that matches the workspace root so the prefilled
+      // path looks native on the user's platform (Electron's Save dialog
+      // accepts either on Windows but mixed slashes look sloppy).
+      const sep = rootPath?.includes('\\') ? '\\' : '/'
+      const defaultPath = rootPath ? `${rootPath}${sep}${defaultName}` : defaultName
+      const chosen = await window.electronAPI.saveFileDialog({ defaultName, defaultPath })
+      if (!chosen) return false
+      targetPath = chosen
+      isInitialSave = true
+    }
+
     try {
-      await window.electronAPI.fsWriteFile(filePathRef.current, content)
+      await window.electronAPI.fsWriteFile(targetPath, content)
     } catch (err) {
       log.error('[EditorPanel] Failed to save file:', err)
-      return
+      return false
     }
 
     isDirtyRef.current = false
     useAppStore.getState().setPanelDirty(workspaceId, panelId, false)
 
-    const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
+    // Use both separators so the basename is correct on Windows (`\\`) as
+    // well as POSIX (`/`).
+    const fileName = targetPath.split(/[\\/]/).pop() || 'Untitled'
     useAppStore.getState().updatePanelTitle(workspaceId, panelId, fileName)
-  }, [workspaceId, panelId, diffMode])
+
+    if (isInitialSave) {
+      // Persist the new filePath in the global appStore (the source of
+      // truth for the main window's panels). In detached/dock windows the
+      // shell maintains its own local panels state instead, so we ALSO
+      // update filePathRef directly: that makes the next Cmd+S in this
+      // exact mount write to the chosen file instead of reopening Save-As,
+      // regardless of whether the prop ever updates.
+      filePathRef.current = targetPath
+      useAppStore.getState().updatePanelFilePath(workspaceId, panelId, targetPath)
+      // Clear the unsaved-content cache so the remount-from-disk path is
+      // the single source of truth for the editor model when the prop
+      // does flip (main window).
+      useAppStore.getState().setPanelUnsavedContent(workspaceId, panelId, undefined)
+      // Notify the surrounding shell (DockWindowShell / PanelWindowShell)
+      // so its local `panels` state — which feeds session sync and close
+      // prompts in detached windows — picks up the new filePath, title,
+      // and clean dirty flag. The main window ignores this event because
+      // it reads from appStore directly.
+      window.dispatchEvent(
+        new CustomEvent('editor:panel-saved-as', {
+          detail: { panelId, filePath: targetPath, title: fileName },
+        }),
+      )
+    }
+    return true
+  }, [workspaceId, panelId, diffMode, rootPath])
 
   // ---------------------------------------------------------------------------
   // Mount: create regular editor OR diff editor
@@ -558,6 +620,13 @@ export default function EditorPanel({
       }
     }
 
+    // Track which editor most recently held text focus so the window-level
+    // Cmd+S handler can route to the correct panel even after focus moves
+    // off the textarea (e.g. clicking the markdown preview toggle).
+    const focusDisposable = editor.onDidFocusEditorText(() => {
+      markEditorActive(panelId)
+    })
+
     let unsavedSaveTimer: ReturnType<typeof setTimeout> | null = null
     const changeDisposable = editor.onDidChangeModelContent(() => {
       if (!isDirtyRef.current) {
@@ -587,6 +656,8 @@ export default function EditorPanel({
       cancelled = true
       layoutObserver.disconnect()
       changeDisposable.dispose()
+      focusDisposable.dispose()
+      clearEditorActive(panelId)
       if (unsavedSaveTimer) {
         clearTimeout(unsavedSaveTimer)
         unsavedSaveTimer = null
@@ -611,7 +682,16 @@ export default function EditorPanel({
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
-    const handler = () => { save() }
+    // Cmd+S / Ctrl+S broadcasts a window-wide `save-file` event. Without a
+    // gate every mounted EditorPanel would react — and for an untitled
+    // buffer that would open a Save-As picker for each scratch editor on
+    // the canvas. We route the event to whichever editor most recently held
+    // Monaco text focus (tracked in editorSaveRegistry). This survives the
+    // user clicking off the textarea onto e.g. the markdown preview toggle,
+    // which would defeat a raw `hasTextFocus()` check.
+    const handler = () => {
+      if (getActiveEditorPanelId() === panelId) save()
+    }
     window.addEventListener('save-file', handler)
     registerEditorSave(panelId, save)
     return () => {

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -30,11 +30,22 @@ interface DockWindowShellProps {
 
 export default function DockWindowShell({ workspaceId: initialWorkspaceId }: DockWindowShellProps) {
   const [panels, setPanels] = useState<Record<string, PanelState>>({})
+  // panelsRef shadows `panels` synchronously so callers that need to push
+  // metadata to main immediately (e.g. an editor:panel-saved-as handler)
+  // can read the freshly-computed map BEFORE React commits the state and
+  // re-runs the periodic-sync effect that would otherwise refresh
+  // syncNowRef's closure.
+  const panelsRef = useRef<Record<string, PanelState>>({})
   const [wsId, setWsId] = useState(initialWorkspaceId ?? '')
   const [ready, setReady] = useState(false)
   const dockStore = useMemo(() => createDockStore(), [])
   const syncTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const hadPanelsRef = useRef(false)
+
+  // Keep panelsRef in lock-step with the React state for the common path —
+  // any synchronous updater that needs to ship its own new map updates the
+  // ref inside its callback so the next syncNow can see it.
+  panelsRef.current = panels
 
   // Hydrate settings + apply theme so the detached window mirrors the main
   // app's appearance (theme, minimap, canvas grid, etc.). Without this the
@@ -66,6 +77,38 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
 
     return cleanup
   }, [dockStore])
+
+  // Editor Save-As inside this window updates the global appStore in the
+  // detached renderer, but this shell maintains its own local `panels`
+  // map (the source of truth for periodic session sync and close prompts).
+  // Mirror the change so a saved scratch buffer becomes a real file in the
+  // session record instead of being restored as Untitled on next launch.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ panelId: string; filePath: string; title: string }>
+      const { panelId, filePath, title } = ce.detail || ({} as never)
+      if (!panelId) return
+      // Mutate panelsRef synchronously alongside the React state update so
+      // syncNow reads the post-Save-As snapshot regardless of whether the
+      // periodic-sync effect has re-run yet. Without this, a setTimeout-
+      // driven sync could still ship the pre-save map because React's
+      // commit-then-effect cycle had not yet refreshed syncNowRef.
+      setPanels((prev) => {
+        const p = prev[panelId]
+        if (!p) return prev
+        const updated = { ...p, filePath, title, isDirty: false }
+        const next = { ...prev, [panelId]: updated }
+        panelsRef.current = next
+        return next
+      })
+      // Now ship the new state to main. Without this, a quit before the
+      // next 5s tick would persist the panel as untitled and a restart
+      // would restore a stale scratch buffer instead of the saved file.
+      syncNowRef.current()
+    }
+    window.addEventListener('editor:panel-saved-as', handler)
+    return () => window.removeEventListener('editor:panel-saved-as', handler)
+  }, [])
 
   // Listen for incoming panel transfers (drag from other windows)
   useEffect(() => {
@@ -154,12 +197,18 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   }, [dockStore])
 
   // Periodic state sync to main process for session persistence
+  const syncNowRef = useRef<() => void>(() => {})
   useEffect(() => {
     const syncNow = () => {
+      // Read panels from the ref, not the closure: callers that mutate the
+      // map (e.g. the Save-As handler) update panelsRef synchronously and
+      // then invoke syncNow, expecting the freshly-written entries.
+      const currentPanels = panelsRef.current
+
       // Capture per-terminal ptyIds + persist their scrollback so the next
       // launch can replay it into a freshly spawned PTY.
       const terminalPtyIds: Record<string, string> = {}
-      for (const panel of Object.values(panels)) {
+      for (const panel of Object.values(currentPanels)) {
         if (panel.type !== 'terminal') continue
         const entry = terminalRegistry.getEntry(panel.id)
         if (!entry?.ptyId) continue
@@ -182,10 +231,14 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
       const snapshot = dockStore.getState().getSnapshot()
       window.electronAPI.dockWindowSyncState({
         ...snapshot,
-        panels,
+        panels: currentPanels,
         terminalPtyIds,
       })
     }
+    // Expose the latest syncNow via a ref so callers outside this effect
+    // (the editor:panel-saved-as handler) can trigger an immediate sync
+    // without waiting for the next 5-second interval / focus tick.
+    syncNowRef.current = syncNow
 
     // Initial sync ~1s after panels are populated so main learns ptyIds quickly
     const initialSync = setTimeout(syncNow, 1000)

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -63,6 +63,29 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
     return cleanup
   }, [])
 
+  // Editor Save-As inside this detached panel window updates appStore in the
+  // renderer, but our local `panel` state — and the main-process window
+  // registry meta the session snapshot reads from — are both independent.
+  // Mirror filePath/title/isDirty here AND push the snapshot to main so the
+  // saved scratch buffer is treated as a real file on restart.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ panelId: string; filePath: string; title: string }>
+      const detail = ce.detail
+      if (!detail?.panelId) return
+      setPanel((prev) => {
+        if (!prev || prev.id !== detail.panelId) return prev
+        const next = { ...prev, filePath: detail.filePath, title: detail.title, isDirty: false }
+        // Fire-and-forget — failure here only delays the meta update to
+        // the next transfer, not data loss (the file itself is on disk).
+        window.electronAPI.panelWindowSyncMeta?.({ panel: next, workspaceId }).catch(() => {})
+        return next
+      })
+    }
+    window.addEventListener('editor:panel-saved-as', handler)
+    return () => window.removeEventListener('editor:panel-saved-as', handler)
+  }, [workspaceId])
+
   // For terminal panel windows: report ptyId to main + periodically save
   // scrollback so it can be replayed on next launch.
   useEffect(() => {

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -305,6 +305,7 @@ interface AppStoreActions {
   closePanel: (workspaceId: string, panelId: string) => void
   updatePanelTitle: (workspaceId: string, panelId: string, title: string) => void
   updatePanelUrl: (workspaceId: string, panelId: string, url: string) => void
+  updatePanelFilePath: (workspaceId: string, panelId: string, filePath: string) => void
   setPanelDirty: (workspaceId: string, panelId: string, dirty: boolean) => void
   setPanelUnsavedContent: (workspaceId: string, panelId: string, content: string | undefined) => void
   setPanelThemePreset: (workspaceId: string, panelId: string, themePreset: string | undefined) => void
@@ -1079,6 +1080,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
         return {
           ...ws,
           panels: { ...ws.panels, [panelId]: { ...panel, url } },
+        }
+      }),
+    }))
+  },
+
+  updatePanelFilePath(workspaceId, panelId, filePath) {
+    set((state) => ({
+      workspaces: state.workspaces.map((ws) => {
+        if (ws.id !== workspaceId) return ws
+        const panel = ws.panels[panelId]
+        if (!panel) return ws
+        return {
+          ...ws,
+          panels: { ...ws.panels, [panelId]: { ...panel, filePath } },
         }
       }),
     }))

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -317,8 +317,18 @@ export interface ElectronAPI {
   /** Open a native folder picker. Returns the selected path or null if canceled. */
   openFolderDialog(): Promise<string | null>
 
-  /** Native unsaved-changes confirmation. Returns 'save' | 'discard' | 'cancel'. */
-  confirmUnsavedChanges(payload: { fileName?: string; multiple?: boolean }): Promise<'save' | 'discard' | 'cancel'>
+  /** Open a native Save-As dialog. Returns the chosen path or null if canceled.
+   *  defaultName is used as the filename pre-fill, defaultPath as the starting
+   *  directory + filename (takes precedence). The returned path is the canonical
+   *  (realpath-of-parent + basename) form that the main process granted access
+   *  to — store that exact string on the panel state to keep future
+   *  reads/writes aligned with the grant set. */
+  saveFileDialog(payload?: { defaultName?: string; defaultPath?: string }): Promise<string | null>
+
+  /** Native unsaved-changes confirmation. Returns 'save' | 'discard' | 'cancel'.
+   *  `filePath`, when supplied for a single dirty file, is shown as the dialog
+   *  detail so the user can see exactly which file on disk is about to change. */
+  confirmUnsavedChanges(payload: { fileName?: string; multiple?: boolean; filePath?: string }): Promise<'save' | 'discard' | 'cancel'>
 
   /** Native confirmation shown when closing a canvas panel. When the canvas is
    *  not the last and has open panels, returns 'move' | 'delete' | 'cancel'.
@@ -407,6 +417,11 @@ export interface ElectronAPI {
 
   /** Report the terminal ptyId for this panel window so the main process can persist it. */
   panelWindowSyncPty(ptyId: string): Promise<void>
+
+  /** Push an updated PanelState snapshot for this panel window so the
+   *  main-process windowRegistry meta (used by session persistence and the
+   *  panel-window list) reflects post-Save-As filePath/title/dirty state. */
+  panelWindowSyncMeta(payload: { panel: PanelState; workspaceId?: string }): Promise<void>
 
   /** Request this panel window to dock back into the main window. */
   panelWindowDockBack(): Promise<void>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -131,9 +131,16 @@ export const MENU_SHOW_CONTEXT = 'menu:showContext'
 
 // Dialog
 export const DIALOG_OPEN_FOLDER = 'dialog:openFolder'
+export const DIALOG_SAVE_FILE = 'dialog:saveFile'
 export const DIALOG_CONFIRM_UNSAVED = 'dialog:confirmUnsaved'
 export const DIALOG_CONFIRM_CLOSE_CANVAS = 'dialog:confirmCloseCanvas'
 export const DIALOG_CONFIRM_DELETE_REGION = 'dialog:confirmDeleteRegion'
+
+// Panel window: renderer pushes an updated PanelState snapshot to main so
+// the windowRegistry's panel meta (used by session persistence and the
+// panel-window list) stays current — needed after Save-As turns an
+// untitled buffer into a real file inside a detached panel window.
+export const PANEL_WINDOW_SYNC_META = 'panel:windowSyncMeta'
 
 // Recent Projects
 export const RECENT_PROJECTS_GET = 'recent-projects:get'


### PR DESCRIPTION
## Summary
Untitled editor buffers — created via Canvas right-click → "New Editor" or the document-icon bubble — had no way to ever reach disk. This PR adds a native Save-As flow on Cmd+S / Ctrl+S (and on the close-confirm dialog's "Save" button) for those scratch editors, and threads the resulting filePath through every persistence layer.

## What changed (renderer)
- **EditorPanel.save()** opens `dialog.showSaveDialog` when no filePath is set, writes the file, persists the chosen path on the panel, then returns `true | false`. Cmd+S routes to the editor that most recently held Monaco text focus (tracked in editorSaveRegistry) rather than whichever editor happens to pass `hasTextFocus()` at the key event — clicking the markdown preview toggle or panel chrome no longer leaves the user without a save target.
- **saveEditor** returns a 3-state result (`saved | cancelled | no-handler`) so close-confirm aborts only on an explicit Save-As cancellation, not on an inactive (unmounted) dock tab. The pre-existing data-loss limitation for inactive dirty tabs is preserved (see Known limitations).
- **confirmCloseDirty / CanvasNode** pass the file path to the unsaved-changes dialog so the user sees exactly which file is about to be overwritten (untitled buffers get a "Save will prompt for a location" hint instead).
- **DockWindowShell / PanelWindowShell** mirror Save-As state into their local panels map AND push it back to main (`dockWindowSyncState` for dock windows, new `PANEL_WINDOW_SYNC_META` IPC for panel windows) so session restore after a quick quit doesn't restore the panel as Untitled. DockWindowShell uses a `panelsRef` so the immediate sync ships the post-Save-As map even before React re-runs the periodic-sync effect.

## What changed (main)
- **Sandbox grants for out-of-workspace paths.** Save-As targets are almost always outside any workspace root, so `validatePath*` would reject the immediate write. Introduced a per-window persistent grant system (`grantFileAccess` / `clearFileGrantsForWindow`) that the validators consult; the grant covers both reads and writes and is cleared on window close.
- **Main-owned persistence.** `src/main/grantedPathStore.ts` keeps the approved paths in `userData/granted-paths.json`. Only DIALOG_SAVE_FILE writes to it — there is no renderer-facing IPC to enrol paths, closing the trivial bypass `grantFilesAccess(['/etc/passwd'])`. Writes are synchronously flushed before the IPC resolves so an immediate quit after Save-As does not lose the grant.
- **Window create gates loadURL on grants.** `createWindow` applies every persisted grant for the new window's id BEFORE the renderer loads, eliminating the race where session restore mounted an editor outside the workspace before its grant landed and saw an empty model.
- **Save-As grants ripple to live windows.** A path approved in one window is also granted to every currently-open window so panel transfers across windows keep their access.
- **DIALOG_CONFIRM_UNSAVED detail line** now shows the on-disk path (single dirty file) or the Save-As hint (untitled).

## Windows behaviour
- Basename extraction in EditorPanel uses `[\\/]` so panel titles are correct after Save-As on POSIX and Windows alike.
- Default save-path picks the separator that matches `rootPath` (`\` vs `/`) so the prefilled path looks native.
- Tested manually only on macOS. Windows is covered by unit tests in `pathValidation.test.ts` but has not been exercised on a Windows runtime.

## Known limitations (carried over; out of scope here)
- Title/dirty updates that happen on every keystroke do NOT propagate from a detached panel/dock renderer's appStore to its local panels state — the shell's title bar can show stale dirty markers in detached windows. Pre-existing; only the Save-As path is now patched.
- An inactive (unmounted) dirty tab in a dock stack has no registered save fn. Close-confirm "Save" proceeds with the close, losing the tab's unsaved content — same as before this PR.

## Test plan
- [x] `npx vitest run src/main/ipc/pathValidation.test.ts` — 5 pass (existing scoped-write tests + new `grantFileAccess` read/write + per-window scoping tests)
- [x] Manual: New Editor → type → Cmd+S → Save-As → typeable + close silent
- [x] Manual: New Editor → type → close → "Save" → Save-As → cancel → panel stays open with unsaved changes
- [x] Manual: Save-As to `/tmp/cate-test.html` → quit → relaunch → editor reopens with file content
- [x] Manual: Multi-editor focus routing (active-editor tracker)
- [ ] Windows manual run — not performed