### PR TITLE
fix(terminal): Ctrl+C copies selected text on Windows/Linux

### DIFF
--- a/src/renderer/lib/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminalRegistry.test.ts
@@ -38,6 +38,7 @@ vi.mock('@xterm/xterm', () => {
     }
     onData(): { dispose: () => void } { return { dispose: () => {} } }
     onResize(): { dispose: () => void } { return { dispose: () => {} } }
+    hasSelection(): boolean { return false }
     attachCustomKeyEventHandler(): void { /* no-op */ }
     refresh(): void { /* no-op */ }
     scrollToBottom(): void { /* no-op */ }
@@ -145,6 +146,41 @@ describe('isTerminalPasteChord', () => {
     const { isTerminalPasteChord } = await import('./terminalRegistry')
     const up = new KeyboardEvent('keyup', { ctrlKey: true, key: 'v' })
     expect(isTerminalPasteChord(up, false)).toBe(false)
+  })
+})
+
+describe('isTerminalCopyChord', () => {
+  const kd = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init)
+  const withSelection = { hasSelection: () => true }
+  const noSelection = { hasSelection: () => false }
+
+  it('matches Ctrl+C on non-mac when terminal has a selection', async () => {
+    const { isTerminalCopyChord } = await import('./terminalRegistry')
+    expect(isTerminalCopyChord(kd({ ctrlKey: true, key: 'c' }), withSelection, false)).toBe(true)
+    expect(isTerminalCopyChord(kd({ ctrlKey: true, shiftKey: true, key: 'C' }), withSelection, false)).toBe(true)
+  })
+
+  it('does not match when there is no selection (SIGINT should go through)', async () => {
+    const { isTerminalCopyChord } = await import('./terminalRegistry')
+    expect(isTerminalCopyChord(kd({ ctrlKey: true, key: 'c' }), noSelection, false)).toBe(false)
+  })
+
+  it('ignores Ctrl+C on macOS (Cmd+C handles copy; Ctrl+C is SIGINT)', async () => {
+    const { isTerminalCopyChord } = await import('./terminalRegistry')
+    expect(isTerminalCopyChord(kd({ ctrlKey: true, key: 'c' }), withSelection, true)).toBe(false)
+  })
+
+  it('does not match when alt or meta is also held, or without ctrl', async () => {
+    const { isTerminalCopyChord } = await import('./terminalRegistry')
+    expect(isTerminalCopyChord(kd({ ctrlKey: true, altKey: true, key: 'c' }), withSelection, false)).toBe(false)
+    expect(isTerminalCopyChord(kd({ metaKey: true, key: 'c' }), withSelection, false)).toBe(false)
+    expect(isTerminalCopyChord(kd({ key: 'c' }), withSelection, false)).toBe(false)
+  })
+
+  it('only matches keydown, not keyup', async () => {
+    const { isTerminalCopyChord } = await import('./terminalRegistry')
+    const up = new KeyboardEvent('keyup', { ctrlKey: true, key: 'c' })
+    expect(isTerminalCopyChord(up, withSelection, false)).toBe(false)
   })
 })
 

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -43,6 +43,17 @@ export function isTerminalPasteChord(event: KeyboardEvent, isMac = isMacPlatform
   return event.key === 'v' || event.key === 'V'
 }
 
+export function isTerminalCopyChord(
+  event: KeyboardEvent,
+  terminal: { hasSelection(): boolean },
+  isMac = isMacPlatform,
+): boolean {
+  if (isMac) return false
+  if (event.type !== 'keydown' || !event.ctrlKey || event.altKey || event.metaKey) return false
+  if (event.key !== 'c' && event.key !== 'C') return false
+  return terminal.hasSelection()
+}
+
 // ---------------------------------------------------------------------------
 // Themes — three palettes for dark-warm, light-subtle, dark-cold
 // ---------------------------------------------------------------------------
@@ -487,6 +498,7 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
       // xterm's textarea and xterm performs the paste once. Do NOT preventDefault
       // here — that would also cancel the paste event and nothing would paste.
       if (isTerminalPasteChord(event)) return false
+      if (isTerminalCopyChord(event, terminal)) return false
 
       const keyCode = CSI_U_KEYS[event.key]
       if (keyCode === undefined) return true // let xterm handle all other keys
@@ -645,6 +657,7 @@ async function reconnectTerminal(
   terminal.attachCustomKeyEventHandler((event) => {
     if (event.type !== 'keydown') return true
     if (isTerminalPasteChord(event)) return false
+    if (isTerminalCopyChord(event, terminal)) return false
     const keyCode = CSI_U_KEYS[event.key]
     if (keyCode === undefined) return true
     let mod = 1


### PR DESCRIPTION
## Summary
- Adds `isTerminalCopyChord` that detects Ctrl+C when the terminal has a selection (Windows/Linux only)
- Wired into both `attachCustomKeyEventHandler` callbacks (initial create + reconnect paths)
- Uses the same "return false without preventDefault" pattern as the existing Ctrl+V paste chord — xterm skips the key, browser fires native copy

## Behavior
| State | Ctrl+C action |
|---|---|
| Text selected (Win/Linux) | Copies to clipboard |
| No selection (Win/Linux) | Sends SIGINT |
| macOS (any) | Always SIGINT (Cmd+C handles copy) |

## Test plan
- [x] Unit tests for `isTerminalCopyChord` (selection, no selection, macOS, modifiers, keydown-only)
- [ ] Manual: `npm run dev` → terminal panel → select text → Ctrl+C → verify clipboard
- [ ] Manual: no selection → Ctrl+C → verify SIGINT sent

Closes #123