### PR TITLE
feat(palette): unified accent palette for workspaces + canvas regions

### DIFF
--- a/src/renderer/canvas/CanvasRegionComponent.tsx
+++ b/src/renderer/canvas/CanvasRegionComponent.tsx
@@ -4,18 +4,7 @@ import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreC
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import { useAppStore, getCanvasOpsById } from '../stores/appStore'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
-
-// Preset region colors
-const REGION_COLORS = [
-  'rgba(0, 128, 255, 0.08)',    // blue (default)
-  'rgba(0, 255, 0, 0.08)',      // green
-  'rgba(255, 128, 0, 0.08)',    // orange
-  'rgba(255, 0, 0, 0.08)',      // red
-  'rgba(170, 0, 255, 0.08)',    // purple
-  'rgba(255, 255, 0, 0.08)',    // yellow
-  'rgba(0, 255, 255, 0.08)',    // teal
-  'rgba(255, 0, 128, 0.08)',    // pink
-]
+import { ACCENT_COLORS, ACCENT_COLOR_NAMES, REGION_FILL_COLORS } from '../../shared/colors'
 
 // Parse rgba(...) string → { r, g, b, a }
 function parseRgba(str: string): { r: number; g: number; b: number; a: number } {
@@ -237,16 +226,17 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
     requestAnimationFrame(tryTransfer)
   }, [region.id, canvasApi])
 
-  const REGION_COLOR_LABELS = ['Blue', 'Green', 'Orange', 'Red', 'Purple', 'Yellow', 'Teal', 'Pink']
-
   const handleContextMenu = useCallback(async (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
     if (!window.electronAPI) return
-    const colorSubmenu: NativeContextMenuItem[] = REGION_COLORS.map((color, i) => ({
-      id: `color:${i}`,
-      label: region.color === color ? `${REGION_COLOR_LABELS[i]} ✓` : REGION_COLOR_LABELS[i],
-    }))
+    const colorSubmenu: NativeContextMenuItem[] = REGION_FILL_COLORS.map((color, i) => {
+      const label = ACCENT_COLOR_NAMES[ACCENT_COLORS[i]] ?? ACCENT_COLORS[i]
+      return {
+        id: `color:${i}`,
+        label: region.color === color ? `${label} ✓` : label,
+      }
+    })
     const cwdLabel = region.defaultCwd
       ? `Default Folder: …/${region.defaultCwd.split('/').filter(Boolean).slice(-2).join('/')}`
       : 'Set Default Folder…'
@@ -269,7 +259,7 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
     }
     if (id.startsWith('color:')) {
       const idx = parseInt(id.slice(6), 10)
-      canvasApi.getState().updateRegionColor(region.id, REGION_COLORS[idx])
+      canvasApi.getState().updateRegionColor(region.id, REGION_FILL_COLORS[idx])
       return
     }
     if (id === 'set-cwd') {
@@ -462,7 +452,7 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
                 top: region.origin.y + (handle.includes('top') || handle === 'topLeft' || handle === 'topRight' ? -handleSize / 2 : region.size.height - handleSize / 2),
                 width: handleSize,
                 height: handleSize,
-                backgroundColor: 'rgba(74, 158, 255, 0.9)',
+                backgroundColor: `rgba(${parseRgba(region.color).r}, ${parseRgba(region.color).g}, ${parseRgba(region.color).b}, 0.9)`,
                 borderRadius: 2,
                 cursor: HANDLE_CURSORS[handle],
                 zIndex: 1,
@@ -482,7 +472,7 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
                   top: region.origin.y + (handle === 'top' ? -handleSize / 2 : handle === 'bottom' ? region.size.height - handleSize / 2 : region.size.height / 2 - handleSize / 2),
                   width: isHoriz ? handleSize : handleSize,
                   height: isHoriz ? handleSize : handleSize,
-                  backgroundColor: 'rgba(74, 158, 255, 0.7)',
+                  backgroundColor: `rgba(${parseRgba(region.color).r}, ${parseRgba(region.color).g}, ${parseRgba(region.color).b}, 0.7)`,
                   borderRadius: 2,
                   cursor: HANDLE_CURSORS[handle],
                   zIndex: 1,

--- a/src/renderer/canvas/CanvasRegionComponent.tsx
+++ b/src/renderer/canvas/CanvasRegionComponent.tsx
@@ -4,12 +4,14 @@ import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreC
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import { useAppStore, getCanvasOpsById } from '../stores/appStore'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
-import { ACCENT_COLORS, ACCENT_COLOR_NAMES, REGION_FILL_COLORS } from '../../shared/colors'
+import { ACCENT_COLORS, ACCENT_COLOR_NAMES, ACCENT_PALETTE, REGION_FILL_ALPHA, REGION_FILL_COLORS } from '../../shared/colors'
 
-// Parse rgba(...) string → { r, g, b, a }
+// Parse rgba(...) string → { r, g, b, a }. Falls back to the first slot of the
+// shared accent palette so unparseable values stay in sync with the palette.
+const [FALLBACK_R, FALLBACK_G, FALLBACK_B] = ACCENT_PALETTE[0].vividRgb
 function parseRgba(str: string): { r: number; g: number; b: number; a: number } {
   const m = str.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)/)
-  if (!m) return { r: 74, g: 158, b: 255, a: 0.08 }
+  if (!m) return { r: FALLBACK_R, g: FALLBACK_G, b: FALLBACK_B, a: REGION_FILL_ALPHA }
   return { r: +m[1], g: +m[2], b: +m[3], a: m[4] ? +m[4] : 1 }
 }
 

