### PR TITLE
feat: add native Windows app panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test-results/
 
 # Claude Code local settings
 .claude/settings.local.json
+.tmp-pkgs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "electron-log": "^5.4.3",
         "electron-store": "^10.0.0",
         "electron-updater": "^6.8.3",
+        "koffi": "^3.0.2",
         "mammoth": "^1.12.0",
         "monaco-editor": "^0.52.0",
         "node-pty": "^1.0.0",
@@ -4318,6 +4319,230 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-OaL5EViEvsdbc8Ut90zY44AKF3mq6JBqkK/xLkGaSXcLsOJUsD+XaPAZb/WOWcKVg7On31wP+4hB7MwHQPdiUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-ZkBKudZkIOy5yVcp8cUTFCrE5DSgxkcH26mUxV6m8JgUtvtps4iMIGAAZLSq5aouvQQKhbKpXtZ3YdzpcytM+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.0.2.tgz",
+      "integrity": "sha512-eVHMjYL6yMc7GOdH0juDVEYFU4D9Az6cqyI7+ytWwovwAjHNtf96S17Ag/aI2qs7WVCoHceKDdMUATzs5grvMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.0.2.tgz",
+      "integrity": "sha512-qiSkR5fF/oa8MIukjsXMmFPC/FWGfUtw3ee+jgURg0R+Tuhlvqlfh50W4rQ0Y0faITJcF+3wmCI6WSt7p4iCkA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.0.2.tgz",
+      "integrity": "sha512-RDqoD8tBiRoe1C/lZEdMWETKk2dTR298XgJ9PBXbw2ETMVpIX+ci++X+j+4e7J3kVldxHLdFCykNei6d1wmhTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-zIm5NlzFuxt4f6mDjwTDgfzu8oZngcALTmOkWbp7HSeWdjQeiy8JRaSOEpfzlIlqWoPxhRUX5Yniqkt8564VnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.0.2.tgz",
+      "integrity": "sha512-Le3JxJswxBhO3OeeSWA400/v2sTPwTWz/IIc6ARc4SbTGUcz2jm6jXXQviW01r5OvCQ+w2Q2T4PxP+eaRa2+fQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.0.2.tgz",
+      "integrity": "sha512-TiPOFy4OX0tLhKwL6oSOhDIhwd5b48x7nxCBT8u6IW+nLXMIo2j+jla1h9niQ8HVGknGOzu48k55KVl0YMsaew==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.0.2.tgz",
+      "integrity": "sha512-U44szVAHW4WKTV0s6K6rjeZEURJ0CFHbZC0Ik3lpzvEidbOu8dTft7OGNr4hhBvx/XaeLMCCebPLBoYZZNW2Dg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-bm4qT+e59KWn4V/jK8uF1RV2k0/JJvmGPUj4qCJ3E9663H+6ZLqz1rpCdgXSEA95f5CNR3RWcgjQwxgKO9xFtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.0.2.tgz",
+      "integrity": "sha512-tUu2LMSyeCSe1DbJKZrjGOKRQzDhj/RAw4rVdlHXlU/B26sdyKZjEwE3GxVlYDdEBX4FiYYmoVuG3BwGWSefCw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.0.2.tgz",
+      "integrity": "sha512-o4QZwsKIQvlMSIJaCXsu8d2sz4bbKEJrZhmnCeT/SKEU1VEiegmDn/I6DYrg5mOMDC15GWlUP1qP6AsVlrxqXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.0.2.tgz",
+      "integrity": "sha512-Yz/iP2xLaq8t3TFy5+f2Oww7rBpXgZ4YRexdYffSm2EwcnDeCtPudQSjIiKyEBdvDsU2vQetTrxyqDHStXXocw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-zozoHzvSi61jch4sKqFi3ATsDC7lviFthoivzPKVk4VeJvFeSdqueKoYGHNXEzfhIXn9Y5K85l9a59nwfutkUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -10501,6 +10726,32 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.0.2.tgz",
+      "integrity": "sha512-YS4sGzlVMhFNNkKbkB3tcLKJxH9WGP3jHTxi4Eyx+ieMRKVz4K2i+6rebYr9ngHN36jhIW6YXnxkzBeOQ51lsw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.0.2",
+        "@koromix/koffi-darwin-x64": "3.0.2",
+        "@koromix/koffi-freebsd-arm64": "3.0.2",
+        "@koromix/koffi-freebsd-ia32": "3.0.2",
+        "@koromix/koffi-freebsd-x64": "3.0.2",
+        "@koromix/koffi-linux-arm64": "3.0.2",
+        "@koromix/koffi-linux-ia32": "3.0.2",
+        "@koromix/koffi-linux-loong64": "3.0.2",
+        "@koromix/koffi-linux-riscv64": "3.0.2",
+        "@koromix/koffi-linux-x64": "3.0.2",
+        "@koromix/koffi-openbsd-ia32": "3.0.2",
+        "@koromix/koffi-openbsd-x64": "3.0.2",
+        "@koromix/koffi-win32-ia32": "3.0.2",
+        "@koromix/koffi-win32-x64": "3.0.2"
       }
     },
     "node_modules/lazy-val": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "node": ">=20 <23"
   },
   "scripts": {
-    "postinstall": "bash scripts/patch-electron-name.sh",
-    "predev": "bash scripts/patch-electron-name.sh",
+    "postinstall": "node scripts/patch-electron-name.mjs",
+    "predev": "node scripts/patch-electron-name.mjs",
     "dev": "electron-vite dev",
     "dev:sentry": "SENTRY_DSN='https://any@analytics.cero-ai.com/1' electron-vite dev",
     "dev:dialog": "DEV_FORCE_DIALOG=1 electron-vite dev",
@@ -55,6 +55,7 @@
     "electron-log": "^5.4.3",
     "electron-store": "^10.0.0",
     "electron-updater": "^6.8.3",
+    "koffi": "^3.0.2",
     "mammoth": "^1.12.0",
     "monaco-editor": "^0.52.0",
     "node-pty": "^1.0.0",

--- a/scripts/patch-electron-name.mjs
+++ b/scripts/patch-electron-name.mjs
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import path from 'path'
+import { execFileSync } from 'child_process'
+
+const root = process.cwd()
+
+function chmodSpawnHelpers() {
+  const prebuilds = path.join(root, 'node_modules', 'node-pty', 'prebuilds')
+  if (process.platform === 'win32' || !fs.existsSync(prebuilds)) return
+
+  for (const platformDir of fs.readdirSync(prebuilds)) {
+    const helper = path.join(prebuilds, platformDir, 'spawn-helper')
+    if (!fs.existsSync(helper)) continue
+    try {
+      fs.chmodSync(helper, 0o755)
+    } catch {
+      // Best-effort only. Dev/build should not fail if chmod is unnecessary.
+    }
+  }
+}
+
+function patchMacElectronApp() {
+  if (process.platform !== 'darwin') return
+
+  const plist = path.join(root, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'Info.plist')
+  if (!fs.existsSync(plist)) return
+
+  const plistBuddy = '/usr/libexec/PlistBuddy'
+  for (const [key, value] of [['CFBundleDisplayName', 'Cate'], ['CFBundleName', 'Cate']]) {
+    try {
+      execFileSync(plistBuddy, ['-c', `Set ${key} ${value}`, plist], { stdio: 'ignore' })
+    } catch {
+      // Electron package layout can differ in dev; patch is cosmetic.
+    }
+  }
+
+  const icon = path.join(root, 'build', 'icon.icns')
+  const targetIcon = path.join(root, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'Resources', 'electron.icns')
+  if (fs.existsSync(icon)) {
+    try {
+      fs.copyFileSync(icon, targetIcon)
+    } catch {
+      // Cosmetic patch only.
+    }
+  }
+}
+
+chmodSpawnHelpers()
+patchMacElectronApp()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import log from './logger'
 import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session } from 'electron'
 import fs from 'fs'
 import path from 'path'
