### PR TITLE
feat: store workspace state in project directory (.cate/)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,7 +19,8 @@ import { registerHandlers as registerFilesystemHandlers, stopWatchersForWindow }
 import { registerHandlers as registerGitHandlers } from './ipc/git'
 import { registerHandlers as registerShellHandlers, unregisterTerminalsForWindow } from './ipc/shell'
 import { registerHandlers as registerGitMonitorHandlers, stopMonitorsForWindow } from './ipc/git-monitor'
-import { registerHandlers as registerStoreHandlers, getLastSavedSession, saveSessionSync, loadSettingsSyncFromDisk, getSettingSync, readBootSnapshot, writeBootSnapshot } from './store'
+import { registerHandlers as registerStoreHandlers, loadSettingsSyncFromDisk, getSettingSync, readBootSnapshot, writeBootSnapshot } from './store'
+import { registerProjectStateHandlers, saveProjectStateSync, runLegacyMigrationIfNeeded } from './projectWorkspaceStore'
 import { registerHandlers as registerMenuHandlers } from './ipc/menu'
 import { registerHandlers as registerNotificationHandlers } from './ipc/notifications'
 import { registerAgentHandlers } from '../agent/main/ipcAgent'
@@ -427,6 +428,7 @@ function destroyDragGhostWindow(): void {
  */
 function registerCriticalHandlers(): void {
   registerStoreHandlers()
+  registerProjectStateHandlers()
   registerWorkspaceHandlers()
   registerFilesystemHandlers()
   registerTerminalHandlers()
@@ -1230,6 +1232,8 @@ app.whenReady().then(async () => {
   registerCriticalHandlers()
   log.info('Critical IPC handlers registered')
 
+  await runLegacyMigrationIfNeeded()
+
   const mainWin = createWindow({ type: 'main' })
   log.info('Main window created (id=%d)', mainWin.id)
 
@@ -1343,8 +1347,8 @@ app.on('will-quit', () => {
   // Last-resort synchronous save from cached session data.
   // The renderer flush above should have completed, but this ensures
   // we write something if it didn't.
-  log.info('will-quit: sync session save fallback')
-  saveSessionSync(getLastSavedSession())
+  log.info('will-quit: sync project state save fallback')
+  saveProjectStateSync()
   // Kill all PTYs now — AFTER session save so the renderer had access to live
   // PTY data (CWD, scrollback) during the flush triggered in before-quit.
   // Must happen while the JS environment is still alive. If we let them die

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -1,0 +1,329 @@
+import { ipcMain, app } from 'electron'
+import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
+import log from './logger'
+import {
+  PROJECT_STATE_SAVE,
+  PROJECT_STATE_LOAD,
+} from '../shared/ipc-channels'
+import type { ProjectWorkspaceFile, ProjectSessionFile, MultiWorkspaceSession, SessionSnapshot, DockLayoutNode, WindowDockState } from '../shared/types'
+import { toRelativePath } from '../shared/pathUtils'
+
+const CATE_DIR = '.cate'
+const WORKSPACE_FILE = 'workspace.json'
+const SESSION_FILE = 'session.json'
+
+function cateDir(rootPath: string): string {
+  return path.join(rootPath, CATE_DIR)
+}
+
+function workspacePath(rootPath: string): string {
+  return path.join(rootPath, CATE_DIR, WORKSPACE_FILE)
+}
+
+function sessionPath(rootPath: string): string {
+  return path.join(rootPath, CATE_DIR, SESSION_FILE)
+}
+
+async function atomicWrite(filePath: string, json: string): Promise<void> {
+  const dir = path.dirname(filePath)
+  const tmpPath = filePath + '.tmp'
+  const bakPath = filePath + '.bak'
+
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(tmpPath, json, 'utf-8')
+  const stat = await fs.stat(tmpPath)
+  if (stat.size === 0) {
+    await fs.unlink(tmpPath).catch(() => {})
+    throw new Error('tmp file is empty after write')
+  }
+  await fs.rename(filePath, bakPath).catch(() => {})
+  await fs.rename(tmpPath, filePath)
+}
+
+function atomicWriteSync(filePath: string, json: string): void {
+  const dir = path.dirname(filePath)
+  const tmpPath = filePath + '.tmp'
+  const bakPath = filePath + '.bak'
+
+  fsSync.mkdirSync(dir, { recursive: true })
+  fsSync.writeFileSync(tmpPath, json, 'utf-8')
+  const stat = fsSync.statSync(tmpPath)
+  if (stat.size === 0) {
+    throw new Error('tmp file is empty after write')
+  }
+  try { fsSync.renameSync(filePath, bakPath) } catch { /* OK */ }
+  fsSync.renameSync(tmpPath, filePath)
+}
+
+async function tryReadJson<T>(filePath: string): Promise<T | null> {
+  try {
+    const data = await fs.readFile(filePath, 'utf-8')
+    return JSON.parse(data) as T
+  } catch {
+    return null
+  }
+}
+
+async function tryReadWithFallback<T>(filePath: string): Promise<T | null> {
+  const result = await tryReadJson<T>(filePath)
+  if (result) return result
+  const tmp = await tryReadJson<T>(filePath + '.tmp')
+  if (tmp) return tmp
+  return tryReadJson<T>(filePath + '.bak')
+}
+
+function isValidWorkspace(data: unknown): data is ProjectWorkspaceFile {
+  if (!data || typeof data !== 'object') return false
+  const obj = data as Record<string, unknown>
+  return obj.version === 1 && obj.canvas != null && typeof obj.canvas === 'object'
+}
+
+function isValidSession(data: unknown): data is ProjectSessionFile {
+  if (!data || typeof data !== 'object') return false
+  const obj = data as Record<string, unknown>
+  return obj.version === 1 && obj.nodes != null
+}
+
+export async function saveProjectState(
+  rootPath: string,
+  workspace: ProjectWorkspaceFile,
+  session: ProjectSessionFile,
+): Promise<void> {
+  const wsJson = JSON.stringify(workspace, null, 2)
+  const sessJson = JSON.stringify(session, null, 2)
+  await Promise.all([
+    atomicWrite(workspacePath(rootPath), wsJson),
+    atomicWrite(sessionPath(rootPath), sessJson),
+  ])
+  log.debug('Project state saved to %s', cateDir(rootPath))
+}
+
+export async function loadProjectState(rootPath: string): Promise<{
+  workspace: ProjectWorkspaceFile
+  session: ProjectSessionFile | null
+} | null> {
+  const ws = await tryReadWithFallback<ProjectWorkspaceFile>(workspacePath(rootPath))
+  if (!ws || !isValidWorkspace(ws)) return null
+  const sess = await tryReadWithFallback<ProjectSessionFile>(sessionPath(rootPath))
+  return {
+    workspace: ws,
+    session: sess && isValidSession(sess) ? sess : null,
+  }
+}
+
+// Last-saved JSON for sync fallback on quit
+let lastSavedProjectStates: Map<string, { workspace: string; session: string }> = new Map()
+
+export function saveProjectStateSync(): void {
+  for (const [rootPath, { workspace, session }] of lastSavedProjectStates) {
+    try {
+      atomicWriteSync(workspacePath(rootPath), workspace)
+      atomicWriteSync(sessionPath(rootPath), session)
+    } catch (err) {
+      log.warn('Sync project state save failed for %s: %O', rootPath, err)
+    }
+  }
+}
+
+// MIGRATION: Legacy Sessions/session.json → .cate/ per-project files.
+// Safe to delete runLegacyMigrationIfNeeded, snapshotToWorkspaceFile,
+// snapshotToSessionFile, and the collectPanelIds helpers once all users
+// have launched at least once on a version that includes this migration.
+
+export async function runLegacyMigrationIfNeeded(): Promise<void> {
+  const legacySessionDir = path.join(app.getPath('userData'), 'Sessions')
+  const legacySessionPath = path.join(legacySessionDir, 'session.json')
+
+  let legacyData: MultiWorkspaceSession | null = null
+  try {
+    const raw = await fs.readFile(legacySessionPath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (parsed?.version === 2 && Array.isArray(parsed.workspaces)) {
+      legacyData = parsed as MultiWorkspaceSession
+    }
+  } catch {
+    return
+  }
+
+  if (!legacyData) return
+
+  let migrated = 0
+  for (const snapshot of legacyData.workspaces) {
+    if (!snapshot.rootPath) continue
+    const existing = await tryReadJson(workspacePath(snapshot.rootPath))
+    if (existing) continue
+
+    const workspace = snapshotToWorkspaceFile(snapshot)
+    const session = snapshotToSessionFile(snapshot)
+    try {
+      await saveProjectState(snapshot.rootPath, workspace, session)
+      migrated++
+      log.info('[migration] Converted legacy session for %s', snapshot.rootPath)
+    } catch (err) {
+      log.warn('[migration] Failed for %s: %O', snapshot.rootPath, err)
+    }
+  }
+
+  // Rename legacy files so this path is never hit again
+  const suffixes = ['', '.tmp', '.bak']
+  for (const suffix of suffixes) {
+    const src = legacySessionPath + suffix
+    await fs.rename(src, src + '.migrated').catch(() => {})
+  }
+
+  log.info('[migration] Legacy session migration complete (%d workspaces converted)', migrated)
+}
+
+function snapshotToWorkspaceFile(snapshot: SessionSnapshot): ProjectWorkspaceFile {
+  const rootPath = snapshot.rootPath || ''
+  const regions = snapshot.regions
+    ? Object.values(snapshot.regions).map((r) => ({
+        id: r.id,
+        origin: r.origin,
+        size: r.size,
+        label: r.label,
+        color: r.color,
+        zOrder: r.zOrder,
+      }))
+    : []
+
+  const nodes = snapshot.nodes.map((n) => {
+    let regionId = n.regionId
+    // Auto-assign regionId for nodes from pre-region sessions
+    if (!regionId && regions.length > 0) {
+      for (const r of regions) {
+        const overlapX = Math.max(0, Math.min(n.origin.x + n.size.width, r.origin.x + r.size.width) - Math.max(n.origin.x, r.origin.x))
+        const overlapY = Math.max(0, Math.min(n.origin.y + n.size.height, r.origin.y + r.size.height) - Math.max(n.origin.y, r.origin.y))
+        if (n.size.width * n.size.height > 0 && (overlapX * overlapY) / (n.size.width * n.size.height) > 0.5) {
+          regionId = r.id
+          break
+        }
+      }
+    }
+    return {
+      panelId: n.panelId,
+      panelType: n.panelType,
+      title: n.title,
+      origin: n.origin,
+      size: n.size,
+      filePath: n.filePath ? toRelativePath(n.filePath, rootPath) : undefined,
+      url: n.url ?? undefined,
+      regionId,
+      documentType: n.documentType,
+    }
+  })
+
+  // Derive dockPanels from dockState for sessions saved before dockPanels existed
+  let dockPanels: ProjectWorkspaceFile['dockPanels']
+  if (snapshot.dockPanels) {
+    dockPanels = Object.fromEntries(
+      Object.entries(snapshot.dockPanels).map(([id, p]) => [
+        id,
+        {
+          type: p.type,
+          title: p.title,
+          filePath: p.filePath ? toRelativePath(p.filePath, rootPath) : undefined,
+          url: p.url ?? undefined,
+        },
+      ]),
+    )
+  } else if (snapshot.dockState) {
+    const panelIds = collectPanelIdsFromZones(snapshot.dockState.zones)
+    const canvasNodeIds = new Set(snapshot.nodes.map((n) => n.panelId))
+    dockPanels = {}
+    for (const id of panelIds) {
+      if (!canvasNodeIds.has(id)) {
+        dockPanels[id] = { type: 'canvas', title: 'Canvas' }
+      }
+    }
+  }
+
+  return {
+    version: 1,
+    name: snapshot.workspaceName,
+    color: '',
+    canvas: { nodes, regions, zoomLevel: snapshot.zoomLevel, viewportOffset: snapshot.viewportOffset },
+    dockState: snapshot.dockState,
+    dockPanels,
+  }
+}
+
+function collectPanelIdsFromZones(zones: WindowDockState): string[] {
+  const ids: string[] = []
+  for (const zone of Object.values(zones)) {
+    if (zone.layout) collectPanelIdsFromNode(zone.layout, ids)
+  }
+  return ids
+}
+
+function collectPanelIdsFromNode(node: DockLayoutNode, ids: string[]): void {
+  if (node.type === 'tabs') {
+    ids.push(...node.panelIds)
+  } else {
+    for (const child of node.children) {
+      collectPanelIdsFromNode(child, ids)
+    }
+  }
+}
+
+function snapshotToSessionFile(snapshot: SessionSnapshot): ProjectSessionFile {
+  const nodes: Record<string, { panelId: string; zOrder: number; creationIndex: number; ptyId?: string; workingDirectory?: string; unsavedContent?: string }> = {}
+  snapshot.nodes.forEach((n, i) => {
+    nodes[n.panelId] = {
+      panelId: n.panelId,
+      zOrder: i,
+      creationIndex: i,
+      ptyId: n.ptyId,
+      workingDirectory: n.workingDirectory ?? undefined,
+      unsavedContent: n.unsavedContent,
+    }
+  })
+  return {
+    version: 1,
+    focusedNodeId: null,
+    nodes,
+  }
+}
+
+const SKILL_FILE = 'skill.md'
+const seededSkillRoots = new Set<string>()
+
+async function seedSkillFile(rootPath: string): Promise<void> {
+  if (seededSkillRoots.has(rootPath)) return
+  seededSkillRoots.add(rootPath)
+  const skillPath = path.join(rootPath, CATE_DIR, SKILL_FILE)
+  try {
+    await fs.access(skillPath)
+  } catch {
+    try {
+      const { SKILL_TEMPLATE } = await import('./templates/skillTemplate')
+      await fs.writeFile(skillPath, SKILL_TEMPLATE, 'utf-8')
+      log.debug('Seeded skill.md in %s', cateDir(rootPath))
+    } catch (err) {
+      log.warn('Failed to seed skill.md: %O', err)
+    }
+  }
+}
+
+export function registerProjectStateHandlers(): void {
+  ipcMain.handle(
+    PROJECT_STATE_SAVE,
+    async (_event, rootPath: string, workspace: ProjectWorkspaceFile, session: ProjectSessionFile) => {
+      const wsJson = JSON.stringify(workspace, null, 2)
+      const sessJson = JSON.stringify(session, null, 2)
+      lastSavedProjectStates.set(rootPath, { workspace: wsJson, session: sessJson })
+      await Promise.all([
+        atomicWrite(workspacePath(rootPath), wsJson),
+        atomicWrite(sessionPath(rootPath), sessJson),
+      ])
+      seedSkillFile(rootPath).catch(() => {})
+      log.debug('Project state saved to %s', cateDir(rootPath))
+    },
+  )
+
+  ipcMain.handle(PROJECT_STATE_LOAD, async (_event, rootPath: string) => {
+    return loadProjectState(rootPath)
+  })
+}

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -13,8 +13,6 @@ import {
   SETTINGS_SET,
   SETTINGS_GET_ALL,
   SETTINGS_RESET,
-  SESSION_SAVE,
-  SESSION_LOAD,
   BOOT_SNAPSHOT_WRITE,
   RECENT_PROJECTS_GET,
   RECENT_PROJECTS_ADD,
@@ -24,10 +22,7 @@ import {
   LAYOUT_DELETE,
 } from '../shared/ipc-channels'
 import { DEFAULT_SETTINGS } from '../shared/types'
-import type { AppSettings, SessionSnapshot, MultiWorkspaceSession } from '../shared/types'
-import { addAllowedRoot } from './ipc/pathValidation'
-import { hydrateSessionTrust } from './sessionTrust'
-import { resolveTrustedWorkspaceRoot } from './workspaceRoots'
+import type { AppSettings } from '../shared/types'
 
 // ---------------------------------------------------------------------------
 // Settings schema: expected key → expected typeof value (or 'array')
@@ -187,114 +182,6 @@ export function writeBootSnapshot(partial: Partial<BootSnapshot>): void {
   bootSnapshotTimer = setTimeout(() => { void flushBootSnapshot() }, BOOT_SNAPSHOT_DEBOUNCE_MS)
 }
 
-function getSessionPath(): string {
-  return path.join(app.getPath('userData'), 'Sessions', 'session.json')
-}
-
-// ---------------------------------------------------------------------------
-// Write serialization — ensures only one session write runs at a time
-// ---------------------------------------------------------------------------
-let writeQueue: Promise<void> = Promise.resolve()
-function serialized(fn: () => Promise<void>): Promise<void> {
-  writeQueue = writeQueue.then(fn, fn)
-  return writeQueue
-}
-
-// ---------------------------------------------------------------------------
-// Last-saved session cache (for sync fallback on quit)
-// ---------------------------------------------------------------------------
-let lastSavedSessionJson: string | null = null
-
-export function getLastSavedSession(): string | null {
-  return lastSavedSessionJson
-}
-
-// ---------------------------------------------------------------------------
-// Atomic write: write to .tmp, rotate .bak, rename .tmp → target
-// ---------------------------------------------------------------------------
-async function atomicWriteSession(sessionPath: string, json: string): Promise<void> {
-  const dir = path.dirname(sessionPath)
-  const tmpPath = sessionPath + '.tmp'
-  const bakPath = sessionPath + '.bak'
-
-  await fs.mkdir(dir, { recursive: true })
-  await fs.writeFile(tmpPath, json, 'utf-8')
-  // Guard against silent write failures clobbering a good session.
-  const tmpStat = await fs.stat(tmpPath)
-  if (tmpStat.size === 0) {
-    await fs.unlink(tmpPath).catch(() => {})
-    throw new Error('tmp session file is empty after write')
-  }
-  await fs.rename(sessionPath, bakPath).catch(() => {}) // OK if no previous file
-  await fs.rename(tmpPath, sessionPath)
-}
-
-/** Synchronous variant — only used as last-resort in will-quit */
-export function saveSessionSync(json: string | null): void {
-  if (!json) return
-  const sessionPath = getSessionPath()
-  const dir = path.dirname(sessionPath)
-  const tmpPath = sessionPath + '.tmp'
-  const bakPath = sessionPath + '.bak'
-
-  try {
-    fsSync.mkdirSync(dir, { recursive: true })
-    fsSync.writeFileSync(tmpPath, json, 'utf-8')
-    // Verify the tmp file was actually written before clobbering the previous
-    // session — a zero-byte tmp from a silent write failure must not destroy
-    // the existing good session.
-    const tmpStat = fsSync.statSync(tmpPath)
-    if (tmpStat.size === 0) {
-      throw new Error('tmp session file is empty after write')
-    }
-    try { fsSync.renameSync(sessionPath, bakPath) } catch { /* OK */ }
-    fsSync.renameSync(tmpPath, sessionPath)
-  } catch (err) {
-    log.warn('Sync session save failed: %O', err)
-    try { fsSync.unlinkSync(tmpPath) } catch { /* noop */ }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Session validation
-// ---------------------------------------------------------------------------
-function isValidSession(data: unknown): boolean {
-  if (!data || typeof data !== 'object') return false
-  const obj = data as Record<string, unknown>
-  if (obj.version === 2 && Array.isArray(obj.workspaces)) return true
-  return false
-}
-
-// ---------------------------------------------------------------------------
-// Session pruning — removes stale dockPanels entries to bound session size
-// ---------------------------------------------------------------------------
-function pruneSession(session: MultiWorkspaceSession): MultiWorkspaceSession {
-  return {
-    ...session,
-    workspaces: session.workspaces.map((ws) => {
-      if (!ws.dockPanels || !ws.dockState?.locations) return ws
-      const knownKeys = new Set(Object.keys(ws.dockState.locations))
-      const prunedPanels: typeof ws.dockPanels = {}
-      for (const [k, v] of Object.entries(ws.dockPanels)) {
-        if (knownKeys.has(k)) prunedPanels[k] = v
-      }
-      return { ...ws, dockPanels: prunedPanels }
-    }),
-  }
-}
-
-/** Try to read and parse a session file, returning null on any failure */
-async function tryLoadSession(filePath: string): Promise<unknown | null> {
-  try {
-    const data = await fs.readFile(filePath, 'utf-8')
-    const parsed = JSON.parse(data)
-    if (isValidSession(parsed)) return parsed
-    log.warn('Session file failed validation: %s', filePath)
-    return null
-  } catch {
-    return null
-  }
-}
 
 export function registerHandlers(): void {
   // Settings
@@ -336,58 +223,12 @@ export function registerHandlers(): void {
     }
   })
 
-  // Session persistence (atomic writes with backup rotation)
-  ipcMain.handle(SESSION_SAVE, async (_event, snapshot: MultiWorkspaceSession) => {
-    // Prune stale dockPanels entries before serialising to bound session size
-    const pruned = isValidSession(snapshot) ? pruneSession(snapshot) : snapshot
-    const json = JSON.stringify(pruned, null, 2)
-    lastSavedSessionJson = json
-    await serialized(async () => {
-      const sessionPath = getSessionPath()
-      await atomicWriteSession(sessionPath, json)
-      log.debug('Session saved to %s', sessionPath)
-    })
-  })
-
   // Boot snapshot — renderer pushes geometry/theme/etc. updates here. The
   // write is debounced internally; this handler returns immediately.
   ipcMain.handle(BOOT_SNAPSHOT_WRITE, async (_event, partial: Partial<BootSnapshot>) => {
     if (partial && typeof partial === 'object') {
       writeBootSnapshot(partial)
     }
-  })
-
-  ipcMain.handle(SESSION_LOAD, async (): Promise<SessionSnapshot | null> => {
-    const sessionPath = getSessionPath()
-    const tmpPath = sessionPath + '.tmp'
-    const bakPath = sessionPath + '.bak'
-
-    // Fallback chain: session.json → .tmp (crash mid-rename) → .bak (last known good)
-    const candidates = [
-      { path: sessionPath, label: 'session.json' },
-      { path: tmpPath, label: 'session.json.tmp' },
-      { path: bakPath, label: 'session.json.bak' },
-    ]
-
-    for (const candidate of candidates) {
-      const result = await tryLoadSession(candidate.path)
-      if (result) {
-        const { sanitizedSession, acceptedRoots } = await hydrateSessionTrust(
-          result as SessionSnapshot | MultiWorkspaceSession,
-          resolveTrustedWorkspaceRoot,
-        )
-        for (const root of acceptedRoots) addAllowedRoot(root)
-        if (candidate.path !== sessionPath) {
-          log.warn('Recovered session from %s', candidate.label)
-        } else {
-          log.debug('Session loaded from %s', sessionPath)
-        }
-        return sanitizedSession as SessionSnapshot
-      }
-    }
-
-    log.debug('No valid session file found')
-    return null
   })
 
   // Recent Projects

--- a/src/main/templates/skillTemplate.ts
+++ b/src/main/templates/skillTemplate.ts
@@ -1,0 +1,149 @@
+export const SKILL_TEMPLATE = `# Cate Workspace Skill
+
+Read and write \`.cate/workspace.json\` to control the Cate canvas layout for this project. Changes are picked up on next app launch or workspace switch.
+
+## File location
+
+\`\`\`
+<project-root>/.cate/workspace.json   # layout (committable)
+<project-root>/.cate/session.json     # ephemeral runtime state (gitignored)
+\`\`\`
+
+Only edit \`workspace.json\`. Never touch \`session.json\`.
+
+## Schema
+
+\`\`\`jsonc
+{
+  "version": 1,
+  "name": "My Project",           // workspace display name
+  "color": "",                     // accent color (hex or empty)
+  "canvas": {
+    "zoomLevel": 1,                // 0.3 – 3.0
+    "viewportOffset": { "x": 0, "y": 0 },
+    "nodes": [
+      {
+        "panelId": "unique-id",    // stable UUID — generate one per panel
+        "panelType": "editor",     // see panel types below
+        "title": "main.ts",
+        "origin": { "x": 0, "y": 0 },
+        "size": { "width": 600, "height": 500 },
+        "filePath": "src/main.ts", // relative to project root (editors only)
+        "url": null,               // browsers only
+        "regionId": null,          // ID of containing region, if any
+        "documentType": null       // "pdf" | "docx" | "image" (document panels only)
+      }
+    ],
+    "regions": [
+      {
+        "id": "region-id",
+        "origin": { "x": -20, "y": -20 },
+        "size": { "width": 1300, "height": 500 },
+        "label": "Frontend",
+        "color": "#4A9EFF",
+        "zOrder": 0
+      }
+    ]
+  }
+}
+\`\`\`
+
+## Panel types and default sizes
+
+| type           | use for                        | default size  |
+|----------------|--------------------------------|---------------|
+| \`terminal\`     | shell / command runner         | 640 x 400     |
+| \`editor\`       | code file (set \`filePath\`)     | 600 x 500     |
+| \`browser\`      | embedded web view (set \`url\`)  | 800 x 600     |
+| \`agent\`        | AI agent chat                  | 760 x 480     |
+| \`document\`     | PDF / docx / image viewer      | 700 x 500     |
+| \`git\`          | git status / diff panel        | 500 x 600     |
+| \`fileExplorer\` | file tree sidebar              | 300 x 500     |
+
+## Rules
+
+- All \`filePath\` values are relative to the project root, forward-slash separated.
+- Every \`panelId\` must be a unique UUID.
+- Coordinates are in canvas-space pixels. Positive x = right, positive y = down.
+- Place nodes so they don't overlap. Leave ~20px gaps.
+- Regions are visual group containers. Set \`regionId\` on nodes to place them inside a region.
+- Omit fields you don't need (\`url\`, \`filePath\`, \`regionId\`, \`documentType\`).
+
+## Examples
+
+### Open two editors side by side
+
+\`\`\`json
+{
+  "version": 1,
+  "name": "My Project",
+  "color": "",
+  "canvas": {
+    "zoomLevel": 1,
+    "viewportOffset": { "x": 0, "y": 0 },
+    "nodes": [
+      {
+        "panelId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "panelType": "editor",
+        "title": "index.ts",
+        "origin": { "x": 0, "y": 0 },
+        "size": { "width": 600, "height": 500 },
+        "filePath": "src/index.ts"
+      },
+      {
+        "panelId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+        "panelType": "editor",
+        "title": "utils.ts",
+        "origin": { "x": 620, "y": 0 },
+        "size": { "width": 600, "height": 500 },
+        "filePath": "src/utils.ts"
+      }
+    ],
+    "regions": []
+  }
+}
+\`\`\`
+
+### Editor + terminal grouped in a region
+
+\`\`\`json
+{
+  "version": 1,
+  "name": "Debug Setup",
+  "color": "",
+  "canvas": {
+    "zoomLevel": 1,
+    "viewportOffset": { "x": 0, "y": 0 },
+    "nodes": [
+      {
+        "panelId": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+        "panelType": "editor",
+        "title": "server.ts",
+        "origin": { "x": 0, "y": 0 },
+        "size": { "width": 600, "height": 500 },
+        "filePath": "src/server.ts",
+        "regionId": "region-backend"
+      },
+      {
+        "panelId": "d4e5f6a7-b8c9-0123-defa-234567890123",
+        "panelType": "terminal",
+        "title": "Dev Server",
+        "origin": { "x": 620, "y": 0 },
+        "size": { "width": 640, "height": 500 },
+        "regionId": "region-backend"
+      }
+    ],
+    "regions": [
+      {
+        "id": "region-backend",
+        "origin": { "x": -20, "y": -40 },
+        "size": { "width": 1300, "height": 580 },
+        "label": "Backend",
+        "color": "#4DD964",
+        "zOrder": 0
+      }
+    ]
+  }
+}
+\`\`\`
+`

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,10 +60,10 @@ import {
   SETTINGS_SET,
   SETTINGS_GET_ALL,
   SETTINGS_RESET,
-  SESSION_SAVE,
-  SESSION_LOAD,
   SESSION_FLUSH_SAVE,
   SESSION_FLUSH_SAVE_DONE,
+  PROJECT_STATE_SAVE,
+  PROJECT_STATE_LOAD,
   BOOT_SNAPSHOT_WRITE,
   APP_OPEN_PATH,
   MENU_OPEN_SETTINGS,
@@ -576,13 +576,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Session
   // ---------------------------------------------------------------------------
 
-  sessionSave(snapshot: unknown): Promise<void> {
-    return ipcRenderer.invoke(SESSION_SAVE, snapshot)
-  },
-
-  sessionLoad(): Promise<unknown> {
-    return ipcRenderer.invoke(SESSION_LOAD)
-  },
 
   onSessionFlushSave(callback: () => void): () => void {
     const handler = () => callback()
@@ -593,6 +586,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sessionFlushSaveDone(): void {
     ipcRenderer.send(SESSION_FLUSH_SAVE_DONE)
   },
+
+  projectStateSave(rootPath: string, workspace: unknown, session: unknown): Promise<void> {
+    return ipcRenderer.invoke(PROJECT_STATE_SAVE, rootPath, workspace, session)
+  },
+
+  projectStateLoad(rootPath: string): Promise<unknown> {
+    return ipcRenderer.invoke(PROJECT_STATE_LOAD, rootPath)
+  },
+
 
   /** Push a partial boot snapshot to main (geometry, theme, etc.). Main
    *  debounces and writes `<userData>/boot.json` for the next cold launch. */

--- a/src/renderer/lib/session.ts
+++ b/src/renderer/lib/session.ts
@@ -20,7 +20,14 @@ import type {
   PanelWindowSnapshot,
   DetachedDockWindowSnapshot,
   PanelType,
+  ProjectWorkspaceFile,
+  ProjectSessionFile,
+  ProjectCanvasNode,
+  ProjectCanvasRegion,
+  ProjectPanelRef,
+  ProjectSessionNode,
 } from '../../shared/types'
+import { toRelativePath } from '../../shared/pathUtils'
 import { useDockStore } from '../stores/dockStore'
 import { terminalRegistry } from './terminalRegistry'
 import { mark } from './perfMarks'
@@ -59,38 +66,21 @@ export const deferredSnapshots = new Map<string, SessionSnapshot>()
 // actually changed. saveSession() itself mutates the store via
 // syncCanvasToWorkspace, which re-fires the auto-save subscriptions; without
 // this guard those phantom changes produce a save loop every ~1s.
-let lastSerializedSession: string | null = null
+const lastSerializedByRoot = new Map<string, string>()
 
 function restoreDockPanelsForWorkspace(workspaceId: string, snapshot: SessionSnapshot): number {
   const appStore = useAppStore.getState()
   let restoredCount = 0
 
-  if (snapshot.dockPanels) {
-    for (const panel of Object.values(snapshot.dockPanels)) {
-      const existing = appStore.getWorkspace(workspaceId)?.panels[panel.id]
-      if (!existing) {
-        appStore.addPanel(workspaceId, panel)
-        restoredCount += 1
-      }
-    }
-    return restoredCount
-  }
+  if (!snapshot.dockPanels) return 0
 
-  if (!snapshot.dockState) return 0
-
-  // Migration: sessions saved before dockPanels was introduced.
-  // Any panel IDs in the dock state that don't exist in the workspace are
-  // almost certainly canvas panels (the only dock-only panel type).
-  const dockPanelIds = collectPanelIdsFromDockState(snapshot.dockState.zones)
-  for (const panelId of dockPanelIds) {
-    const existing = appStore.getWorkspace(workspaceId)?.panels[panelId]
+  for (const panel of Object.values(snapshot.dockPanels)) {
+    const existing = appStore.getWorkspace(workspaceId)?.panels[panel.id]
     if (!existing) {
-      appStore.addPanel(workspaceId, { id: panelId, type: 'canvas', title: 'Canvas', isDirty: false })
+      appStore.addPanel(workspaceId, panel)
       restoredCount += 1
-      log.debug(`[session] migration: created missing dock panel ${panelId} as canvas`)
     }
   }
-
   return restoredCount
 }
 
@@ -114,6 +104,86 @@ function resolveSnapshotCanvasPanelId(snapshot: SessionSnapshot): string | null 
 
   const canvasPanel = Object.values(snapshot.dockPanels ?? {}).find((panel) => panel.type === 'canvas')
   return canvasPanel?.id ?? null
+}
+
+// -----------------------------------------------------------------------------
+// Project-local state builders (.cate/workspace.json + .cate/session.json)
+// -----------------------------------------------------------------------------
+
+function buildWorkspaceFile(
+  snapshot: SessionSnapshot,
+  rootPath: string,
+  color?: string,
+): ProjectWorkspaceFile {
+  const nodes: ProjectCanvasNode[] = snapshot.nodes.map((n) => ({
+    panelId: n.panelId,
+    panelType: n.panelType,
+    title: n.title,
+    origin: n.origin,
+    size: n.size,
+    filePath: n.filePath ? toRelativePath(n.filePath, rootPath) : undefined,
+    url: n.url ?? undefined,
+    regionId: n.regionId,
+    documentType: n.documentType,
+  }))
+
+  const regions: ProjectCanvasRegion[] = snapshot.regions
+    ? Object.values(snapshot.regions).map((r) => ({
+        id: r.id,
+        origin: r.origin,
+        size: r.size,
+        label: r.label,
+        color: r.color,
+        zOrder: r.zOrder,
+      }))
+    : []
+
+  let dockPanels: Record<string, ProjectPanelRef> | undefined
+  if (snapshot.dockPanels) {
+    dockPanels = {}
+    for (const [id, p] of Object.entries(snapshot.dockPanels)) {
+      dockPanels[id] = {
+        type: p.type,
+        title: p.title,
+        filePath: p.filePath ? toRelativePath(p.filePath, rootPath) : undefined,
+        url: p.url ?? undefined,
+      }
+    }
+  }
+
+  return {
+    version: 1,
+    name: snapshot.workspaceName,
+    color: color ?? '',
+    canvas: { nodes, regions, zoomLevel: snapshot.zoomLevel, viewportOffset: snapshot.viewportOffset },
+    dockState: snapshot.dockState,
+    dockPanels,
+  }
+}
+
+function buildSessionFile(
+  snapshot: SessionSnapshot,
+  panelWindows?: PanelWindowSnapshot[],
+  dockWindows?: DetachedDockWindowSnapshot[],
+): ProjectSessionFile {
+  const nodes: Record<string, ProjectSessionNode> = {}
+  snapshot.nodes.forEach((n, i) => {
+    nodes[n.panelId] = {
+      panelId: n.panelId,
+      zOrder: i,
+      creationIndex: i,
+      ptyId: n.ptyId,
+      workingDirectory: n.workingDirectory ?? undefined,
+      unsavedContent: n.unsavedContent,
+    }
+  })
+  return {
+    version: 1,
+    focusedNodeId: null,
+    nodes,
+    panelWindows: panelWindows?.length ? panelWindows : undefined,
+    dockWindows: dockWindows?.length ? dockWindows : undefined,
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -256,9 +326,7 @@ export async function saveSession(): Promise<void> {
     })
   }
 
-  const selectedIndex = persistableWorkspaces.findIndex((w) => w.id === appState.selectedWorkspaceId)
-
-  // Capture panel window snapshots from main process
+  // Capture detached window snapshots for inclusion in .cate/session.json
   let panelWindows: PanelWindowSnapshot[] | undefined
   try {
     const pwList = await window.electronAPI.panelWindowsList()
@@ -274,7 +342,6 @@ export async function saveSession(): Promise<void> {
     log.warn('[session] Panel window listing failed:', err)
   }
 
-  // Capture dock window snapshots from main process
   let dockWindows: DetachedDockWindowSnapshot[] | undefined
   try {
     const dwList = await window.electronAPI.dockWindowsList()
@@ -285,25 +352,30 @@ export async function saveSession(): Promise<void> {
     log.warn('[session] Dock window listing failed:', err)
   }
 
-  const session: MultiWorkspaceSession = {
-    version: 2,
-    selectedWorkspaceIndex: selectedIndex >= 0 ? selectedIndex : null,
-    workspaces: snapshots,
-    panelWindows,
-    dockWindows,
-  }
+  // Save to .cate/workspace.json + .cate/session.json per workspace
+  const workspacesByRoot = new Map(
+    persistableWorkspaces.filter((w) => w.rootPath).map((w) => [w.rootPath, w]),
+  )
+  for (const snapshot of snapshots) {
+    if (!snapshot.rootPath) continue
 
-  // Dedup: only hit IPC + disk when the serialized payload differs from the
-  // last successfully-saved one. Without this, syncCanvasToWorkspace above
-  // re-triggers the auto-save subscriptions and produces a save loop.
-  const serialized = JSON.stringify(session)
-  if (serialized === lastSerializedSession) return
+    const ws = workspacesByRoot.get(snapshot.rootPath)
+    const wsFile = buildWorkspaceFile(snapshot, snapshot.rootPath, ws?.color)
 
-  try {
-    await window.electronAPI.sessionSave(session as any) // session save accepts any JSON
-    lastSerializedSession = serialized
-  } catch (err) {
-    log.warn('[session] Save failed:', err)
+    // Filter detached windows belonging to this workspace
+    const wsPanelWindows = panelWindows?.filter((pw) => pw.workspaceId === ws?.id)
+    const wsDockWindows = dockWindows?.filter((dw) => (dw as any).workspaceId === ws?.id)
+    const sessFile = buildSessionFile(snapshot, wsPanelWindows, wsDockWindows)
+
+    // Dedup: skip IPC when the payload hasn't changed
+    const serialized = JSON.stringify({ ws: wsFile, sess: sessFile })
+    if (lastSerializedByRoot.get(snapshot.rootPath) === serialized) continue
+
+    window.electronAPI.projectStateSave(snapshot.rootPath, wsFile, sessFile)
+      .then(() => { lastSerializedByRoot.set(snapshot.rootPath!, serialized) })
+      .catch((err) => {
+        log.warn('[session] Project state save failed for %s: %s', snapshot.rootPath, err)
+      })
   }
 }
 
@@ -311,19 +383,107 @@ export async function saveSession(): Promise<void> {
 // Load
 // -----------------------------------------------------------------------------
 
-export async function loadSession(): Promise<MultiWorkspaceSession | SessionSnapshot | null> {
+export async function loadSession(): Promise<MultiWorkspaceSession | null> {
+  return loadFromProjectFiles()
+}
+
+async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
+  const { toAbsolutePath } = await import('../../shared/pathUtils')
+
+  let recentProjects: string[] = []
   try {
-    const data = await window.electronAPI.sessionLoad()
-    if (!data) return null
-    // Check if it's the new multi-workspace format
-    if ((data as any).version === 2 || Array.isArray((data as any).workspaces)) {
-      return data as unknown as MultiWorkspaceSession
-    }
-    // Legacy single-workspace format
-    return data as SessionSnapshot
-  } catch (err) {
-    log.warn('[session] Load failed:', err)
+    recentProjects = (await window.electronAPI.recentProjectsGet()) ?? []
+  } catch {
     return null
+  }
+  if (recentProjects.length === 0) return null
+
+  const snapshots: SessionSnapshot[] = []
+  let panelWindows: PanelWindowSnapshot[] = []
+  let dockWindows: DetachedDockWindowSnapshot[] = []
+
+  for (const rootPath of recentProjects) {
+    try {
+      const projectState = await window.electronAPI.projectStateLoad(rootPath) as {
+        workspace: import('../../shared/types').ProjectWorkspaceFile
+        session: import('../../shared/types').ProjectSessionFile | null
+      } | null
+      if (!projectState?.workspace) continue
+
+      const ws = projectState.workspace
+      const sess = projectState.session
+
+      const nodes: NodeSnapshot[] = ws.canvas.nodes.map((pn) => {
+        const ephemeral = sess?.nodes?.[pn.panelId]
+        return {
+          panelId: pn.panelId,
+          panelType: pn.panelType,
+          title: pn.title,
+          origin: pn.origin,
+          size: pn.size,
+          filePath: pn.filePath ? toAbsolutePath(pn.filePath, rootPath) : undefined,
+          url: pn.url,
+          regionId: pn.regionId,
+          documentType: pn.documentType,
+          ptyId: ephemeral?.ptyId,
+          workingDirectory: ephemeral?.workingDirectory,
+          unsavedContent: ephemeral?.unsavedContent,
+        }
+      })
+
+      const regions: Record<string, import('../../shared/types').CanvasRegion> = {}
+      for (const r of ws.canvas.regions) {
+        regions[r.id] = {
+          id: r.id,
+          origin: r.origin,
+          size: r.size,
+          label: r.label,
+          color: r.color,
+          zOrder: r.zOrder,
+        }
+      }
+
+      let snapshotDockPanels: Record<string, import('../../shared/types').PanelState> | undefined
+      if (ws.dockPanels) {
+        snapshotDockPanels = {}
+        for (const [id, ref] of Object.entries(ws.dockPanels)) {
+          snapshotDockPanels[id] = {
+            id,
+            type: ref.type as PanelType,
+            title: ref.title,
+            isDirty: false,
+            filePath: ref.filePath ? toAbsolutePath(ref.filePath, rootPath) : undefined,
+            url: ref.url,
+          }
+        }
+      }
+
+      snapshots.push({
+        workspaceName: ws.name,
+        rootPath,
+        zoomLevel: ws.canvas.zoomLevel,
+        viewportOffset: ws.canvas.viewportOffset,
+        nodes,
+        regions: Object.keys(regions).length > 0 ? regions : undefined,
+        dockState: ws.dockState,
+        dockPanels: snapshotDockPanels,
+      })
+
+      if (sess?.panelWindows) panelWindows.push(...sess.panelWindows)
+      if (sess?.dockWindows) dockWindows.push(...sess.dockWindows)
+    } catch (err) {
+      log.warn('[session] Failed to load project state for %s: %s', rootPath, err)
+    }
+  }
+
+  if (snapshots.length === 0) return null
+
+  return {
+    version: 2,
+    selectedWorkspaceIndex: 0,
+    workspaces: snapshots,
+    panelWindows: panelWindows.length > 0 ? panelWindows : undefined,
+    dockWindows: dockWindows.length > 0 ? dockWindows : undefined,
   }
 }
 
@@ -482,24 +642,6 @@ export async function restoreSession(snapshot: SessionSnapshot, canvasStoreApi?:
   if (canvasState) {
     canvasState.setZoom(snapshot.zoomLevel)
     canvasState.setViewportOffset(snapshot.viewportOffset)
-
-    // Auto-assign regionId for migrated workspaces (nodes without regionId)
-    const finalState = getCanvasState()!
-    const allRegions = Object.values(finalState.regions)
-    for (const node of Object.values(finalState.nodes)) {
-      if (!node.regionId && allRegions.length > 0) {
-        for (const region of allRegions) {
-          const overlapX = Math.max(0, Math.min(node.origin.x + node.size.width, region.origin.x + region.size.width) - Math.max(node.origin.x, region.origin.x))
-          const overlapY = Math.max(0, Math.min(node.origin.y + node.size.height, region.origin.y + region.size.height) - Math.max(node.origin.y, region.origin.y))
-          const overlapArea = overlapX * overlapY
-          const nodeArea = node.size.width * node.size.height
-          if (nodeArea > 0 && overlapArea / nodeArea > 0.5) {
-            canvasState.setNodeRegion(node.id, region.id)
-            break
-          }
-        }
-      }
-    }
   }
 
   // Restore dock state if present

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -289,17 +289,25 @@ export interface ElectronAPI {
   // Session
   // ---------------------------------------------------------------------------
 
-  /** Save a session snapshot. */
-  sessionSave(snapshot: SessionSnapshot): Promise<void>
-
-  /** Load the last saved session snapshot. Returns null if none exists. */
-  sessionLoad(): Promise<SessionSnapshot | null>
 
   /** Register a callback for flush-save requests from the main process. Returns unsubscribe. */
   onSessionFlushSave(callback: () => void): () => void
 
   /** Notify the main process that the flush save completed. */
   sessionFlushSaveDone(): void
+
+  /** Save project-local workspace + session state to .cate/ directory. */
+  projectStateSave(
+    rootPath: string,
+    workspace: import('./types').ProjectWorkspaceFile,
+    session: import('./types').ProjectSessionFile,
+  ): Promise<void>
+
+  /** Load project-local state from .cate/ directory. Returns null if not found. */
+  projectStateLoad(rootPath: string): Promise<{
+    workspace: import('./types').ProjectWorkspaceFile
+    session: import('./types').ProjectSessionFile | null
+  } | null>
 
   // ---------------------------------------------------------------------------
   // App

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -79,10 +79,12 @@ export const SETTINGS_GET_ALL = 'settings:getAll'
 export const SETTINGS_RESET = 'settings:reset'
 
 // Session
-export const SESSION_SAVE = 'session:save'
-export const SESSION_LOAD = 'session:load'
 export const SESSION_FLUSH_SAVE = 'session:flushSave' // main -> renderer
 export const SESSION_FLUSH_SAVE_DONE = 'session:flushSaveDone' // renderer -> main
+
+// Project-local workspace persistence (.cate/)
+export const PROJECT_STATE_SAVE = 'project:stateSave'     // renderer -> main
+export const PROJECT_STATE_LOAD = 'project:stateLoad'     // renderer -> main
 
 // Boot snapshot — a tiny JSON file (geometry, theme, last workspace id, native
 // tabs flag) written by the renderer whenever the relevant settings change.

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -1,0 +1,15 @@
+export function toRelativePath(absPath: string, rootPath: string): string {
+  const normAbs = absPath.replace(/\\/g, '/')
+  const normRoot = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
+  if (!normAbs.startsWith(normRoot + '/')) return absPath
+  return normAbs.slice(normRoot.length + 1)
+}
+
+export function toAbsolutePath(relPath: string, rootPath: string): string {
+  if (relPath.startsWith('/') || /^[A-Za-z]:/.test(relPath)) return relPath
+  const normRoot = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
+  const normRel = relPath.replace(/\\/g, '/')
+  const joined = normRoot + '/' + normRel
+  if (process.platform === 'win32') return joined.replace(/\//g, '\\')
+  return joined
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -623,6 +623,76 @@ export interface MultiWorkspaceSession {
 }
 
 // -----------------------------------------------------------------------------
+// Project-local workspace file (.cate/workspace.json) — VCS-friendly, shareable
+// -----------------------------------------------------------------------------
+
+export interface ProjectWorkspaceFile {
+  version: 1
+  name: string
+  color: string
+  canvas: {
+    nodes: ProjectCanvasNode[]
+    regions: ProjectCanvasRegion[]
+    zoomLevel: number
+    viewportOffset: Point
+  }
+  dockState?: DockStateSnapshot
+  dockPanels?: Record<string, ProjectPanelRef>
+}
+
+export interface ProjectCanvasNode {
+  panelId: string
+  panelType: string
+  title: string
+  origin: Point
+  size: Size
+  filePath?: string
+  url?: string
+  regionId?: string
+  documentType?: 'pdf' | 'docx' | 'image'
+  dockLayout?: DockLayoutNode | null
+}
+
+export interface ProjectCanvasRegion {
+  id: string
+  origin: Point
+  size: Size
+  label: string
+  color: string
+  zOrder: number
+}
+
+export interface ProjectPanelRef {
+  type: string
+  title: string
+  filePath?: string
+  url?: string
+}
+
+// -----------------------------------------------------------------------------
+// Project-local session file (.cate/session.json) — ephemeral, gitignored
+// -----------------------------------------------------------------------------
+
+export interface ProjectSessionFile {
+  version: 1
+  focusedNodeId: string | null
+  nodes: Record<string, ProjectSessionNode>
+  /** Detached panel windows (machine-local, not committed). */
+  panelWindows?: PanelWindowSnapshot[]
+  /** Detached dock windows (machine-local, not committed). */
+  dockWindows?: DetachedDockWindowSnapshot[]
+}
+
+export interface ProjectSessionNode {
+  panelId: string
+  zOrder: number
+  creationIndex: number
+  ptyId?: string
+  workingDirectory?: string
+  unsavedContent?: string
+}
+
+// -----------------------------------------------------------------------------
 // Layout snapshot (saved canvas arrangements)
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Moves canvas/workspace persistence from `~/.config/Cate/Sessions/session.json` to `.cate/workspace.json` + `.cate/session.json` inside the project directory
- `workspace.json` uses relative file paths and excludes ephemeral state — safe to commit and share
- `session.json` holds runtime state (terminal ptyIds, unsaved content, detached windows) — should be gitignored
- One-time migration converts the legacy session file on first launch, then renames it to `.migrated`
- Seeds `.cate/skill.md` on first save — a reference doc agents can use to read/write workspace layouts
- Removes the old `SESSION_SAVE`/`SESSION_LOAD` system from `store.ts`; only `SESSION_FLUSH_SAVE` (quit coordination) remains

## Test plan

- [ ] Open a project, arrange panels — verify `.cate/workspace.json` and `.cate/session.json` appear
- [ ] Inspect `workspace.json`: relative paths, no ptyIds/scrollback, diffable JSON
- [ ] Restart app — layout restores from `.cate/` files
- [ ] Delete `.cate/session.json`, restart — layout restores (panels reopen without ephemeral state)
- [ ] Test with legacy `Sessions/session.json` present — migration converts and renames to `.migrated`
- [ ] Verify `.cate/skill.md` is created on first save
- [ ] Test workspace switching between two projects

Closes #128