--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -190,7 +190,7 @@ export function DockTabBar(props: DockTabBarProps) {
             {isActive && (
               <span
                 className="absolute left-0 right-0 top-0 h-[2px]"
-                style={{ backgroundColor: 'var(--node-chrome-accent, #3b82f6)' }}
+                style={{ backgroundColor: 'var(--workspace-accent, var(--node-chrome-accent, #3b82f6))' }}
               />
             )}
             <span

--- a/src/renderer/shells/MainWindowShell.tsx
+++ b/src/renderer/shells/MainWindowShell.tsx
@@ -6,6 +6,7 @@
 
 import React, { useCallback, useEffect, useRef } from 'react'
 import { useDockStoreContext, useDockStoreApi } from '../stores/DockStoreContext'
+import { useSelectedWorkspace } from '../stores/appStore'
 import type { DockZonePosition } from '../../shared/types'
 import DockZone from '../docking/DockZone'
 import DockResizeHandle from '../docking/DockResizeHandle'
@@ -116,8 +117,14 @@ export default function MainWindowShell({
     activeDropTarget?.kind === 'dock-zone' &&
     activeDropTarget.zone === 'bottom'
 
+  const workspaceAccent = useSelectedWorkspace()?.color || undefined
+
   return (
-    <div ref={shellRef} className="flex flex-col h-full w-full min-h-0 min-w-0 relative">
+    <div
+      ref={shellRef}
+      className="flex flex-col h-full w-full min-h-0 min-w-0 relative"
+      style={workspaceAccent ? ({ ['--workspace-accent' as string]: workspaceAccent } as React.CSSProperties) : undefined}
+    >
       {/* Top row: left dock | center dock | right dock */}
       <div className="flex flex-1 min-h-0 min-w-0">
         {/* Left dock zone */}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -5,6 +5,7 @@ import type { WorkspaceState, PanelType, PanelLocation, DockLayoutNode } from '.
 import { ALL_ZONES } from '../../shared/types'
 import { useStatusStore } from '../stores/statusStore'
 import { useAppStore, WORKSPACE_COLORS, getCanvasOperations, getWorkspaceCanvasPanelId, ensureCanvasOpsForPanel } from '../stores/appStore'
+import { ACCENT_COLOR_NAMES } from '../../shared/colors'
 import { useDockStore } from '../stores/dockStore'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { findTabStack, findStackContainingPanel } from '../stores/dockTreeUtils'
@@ -171,14 +172,6 @@ const PANEL_ICONS: Record<PanelType, PhosphorIcon> = Object.fromEntries(
   (Object.keys(PANEL_REGISTRY) as PanelType[]).map((t) => [t, PANEL_REGISTRY[t].icon]),
 ) as Record<PanelType, PhosphorIcon>
 
-const COLOR_NAMES: Record<string, string> = {
-  '#6b8fb0': 'Slate Blue',
-  '#c08a5a': 'Tan',
-  '#7aa074': 'Sage',
-  '#9d7fb5': 'Violet',
-  '#c07070': 'Dusty Red',
-  '#6aa5a5': 'Teal',
-}
 
 interface WorkspaceTabProps {
   workspace: WorkspaceState
@@ -295,7 +288,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       },
       ...WORKSPACE_COLORS.map((color) => ({
         id: `color:${color}`,
-        label: (COLOR_NAMES[color] || color) + (color === workspace.color ? ' ✓' : ''),
+        label: (ACCENT_COLOR_NAMES[color] || color) + (color === workspace.color ? ' ✓' : ''),
         enabled: color !== workspace.color,
       })),
     ]

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -20,6 +20,7 @@ import type {
   WorktreeMeta,
 } from '../../shared/types'
 import { PANEL_DEFAULT_SIZES, ZOOM_DEFAULT, ALL_ZONES } from '../../shared/types'
+import { ACCENT_COLORS } from '../../shared/colors'
 import type { CanvasNodeId, CanvasNodeState, CanvasRegion } from '../../shared/types'
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from './canvasStore'
@@ -103,15 +104,8 @@ function generateId(): string {
   return crypto.randomUUID()
 }
 
-/** Workspace accent colors — muted palette, user-selectable. */
-export const WORKSPACE_COLORS = [
-  '#6b8fb0', // slate blue
-  '#c08a5a', // warm tan
-  '#7aa074', // sage
-  '#9d7fb5', // muted violet
-  '#c07070', // dusty red
-  '#6aa5a5', // muted teal
-]
+/** Workspace accent colors — re-exported from the shared accent palette. */
+export const WORKSPACE_COLORS = ACCENT_COLORS
 
 function createDefaultWorkspace(name?: string, rootPath?: string): WorkspaceState {
   return {

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -26,6 +26,7 @@ import {
   autoLayoutAll as computeAutoLayoutAll,
 } from '../canvas/layoutEngine'
 import { viewToCanvas as viewToCanvasCoords } from '../lib/coordinates'
+import { REGION_FILL_COLORS } from '../../shared/colors'
 
 // -----------------------------------------------------------------------------
 // Store interface
@@ -1014,7 +1015,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
       origin,
       size,
       label,
-      color: color || 'rgba(74, 158, 255, 0.08)',
+      color: color || REGION_FILL_COLORS[0],
       zOrder: -1000,
     }
     set((state) => ({

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// Shared accent palette — single source of truth for workspace accents and
+// canvas-region fills.
+//
+// Each slot has two presentations of the same logical hue:
+//   - `workspace`: muted hex shown as a solid accent on workspace tabs
+//   - `vividRgb`:  saturated RGB used at low alpha for canvas-region fills,
+//                  so regions still read as the named hue once the gradient
+//                  flattens them on top of the dark canvas.
+//
+// The slot list defines the order shown in every "Change Color" menu — sorted
+// by main colors first (rainbow-ish), so red/orange/yellow live next to one
+// another in both the workspace context menu and the region color picker.
+// =============================================================================
+
+export interface AccentColor {
+  name: string
+  workspace: string
+  vividRgb: readonly [number, number, number]
+}
+
+export const ACCENT_PALETTE: readonly AccentColor[] = [
+  { name: 'Blue',   workspace: '#4a8ad0', vividRgb: [0, 128, 255] },
+  { name: 'Red',    workspace: '#d05c5c', vividRgb: [255, 0, 0] },
+  { name: 'Orange', workspace: '#e09040', vividRgb: [255, 128, 0] },
+  { name: 'Yellow', workspace: '#d4b04a', vividRgb: [255, 255, 0] },
+  { name: 'Green',  workspace: '#6bbf5c', vividRgb: [0, 255, 0] },
+  { name: 'Teal',   workspace: '#5ab8b8', vividRgb: [0, 255, 255] },
+  { name: 'Purple', workspace: '#a874c8', vividRgb: [170, 0, 255] },
+  { name: 'Pink',   workspace: '#c87090', vividRgb: [255, 0, 128] },
+]
+
+/** Workspace accent hex list — parallel to `ACCENT_PALETTE`. */
+export const ACCENT_COLORS = ACCENT_PALETTE.map((p) => p.workspace)
+
+/** Hex → human name lookup for the workspace context menu. */
+export const ACCENT_COLOR_NAMES: Record<string, string> = Object.fromEntries(
+  ACCENT_PALETTE.map((p) => [p.workspace, p.name]),
+)
+
+/** Convert `#rrggbb` to `rgba(r, g, b, a)`. Falls through unchanged for
+ *  inputs that don't match the hex shape so existing rgba values from
+ *  persisted sessions keep working. */
+export function withAlpha(hex: string, alpha: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return hex
+  const n = parseInt(m[1], 16)
+  const r = (n >> 16) & 0xff
+  const g = (n >> 8) & 0xff
+  const b = n & 0xff
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+/** Alpha used when storing the region fill color. The actual rendered alpha
+ *  lives in `CanvasRegionComponent`'s gradient — `parseRgba` only pulls the
+ *  RGB out of this string. */
+export const REGION_FILL_ALPHA = 0.15
+
+/** Region fill colors derived from the vivid RGB slots in `ACCENT_PALETTE`. */
+export const REGION_FILL_COLORS = ACCENT_PALETTE.map(
+  (p) => `rgba(${p.vividRgb[0]}, ${p.vividRgb[1]}, ${p.vividRgb[2]}, ${REGION_FILL_ALPHA})`,
+)


### PR DESCRIPTION
## Summary

Workspaces and canvas regions used to live on two independent color palettes — six muted hex accents for the workspace context menu and eight pure-rgba fills for the region picker. The lists drifted in count, order, and hue choices, with no path to keep them in sync.

This PR introduces a single source of truth in `src/shared/colors.ts`:

- `ACCENT_PALETTE` — eight slots, each pairing a **muted hex** (workspace tab accent) with a **saturated rgb tuple** (region fill).
- Shared slot order — Blue first, then a rainbow run through Red, Orange, Yellow, Green, Teal, Purple, Pink. Same logical hue at the same index in either picker.
- Both pickers now read names from `ACCENT_COLOR_NAMES`, so renaming a slot updates every menu at once.

### Wiring

- `appStore.ts` re-exports `WORKSPACE_COLORS` from the shared palette.
- `WorkspaceTab.tsx` drops its local `COLOR_NAMES` and uses `ACCENT_COLOR_NAMES`.
- `CanvasRegionComponent.tsx` drops its local `REGION_COLORS`/`REGION_COLOR_LABELS` and uses `REGION_FILL_COLORS` + `ACCENT_COLOR_NAMES`. Resize-handle backgrounds now inherit the region's color instead of a hardcoded blue.
- `canvasStore.addRegion` defaults to `REGION_FILL_COLORS[0]`.

### Workspace accent in the dock tab strip

`MainWindowShell.tsx` publishes the active workspace's color as a `--workspace-accent` CSS variable on the shell root. The dock tab-bar's active-tab top stripe (`DockTabBar.tsx:193`) now resolves:

```
var(--workspace-accent, var(--node-chrome-accent, #3b82f6))
```

Workspace color wins when set, the per-terminal `--node-chrome-accent` is the fallback when no workspace color is configured, and #3b82f6 is the final fallback. The cascade was a deliberate choice — terminal-theme accents stay available for un-colored workspaces, and a colored workspace gets a consistent stripe across both the canvas dock and every canvas-node mini-dock inside it. Detached `PanelWindow`/`DockWindow` shells don't set `--workspace-accent`, so they fall back to the existing behaviour.

### Glow — considered, deferred

We discussed extending the workspace tint to the focus glow on canvas nodes (currently a hardcoded `rgba(74, 158, 255, ...)` halo in `useCanvasNodeStyle.ts:15`). Decided to leave it alone for now — the stripe already telegraphs the workspace identity, the glow's very-low alpha makes it cosmetically neutral, and recoloring it risks making heavily-populated canvases feel washed in workspace color. Easy to revisit if we want it.

### Backward compatibility

Legacy persisted `region.color` strings keep working — `parseRgba` and the minimap regex both handle any well-formed `rgba(...)` value. The "Change Color" context menu just shows no ✓ for old values until the user picks a new one.

## Test plan

- [x] Right-click a workspace → menu shows 8 colors with shared names.
- [x] Right-click a canvas region → same 8 names, same order.
- [x] Pick a workspace color → active dock tab + every canvas-node mini-dock tab show the workspace color on the top stripe.
- [x] Pick a region color → fill + resize handles + selection border all tint to the picked hue.
- [x] Type-check + drag/docking tests unaffected (`npm test`).