-import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, APP_OPEN_PATH } from '../shared/ipc-channels'
+import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_OPEN_FILE, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, APP_OPEN_PATH } from '../shared/ipc-channels'
 import {
   WINDOW_SET_TITLE,
   PANEL_TRANSFER, PANEL_RECEIVE, PANEL_TRANSFER_ACK,
@@ -13,6 +13,13 @@ import {
   CROSS_WINDOW_DRAG_START, CROSS_WINDOW_DRAG_UPDATE, CROSS_WINDOW_DRAG_DROP, CROSS_WINDOW_DRAG_CANCEL, CROSS_WINDOW_DRAG_RESOLVE,
   SESSION_FLUSH_SAVE,
   SESSION_FLUSH_SAVE_DONE,
+  NATIVE_APP_LIST_WINDOWS,
+  NATIVE_APP_LAUNCH,
+  NATIVE_APP_BIND,
+  NATIVE_APP_UNBIND,
+  NATIVE_APP_SET_BOUNDS,
+  NATIVE_APP_SET_VISIBLE,
+  NATIVE_APP_GET_BINDING,
 } from '../shared/ipc-channels'
 import { registerHandlers as registerTerminalHandlers, flushAllLoggers, killAllTerminals, terminalPids } from './ipc/terminal'
 import { registerHandlers as registerFilesystemHandlers, stopWatchersForWindow } from './ipc/filesystem'
@@ -40,7 +47,7 @@ import { initAutoUpdater, isInstallingUpdate } from './auto-updater'
 import { initSentry, captureMainException, flushSentry } from './sentry'
 import { initAnalytics, trackAppStart, checkAndReportUpdate } from './analytics'
 import { beginTerminalTransfer, acknowledgeTerminalTransfer, handleCrossWindowDropTerminalTransfer } from './ipc/terminal'
-import type { CateWindowParams, DockWindowInitPayload, PanelState, PanelTransferSnapshot, WindowDockState } from '../shared/types'
+import type { CateWindowParams, DockWindowInitPayload, NativeAppBindRequest, NativeAppBounds, PanelState, PanelTransferSnapshot, WindowDockState } from '../shared/types'
 import { disableRendererSandbox, disableTrustScoping } from './featureFlags'
 import { getSharedPanelDef } from '../shared/panels'
 import { installWebContentsSecurity } from './webSecurity'
@@ -59,6 +66,7 @@ import {
   type CrossWindowDragState,
   type GhostHostWindow,
 } from './dragLogic'
+import { nativeWindowHost } from './nativeWindowHost'
 
 /** True when any existing Cate BrowserWindow is in macOS native fullscreen.
  *  Used to reject window-creation IPCs so the app can never "escape" into a
@@ -231,6 +239,7 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
     stopWatchersForWindow(windowId)
     unregisterTerminalsForWindow(windowId)
     stopMonitorsForWindow(windowId)
+    nativeWindowHost.unbindForHostWindow(windowId)
     clearScopedWriteAllowancesForWindow(windowId)
     clearFileGrantsForWindow(windowId)
     // Rebuild menu to update panel/dock window list
@@ -479,6 +488,21 @@ function registerWindowAndDialogHandlers(): void {
     return result.filePaths[0]
   })
 
+  ipcMain.handle(DIALOG_OPEN_FILE, async (event, options?: { title?: string; filters?: Electron.FileFilter[] }) => {
+    const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
+    const result = await dialog.showOpenDialog(win!, {
+      title: options?.title,
+      filters: options?.filters,
+      properties: ['openFile'],
+    })
+    if (result.canceled || result.filePaths.length === 0) return null
+    const selectedPath = result.filePaths[0]
+    if (win) {
+      try { await grantFileAccess(win.id, selectedPath) } catch { /* picker path may not need renderer FS access */ }
+    }
+    return selectedPath
+  })
+
   // Native Save-As dialog for untitled editor buffers.
   ipcMain.handle(DIALOG_SAVE_FILE, async (event, payload: { defaultName?: string; defaultPath?: string }) => {
     const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
@@ -676,6 +700,37 @@ function registerWindowAndDialogHandlers(): void {
       log.error('[NATIVE_FILE_DRAG]', error)
       throw error instanceof Error ? error : new Error(String(error))
     }
+  })
+
+  ipcMain.handle(NATIVE_APP_LIST_WINDOWS, async () => {
+    return nativeWindowHost.listWindows()
+  })
+
+  ipcMain.handle(NATIVE_APP_LAUNCH, async (event, request: NativeAppBindRequest) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    return nativeWindowHost.launch(request, win?.id ?? -1)
+  })
+
+  ipcMain.handle(NATIVE_APP_BIND, async (event, request: NativeAppBindRequest) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    return nativeWindowHost.bind(request, win?.id ?? -1)
+  })
+
+  ipcMain.handle(NATIVE_APP_UNBIND, async (_event, panelId: string) => {
+    nativeWindowHost.unbind(panelId)
+  })
+
+  ipcMain.handle(NATIVE_APP_SET_BOUNDS, async (event, panelId: string, bounds: NativeAppBounds) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    nativeWindowHost.setBounds(panelId, bounds, win?.id ?? -1)
+  })
+
+  ipcMain.handle(NATIVE_APP_SET_VISIBLE, async (_event, panelId: string, visible: boolean) => {
+    nativeWindowHost.setVisible(panelId, visible)
+  })
+
+  ipcMain.handle(NATIVE_APP_GET_BINDING, async (_event, panelId: string) => {
+    return nativeWindowHost.getBinding(panelId)
   })
 
   // Renderer-driven title sync — used so each native macOS tab shows the

