### PR TITLE
fix(drag): bind window blur listener in bubble phase

### DIFF
--- a/src/renderer/drag/__tests__/harness.tsx
+++ b/src/renderer/drag/__tests__/harness.tsx
@@ -4,8 +4,8 @@
 //   - `mousedown` on the rendered `[data-node-id]` element bubbles to React's
 //     synthetic-event listener, which invokes the `onMouseDown` prop calling
 //     `handleDragStart`. The dispatcher is not invoked by any back-channel.
-//   - `mousemove`/`mouseup`/`blur` are real window events caught by the
-//     capture-phase listeners installed by `useDragOp`.
+//   - `mousemove`/`mouseup` are real window events caught by the capture-phase
+//     listeners installed by `useDragOp`; `blur` is caught in bubble phase.
 //   - `document.elementFromPoint` is replaced by a real top-down scan over the
 //     rendered `[data-canvas-container]` / `[data-node-id]` nodes (using their
 //     stubbed `getBoundingClientRect`), so `resolveDrop`'s DOM-coupling path

--- a/src/renderer/drag/useDragOp.ts
+++ b/src/renderer/drag/useDragOp.ts
@@ -39,7 +39,11 @@ function attachListeners() {
   if (session.listenersAttached) return
   window.addEventListener('mousemove', onMouseMove, true)
   window.addEventListener('mouseup', onMouseUp, true)
-  window.addEventListener('blur', onBlur, true)
+  // Bubble phase (not capture): we only want the window's own blur event.
+  // Capture-phase would also fire for element-level blur events bubbling up,
+  // and xterm's textarea.focus() — triggered by the focus-on-focus effect on
+  // terminal panels — would otherwise cancel an in-flight drag.
+  window.addEventListener('blur', onBlur, false)
   session.listenersAttached = true
   // Body marker so resize-cursor / resize-start can guard against starting an
   // edge-resize on top of an in-flight drag. Mirrors `canvas-interacting`
@@ -52,7 +56,7 @@ function detachListeners() {
   if (!session.listenersAttached) return
   window.removeEventListener('mousemove', onMouseMove, true)
   window.removeEventListener('mouseup', onMouseUp, true)
-  window.removeEventListener('blur', onBlur, true)
+  window.removeEventListener('blur', onBlur, false)
   session.listenersAttached = false
   document.body.classList.remove('canvas-dragging')
 }


### PR DESCRIPTION
## Summary

- Canvas-node drag was unusable for terminal panels until the 2nd/3rd mousedown after first focus. Root cause: `attachListeners` registered the window blur handler with `capture: true`. Capture-phase fires for **every** element-level blur bubbling up to the window, not just the window's own blur.
- After PR #107 (minimap focus + `focusEpoch` polling), focusing a terminal node calls `textarea.focus()`, which fires a blur event on whatever element previously held focus. That blur reached our capture-phase listener, hit `step(active, { type: 'CANCEL' })`, and killed the freshly armed drag session.
- Switching the listener to bubble phase (`capture: false`) means we only see the window's own blur, leaving inner focus shuffling alone.

## Test plan
- [x] Click + hold + move on a terminal node tab bar — drag begins on the first gesture (previously required 2-3)
- [x] All existing drag scenario / commit / cross-window tests pass (`npm test -- --run drag`)
- [x] Switching focus between OS windows still cancels in-flight drags (window-level blur still fires in bubble phase)