### PR TITLE
fix(docking): clearer cursors on canvas-node tab bar

### DIFF
--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -136,6 +136,7 @@ export function DockTabBar(props: DockTabBarProps) {
   return (
     <div
       className="flex items-stretch flex-1 min-w-0"
+      style={onEmptyMouseDown ? { cursor: 'grab' } : undefined}
       onContextMenu={onEmptyContextMenu}
       onMouseDown={(e) => {
         if (e.target !== e.currentTarget) return
@@ -216,7 +217,7 @@ export function DockTabBar(props: DockTabBarProps) {
               />
             ) : (
               <span
-                className="truncate flex-1 min-w-0"
+                className={`truncate flex-1 min-w-0 ${panel?.type === 'terminal' ? 'cursor-text' : ''}`}
                 onDoubleClick={(e) => {
                   if (panel?.type !== 'terminal') return
                   e.stopPropagation()
@@ -226,7 +227,7 @@ export function DockTabBar(props: DockTabBarProps) {
             )}
             {onClosePanel && (
               <span
-                className={`shrink-0 p-0.5 rounded-sm hover:bg-hover ${
+                className={`shrink-0 p-0.5 rounded-sm hover:bg-hover cursor-pointer ${
                   isActive ? 'opacity-80' : 'opacity-0 group-hover:opacity-70'
                 }`}
                 onClick={(e) => {
@@ -253,7 +254,7 @@ export function DockTabBar(props: DockTabBarProps) {
         className="flex-1 min-w-[20px] self-stretch"
         style={
           onTabBarMouseDown
-            ? undefined
+            ? { cursor: 'grab' }
             : ({ WebkitAppRegion: 'drag' } as React.CSSProperties)
         }
         onMouseDown={onTabBarMouseDown}

--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -208,6 +208,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         className={`dock-tab-bar flex items-stretch overflow-hidden ${compact ? 'min-h-[26px]' : 'min-h-[36px]'}`}
         style={{
           backgroundColor: 'var(--node-chrome-bg, var(--surface-1))',
+          ...(onTabBarMouseDown ? { cursor: 'grab' } : null),
           ...(zoneProp === 'center' && leftEdge
             ? { marginLeft: 'var(--cate-left-sidebar-width, 0px)' }
             : null),
@@ -260,7 +261,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         {/* "+" tab — adds a new tab of the active panel's type into this stack. */}
         {activePanel && (
           <button
-            className={`flex items-center justify-center self-center rounded text-secondary hover:text-primary hover:bg-hover ${compact ? 'mx-0.5 my-0.5 w-[18px] h-[18px]' : 'mx-1 my-1 w-[22px] h-[22px]'}`}
+            className={`flex items-center justify-center self-center rounded text-secondary hover:text-primary hover:bg-hover cursor-pointer ${compact ? 'mx-0.5 my-0.5 w-[18px] h-[18px]' : 'mx-1 my-1 w-[22px] h-[22px]'}`}
             title={`New ${PANEL_TYPE_LABELS[activePanel.type] ?? 'Tab'}`}
             onClick={() => actions.addTabOfType(activePanel.type)}
           >
@@ -273,7 +274,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
           <div className={`relative flex items-center self-center ${compact ? 'px-0.5' : 'px-1'}`}>
             <button
               ref={splitButtonRef}
-              className={`flex items-center justify-center rounded text-secondary hover:text-primary hover:bg-hover ${compact ? 'w-[18px] h-[18px]' : 'w-[22px] h-[22px]'}`}
+              className={`flex items-center justify-center rounded text-secondary hover:text-primary hover:bg-hover cursor-pointer ${compact ? 'w-[18px] h-[18px]' : 'w-[22px] h-[22px]'}`}
               title="Split (hold to choose type)"
               onClick={handleSplitClick}
               onMouseDown={handleSplitMouseDown}


### PR DESCRIPTION
## Summary

- Tab bar regions in canvas-node mini-docks now show cursors that match their action — previously the empty drag area showed the default arrow and the close X inherited the pill's grab cursor.

| Region | Before | After |
|---|---|---|
| Empty tab-bar area (drags the node) | default | `grab` |
| Trailing drag spacer | default | `grab` |
| `+` / split buttons | default | `pointer` |
| Tab close X | grab (inherited) | `pointer` |
| Terminal tab title (double-click renames) | grab | `text` |
| Lock / Maximize / Close (trailing controls) | `pointer` | unchanged |

- Detached dock window paths are untouched: `WebkitAppRegion: 'drag'` still applies to the trailing spacer when `onTabBarMouseDown` is not supplied.

## Test plan
- [x] Hover each region in a canvas-node mini-dock and confirm the cursor matches the action
- [x] Confirm detached dock window title bar still drags the OS window
- [x] `npm test` — drag + docking suites unaffected