--- a/src/main/nativeWindowHost.ts
+++ b/src/main/nativeWindowHost.ts
@@ -1,0 +1,334 @@
+import { spawn } from 'child_process'
+import fs from 'fs'
+import type {
+  NativeAppBindRequest,
+  NativeAppBindingStatus,
+  NativeAppBounds,
+  NativeAppConfig,
+  NativeAppWindowInfo,
+} from '../shared/types'
+import { getNativeAppPreset } from '../shared/nativeAppPresets'
+import log from './logger'
+
+const SW_HIDE = 0
+const SW_SHOWNOACTIVATE = 4
+const HWND_TOPMOST = -1
+const HWND_NOTOPMOST = -2
+const SWP_NOSIZE = 0x0001
+const SWP_NOMOVE = 0x0002
+const SWP_NOZORDER = 0x0004
+const SWP_NOACTIVATE = 0x0010
+const SWP_SHOWWINDOW = 0x0040
+
+interface Win32Api {
+  koffi: any
+  EnumWindowsProc: any
+  EnumWindows: (callback: unknown, lParam: number) => boolean
+  GetWindowTextLengthW: (hwnd: number) => number
+  GetWindowTextW: (hwnd: number, buffer: Buffer, maxCount: number) => number
+  IsWindowVisible: (hwnd: number) => boolean
+  IsWindow: (hwnd: number) => boolean
+  GetWindowThreadProcessId: (hwnd: number, pid: Buffer) => number
+  SetWindowPos: (
+    hwnd: number,
+    insertAfter: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    flags: number,
+  ) => boolean
+  ShowWindow: (hwnd: number, command: number) => boolean
+}
+
+interface NativeBinding {
+  panelId: string
+  hwnd: number
+  title: string
+  hostWindowId: number
+  config: NativeAppConfig
+  visible: boolean
+  bounds?: NativeAppBounds
+}
+
+function expandEnv(candidate: string): string {
+  return candidate.replace(/%([^%]+)%/g, (_match, name: string) => process.env[name] ?? '')
+}
+
+function normalizeTitlePattern(config: NativeAppConfig): string | undefined {
+  return config.windowTitlePattern ?? getNativeAppPreset(config.presetId)?.titlePattern
+}
+
+function hwndToString(hwnd: number): string {
+  return String(hwnd)
+}
+
+function hwndFromString(hwnd: string | undefined): number | null {
+  if (!hwnd) return null
+  const parsed = Number(hwnd)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function matchesPattern(title: string, pattern: string | undefined): boolean {
+  if (!pattern) return false
+  return title.toLowerCase().includes(pattern.toLowerCase())
+}
+
+function resolveExePath(config: NativeAppConfig): string | null {
+  const direct = config.exePath ? expandEnv(config.exePath) : null
+  if (direct && fs.existsSync(direct)) return direct
+
+  const preset = getNativeAppPreset(config.presetId)
+  for (const candidate of preset?.exeCandidates ?? []) {
+    const expanded = expandEnv(candidate)
+    if (expanded && fs.existsSync(expanded)) return expanded
+  }
+
+  return direct
+}
+
+function makeUnavailableStatus(panelId: string, error: string): NativeAppBindingStatus {
+  return { panelId, visible: false, alive: false, error }
+}
+
+class NativeWindowHost {
+  private api: Win32Api | null | undefined
+  private lastInitFailureAt = 0
+  private bindings = new Map<string, NativeBinding>()
+
+  listWindows(): NativeAppWindowInfo[] {
+    const api = this.getApi()
+    if (!api) return []
+
+    const windows: NativeAppWindowInfo[] = []
+    const callback = api.koffi.register((hwnd: number) => {
+      if (!api.IsWindowVisible(hwnd)) return true
+      const title = this.getWindowTitle(api, hwnd)
+      if (!title) return true
+      const pid = this.getWindowProcessId(api, hwnd)
+      windows.push({
+        hwnd: hwndToString(hwnd),
+        title,
+        processId: pid,
+        isBound: this.isHwndBound(hwnd),
+      })
+      return true
+    }, api.koffi.pointer(api.EnumWindowsProc))
+
+    try {
+      api.EnumWindows(callback, 0)
+    } finally {
+      api.koffi.unregister(callback)
+    }
+
+    return windows.sort((a, b) => a.title.localeCompare(b.title))
+  }
+
+  async launch(request: NativeAppBindRequest, hostWindowId: number): Promise<NativeAppBindingStatus> {
+    if (process.platform !== 'win32') {
+      return makeUnavailableStatus(request.panelId, 'Native app panels are Windows-only in v1.')
+    }
+
+    const exePath = resolveExePath(request.config)
+    if (!exePath) {
+      return makeUnavailableStatus(request.panelId, 'Executable not found.')
+    }
+
+    try {
+      const child = spawn(exePath, request.config.launchArgs ?? [], {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: false,
+      })
+      child.unref()
+      const hwnd = await this.waitForWindow(child.pid, normalizeTitlePattern(request.config))
+      if (!hwnd) return makeUnavailableStatus(request.panelId, 'Launched app, but no top-level window appeared.')
+      return this.bind({ ...request, hwnd: hwndToString(hwnd) }, hostWindowId)
+    } catch (error) {
+      return makeUnavailableStatus(request.panelId, error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  async bind(request: NativeAppBindRequest, hostWindowId: number): Promise<NativeAppBindingStatus> {
+    const api = this.getApi()
+    if (!api) return makeUnavailableStatus(request.panelId, 'Native app panels are Windows-only in v1.')
+
+    let hwnd = hwndFromString(request.hwnd)
+    if (!hwnd) {
+      const pattern = normalizeTitlePattern(request.config)
+      const match = this.listWindows().find((win) => !win.isBound && matchesPattern(win.title, pattern))
+      hwnd = hwndFromString(match?.hwnd)
+    }
+    if (!hwnd || !api.IsWindow(hwnd)) return makeUnavailableStatus(request.panelId, 'Window not found.')
+    if (this.isHwndBound(hwnd, request.panelId)) {
+      return makeUnavailableStatus(request.panelId, 'Window is already bound to another panel.')
+    }
+
+    const title = this.getWindowTitle(api, hwnd) || request.config.windowTitlePattern || 'Native App'
+    const existing = this.bindings.get(request.panelId)
+    if (existing && existing.hwnd !== hwnd) this.show(api, existing.hwnd, true)
+
+    const binding: NativeBinding = {
+      panelId: request.panelId,
+      hwnd,
+      title,
+      hostWindowId,
+      config: request.config,
+      visible: true,
+      bounds: existing?.bounds,
+    }
+    this.bindings.set(request.panelId, binding)
+    if (binding.bounds) this.applyBounds(api, binding)
+    this.show(api, hwnd, true)
+    return this.statusFor(binding)
+  }
+
+  unbind(panelId: string): void {
+    const binding = this.bindings.get(panelId)
+    if (!binding) return
+    const api = this.getApi()
+    if (api && api.IsWindow(binding.hwnd)) this.releaseOverlay(api, binding.hwnd)
+    this.bindings.delete(panelId)
+  }
+
+  setBounds(panelId: string, bounds: NativeAppBounds, hostWindowId: number): void {
+    const api = this.getApi()
+    const binding = this.bindings.get(panelId)
+    if (!api || !binding) return
+    binding.hostWindowId = hostWindowId
+    binding.bounds = bounds
+    this.applyBounds(api, binding)
+  }
+
+  setVisible(panelId: string, visible: boolean): void {
+    const api = this.getApi()
+    const binding = this.bindings.get(panelId)
+    if (!api || !binding) return
+    binding.visible = visible
+    this.show(api, binding.hwnd, visible)
+    if (visible && binding.bounds) this.applyBounds(api, binding)
+  }
+
+  getBinding(panelId: string): NativeAppBindingStatus | null {
+    const binding = this.bindings.get(panelId)
+    if (!binding) return null
+    return this.statusFor(binding)
+  }
+
+  unbindForHostWindow(hostWindowId: number): void {
+    for (const binding of this.bindings.values()) {
+      if (binding.hostWindowId === hostWindowId) this.unbind(binding.panelId)
+    }
+  }
+
+  private getApi(): Win32Api | null {
+    if (process.platform !== 'win32') return null
+    if (this.api) return this.api
+    if (this.api === null && Date.now() - this.lastInitFailureAt < 2000) return null
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const koffi = require('koffi')
+      koffi.pointer('HANDLE', koffi.opaque())
+      const user32 = koffi.load('user32.dll')
+      const EnumWindowsProc = koffi.proto('bool __stdcall EnumWindowsProc(intptr_t hwnd, long lParam)')
+      this.api = {
+        koffi,
+        EnumWindowsProc,
+        EnumWindows: user32.func('bool __stdcall EnumWindows(void *callback, intptr_t lParam)'),
+        GetWindowTextLengthW: user32.func('int __stdcall GetWindowTextLengthW(intptr_t hwnd)'),
+        GetWindowTextW: user32.func('int __stdcall GetWindowTextW(intptr_t hwnd, void *buffer, int maxCount)'),
+        IsWindowVisible: user32.func('bool __stdcall IsWindowVisible(intptr_t hwnd)'),
+        IsWindow: user32.func('bool __stdcall IsWindow(intptr_t hwnd)'),
+        GetWindowThreadProcessId: user32.func('uint32 __stdcall GetWindowThreadProcessId(intptr_t hwnd, void *pid)'),
+        SetWindowPos: user32.func('bool __stdcall SetWindowPos(intptr_t hwnd, intptr_t insertAfter, int x, int y, int cx, int cy, uint flags)'),
+        ShowWindow: user32.func('bool __stdcall ShowWindow(intptr_t hwnd, int command)'),
+      }
+    } catch (error) {
+      log.error('[nativeApp] failed to initialize Win32 bridge:', error)
+      this.api = null
+      this.lastInitFailureAt = Date.now()
+    }
+
+    return this.api
+  }
+
+  private getWindowTitle(api: Win32Api, hwnd: number): string {
+    const length = api.GetWindowTextLengthW(hwnd)
+    if (length <= 0) return ''
+    const buffer = Buffer.alloc((length + 1) * 2)
+    api.GetWindowTextW(hwnd, buffer, length + 1)
+    return buffer.toString('ucs2').replace(/\0+$/, '').trim()
+  }
+
+  private getWindowProcessId(api: Win32Api, hwnd: number): number {
+    const buffer = Buffer.alloc(4)
+    api.GetWindowThreadProcessId(hwnd, buffer)
+    return buffer.readUInt32LE(0)
+  }
+
+  private isHwndBound(hwnd: number, exceptPanelId?: string): boolean {
+    for (const binding of this.bindings.values()) {
+      if (binding.hwnd === hwnd && binding.panelId !== exceptPanelId) return true
+    }
+    return false
+  }
+
+  private async waitForWindow(pid: number | undefined, pattern: string | undefined): Promise<number | null> {
+    const deadline = Date.now() + 15000
+    while (Date.now() < deadline) {
+      const windows = this.listWindows()
+      const match = windows.find((win) => (
+        (!win.isBound && pid != null && win.processId === pid) ||
+        (!win.isBound && matchesPattern(win.title, pattern))
+      ))
+      const hwnd = hwndFromString(match?.hwnd)
+      if (hwnd) return hwnd
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    return null
+  }
+
+  private applyBounds(api: Win32Api, binding: NativeBinding): void {
+    if (!api.IsWindow(binding.hwnd) || !binding.bounds) return
+    const bounds = binding.bounds
+    api.SetWindowPos(
+      binding.hwnd,
+      HWND_TOPMOST,
+      Math.round(bounds.x),
+      Math.round(bounds.y),
+      Math.max(1, Math.round(bounds.width)),
+      Math.max(1, Math.round(bounds.height)),
+      SWP_NOACTIVATE | SWP_SHOWWINDOW,
+    )
+  }
+
+  private show(api: Win32Api, hwnd: number, visible: boolean): void {
+    if (!api.IsWindow(hwnd)) return
+    if (visible) {
+      api.ShowWindow(hwnd, SW_SHOWNOACTIVATE)
+      api.SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW)
+    } else {
+      api.ShowWindow(hwnd, SW_HIDE)
+    }
+  }
+
+  private releaseOverlay(api: Win32Api, hwnd: number): void {
+    api.ShowWindow(hwnd, SW_SHOWNOACTIVATE)
+    api.SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW)
+  }
+
+  private statusFor(binding: NativeBinding): NativeAppBindingStatus {
+    const api = this.getApi()
+    const alive = !!api && api.IsWindow(binding.hwnd)
+    return {
+      panelId: binding.panelId,
+      hwnd: hwndToString(binding.hwnd),
+      title: binding.title,
+      visible: binding.visible,
+      alive,
+    }
+  }
+}
+
+export const nativeWindowHost = new NativeWindowHost()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,6 +70,7 @@ import {
   MENU_TRIGGER_ACTION,
   MENU_SHOW_CONTEXT,
   DIALOG_OPEN_FOLDER,
+  DIALOG_OPEN_FILE,
   DIALOG_SAVE_FILE,
   DIALOG_CONFIRM_UNSAVED,
   DIALOG_CONFIRM_CLOSE_CANVAS,
@@ -114,6 +115,13 @@ import {
   WORKSPACE_CHANGED,
   WEBVIEW_SCREENSHOT,
   NATIVE_FILE_DRAG,
+  NATIVE_APP_LIST_WINDOWS,
+  NATIVE_APP_LAUNCH,
+  NATIVE_APP_BIND,
+  NATIVE_APP_UNBIND,
+  NATIVE_APP_SET_BOUNDS,
+  NATIVE_APP_SET_VISIBLE,
+  NATIVE_APP_GET_BINDING,
   CAPTURE_PAGE,
   UPDATE_STATUS,
   UPDATE_INSTALL,
@@ -620,6 +628,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(DIALOG_OPEN_FOLDER)
   },
 
+  openFileDialog(options?: { title?: string; filters?: Array<{ name: string; extensions: string[] }> }): Promise<string | null> {
+    return ipcRenderer.invoke(DIALOG_OPEN_FILE, options ?? {})
+  },
+
   saveFileDialog(payload?: { defaultName?: string; defaultPath?: string }): Promise<string | null> {
     return ipcRenderer.invoke(DIALOG_SAVE_FILE, payload ?? {})
   },
@@ -678,6 +690,34 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   nativeFileDrag(filePath: string): Promise<void> {
     return ipcRenderer.invoke(NATIVE_FILE_DRAG, filePath)
+  },
+
+  nativeAppListWindows(): Promise<unknown> {
+    return ipcRenderer.invoke(NATIVE_APP_LIST_WINDOWS)
+  },
+
+  nativeAppLaunch(request: unknown): Promise<unknown> {
+    return ipcRenderer.invoke(NATIVE_APP_LAUNCH, request)
+  },
+
+  nativeAppBind(request: unknown): Promise<unknown> {
+    return ipcRenderer.invoke(NATIVE_APP_BIND, request)
+  },
+
+  nativeAppUnbind(panelId: string): Promise<void> {
+    return ipcRenderer.invoke(NATIVE_APP_UNBIND, panelId)
+  },
+
+  nativeAppSetBounds(panelId: string, bounds: unknown): Promise<void> {
+    return ipcRenderer.invoke(NATIVE_APP_SET_BOUNDS, panelId, bounds)
+  },
+
+  nativeAppSetVisible(panelId: string, visible: boolean): Promise<void> {
+    return ipcRenderer.invoke(NATIVE_APP_SET_VISIBLE, panelId, visible)
+  },
+
+  nativeAppGetBinding(panelId: string): Promise<unknown> {
+    return ipcRenderer.invoke(NATIVE_APP_GET_BINDING, panelId)
   },
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/lib/panelTransfer.ts
+++ b/src/renderer/lib/panelTransfer.ts
@@ -74,6 +74,10 @@ export function createTransferSnapshot(
     }
   }
 
+  if (panel.type === 'nativeApp' && panel.nativeApp) {
+    snapshot.nativeAppState = { ...panel.nativeApp }
+  }
+
   // Canvas-specific: capture child nodes + regions + viewport AND the PanelState
   // record for each child panel. Without the PanelStates the receiving window
   // can't resolve child panel types/titles and renders generic "Panel" stubs.

--- a/src/renderer/panels/NativeAppPanel.tsx
+++ b/src/renderer/panels/NativeAppPanel.tsx
@@ -1,0 +1,327 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { NATIVE_APP_PRESETS } from '../../shared/nativeAppPresets'
+import type { NativeAppBindingStatus, NativeAppConfig, NativeAppWindowInfo } from '../../shared/types'
+import { useAppStore } from '../stores/appStore'
+import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import type { PanelProps } from './types'
+
+function isConfigured(config: NativeAppConfig | undefined): boolean {
+  return !!(config?.presetId || config?.exePath || config?.windowTitlePattern)
+}
+
+function labelForConfig(config: NativeAppConfig | undefined): string {
+  if (!config) return 'Native App'
+  const preset = NATIVE_APP_PRESETS.find((candidate) => candidate.id === config.presetId)
+  return preset?.label ?? config.windowTitlePattern ?? config.exePath?.split(/[\\/]/).pop() ?? 'Native App'
+}
+
+function statusText(status: NativeAppBindingStatus | null, connecting: boolean): string {
+  if (connecting) return 'Connecting...'
+  if (!status) return 'Not connected'
+  if (status.error) return status.error
+  if (!status.alive) return 'App window closed'
+  return status.visible ? 'Synced' : 'Hidden while canvas moves'
+}
+
+export default function NativeAppPanel({ panelId, workspaceId }: PanelProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const syncFrame = useRef<number>(0)
+  const autoBound = useRef(false)
+  const canvasStoreApi = useCanvasStoreApi()
+
+  const panel = useAppStore((state) => state.workspaces.find((ws) => ws.id === workspaceId)?.panels[panelId])
+  const updatePanelTitle = useAppStore((state) => state.updatePanelTitle)
+  const updatePanelNativeApp = useAppStore((state) => state.updatePanelNativeApp)
+
+  const [status, setStatus] = useState<NativeAppBindingStatus | null>(null)
+  const [connecting, setConnecting] = useState(false)
+  const [windows, setWindows] = useState<NativeAppWindowInfo[]>([])
+  const [showAttachPicker, setShowAttachPicker] = useState(false)
+  const [customPath, setCustomPath] = useState('')
+
+  const config = panel?.nativeApp
+  const title = useMemo(() => labelForConfig(config), [config])
+  const isWindows = navigator.userAgent.includes('Windows')
+
+  const syncBounds = useCallback(() => {
+    if (syncFrame.current) cancelAnimationFrame(syncFrame.current)
+    syncFrame.current = requestAnimationFrame(() => {
+      syncFrame.current = 0
+      const el = contentRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      if (rect.width <= 1 || rect.height <= 1) return
+      // Native top-level windows include resize shadows/borders that can bleed
+      // outside the DOM rect. Slightly shrink height to avoid bottom overflow.
+      const bottomInset = 8
+      window.electronAPI.nativeAppSetBounds(panelId, {
+        x: window.screenX + rect.left,
+        y: window.screenY + rect.top,
+        width: rect.width,
+        height: Math.max(1, rect.height - bottomInset),
+      }).catch(() => undefined)
+    })
+  }, [panelId])
+
+  const bindConfig = useCallback(async (nextConfig: NativeAppConfig, hwnd?: string, attachFirst = false) => {
+    setConnecting(true)
+    setStatus(null)
+    try {
+      const request = { panelId, config: nextConfig, hwnd }
+      let nextStatus = attachFirst
+        ? await window.electronAPI.nativeAppBind(request)
+        : null
+      if (!nextStatus?.alive && nextConfig.bindingMode === 'launch') {
+        nextStatus = await window.electronAPI.nativeAppLaunch(request)
+      } else if (!nextStatus) {
+        nextStatus = await window.electronAPI.nativeAppBind(request)
+      }
+      const finalStatus = nextStatus
+      setStatus(finalStatus)
+      if (finalStatus.alive && finalStatus.title) {
+        updatePanelTitle(workspaceId, panelId, finalStatus.title)
+        syncBounds()
+      }
+    } finally {
+      setConnecting(false)
+    }
+  }, [panelId, syncBounds, updatePanelTitle, workspaceId])
+
+  const bindUserChoice = useCallback(async (nextConfig: NativeAppConfig, hwnd?: string) => {
+    setConnecting(true)
+    setStatus(null)
+    try {
+      const request = { panelId, config: nextConfig, hwnd }
+      const nextStatus = nextConfig.bindingMode === 'launch'
+        ? await window.electronAPI.nativeAppLaunch(request)
+        : await window.electronAPI.nativeAppBind(request)
+      setStatus(nextStatus)
+      if (nextStatus.alive && nextStatus.title) {
+        updatePanelTitle(workspaceId, panelId, nextStatus.title)
+        syncBounds()
+      }
+    } finally {
+      setConnecting(false)
+    }
+  }, [panelId, syncBounds, updatePanelTitle, workspaceId])
+
+  const persistAndBind = useCallback((nextConfig: NativeAppConfig, hwnd?: string, nextTitle?: string) => {
+    const title = nextTitle ?? labelForConfig(nextConfig)
+    updatePanelNativeApp(workspaceId, panelId, nextConfig, title)
+    if (panel) {
+      window.electronAPI.panelWindowSyncMeta?.({
+        panel: { ...panel, nativeApp: nextConfig, title },
+        workspaceId,
+      }).catch(() => undefined)
+    }
+    void bindUserChoice(nextConfig, hwnd)
+  }, [bindUserChoice, panel, panelId, updatePanelNativeApp, workspaceId])
+
+  const openAttachPicker = useCallback(async () => {
+    const result = await window.electronAPI.nativeAppListWindows()
+    setWindows(result)
+    setShowAttachPicker(true)
+  }, [])
+
+  const chooseExe = useCallback(async () => {
+    const filePath = await window.electronAPI.openFileDialog({
+      title: 'Choose Windows app',
+      filters: [{ name: 'Applications', extensions: ['exe'] }],
+    })
+    if (!filePath) return
+    setCustomPath(filePath)
+    const titleHint = filePath.split(/[\\/]/).pop()?.replace(/\.exe$/i, '') || 'Native App'
+    persistAndBind({
+      bindingMode: 'launch',
+      exePath: filePath,
+      windowTitlePattern: titleHint,
+    }, undefined, titleHint)
+  }, [persistAndBind])
+
+  const launchPreset = useCallback((presetId: string) => {
+    const preset = NATIVE_APP_PRESETS.find((candidate) => candidate.id === presetId)
+    if (!preset) return
+    persistAndBind({
+      bindingMode: 'launch',
+      presetId,
+      windowTitlePattern: preset.titlePattern,
+      launchArgs: preset.launchArgs,
+    }, undefined, preset.label)
+  }, [persistAndBind])
+
+  const attachWindow = useCallback((win: NativeAppWindowInfo) => {
+    const nextConfig: NativeAppConfig = {
+      bindingMode: 'attach',
+      windowTitlePattern: win.title,
+      exePath: win.exePath,
+    }
+    setShowAttachPicker(false)
+    persistAndBind(nextConfig, win.hwnd, win.title)
+  }, [persistAndBind])
+
+  useEffect(() => {
+    if (autoBound.current || !isConfigured(config)) return
+    autoBound.current = true
+    void bindConfig(config!, undefined, true)
+  }, [bindConfig, config])
+
+  useEffect(() => {
+    return () => {
+      if (syncFrame.current) cancelAnimationFrame(syncFrame.current)
+      window.electronAPI.nativeAppUnbind(panelId).catch(() => undefined)
+    }
+  }, [panelId])
+
+  useEffect(() => {
+    const el = contentRef.current
+    if (!el) return
+    const observer = new ResizeObserver(syncBounds)
+    observer.observe(el)
+    window.addEventListener('resize', syncBounds)
+    window.addEventListener('scroll', syncBounds, true)
+    syncBounds()
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', syncBounds)
+      window.removeEventListener('scroll', syncBounds, true)
+    }
+  }, [syncBounds])
+
+  useEffect(() => {
+    // CSS transform changes (canvas pan/zoom) do not trigger ResizeObserver,
+    // so explicitly resync the overlay whenever viewport transform changes.
+    const unsubscribe = canvasStoreApi.subscribe((state, prev) => {
+      if (
+        state.zoomLevel !== prev.zoomLevel ||
+        state.viewportOffset.x !== prev.viewportOffset.x ||
+        state.viewportOffset.y !== prev.viewportOffset.y
+      ) {
+        syncBounds()
+      }
+    })
+    return unsubscribe
+  }, [canvasStoreApi, syncBounds])
+
+  useEffect(() => {
+    const applyGestureVisibility = () => {
+      window.electronAPI.nativeAppSetVisible(panelId, true).catch(() => undefined)
+      syncBounds()
+    }
+    const observer = new MutationObserver(applyGestureVisibility)
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] })
+    applyGestureVisibility()
+    return () => observer.disconnect()
+  }, [panelId, syncBounds])
+
+  useEffect(() => {
+    const timer = setInterval(async () => {
+      const next = await window.electronAPI.nativeAppGetBinding(panelId).catch(() => null)
+      if (next) setStatus(next)
+    }, 2000)
+    return () => clearInterval(timer)
+  }, [panelId])
+
+  const connected = !!status?.alive && !status.error
+
+  return (
+    <div className="relative h-full w-full bg-[#0b0d12] text-foreground flex flex-col overflow-hidden" data-panel-content>
+      <div className="flex items-center gap-2 border-b border-border/60 bg-card/80 px-3 py-2 text-xs">
+        <div className={`h-2 w-2 rounded-full ${connected ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+        <div className="min-w-0 flex-1 truncate font-medium">{panel?.title ?? title}</div>
+        <button className="rounded border border-border px-2 py-1 hover:bg-accent" onClick={openAttachPicker}>
+          Attach
+        </button>
+        <button className="rounded border border-border px-2 py-1 hover:bg-accent" onClick={chooseExe}>
+          Browse .exe
+        </button>
+        {connected && (
+          <button
+            className="rounded border border-border px-2 py-1 hover:bg-accent"
+            onClick={() => {
+              window.electronAPI.nativeAppUnbind(panelId).catch(() => undefined)
+              setStatus(null)
+            }}
+          >
+            Unlink
+          </button>
+        )}
+      </div>
+
+      <div ref={contentRef} className="relative flex-1 overflow-hidden bg-black/70">
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-6 text-center">
+          <div>
+            <div className="text-lg font-semibold">{connected ? status?.title ?? title : 'Native Windows App'}</div>
+            <div className="mt-1 text-sm text-muted">{statusText(status, connecting)}</div>
+          </div>
+
+          {!isWindows && (
+            <div className="max-w-md rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+              Native app panels are Windows-only in v1.
+            </div>
+          )}
+
+          {!connected && (
+            <div className="flex max-w-2xl flex-wrap items-center justify-center gap-2">
+              {NATIVE_APP_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  className="rounded border border-border bg-card px-3 py-2 text-sm hover:bg-accent"
+                  onClick={() => launchPreset(preset.id)}
+                  disabled={connecting}
+                >
+                  Launch {preset.label}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {!connected && (
+            <div className="flex w-full max-w-xl gap-2">
+              <input
+                className="min-w-0 flex-1 rounded border border-border bg-background px-3 py-2 text-sm outline-none"
+                placeholder="C:\\Path\\To\\App.exe"
+                value={customPath}
+                onChange={(event) => setCustomPath(event.target.value)}
+              />
+              <button
+                className="rounded border border-border bg-card px-3 py-2 text-sm hover:bg-accent disabled:opacity-50"
+                disabled={!customPath.trim() || connecting}
+                onClick={() => {
+                  const titleHint = customPath.split(/[\\/]/).pop()?.replace(/\.exe$/i, '') || 'Native App'
+                  persistAndBind({ bindingMode: 'launch', exePath: customPath, windowTitlePattern: titleHint }, undefined, titleHint)
+                }}
+              >
+                Launch custom
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showAttachPicker && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="max-h-[70%] w-full max-w-2xl overflow-hidden rounded-lg border border-border bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div className="font-medium">Attach Running Window</div>
+              <button className="text-sm text-muted hover:text-foreground" onClick={() => setShowAttachPicker(false)}>Close</button>
+            </div>
+            <div className="max-h-96 overflow-auto p-2">
+              {windows.length === 0 && <div className="p-4 text-sm text-muted">No attachable windows found.</div>}
+              {windows.map((win) => (
+                <button
+                  key={win.hwnd}
+                  className="flex w-full items-center justify-between gap-3 rounded px-3 py-2 text-left text-sm hover:bg-accent disabled:opacity-40"
+                  disabled={win.isBound}
+                  onClick={() => attachWindow(win)}
+                >
+                  <span className="min-w-0 flex-1 truncate">{win.title}</span>
+                  <span className="shrink-0 text-xs text-muted">{win.isBound ? 'Bound' : `PID ${win.processId}`}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/panels/registry.ts
+++ b/src/renderer/panels/registry.ts
@@ -22,10 +22,11 @@ import {
   SquaresFour,
   List,
   FileDoc,
+  Monitor,
   type Icon as PhosphorIcon,
 } from '@phosphor-icons/react'
 import { CateLogo } from '../ui/CateLogo'
-import type { PanelType, Point } from '../../shared/types'
+import type { NativeAppConfig, PanelType, Point } from '../../shared/types'
 import type { PanelPlacement } from '../stores/appStore'
 import { useAppStore } from '../stores/appStore'
 import { PANEL_DEFINITIONS, type SharedPanelDefinition } from '../../shared/panels'
@@ -46,6 +47,7 @@ const ProjectListPanel = React.lazy(() => import('./ProjectListPanel'))
 const CanvasPanel = React.lazy(() => import('./CanvasPanel'))
 const AgentPanel = React.lazy(() => import('../../agent/renderer/AgentPanel'))
 const DocumentPanel = React.lazy(() => import('./DocumentPanel'))
+const NativeAppPanel = React.lazy(() => import('./NativeAppPanel'))
 
 // -----------------------------------------------------------------------------
 // Renderer definition
@@ -65,6 +67,8 @@ export interface PanelCreateArgs {
   initialInput?: string
   /** Document only. */
   documentType?: 'pdf' | 'docx' | 'image'
+  /** Native app only. */
+  nativeApp?: NativeAppConfig
 }
 
 export interface RendererPanelDefinition extends SharedPanelDefinition {
@@ -146,6 +150,13 @@ export const PANEL_REGISTRY: Record<PanelType, RendererPanelDefinition> = {
     Component: DocumentPanel,
     create: ({ workspaceId, canvasPoint, placement, filePath, documentType }) =>
       useAppStore.getState().createDocument(workspaceId, filePath, documentType, canvasPoint, placement) || null,
+  },
+  nativeApp: {
+    ...PANEL_DEFINITIONS.nativeApp,
+    icon: Monitor,
+    Component: NativeAppPanel,
+    create: ({ workspaceId, canvasPoint, placement, nativeApp }) =>
+      useAppStore.getState().createNativeApp(workspaceId, nativeApp, canvasPoint, placement) || null,
   },
 }
 

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -14,6 +14,7 @@ import type {
   WorkspaceMutationResult,
   PanelState,
   PanelType,
+  NativeAppConfig,
   Point,
   Size,
   DockZonePosition,
@@ -295,6 +296,7 @@ interface AppStoreActions {
   createCanvas: (workspaceId: string, position?: Point, placement?: PanelPlacement) => string
   createAgent: (workspaceId: string, position?: Point, placement?: PanelPlacement) => string
   createDocument: (workspaceId: string, filePath?: string, documentType?: 'pdf' | 'docx' | 'image', position?: Point, placement?: PanelPlacement) => string
+  createNativeApp: (workspaceId: string, config?: NativeAppConfig, position?: Point, placement?: PanelPlacement) => string
 
   // Ensure the center dock zone contains a canvas panel for the given workspace.
   // Covers session-restore and new-workspace paths where the center layout may
@@ -306,6 +308,7 @@ interface AppStoreActions {
   updatePanelTitle: (workspaceId: string, panelId: string, title: string) => void
   updatePanelUrl: (workspaceId: string, panelId: string, url: string) => void
   updatePanelFilePath: (workspaceId: string, panelId: string, filePath: string) => void
+  updatePanelNativeApp: (workspaceId: string, panelId: string, nativeApp: NativeAppConfig, title?: string) => void
   setPanelDirty: (workspaceId: string, panelId: string, dirty: boolean) => void
   setPanelUnsavedContent: (workspaceId: string, panelId: string, content: string | undefined) => void
   setPanelThemePreset: (workspaceId: string, panelId: string, themePreset: string | undefined) => void
@@ -1005,6 +1008,41 @@ export const useAppStore = create<AppStore>((set, get) => ({
     return panelId
   },
 
+  createNativeApp(workspaceId, config?, position?, placement?) {
+    const panelId = generateId()
+    const title = config?.windowTitlePattern || config?.presetId || 'Native App'
+    const panel: PanelState = {
+      id: panelId,
+      type: 'nativeApp',
+      title,
+      isDirty: false,
+      nativeApp: config ?? { bindingMode: 'attach' },
+    }
+    set((state) => ({
+      workspaces: state.workspaces.map((ws) =>
+        ws.id === workspaceId
+          ? { ...ws, panels: { ...ws.panels, [panelId]: panel } }
+          : ws,
+      ),
+    }))
+    try {
+      placePanel(panelId, 'nativeApp', placement, position, workspaceId === get().selectedWorkspaceId)
+    } catch (error) {
+      set((state) => ({
+        workspaces: state.workspaces.map((ws) =>
+          ws.id === workspaceId
+            ? { ...ws, panels: Object.fromEntries(
+                Object.entries(ws.panels).filter(([id]) => id !== panelId)
+              )}
+            : ws,
+        ),
+      }))
+      log.error('Failed to place native app panel:', error)
+      return null as unknown as string
+    }
+    return panelId
+  },
+
   // --- Panel management ---
 
   closePanel(workspaceId, panelId) {
@@ -1016,6 +1054,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
     if (panel?.type === 'canvas') {
       releaseCanvasStoreForPanel(panelId)
+    }
+    if (panel?.type === 'nativeApp') {
+      window.electronAPI.nativeAppUnbind(panelId).catch((error) => {
+        log.warn('[nativeApp] unbind failed during close:', error)
+      })
     }
 
     // Remove from dock/canvas first (less critical — log errors but continue)
@@ -1094,6 +1137,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
         return {
           ...ws,
           panels: { ...ws.panels, [panelId]: { ...panel, filePath } },
+        }
+      }),
+    }))
+  },
+
+  updatePanelNativeApp(workspaceId, panelId, nativeApp, title) {
+    set((state) => ({
+      workspaces: state.workspaces.map((ws) => {
+        if (ws.id !== workspaceId) return ws
+        const panel = ws.panels[panelId]
+        if (!panel) return ws
+        return {
+          ...ws,
+          panels: { ...ws.panels, [panelId]: { ...panel, nativeApp, title: title ?? panel.title } },
         }
       }),
     }))

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -17,12 +17,14 @@ import {
   ArrowsOutSimple,
   Square,
   FloppyDisk,
+  Monitor,
 } from '@phosphor-icons/react'
 import { CateLogo } from './CateLogo'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { openFileAsPanel } from '../lib/fileRouting'
+import { NATIVE_APP_PRESETS } from '../../shared/nativeAppPresets'
 
 // -----------------------------------------------------------------------------
 // Command definitions
@@ -50,6 +52,7 @@ const ZoomToFitIcon = () => <ArrowsOutSimple size={ICON_SIZE} />
 const RectangleIcon = () => <Square size={ICON_SIZE} />
 const SaveIcon = () => <FloppyDisk size={ICON_SIZE} />
 const AgentIcon = () => <CateLogo size={ICON_SIZE} />
+const NativeAppIcon = () => <Monitor size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
 // Component
@@ -65,6 +68,7 @@ export const CommandPalette: React.FC = () => {
   const createEditor = useAppStore((s) => s.createEditor)
   const createCanvas = useAppStore((s) => s.createCanvas)
   const createAgent = useAppStore((s) => s.createAgent)
+  const createNativeApp = useAppStore((s) => s.createNativeApp)
   const toggleSidebar = useUIStore((s) => s.toggleSidebar)
   const setActiveRightSidebarView = useUIStore((s) => s.setActiveRightSidebarView)
   const canvasApi = useCanvasStoreApi()
@@ -94,6 +98,7 @@ export const CommandPalette: React.FC = () => {
   }, [setShowCommandPalette])
 
   const dockCenter = { target: 'dock', zone: 'center' } as const
+  const canCreateNativeApps = navigator.userAgent.includes('Windows')
 
   // Build command items
   const allCommands: CommandItem[] = useMemo(
@@ -133,6 +138,27 @@ export const CommandPalette: React.FC = () => {
         icon: <LayoutIcon />,
         action: () => createCanvas(selectedWorkspaceId),
       },
+      ...(canCreateNativeApps ? [
+        {
+          id: 'newNativeApp',
+          title: 'Add Native App...',
+          shortcutText: '',
+          icon: <NativeAppIcon />,
+          action: () => createNativeApp(selectedWorkspaceId),
+        },
+        ...NATIVE_APP_PRESETS.map((preset) => ({
+          id: `newNativeApp-${preset.id}`,
+          title: `Add ${preset.label}`,
+          shortcutText: '',
+          icon: <NativeAppIcon />,
+          action: () => createNativeApp(selectedWorkspaceId, {
+            bindingMode: 'launch' as const,
+            presetId: preset.id,
+            windowTitlePattern: preset.titlePattern,
+            launchArgs: preset.launchArgs,
+          }),
+        })),
+      ] : []),
       {
         id: 'toggleSidebar',
         title: 'Toggle Sidebar',
@@ -197,6 +223,8 @@ export const CommandPalette: React.FC = () => {
       createEditor,
       createCanvas,
       createAgent,
+      createNativeApp,
+      canCreateNativeApps,
       toggleSidebar,
       setActiveRightSidebarView,
       setShowNodeSwitcher,

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -2,7 +2,7 @@
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
 
-import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
+import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NativeAppBindRequest, NativeAppBindingStatus, NativeAppBounds, NativeAppWindowInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
 
 export interface NativeContextMenuItem {
   id?: string
@@ -317,6 +317,9 @@ export interface ElectronAPI {
   /** Open a native folder picker. Returns the selected path or null if canceled. */
   openFolderDialog(): Promise<string | null>
 
+  /** Open a native file picker. Returns the selected path or null if canceled. */
+  openFileDialog(options?: { title?: string; filters?: Array<{ name: string; extensions: string[] }> }): Promise<string | null>
+
   /** Open a native Save-As dialog. Returns the chosen path or null if canceled.
    *  defaultName is used as the filename pre-fill, defaultPath as the starting
    *  directory + filename (takes precedence). The returned path is the canonical
@@ -374,6 +377,18 @@ export interface ElectronAPI {
 
   /** Initiate a native OS file drag from the renderer. */
   nativeFileDrag(filePath: string): Promise<void>
+
+  // ---------------------------------------------------------------------------
+  // Native Windows app panels
+  // ---------------------------------------------------------------------------
+
+  nativeAppListWindows(): Promise<NativeAppWindowInfo[]>
+  nativeAppLaunch(request: NativeAppBindRequest): Promise<NativeAppBindingStatus>
+  nativeAppBind(request: NativeAppBindRequest): Promise<NativeAppBindingStatus>
+  nativeAppUnbind(panelId: string): Promise<void>
+  nativeAppSetBounds(panelId: string, bounds: NativeAppBounds): Promise<void>
+  nativeAppSetVisible(panelId: string, visible: boolean): Promise<void>
+  nativeAppGetBinding(panelId: string): Promise<NativeAppBindingStatus | null>
 
   // ---------------------------------------------------------------------------
   // Shell utilities

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -131,6 +131,7 @@ export const MENU_SHOW_CONTEXT = 'menu:showContext'
 
 // Dialog
 export const DIALOG_OPEN_FOLDER = 'dialog:openFolder'
+export const DIALOG_OPEN_FILE = 'dialog:openFile'
 export const DIALOG_SAVE_FILE = 'dialog:saveFile'
 export const DIALOG_CONFIRM_UNSAVED = 'dialog:confirmUnsaved'
 export const DIALOG_CONFIRM_CLOSE_CANVAS = 'dialog:confirmCloseCanvas'
@@ -194,6 +195,15 @@ export const CROSS_WINDOW_DRAG_RESOLVE = 'crossDrag:resolve'   // renderer -> ma
 // Webview
 export const WEBVIEW_SCREENSHOT = 'webview:screenshot'
 export const NATIVE_FILE_DRAG = 'native:fileDrag'
+
+// Native Windows app panels
+export const NATIVE_APP_LIST_WINDOWS = 'nativeApp:listWindows'
+export const NATIVE_APP_LAUNCH = 'nativeApp:launch'
+export const NATIVE_APP_BIND = 'nativeApp:bind'
+export const NATIVE_APP_UNBIND = 'nativeApp:unbind'
+export const NATIVE_APP_SET_BOUNDS = 'nativeApp:setBounds'
+export const NATIVE_APP_SET_VISIBLE = 'nativeApp:setVisible'
+export const NATIVE_APP_GET_BINDING = 'nativeApp:getBinding'
 
 // Page capture
 export const CAPTURE_PAGE = 'capture-page'

--- a/src/shared/nativeAppPresets.ts
+++ b/src/shared/nativeAppPresets.ts
@@ -1,0 +1,62 @@
+export interface NativeAppPreset {
+  id: string
+  label: string
+  exeCandidates: string[]
+  titlePattern: string
+  launchArgs?: string[]
+}
+
+export const NATIVE_APP_PRESETS: NativeAppPreset[] = [
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    exeCandidates: [
+      '%LOCALAPPDATA%\\Programs\\cursor\\Cursor.exe',
+      '%LOCALAPPDATA%\\Programs\\Cursor\\Cursor.exe',
+    ],
+    titlePattern: 'Cursor',
+  },
+  {
+    id: 'warp',
+    label: 'Warp',
+    exeCandidates: [
+      '%LOCALAPPDATA%\\Programs\\Warp\\warp.exe',
+      '%LOCALAPPDATA%\\Microsoft\\WindowsApps\\warp.exe',
+    ],
+    titlePattern: 'Warp',
+  },
+  {
+    id: 'zen',
+    label: 'Zen Browser',
+    exeCandidates: [
+      '%LOCALAPPDATA%\\Programs\\Zen Browser\\zen.exe',
+      '%PROGRAMFILES%\\Zen Browser\\zen.exe',
+      '%PROGRAMFILES(X86)%\\Zen Browser\\zen.exe',
+    ],
+    titlePattern: 'Zen',
+  },
+  {
+    id: 'helium',
+    label: 'Helium',
+    exeCandidates: [
+      '%LOCALAPPDATA%\\Programs\\Helium\\Helium.exe',
+      '%PROGRAMFILES%\\Helium\\Helium.exe',
+    ],
+    titlePattern: 'Helium',
+  },
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    exeCandidates: [
+      '%LOCALAPPDATA%\\Programs\\OpenCode\\OpenCode.exe',
+      '%PROGRAMFILES%\\OpenCode\\OpenCode.exe',
+      '%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps\\opencode.exe',
+    ],
+    titlePattern: 'OpenCode',
+  },
+]
+
+export function getNativeAppPreset(id: string | undefined): NativeAppPreset | undefined {
+  if (!id) return undefined
+  return NATIVE_APP_PRESETS.find((preset) => preset.id === id)
+}

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -153,6 +153,18 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(175,82,222)', '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><circle cx="12" cy="15" r="3"/>'),
     canLiveOnCanvas: true,
   },
+  nativeApp: {
+    type: 'nativeApp',
+    label: 'Native App',
+    brandColor: '#64D2FF',
+    switcherColor: '#64D2FF',
+    mutedColor: '#4a8aa5',
+    tintClass: 'text-cyan-300',
+    defaultSize: { width: 900, height: 620 },
+    minimumSize: { width: 360, height: 260 },
+    ghostSvg: ghost('rgb(100,210,255)', '<rect x="3" y="4" width="18" height="14" rx="2"/><path d="M8 20h8"/><path d="M12 18v2"/><path d="M7 8h10"/>'),
+    canLiveOnCanvas: true,
+  },
   canvas: {
     type: 'canvas',
     label: 'Canvas',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -26,7 +26,47 @@ export interface Rect {
 // Panel types
 // -----------------------------------------------------------------------------
 
-export type PanelType = 'terminal' | 'browser' | 'editor' | 'git' | 'fileExplorer' | 'projectList' | 'canvas' | 'agent' | 'document'
+export type PanelType = 'terminal' | 'browser' | 'editor' | 'git' | 'fileExplorer' | 'projectList' | 'canvas' | 'agent' | 'document' | 'nativeApp'
+
+export type NativeAppBindingMode = 'launch' | 'attach'
+
+export interface NativeAppConfig {
+  presetId?: string
+  exePath?: string
+  launchArgs?: string[]
+  windowTitlePattern?: string
+  bindingMode: NativeAppBindingMode
+}
+
+export interface NativeAppWindowInfo {
+  hwnd: string
+  title: string
+  processId: number
+  exePath?: string
+  isBound: boolean
+}
+
+export interface NativeAppBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface NativeAppBindRequest {
+  panelId: string
+  config: NativeAppConfig
+  hwnd?: string
+}
+
+export interface NativeAppBindingStatus {
+  panelId: string
+  hwnd?: string
+  title?: string
+  visible: boolean
+  alive: boolean
+  error?: string
+}
 
 // -----------------------------------------------------------------------------
 // Canvas node
@@ -109,6 +149,9 @@ export interface PanelState {
   cwd?: string
   /** Document panels only: sub-type discriminator for the viewer. */
   documentType?: 'pdf' | 'docx' | 'image'
+  /** Native app panels only: persisted launch/attach configuration. HWNDs are
+   *  runtime-only because window handles are invalid after restart/transfer. */
+  nativeApp?: NativeAppConfig
   /** Id of the WorktreeMeta in the parent workspace that this panel is
    *  associated with. Drives the per-panel color accent and the title-bar
    *  "switch worktree" pill. Applies to terminal + agent panels. */
@@ -218,6 +261,9 @@ export interface PanelTransferSnapshot {
     canGoBack: boolean
     canGoForward: boolean
   }
+
+  // Native app-specific — persisted config only, never runtime HWND.
+  nativeAppState?: NativeAppConfig
 
   // Canvas-specific — child nodes/regions/viewport for nested canvas panels.
   // Without this, detaching a canvas panel to a new window would land with an
@@ -836,6 +882,7 @@ export const PANEL_CANVAS_DROP_SIZES: Record<PanelType, Size> = {
   canvas: { width: 640, height: 480 },
   agent: { width: 520, height: 440 },
   document: { width: 640, height: 480 },
+  nativeApp: { width: 720, height: 500 },
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Add a Windows-only native app panel that can launch or attach external apps and keep their windows synced over the canvas, so users can bring their existing tools into Cate.

## note
this is a very basic thing which i managed to make in like one pass 
this can be refined further.

#122 