### PR TITLE
fix(terminal): prevent dismissed URLs from being re-queued

### DIFF
--- a/src/renderer/lib/terminalUrlAutoOpen.ts
+++ b/src/renderer/lib/terminalUrlAutoOpen.ts
@@ -168,11 +168,14 @@ export function scanTerminalChunkForUrls(
   // eligible URL so the user can decide per-URL.
   const toOpen = mode === 'auto' ? eligible.slice(0, 1) : eligible
   // Mark every matched URL as seen — including ones we deliberately skip —
-  // so future chunks don't re-trigger them.
+  // so future chunks don't re-trigger them. Track which are newly seen so
+  // the request loop below skips URLs already handled in a previous scan.
+  const newlySeen = new Set<string>()
   for (const { url } of matches) {
     const canonical = canonicalize(url)
     if (OPENED.has(canonical)) continue
     OPENED.add(canonical)
+    newlySeen.add(canonical)
     if (OPENED.size > MAX_OPENED) {
       const first = OPENED.values().next().value as string | undefined
       if (first !== undefined) OPENED.delete(first)
@@ -180,6 +183,7 @@ export function scanTerminalChunkForUrls(
   }
   for (const { url } of toOpen) {
     const canonical = canonicalize(url)
+    if (!newlySeen.has(canonical)) continue
     if (mode === 'auto') {
       openInBrowser(workspaceId, canonical)
     } else {

--- a/src/renderer/lib/terminalUrlAutoOpen.ts
+++ b/src/renderer/lib/terminalUrlAutoOpen.ts
@@ -103,7 +103,12 @@ function findBrowserPanelId(workspaceId: string): string | null {
 }
 
 export function openTerminalUrl(workspaceId: string, url: string): void {
+  OPENED.add(url)
   openInBrowser(workspaceId, url)
+}
+
+export function markUrlHandled(url: string): void {
+  OPENED.add(url)
 }
 
 function openInBrowser(workspaceId: string, url: string): void {

--- a/src/renderer/stores/urlPromptStore.ts
+++ b/src/renderer/stores/urlPromptStore.ts
@@ -7,7 +7,7 @@
 // =============================================================================
 
 import { create } from 'zustand'
-import { openTerminalUrl } from '../lib/terminalUrlAutoOpen'
+import { openTerminalUrl, markUrlHandled } from '../lib/terminalUrlAutoOpen'
 
 export interface UrlPrompt {
   id: string
@@ -20,6 +20,8 @@ interface UrlPromptStoreState {
   /** Pending prompts queued per terminal panelId. The first entry is the one
    *  currently displayed; accept/dismiss advances to the next. */
   promptsByPanel: Record<string, UrlPrompt[]>
+  /** URLs that have been accepted or dismissed — never re-queue these. */
+  handled: Set<string>
 }
 
 interface UrlPromptStoreActions {
@@ -32,12 +34,15 @@ export type UrlPromptStore = UrlPromptStoreState & UrlPromptStoreActions
 
 let counter = 0
 const MAX_QUEUE_PER_PANEL = 8
+const MAX_HANDLED = 500
 
 export const useUrlPromptStore = create<UrlPromptStore>((set, get) => ({
   promptsByPanel: {},
+  handled: new Set<string>(),
 
   request(panelId, workspaceId, url) {
     set((state) => {
+      if (state.handled.has(url)) return state
       const queue = state.promptsByPanel[panelId] ?? []
       if (queue.some((p) => p.url === url)) return state
       const prompt: UrlPrompt = { id: `urlprompt-${++counter}`, panelId, workspaceId, url }
@@ -52,10 +57,16 @@ export const useUrlPromptStore = create<UrlPromptStore>((set, get) => ({
     const [head, ...rest] = queue
     openTerminalUrl(head.workspaceId, head.url)
     set((state) => {
+      const handled = new Set(state.handled)
+      handled.add(head.url)
+      if (handled.size > MAX_HANDLED) {
+        const first = handled.values().next().value as string | undefined
+        if (first !== undefined) handled.delete(first)
+      }
       const next = { ...state.promptsByPanel }
       if (rest.length === 0) delete next[panelId]
       else next[panelId] = rest
-      return { promptsByPanel: next }
+      return { promptsByPanel: next, handled }
     })
   },
 
@@ -63,11 +74,18 @@ export const useUrlPromptStore = create<UrlPromptStore>((set, get) => ({
     set((state) => {
       const queue = state.promptsByPanel[panelId]
       if (!queue || queue.length === 0) return state
-      const rest = queue.slice(1)
+      const [head, ...rest] = queue
+      markUrlHandled(head.url)
+      const handled = new Set(state.handled)
+      handled.add(head.url)
+      if (handled.size > MAX_HANDLED) {
+        const first = handled.values().next().value as string | undefined
+        if (first !== undefined) handled.delete(first)
+      }
       const next = { ...state.promptsByPanel }
       if (rest.length === 0) delete next[panelId]
       else next[panelId] = rest
-      return { promptsByPanel: next }
+      return { promptsByPanel: next, handled }
     })
   },
 }))


### PR DESCRIPTION
Closes #138

## Summary
- The `toOpen` loop in `scanTerminalChunkForUrls` never checked the `OPENED` set, so URLs still visible in the terminal buffer got re-queued after dismissal
- Track which URLs are newly seen in each scan and skip any already in `OPENED` from a previous pass

## Test plan
- [ ] Start a dev server that prints a localhost URL
- [ ] Dismiss the URL prompt
- [ ] Type in the terminal to trigger new PTY data — prompt should not reappear