### PR TITLE
chore: dedupe close-confirm logic + refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,10 @@ The Electron app lives at the project root. Uses **electron-vite** for bundling.
 npm install        # install dependencies
 npm run dev        # start dev server with hot reload
 npm run build      # production build
+npm test           # run vitest suite
 ```
 
-There are no tests currently.
+Tests use **Vitest** and live alongside the code they cover (`*.test.ts` / `*.test.tsx`). A few git-touching tests assume a clean working repo and may fail when the dev tree has a branch named `main` or local modifications — those failures are environmental, not regressions.
 
 ## Dependencies
 
@@ -29,8 +30,9 @@ Managed via npm (`package.json`):
 - **zustand** — lightweight state management
 - **chokidar** — filesystem watching
 - **simple-git** — git operations
-- **lucide-react** — icons
+- **@phosphor-icons/react** — icons
 - **electron-store** — persistent settings
+- **electron-updater** — auto-update (GitHub Releases)
 
 ## Architecture
 
@@ -52,22 +54,31 @@ The canvas (`Canvas.tsx`) positions nodes using CSS transforms. Panel positions 
 
 ### Panel System
 
-Three panel types in `src/renderer/panels/`:
+Panel definitions are centralised in `src/shared/panels.ts`. Renderer components live in `src/renderer/panels/`:
 - **EditorPanel** — Monaco Editor with syntax highlighting
 - **TerminalPanel** — xterm.js terminal with WebGL renderer, backed by node-pty
-- **BrowserPanel** — embedded webview
+- **BrowserPanel** — embedded webview (file:// allowed for local HTML)
+- **CanvasPanel** — nested canvas
+- **GitPanel** — staged/unstaged diff + commit UI
+- **FileExplorerPanel** — git-aware file tree
+- **ProjectListPanel** — recent projects switcher
+- **DocumentPanel** — PDF / docx preview
+- **AgentPanel** — Claude-Code agent thread (sidebar + dock)
 
-Each panel is wrapped in a `CanvasNode` component (`src/renderer/canvas/CanvasNode.tsx`) providing title bar, drag, resize, and close behavior.
+Each panel can be wrapped in a `CanvasNode` (`src/renderer/canvas/CanvasNode.tsx`) — title bar, drag, resize, close — or live inside a dock zone via `DockTabStack` (`src/renderer/docking/`). Detached panel/dock windows have their own shells (`src/renderer/shells/PanelWindowShell.tsx`, `DockWindowShell.tsx`) with local panels state synced back to main for session persistence.
 
 ### State Management
 
 Zustand stores in `src/renderer/stores/`:
-- **canvasStore** — nodes, zoom, viewport offset, focus state, layout
-- **appStore** — workspaces, sidebar, project paths
+- **canvasStore** — nodes, regions, zoom, viewport offset, focus state, history; per-canvas instances created via `CanvasStoreContext`. A `focusEpoch` counter lets panels re-run focus side effects when the same node is re-focused.
+- **appStore** — workspaces, panels, selected workspace, sidebar
+- **dockStore** — dock-zone layout (per window)
 - **settingsStore** — user preferences
 - **shortcutStore** — keyboard shortcut bindings
 - **statusStore** — status bar state
 - **uiStore** — transient UI state (command palette, etc.)
+- **updateStore** — auto-updater status pushed from main
+- **urlPromptStore** — pending URL-open confirmations from terminals
 
 Session persistence saves/restores workspace state as JSON via electron-store.
 

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -21,7 +21,7 @@ import type { DockStore } from '../stores/dockStore'
 import { DockStoreProvider } from '../stores/DockStoreContext'
 import DockTabStack from '../docking/DockTabStack'
 import DockSplitContainer from '../docking/DockSplitContainer'
-import { saveEditor } from '../lib/editorSaveRegistry'
+import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
 import { ArrowsOutSimple, ArrowsInSimple, X, Lock, LockOpen } from '@phosphor-icons/react'
 import { resolveTerminalPreset } from '../lib/terminalRegistry'
 import { useSettingsStore } from '../stores/settingsStore'
@@ -268,35 +268,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     async (panelIds: string[]): Promise<boolean> => {
       const ws = useAppStore.getState().workspaces.find((w) => w.id === wsId)
       if (!ws) return true
-      const dirty = panelIds
-        .map((id) => ws.panels[id])
-        .filter((p): p is NonNullable<typeof p> => !!p && p.type === 'editor' && !!p.isDirty)
-      if (dirty.length === 0) return true
-      if (!window.electronAPI?.confirmUnsavedChanges) return true
-      const fileName =
-        dirty.length === 1
-          ? dirty[0].title.replace(/\s•\s*$/, '').trim()
-          : `${dirty.length} files`
-      const filePath = dirty.length === 1 ? dirty[0].filePath : undefined
-      const choice = await window.electronAPI.confirmUnsavedChanges({
-        fileName,
-        multiple: dirty.length > 1,
-        filePath,
-      })
-      if (choice === 'cancel') return false
-      if (choice === 'save') {
-        for (const p of dirty) {
-          let result: Awaited<ReturnType<typeof saveEditor>> = 'no-handler'
-          try { result = await saveEditor(p.id) } catch { /* treat as no-handler */ }
-          // Only an explicit Save-As cancellation aborts the close. A
-          // `no-handler` result means this panel isn't mounted (typically an
-          // inactive tab in a dock stack); aborting would leave the user
-          // unable to close. Pre-existing limitation: that tab's unsaved
-          // content is lost.
-          if (result === 'cancelled') return false
-        }
-      }
-      return true
+      return confirmCloseDirtyPanels(panelIds.map((id) => ws.panels[id]))
     },
     [wsId],
   )


### PR DESCRIPTION
## Summary
Two small follow-ups left over from the editor Save-As PR (#115):

### Dedupe close-confirm
`CanvasNode.tsx` carried its own copy of the dirty-editor close-confirm flow that had drifted to be identical to `confirmCloseDirtyPanels` after recent changes (file-path in the detail line, 3-state save result, etc.). Map the panel ids to `PanelState` and delegate to the shared helper — one source of truth means the next behavior change lands in a single place.

### Refresh CLAUDE.md
The repo guidance file was misleading in three places that a newcomer (or Claude) would trust:
- `There are no tests currently` — the repo has **33** Vitest files. Replaced with the actual `npm test` command and a note about Vitest layout + the couple of git-touching tests that are environment-sensitive.
- `Three panel types` — actually **nine** (editor, terminal, browser, canvas, git, fileExplorer, projectList, document, agent). Centralised definition in `src/shared/panels.ts` is now linked.
- Stores list missed `dockStore`, `updateStore`, `urlPromptStore` and understated canvasStore (regions, history, focusEpoch).

Also: dropped a stale `lucide-react` reference (codebase uses `@phosphor-icons/react`), added `electron-updater`, and mentioned the detached panel/dock window shells which are central to multi-window behavior.

## Test plan
- [x] `npm test` — 311 pass, 2 pre-existing git-touching failures (unchanged by this PR)
- [x] Manual: close untitled editor with unsaved changes — Save-As Cancel still aborts the close (regression check for the dedupe)
- [x] Manual: close dock-stack containing dirty editor — close-confirm flow unchanged