### PR TITLE
docs: add multilingual README (French, Chinese, German)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,271 @@
+<p align="center">
+  <a href="https://www.producthunt.com/products/cate?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-cate" target="_blank" rel="noopener noreferrer"><img alt="CATE - Figma like open canvas for development | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1150094&theme=neutral&t=1779630669260"></a>
+</p>
+
+<p align="center">
+  <img src="assets/cate-logo.svg" alt="Cate" width="240" />
+</p>
+
+<h1 align="center">Cate</h1>
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.fr.md">Français</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.de.md">Deutsch</a>
+</p>
+
+> **Hinweis:** Diese Übersetzung wurde automatisch erstellt und kann Ungenauigkeiten enthalten.
+
+<p align="center">
+  Eine räumliche Desktop-IDE mit unendlicher Leinwand für Code, Terminals, Browser, Dokumente, KI-Agenten und Git.
+</p>
+
+<p align="center">
+  <strong>Aktuelle Quellversion:</strong> v1.0.3
+</p>
+
+<p align="center">
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT-Lizenz" /></a>
+  <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Downloads" /></a>
+</p>
+
+---
+
+<p align="center">
+  <img src="assets/demo.gif" alt="Cate Demo" width="900" />
+</p>
+
+Cate ist eine Electron-Desktop-Anwendung zum Anordnen von Entwicklungswerkzeugen im freien Raum. Kombinieren Sie schwebende Canvas-Panels mit angedockten Tabs und Splits, lösen Sie Panels in eigenständige Fenster heraus und halten Sie mehrere Arbeitsbereiche sitzungsübergreifend synchron.
+
+## Erste Schritte
+
+Öffnen Sie einen beliebigen Ordner, um einen Arbeitsbereich zu erstellen — Cate stellt Ihr Canvas-Layout, die Panel-Positionen und geöffnete Terminals bei jedem Neustart wieder her. Klicken Sie mit der rechten Maustaste auf die Leinwand, um Panels hinzuzufügen, drücken Sie `Cmd+K` für die Befehlspalette oder ziehen Sie Panels in das Dock, um Tabs und Splits zu erstellen.
+
+Keine Konfigurationsdateien, keine Projekteinrichtung — richten Sie Cate einfach auf ein Verzeichnis und beginnen Sie zu arbeiten.
+
+## Warum Cate?
+
+Alt-Tab funktioniert gut — bis Sie 12 Terminals, 6 offene Dateien, Dokumentation in einem anderen Fenster und Notizen über verschiedene Desktops verstreut haben. Ab diesem Punkt wird das Fensterwechseln zum eigentlichen Engpass.
+
+Cate ersetzt diesen Fensterstapel durch **eine persistente Leinwand pro Projekt**. Terminals, Editoren, Browser und Notizen bleiben dort, wo Sie sie platziert haben, gruppiert nach Ihrer Denkweise, und sie sind immer noch da, wenn Sie am nächsten Tag zurückkommen.
+
+> Cate ist **kein Ersatz für einen Fenstermanager**. Kachel-/Scroll-WMs (Hyprland, Niri, GlazeWM, KDE) sind großartig, wenn Sie hauptsächlich Betriebssystemfenster anordnen möchten. Cate ist eine räumliche Leinwand um die Werkzeuge eines einzelnen Projekts — näher an Figmas unendlicher Leinwand als an einem WM.
+
+## Funktionen
+
+### 🎨 Leinwand & Layout
+
+- **Unendliche Leinwand** — zoomen, schwenken und Panels überall im freien Raum anordnen. Schwenken mit Zwei-Finger-Drag oder Rechtsklick-Drag; Zoomen mit `Cmd+Scroll` oder den Leinwand-Steuerelementen.
+- **Dock-System** — ziehen Sie schwebende Panels in das Dock, um Tabs und Splits zu erstellen. Jede Dock-Zone (Mitte, Links, Rechts, Unten) kann mehrere Tabs mit typfarbigen Icons aufnehmen.
+- **Abgelöste Fenster** — lösen Sie Panels oder vollständige Dock-Layouts in separate Betriebssystemfenster heraus.
+- **Gespeicherte Layouts** — benennen, speichern, laden und löschen Sie Leinwand-Anordnungen (Knoten und Regionen) über ein In-App-Modal (`Cmd+K → "Gespeicherte Layouts…"`).
+- **Multi-Arbeitsbereich-Sitzungen** — halten Sie mehrere Projekte offen und stellen Sie sie beim Neustart wieder her. Wechseln Sie zwischen Arbeitsbereichen über die Seitenleiste.
+
+### 💻 Code, Dokumente & Terminals
+
+- **Monaco-Editor-Panels** — vollwertiges VS-Code-Editing mit Syntaxhervorhebung, Multi-Cursor, Suchen/Ersetzen, Diff-Unterstützung und Markdown-Vorschau/Quellmodus mit GFM-Rendering. Scratch-Editoren behalten ungespeicherte Inhalte sitzungsübergreifend bei.
+- **Persistente Editor-Puffer** — dateibasierte Modelle werden panelübergreifend wiederverwendet, und Scratch-Editor-Inhalte bleiben mit der Sitzung erhalten.
+- **Dokumenten-Panels** — native Canvas-Viewer für PDFs, DOCX-Dateien und Bilder mit Dateityperkennung basierend auf Magic-Byte-Prüfungen.
+- **Native Terminals** — xterm.js mit WebGL-Rendering, unterstützt durch `node-pty`-PTYs, verwurzelt im aktiven Arbeitsbereich. Automatische Shell-Erkennung mit elegantem Fallback, wenn die konfigurierte Shell nicht verfügbar ist.
+- **Browser-Panels** — eingebettete Webview-Panels zur Vorschau von Dokumentation, Entwicklungsservern oder beliebigen URLs. Kontextisoliert mit gehärteten Sicherheitseinstellungen.
+
+### 🔧 Git & Quellcodeverwaltung
+
+- **Git-fähiger Dateibrowser** — Dateibaum mit Live-Dateisystemüberwachung, Dimmen von verfolgten/nicht verfolgten Dateien, Suche und Kopieren/Einfügen für Dateien und Ordner mit kollisionssicherer Umbenennung.
+- **Quellcodeverwaltungs-Seitenleiste** — Stage/Unstage, Branch-Verwaltung, Worktrees, Commit-Verlauf und Inline-Diff-Ansichten. Der Git-Monitor fragt ab und zeigt Änderungen automatisch an.
+- **Projektweite Suche** — Volltextsuche über Arbeitsbereichsdateien mit sofortigen Ergebnissen.
+
+### 🤖 KI-Agent
+
+- **Pi-Agent-Panel** — führen Sie einen In-App-Coding-Agenten aus, der von `@earendil-works/pi-agent-core` angetrieben wird, mit Chat-Threads, modellbezogener Wiederherstellung pro Chat und arbeitsbereichsbewusster Panel-Platzierung.
+- **Anbieter-Authentifizierung & Modelle** — verbinden Sie OAuth-Anbieter wie Anthropic, OpenAI Codex und GitHub Copilot oder API-Key-Anbieter wie OpenAI, Google Gemini, OpenRouter, Groq, Mistral, DeepSeek und mehr.
+- **Marketplace & Planmodus** — installieren Sie Pi-Erweiterungen aus dem Marketplace und nutzen Sie Cates integrierten Planmodus-Helfer für agentengeführte Implementierungsplanung.
+
+### 🔍 Suche & Navigation
+
+- **Leinwandweite Suche** (`Cmd+Shift+F`) — Spotlight-artiges Overlay, das Arbeitsbereichsdateien, Live-Terminal-Scrollback und geöffnete Panel-Titel/Pfade an einem Ort durchsucht. Ergebnisse nach letztem Fokus sortiert mit typfarbigen Icons.
+- **Panel-Umschalter** (`Ctrl+Space`) — kompaktes Tastatur-Overlay zum Springen zwischen geöffneten Canvas-Panels und Zentrieren des ausgewählten Knotens.
+- **Befehlspalette** (`Cmd+K`) — schneller Zugriff auf Befehle, geöffnete Panels und Arbeitsbereichsdateien. Einheitliches Spotlight-artiges Design über alle Overlays.
+
+### 🖥️ Desktop-Feinschliff
+
+- **Automatisches Speichern & Sitzungswiederherstellung** — alle Panel-Zustände, Positionen und geöffnete Dateien werden automatisch gespeichert.
+- **Optionale native macOS-Fenster-Tabs** — gruppieren Sie Cate-Fenster in der System-Tab-Leiste.
+- **Automatische Update-Prüfungen** — prüft GitHub-Releases und benachrichtigt, wenn eine neue Version verfügbar ist.
+- **Absturz-Resilienz** — Sentry-Diagnosen, Sitzungswiederherstellungs-Validierung, Shell-Fallback-Banner im PTY und geschützte Update/Neustart-Abläufe helfen, laute oder sich wiederholende Absturzzustände zu vermeiden.
+
+## Installation
+
+Wenn Sie Cate einfach nur verwenden möchten, laden Sie ein vorgefertigtes Release herunter — kompilieren Sie nicht aus dem Quellcode. Dieses Repository zielt derzeit auf **v1.0.3** ab.
+
+| Plattform | Formate | Link |
+|-----------|---------|------|
+| macOS | DMG, ZIP (`arm64`, `x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
+| Windows | NSIS-Installer, ZIP (`x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
+| Linux | AppImage, DEB, `tar.gz` (`x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
+
+> **macOS-Hinweis:** Release-Builds sind notarisiert und für gehärtete Laufzeit konfiguriert. Unsignierte lokale oder Test-Builds erfordern möglicherweise:
+> ```bash
+> xattr -cr /Applications/Cate.app
+> ```
+
+> **Linux-Hinweis:** Auf dem Steam Deck oder anderen Distributionen mit schreibgeschütztem Root-Verzeichnis bevorzugen Sie den portablen `tar.gz`-Build. Wenn das AppImage nicht startet, versuchen Sie `--no-sandbox` als Fallback (z.B. `./Cate.AppImage --no-sandbox`).
+
+## Aus dem Quellcode kompilieren
+
+> Die folgenden Schritte sind für **Mitwirkende** — verwenden Sie das vorgefertigte Release oben für den täglichen Gebrauch.
+
+### Voraussetzungen
+
+- [Node.js](https://nodejs.org/) 20 oder 22 LTS (siehe `.nvmrc`). Node 23+ wird nicht unterstützt; `node-pty` hat keine Prebuilds und die native Kompilierung wird fehlschlagen.
+- npm >= 9
+- Python 3 und ein C++-Compiler (für das native `node-pty`-Modul)
+  - macOS: Xcode Command Line Tools (`xcode-select --install`)
+  - Debian/Ubuntu: `sudo apt install build-essential python3`
+  - Fedora/RHEL: `sudo dnf install @development-tools gcc-c++ make python3`
+  - Arch: `sudo pacman -S base-devel python`
+  - Windows: [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (wählen Sie die Workload „Desktopentwicklung mit C++")
+
+### Einrichtung
+
+```bash
+git clone https://github.com/0-AI-UG/cate.git
+cd cate
+npm install
+```
+
+### Entwicklung
+
+```bash
+npm run dev
+```
+
+Dies startet die Electron-App mit Hot Reload über electron-vite.
+
+### Qualitätsprüfungen
+
+```bash
+npm run typecheck
+npm test            # Unit-Tests (vitest)
+npm run test:e2e    # Playwright-Integrationstests
+```
+
+Für den Electron-Smoke-Test:
+
+```bash
+npm run test:smoke:electron
+```
+
+### Produktions-Build
+
+```bash
+npm run build
+```
+
+### Paketierung für die Verteilung
+
+```bash
+npm run package
+# oder eine Plattform gezielt ansteuern:
+npm run package:mac
+npm run package:win
+npm run package:linux
+```
+
+Die paketierten Binärdateien befinden sich im Verzeichnis `release/`.
+
+## Sicherheit & Paketierung
+
+Cate verwendet eine kontextisolierte Preload-Brücke für die gesamte IPC-Kommunikation. Der Dateisystemzugriff ist auf registrierte Arbeitsbereich-Stammverzeichnisse beschränkt, Browser-Panels verwenden gehärtete Webview-Einstellungen mit deaktivierter Node-Integration, und der Updater öffnet als Fallback die GitHub-Release-Seite, wenn kein verifizierter Installer-Pfad verfügbar ist. Die arbeitsbereichsbezogene `allowedRoots`-Validierung verhindert, dass Terminals außerhalb genehmigter Verzeichnisse gestartet werden.
+
+## Architektur
+
+```text
+src/
+├── agent/              # Eingebettete Pi-Coding-Agent-Integration
+│   ├── main/           # Agent-Prozessmanager, Auth, Marketplace, Sitzungsdateien
+│   ├── renderer/       # Agent-Panel-UI, Chat-Thread, Anbieter, Modellpräferenzen
+│   └── extensions/     # Cate-gebündelte Planmodus-Pi-Erweiterung
+├── main/               # Electron-Hauptprozess
+│   ├── ipc/            # IPC-Handler (Dateisystem, Git, Terminal, Menü, Drag)
+│   ├── analytics       # Update/App-Event-Analytics-Helfer
+│   ├── appContext      # Geteilter Hauptprozess-App-Zustand
+│   ├── featureFlags    # Laufzeit-Feature-Flags
+│   ├── shellEnv        # Login-Shell-Umgebungserfassung
+│   ├── shellResolver   # Shell-Pfadauflösung mit Fallback-Kette
+│   ├── workspaceManager# Arbeitsbereich-Lebenszyklus und Sitzungspersistenz
+│   ├── workspaceRoots  # Registrierung und Validierung erlaubter Stammverzeichnisse
+│   ├── windowRegistry  # Fensterverwaltung (Haupt-, Dock-, abgelöste Fenster)
+│   ├── webSecurity     # Webview-Härtung und CSP
+│   ├── auto-updater    # Update-Prüfungen und Release-Abruf
+│   ├── sentry          # Sentry-Integration
+│   ├── store           # electron-store-Persistenz
+│   ├── jsonFileStore   # JSON-Datei-Persistenz-Helfer
+│   ├── menu            # Anwendungsmenü
+│   └── sessionTrust    # Sitzungswiederherstellungs-Validierung
+├── preload/            # Kontextisolierte Brücke zum Renderer
+├── renderer/           # React 18 Anwendung
+│   ├── assets/         # Renderer-Bilder und Asset-Deklarationen
+│   ├── canvas/         # Unendliche Leinwand — Rendering, Drag, Resize, Platzierung
+│   ├── docking/        # Tabs, Splits, abgelöste Dock-Fenster, Drag & Drop
+│   ├── drag/           # Fensterübergreifende Drag-and-Drop-Laufzeit und -Zustand
+│   ├── panels/         # Terminal, Editor, Browser, Dokument, Git, Explorer,
+│   │                   # Projekte, Canvas-Panel-Registry/Komponenten
+│   ├── sidebar/        # Arbeitsbereich, Dateibrowser, Quellcodeverwaltung,
+│   │                   # Parallele Arbeit, Projektliste, Datei-Zwischenablage
+│   ├── dialogs/        # Gespeicherte Layouts und Post-Update-Feedback-Dialoge
+│   ├── settings/       # Einstellungsfenster-Bereiche und Shortcut-Recorder
+│   ├── ui/             # Befehlspalette, Globale Suche, Knotenumschalter,
+│   │                   # Willkommensseite, Shortcut-Hinweis-Overlay
+│   ├── shells/         # Haupt-, Panel- und Dock-Fenster-Shells
+│   ├── stores/         # Zustand-Stores (Canvas, App, Dock, Einstellungen,
+│   │                   # Shortcut, Status, UI, Update, URL-Prompt)
+│   ├── hooks/          # Benutzerdefinierte React-Hooks (Shortcuts, Canvas-Interaktion)
+│   ├── lib/            # Hilfsprogramme (Koordinaten, Routing, Terminal-Registry)
+│   ├── workers/        # Monaco/Editor-Worker
+│   └── styles/         # Tailwind/globale Styles
+└── shared/             # IPC-Kanaldefinitionen und geteilte TypeScript-Typen
+```
+
+### Technologie-Stack
+
+- **Electron 41** — Desktop-Shell (Chromium + Node.js)
+- **React 18** — UI-Framework mit funktionalen Komponenten und Hooks
+- **Zustand 5** — leichtgewichtige Zustandsverwaltung (kein Redux/Context)
+- **Monaco Editor 0.52** — Code-Bearbeitung (VS Codes Editor-Komponente)
+- **xterm.js 5.5 + node-pty 1.0** — Terminal-Emulator mit WebGL-Renderer
+- **@earendil-works/pi-Pakete** — eingebettete Coding-Agent-Laufzeit, Anbieter-Auth und Erweiterungs-Marketplace
+- **pdf.js + mammoth** — natives PDF- und DOCX-Dokument-Rendering
+- **react-markdown + remark-gfm** — Markdown-Vorschau mit GitHub Flavored Markdown
+- **simple-git 3.27** — Git-Operationen
+- **chokidar 4.0** — Dateisystemüberwachung
+- **@phosphor-icons/react** — App-Ikonografie
+- **Tailwind CSS 3.4** — Styling
+- **electron-vite 5.0** — Bundling mit HMR
+- **electron-builder 26** — Paketierung und Verteilung
+- **electron-updater 6.8** — Update-Prüfungen
+- **Sentry Electron 5** — Absturzmeldungen und Diagnosen
+- **Playwright** — End-to-End-Integrationstests
+- **Vitest** — Unit-Test-Runner
+
+## Roadmap
+
+Cate wird aktiv weiterentwickelt. Einen detaillierten Verlauf der Änderungen in jeder Version und einen Ausblick finden Sie im [CHANGELOG](CHANGELOG.md).
+
+## Star-Verlauf
+
+<a href="https://www.star-history.com/#0-AI-UG/cate&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star-Verlaufsdiagramm" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+  </picture>
+</a>
+
+## Mitwirken
+
+Siehe [CONTRIBUTING.md](CONTRIBUTING.md) für Richtlinien.
+
+## Lizenz
+
+[MIT](LICENSE)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,271 @@
+<p align="center">
+  <a href="https://www.producthunt.com/products/cate?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-cate" target="_blank" rel="noopener noreferrer"><img alt="CATE - Figma like open canvas for development | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1150094&theme=neutral&t=1779630669260"></a>
+</p>
+
+<p align="center">
+  <img src="assets/cate-logo.svg" alt="Cate" width="240" />
+</p>
+
+<h1 align="center">Cate</h1>
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.fr.md">Français</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.de.md">Deutsch</a>
+</p>
+
+> **Note :** Cette traduction a été générée automatiquement et peut contenir des inexactitudes.
+
+<p align="center">
+  Un IDE de bureau spatial avec un canevas infini pour le code, les terminaux, les navigateurs, les documents, les agents IA et git.
+</p>
+
+<p align="center">
+  <strong>Version source actuelle :</strong> v1.0.3
+</p>
+
+<p align="center">
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="Licence MIT" /></a>
+  <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Téléchargements" /></a>
+</p>
+
+---
+
+<p align="center">
+  <img src="assets/demo.gif" alt="Démo Cate" width="900" />
+</p>
+
+Cate est une application de bureau Electron pour organiser les outils de développement dans un espace libre. Mélangez des panneaux flottants sur le canevas avec des onglets et des divisions ancrés, détachez des panneaux dans des fenêtres autonomes et gardez plusieurs espaces de travail synchronisés entre les sessions.
+
+## Premiers pas
+
+Ouvrez n'importe quel dossier pour créer un espace de travail — Cate restaure la disposition de votre canevas, les positions des panneaux et les terminaux ouverts à chaque fois que vous revenez. Faites un clic droit sur le canevas pour ajouter des panneaux, appuyez sur `Cmd+K` pour la palette de commandes, ou faites glisser les panneaux vers le dock pour créer des onglets et des divisions.
+
+Pas de fichiers de configuration, pas de configuration de projet — pointez simplement Cate vers un répertoire et commencez à travailler.
+
+## Pourquoi Cate ?
+
+Alt-tab fonctionne bien — jusqu'à ce que vous ayez 12 terminaux, 6 fichiers ouverts, de la documentation dans une autre fenêtre et des notes éparpillées sur les bureaux. À ce stade, changer de fenêtre devient le véritable goulot d'étranglement.
+
+Cate remplace cette pile de fenêtres par **un canevas persistant par projet**. Les terminaux, éditeurs, navigateurs et notes restent là où vous les avez placés, groupés comme vous les concevez, et ils sont toujours là quand vous revenez le lendemain.
+
+> Cate **n'est pas un remplacement de gestionnaire de fenêtres**. Les WM à tuiles/défilement (Hyprland, Niri, GlazeWM, KDE) sont excellents si vous souhaitez principalement organiser les fenêtres de l'OS. Cate est un canevas spatial autour des outils d'un seul projet — plus proche du canevas infini de Figma qu'un WM.
+
+## Fonctionnalités
+
+### 🎨 Canevas et disposition
+
+- **Canevas infini** — zoomez, faites défiler et organisez les panneaux n'importe où dans l'espace libre. Défilement avec deux doigts ou clic droit ; zoom avec `Cmd+scroll` ou les contrôles du canevas.
+- **Système de dock** — glissez les panneaux flottants vers le dock pour créer des onglets et des divisions. Chaque zone de dock (centre, gauche, droite, bas) peut contenir plusieurs onglets avec des icônes colorées par type.
+- **Fenêtres détachées** — extrayez des panneaux ou des dispositions de dock complètes dans des fenêtres OS séparées.
+- **Dispositions sauvegardées** — nommez, sauvegardez, chargez et supprimez des arrangements de canevas (nœuds et régions) depuis une modale intégrée (`Cmd+K → "Dispositions sauvegardées…"`).
+- **Sessions multi-espaces de travail** — gardez plusieurs projets ouverts et restaurez-les au redémarrage. Basculez entre les espaces de travail depuis la barre latérale.
+
+### 💻 Code, Documents et Terminaux
+
+- **Panneaux Monaco Editor** — édition complète de qualité VS Code avec coloration syntaxique, multi-curseur, rechercher/remplacer, support diff et mode Aperçu/Source Markdown avec rendu GFM. Les éditeurs brouillon conservent le contenu non sauvegardé entre les sessions.
+- **Tampons d'éditeur persistants** — les modèles basés sur fichiers sont réutilisés entre les panneaux, et le contenu des éditeurs brouillon persiste avec la session.
+- **Panneaux de documents** — visualiseurs natifs sur le canevas pour les PDF, fichiers DOCX et images, avec détection de type de fichier basée sur les octets magiques.
+- **Terminaux natifs** — xterm.js avec rendu WebGL, supporté par des PTY `node-pty` enracinés dans l'espace de travail actif. Détection automatique du shell avec repli gracieux si le shell configuré n'est pas disponible.
+- **Panneaux navigateur** — panneaux webview intégrés pour prévisualiser la documentation, les serveurs de développement ou toute URL. Isolés avec des paramètres de sécurité renforcés.
+
+### 🔧 Git et Contrôle de Source
+
+- **Explorateur de fichiers compatible git** — arborescence de fichiers avec surveillance en temps réel du système de fichiers, estompage des fichiers suivis/non suivis, recherche, et copier/coller pour les fichiers et dossiers avec renommage sans collision.
+- **Barre latérale de contrôle de source** — stage/unstage, gestion des branches, worktrees, historique des commits et vues diff inline. Le moniteur Git interroge et fait remonter les changements automatiquement.
+- **Recherche à l'échelle du projet** — recherche en texte intégral dans les fichiers de l'espace de travail avec résultats instantanés.
+
+### 🤖 Agent IA
+
+- **Panneau Pi Agent** — exécutez un agent de codage intégré alimenté par `@earendil-works/pi-agent-core`, avec des fils de discussion, restauration du modèle par discussion et placement de panneaux compatible avec l'espace de travail.
+- **Authentification des fournisseurs et modèles** — connectez des fournisseurs OAuth tels qu'Anthropic, OpenAI Codex et GitHub Copilot, ou des fournisseurs par clé API tels qu'OpenAI, Google Gemini, OpenRouter, Groq, Mistral, DeepSeek, et plus encore.
+- **Marketplace et mode plan** — installez des extensions Pi depuis le marketplace et utilisez l'assistant de mode plan intégré de Cate pour la planification d'implémentation guidée par agent.
+
+### 🔍 Recherche et Navigation
+
+- **Recherche à l'échelle du canevas** (`Cmd+Shift+F`) — overlay de type Spotlight qui recherche les fichiers de l'espace de travail, le scrollback des terminaux en direct et les titres/chemins des panneaux ouverts en un seul endroit. Résultats classés par focus récent avec icônes colorées par type.
+- **Sélecteur de panneaux** (`Ctrl+Space`) — overlay clavier compact pour naviguer entre les panneaux ouverts du canevas et centrer le nœud sélectionné.
+- **Palette de commandes** (`Cmd+K`) — accès rapide aux commandes, panneaux ouverts et fichiers de l'espace de travail. Chrome unifié de type Spotlight pour tous les overlays.
+
+### 🖥️ Finitions Bureau
+
+- **Sauvegarde automatique et restauration de session** — tout l'état des panneaux, positions et fichiers ouverts persiste automatiquement.
+- **Onglets natifs macOS optionnels** — groupez les fenêtres Cate dans la barre d'onglets système.
+- **Vérifications automatiques des mises à jour** — vérifie les releases GitHub et notifie quand une nouvelle version est disponible.
+- **Résilience aux pannes** — diagnostics Sentry, validation de restauration de session, bannières de repli shell dans le PTY et flux de mise à jour/redémarrage protégés aident à prévenir les états de crash bruyants ou en boucle.
+
+## Installation
+
+Si vous souhaitez simplement utiliser Cate, téléchargez une version précompilée — ne compilez pas depuis les sources. Ce dépôt cible actuellement la **v1.0.3**.
+
+| Plateforme | Formats | Lien |
+|------------|---------|------|
+| macOS | DMG, ZIP (`arm64`, `x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
+| Windows | Installateur NSIS, ZIP (`x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
+| Linux | AppImage, DEB, `tar.gz` (`x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
+
+> **Note macOS :** les builds de release sont notariés et configurés pour un runtime renforcé. Les builds locaux ou de test non signés peuvent nécessiter :
+> ```bash
+> xattr -cr /Applications/Cate.app
+> ```
+
+> **Note Linux :** sur Steam Deck ou d'autres distributions avec racine en lecture seule, préférez le build portable `tar.gz`. Si l'AppImage ne se lance pas, essayez `--no-sandbox` comme solution de repli (ex. `./Cate.AppImage --no-sandbox`).
+
+## Compiler depuis les Sources
+
+> Les étapes ci-dessous sont pour les **contributeurs** — utilisez la version précompilée ci-dessus pour un usage quotidien.
+
+### Prérequis
+
+- [Node.js](https://nodejs.org/) 20 ou 22 LTS (voir `.nvmrc`). Node 23+ n'est pas supporté ; `node-pty` n'a pas de prebuilds et la compilation native échouera.
+- npm >= 9
+- Python 3 et un compilateur C++ (pour le module natif `node-pty`)
+  - macOS : Xcode Command Line Tools (`xcode-select --install`)
+  - Debian/Ubuntu : `sudo apt install build-essential python3`
+  - Fedora/RHEL : `sudo dnf install @development-tools gcc-c++ make python3`
+  - Arch : `sudo pacman -S base-devel python`
+  - Windows : [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (sélectionnez la charge de travail « Développement Desktop avec C++ »)
+
+### Configuration
+
+```bash
+git clone https://github.com/0-AI-UG/cate.git
+cd cate
+npm install
+```
+
+### Développement
+
+```bash
+npm run dev
+```
+
+Cela démarre l'application Electron avec rechargement à chaud via electron-vite.
+
+### Vérifications de qualité
+
+```bash
+npm run typecheck
+npm test            # tests unitaires (vitest)
+npm run test:e2e    # tests d'intégration Playwright
+```
+
+Pour le harnais de test Electron :
+
+```bash
+npm run test:smoke:electron
+```
+
+### Build de Production
+
+```bash
+npm run build
+```
+
+### Empaquetage pour la Distribution
+
+```bash
+npm run package
+# ou cibler une plateforme :
+npm run package:mac
+npm run package:win
+npm run package:linux
+```
+
+Les binaires empaquetés seront dans le répertoire `release/`.
+
+## Sécurité et Empaquetage
+
+Cate utilise un pont preload isolé par contexte pour toute communication IPC. L'accès au système de fichiers est limité aux racines d'espace de travail enregistrées, les panneaux navigateur utilisent des paramètres webview renforcés avec intégration Node désactivée, et l'outil de mise à jour replie vers l'ouverture de la page de release GitHub lorsqu'un chemin d'installateur vérifié n'est pas disponible. La validation `allowedRoots` à portée d'espace de travail empêche les terminaux de démarrer en dehors des répertoires approuvés.
+
+## Architecture
+
+```text
+src/
+├── agent/              # Intégration de l'agent de codage Pi intégré
+│   ├── main/           # Gestionnaire de processus agent, auth, marketplace, fichiers de session
+│   ├── renderer/       # UI du panneau agent, fil de discussion, fournisseurs, préférences de modèle
+│   └── extensions/     # Extension Pi de mode plan intégrée à Cate
+├── main/               # Processus principal Electron
+│   ├── ipc/            # Gestionnaires IPC (système de fichiers, git, terminal, menu, glisser)
+│   ├── analytics       # Helpers d'analytics d'événements mise à jour/app
+│   ├── appContext      # État partagé du processus principal
+│   ├── featureFlags    # Drapeaux de fonctionnalités à l'exécution
+│   ├── shellEnv        # Capture de l'environnement shell de connexion
+│   ├── shellResolver   # Résolution de chemin shell avec chaîne de repli
+│   ├── workspaceManager# Cycle de vie de l'espace de travail et persistance de session
+│   ├── workspaceRoots  # Enregistrement et validation des racines autorisées
+│   ├── windowRegistry  # Gestion des fenêtres (principale, dock, détachée)
+│   ├── webSecurity     # Renforcement webview et CSP
+│   ├── auto-updater    # Vérifications de mise à jour et récupération de release
+│   ├── sentry          # Intégration Sentry
+│   ├── store           # Persistance electron-store
+│   ├── jsonFileStore   # Helpers de persistance de fichiers JSON
+│   ├── menu            # Menu de l'application
+│   └── sessionTrust    # Validation de restauration de session
+├── preload/            # Pont isolé par contexte exposé au renderer
+├── renderer/           # Application React 18
+│   ├── assets/         # Images et déclarations d'assets du renderer
+│   ├── canvas/         # Rendu du canevas infini, glisser, redimensionner, placement
+│   ├── docking/        # Onglets, divisions, fenêtres dock détachées, glisser-déposer
+│   ├── drag/           # Runtime et état du glisser-déposer inter-fenêtres
+│   ├── panels/         # Terminal, Éditeur, Navigateur, Document, Git, Explorateur,
+│   │                   # Projets, registre/composants de panneaux Canvas
+│   ├── sidebar/        # Espace de travail, Explorateur de fichiers, Contrôle de source,
+│   │                   # Travail parallèle, Liste de projets, presse-papiers de fichiers
+│   ├── dialogs/        # Dispositions sauvegardées et dialogues de retour post-mise à jour
+│   ├── settings/       # Sections de la fenêtre de paramètres et enregistreur de raccourcis
+│   ├── ui/             # Palette de commandes, Recherche globale, Sélecteur de nœuds,
+│   │                   # Page d'accueil, Overlay d'indices de raccourcis
+│   ├── shells/         # Shells de fenêtres principale, panneau et dock
+│   ├── stores/         # Stores Zustand (canevas, app, dock, paramètres,
+│   │                   # raccourci, statut, ui, mise à jour, invite url)
+│   ├── hooks/          # Hooks React personnalisés (raccourcis, interaction canevas)
+│   ├── lib/            # Utilitaires (coordonnées, routage, registre de terminaux)
+│   ├── workers/        # Workers Monaco/éditeur
+│   └── styles/         # Styles Tailwind/globaux
+└── shared/             # Définitions de canaux IPC et types TypeScript partagés
+```
+
+### Stack Technique
+
+- **Electron 41** — shell de bureau (Chromium + Node.js)
+- **React 18** — framework UI avec composants fonctionnels et hooks
+- **Zustand 5** — gestion d'état légère (sans Redux/Context)
+- **Monaco Editor 0.52** — édition de code (composant éditeur de VS Code)
+- **xterm.js 5.5 + node-pty 1.0** — émulateur de terminal avec rendu WebGL
+- **Packages @earendil-works/pi** — runtime d'agent de codage intégré, auth fournisseur et marketplace d'extensions
+- **pdf.js + mammoth** — rendu natif de documents PDF et DOCX
+- **react-markdown + remark-gfm** — aperçu Markdown avec GitHub Flavored Markdown
+- **simple-git 3.27** — opérations git
+- **chokidar 4.0** — surveillance du système de fichiers
+- **@phosphor-icons/react** — iconographie de l'application
+- **Tailwind CSS 3.4** — stylisation
+- **electron-vite 5.0** — bundling avec HMR
+- **electron-builder 26** — empaquetage et distribution
+- **electron-updater 6.8** — vérification des mises à jour
+- **Sentry Electron 5** — rapports de crash et diagnostics
+- **Playwright** — tests d'intégration de bout en bout
+- **Vitest** — exécuteur de tests unitaires
+
+## Feuille de Route
+
+Cate est en développement actif. Pour un historique détaillé de ce qui a changé dans chaque version et un aperçu de la direction, consultez le [CHANGELOG](CHANGELOG.md).
+
+## Historique des Étoiles
+
+<a href="https://www.star-history.com/#0-AI-UG/cate&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Graphique de l'historique des étoiles" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+  </picture>
+</a>
+
+## Contribuer
+
+Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour les directives.
+
+## Licence
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 <h1 align="center">Cate</h1>
 
 <p align="center">
+  <a href="README.md">English</a> | <a href="README.fr.md">Français</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center">
   A spatial desktop IDE with an infinite canvas for code, terminals, browsers, documents, AI agents, and git.
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,271 @@
+<p align="center">
+  <a href="https://www.producthunt.com/products/cate?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-cate" target="_blank" rel="noopener noreferrer"><img alt="CATE - Figma like open canvas for development | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1150094&theme=neutral&t=1779630669260"></a>
+</p>
+
+<p align="center">
+  <img src="assets/cate-logo.svg" alt="Cate" width="240" />
+</p>
+
+<h1 align="center">Cate</h1>
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.fr.md">Français</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.de.md">Deutsch</a>
+</p>
+
+> **注意：** 本翻译由机器自动生成，可能存在不准确之处。
+
+<p align="center">
+  一个拥有无限画布的空间桌面 IDE，集成代码编辑、终端、浏览器、文档、AI 代理和 Git。
+</p>
+
+<p align="center">
+  <strong>当前源码版本：</strong> v1.0.3
+</p>
+
+<p align="center">
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT 许可证" /></a>
+  <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="下载量" /></a>
+</p>
+
+---
+
+<p align="center">
+  <img src="assets/demo.gif" alt="Cate 演示" width="900" />
+</p>
+
+Cate 是一款 Electron 桌面应用程序，用于在自由空间中组织开发工具。将浮动的画布面板与固定的标签页和分栏混合使用，将面板分离到独立窗口中，并在多个会话之间保持多个工作区同步。
+
+## 快速开始
+
+打开任意文件夹即可创建工作区——Cate 会在您每次回来时恢复画布布局、面板位置和已打开的终端。右键点击画布添加面板，按 `Cmd+K` 打开命令面板，或将面板拖到 Dock 栏创建标签页和分栏。
+
+无需配置文件，无需项目设置——只需将 Cate 指向一个目录即可开始工作。
+
+## 为什么选择 Cate？
+
+Alt-Tab 切换在窗口少时很好用——但当你有 12 个终端、6 个打开的文件、另一个窗口中的文档，以及散落在各个桌面上的笔记时，切换窗口本身就成了真正的瓶颈。
+
+Cate 用**每个项目一个持久化画布**替代了那堆窗口。终端、编辑器、浏览器和笔记保持在你放置的位置，按照你的思维方式分组，第二天回来时它们仍然在那里。
+
+> Cate **不是窗口管理器的替代品**。平铺/滚动式窗口管理器（Hyprland、Niri、GlazeWM、KDE）在你主要想要排列操作系统窗口时非常好用。Cate 是围绕单个项目工具的空间画布——更接近 Figma 的无限画布，而非窗口管理器。
+
+## 功能特性
+
+### 🎨 画布与布局
+
+- **无限画布** ——缩放、平移，在自由空间中随意排列面板。双指拖动或右键拖动平移；`Cmd+滚轮` 或画布控件缩放。
+- **Dock 系统** ——将浮动面板拖到 Dock 栏创建标签页和分栏。每个 Dock 区域（中央、左侧、右侧、底部）可容纳多个带有类型着色图标的标签页。
+- **分离窗口** ——将面板或完整的 Dock 布局拉到独立的操作系统窗口中。
+- **保存的布局** ——从应用内弹窗（`Cmd+K → "保存的布局…"`）命名、保存、加载和删除画布排列（节点和区域）。
+- **多工作区会话** ——同时打开多个项目，重启后恢复。通过侧边栏在工作区之间切换。
+
+### 💻 代码、文档与终端
+
+- **Monaco 编辑器面板** ——完整的 VS Code 级编辑体验，支持语法高亮、多光标、查找/替换、差异对比以及 Markdown 预览/源码模式（GFM 渲染）。草稿编辑器在会话之间保留未保存的内容。
+- **持久化编辑器缓冲区** ——基于文件的模型在面板之间复用，草稿编辑器内容随会话持久化。
+- **文档面板** ——画布上的原生 PDF、DOCX 文件和图片查看器，支持基于魔数字节的文件类型检测。
+- **原生终端** ——xterm.js 配合 WebGL 渲染，由 `node-pty` PTY 支持，根植于活动工作区。自动检测 Shell，当配置的 Shell 不可用时优雅降级。
+- **浏览器面板** ——嵌入式 webview 面板，用于预览文档、开发服务器或任意 URL。上下文隔离，安全设置加固。
+
+### 🔧 Git 与源码控制
+
+- **Git 感知的文件浏览器** ——文件树支持实时文件系统监视、已跟踪/未跟踪文件暗显、搜索，以及文件和文件夹的复制/粘贴（带防冲突重命名）。
+- **源码控制侧边栏** ——暂存/取消暂存、分支管理、工作树、提交历史和内联差异视图。Git 监视器自动轮询并展示变更。
+- **项目级搜索** ——在工作区文件中进行全文搜索，结果即时呈现。
+
+### 🤖 AI 代理
+
+- **Pi Agent 面板** ——运行由 `@earendil-works/pi-agent-core` 驱动的应用内编码代理，支持聊天线程、按聊天恢复模型和工作区感知的面板放置。
+- **提供商认证与模型** ——连接 OAuth 提供商如 Anthropic、OpenAI Codex 和 GitHub Copilot，或 API 密钥提供商如 OpenAI、Google Gemini、OpenRouter、Groq、Mistral、DeepSeek 等。
+- **市场与规划模式** ——从市场安装 Pi 扩展，使用 Cate 内置的规划模式助手进行代理引导的实施规划。
+
+### 🔍 搜索与导航
+
+- **画布级搜索**（`Cmd+Shift+F`）——Spotlight 风格的覆盖层，可同时搜索工作区文件、实时终端滚动缓冲区和已打开面板的标题/路径。结果按最近聚焦排序，带有类型着色的图标。
+- **面板切换器**（`Ctrl+Space`）——紧凑的键盘覆盖层，用于在打开的画布面板之间跳转并将选定节点居中。
+- **命令面板**（`Cmd+K`）——快速访问命令、已打开面板和工作区文件。所有覆盖层统一采用 Spotlight 风格的外观。
+
+### 🖥️ 桌面细节
+
+- **自动保存与会话恢复** ——所有面板状态、位置和打开的文件自动持久化。
+- **可选的 macOS 原生窗口标签页** ——在系统标签栏中分组 Cate 窗口。
+- **自动更新检查** ——检查 GitHub 发布版本，有新版本可用时通知。
+- **崩溃恢复能力** ——Sentry 诊断、会话恢复验证、PTY 中的 Shell 降级横幅以及受保护的更新/重启流程，帮助防止嘈杂或循环的崩溃状态。
+
+## 安装
+
+如果您只想使用 Cate，请下载预构建版本——不要从源码编译。本仓库当前目标版本为 **v1.0.3**。
+
+| 平台 | 格式 | 链接 |
+|------|------|------|
+| macOS | DMG, ZIP (`arm64`, `x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+| Windows | NSIS 安装程序, ZIP (`x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+| Linux | AppImage, DEB, `tar.gz` (`x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+
+> **macOS 注意：** 发布版本已公证并配置为强化运行时。未签名的本地或测试版本可能需要：
+> ```bash
+> xattr -cr /Applications/Cate.app
+> ```
+
+> **Linux 注意：** 在 Steam Deck 或其他只读根分区的发行版上，建议使用 `tar.gz` 便携版本。如果 AppImage 无法启动，请尝试 `--no-sandbox` 作为备选方案（例如 `./Cate.AppImage --no-sandbox`）。
+
+## 从源码编译
+
+> 以下步骤面向**贡献者**——日常使用请下载上述预构建版本。
+
+### 前置要求
+
+- [Node.js](https://nodejs.org/) 20 或 22 LTS（见 `.nvmrc`）。不支持 Node 23+；`node-pty` 没有预编译包，原生编译会失败。
+- npm >= 9
+- Python 3 和 C++ 编译器（用于 `node-pty` 原生模块）
+  - macOS：Xcode 命令行工具（`xcode-select --install`）
+  - Debian/Ubuntu：`sudo apt install build-essential python3`
+  - Fedora/RHEL：`sudo dnf install @development-tools gcc-c++ make python3`
+  - Arch：`sudo pacman -S base-devel python`
+  - Windows：[Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)（选择"使用 C++ 的桌面开发"工作负载）
+
+### 设置
+
+```bash
+git clone https://github.com/0-AI-UG/cate.git
+cd cate
+npm install
+```
+
+### 开发
+
+```bash
+npm run dev
+```
+
+这将通过 electron-vite 启动带有热重载的 Electron 应用。
+
+### 质量检查
+
+```bash
+npm run typecheck
+npm test            # 单元测试 (vitest)
+npm run test:e2e    # Playwright 集成测试
+```
+
+Electron 冒烟测试工具：
+
+```bash
+npm run test:smoke:electron
+```
+
+### 生产构建
+
+```bash
+npm run build
+```
+
+### 打包分发
+
+```bash
+npm run package
+# 或指定目标平台：
+npm run package:mac
+npm run package:win
+npm run package:linux
+```
+
+打包后的二进制文件位于 `release/` 目录。
+
+## 安全与打包
+
+Cate 使用上下文隔离的预加载桥接进行所有 IPC 通信。文件系统访问范围限定在已注册的工作区根目录内，浏览器面板使用禁用 Node 集成的强化 webview 设置，更新器在验证的安装程序路径不可用时会回退到打开 GitHub 发布页面。工作区范围的 `allowedRoots` 验证防止终端在批准的目录之外启动。
+
+## 架构
+
+```text
+src/
+├── agent/              # 嵌入式 Pi 编码代理集成
+│   ├── main/           # 代理进程管理器、认证、市场、会话文件
+│   ├── renderer/       # 代理面板 UI、聊天线程、提供商、模型偏好
+│   └── extensions/     # Cate 内置的规划模式 Pi 扩展
+├── main/               # Electron 主进程
+│   ├── ipc/            # IPC 处理器（文件系统、git、终端、菜单、拖拽）
+│   ├── analytics       # 更新/应用事件分析助手
+│   ├── appContext      # 共享主进程应用状态
+│   ├── featureFlags    # 运行时功能标志
+│   ├── shellEnv        # 登录 Shell 环境捕获
+│   ├── shellResolver   # Shell 路径解析与降级链
+│   ├── workspaceManager# 工作区生命周期和会话持久化
+│   ├── workspaceRoots  # 允许的根目录注册和验证
+│   ├── windowRegistry  # 窗口管理（主窗口、Dock、分离窗口）
+│   ├── webSecurity     # Webview 加固和 CSP
+│   ├── auto-updater    # 更新检查和发布获取
+│   ├── sentry          # Sentry 集成
+│   ├── store           # electron-store 持久化
+│   ├── jsonFileStore   # JSON 文件持久化助手
+│   ├── menu            # 应用菜单
+│   └── sessionTrust    # 会话恢复验证
+├── preload/            # 暴露给渲染器的上下文隔离桥接
+├── renderer/           # React 18 应用
+│   ├── assets/         # 渲染器图片和资源声明
+│   ├── canvas/         # 无限画布渲染、拖拽、调整大小、放置
+│   ├── docking/        # 标签页、分栏、分离的 Dock 窗口、拖放
+│   ├── drag/           # 跨窗口拖放运行时和状态
+│   ├── panels/         # 终端、编辑器、浏览器、文档、Git、浏览器、
+│   │                   # 项目、画布面板注册/组件
+│   ├── sidebar/        # 工作区、文件浏览器、源码控制、
+│   │                   # 并行工作、项目列表、文件剪贴板
+│   ├── dialogs/        # 保存的布局和更新后反馈对话框
+│   ├── settings/       # 设置窗口部分和快捷键录制器
+│   ├── ui/             # 命令面板、全局搜索、节点切换器、
+│   │                   # 欢迎页面、快捷键提示覆盖层
+│   ├── shells/         # 主窗口、面板和 Dock 窗口外壳
+│   ├── stores/         # Zustand 状态仓库（画布、应用、Dock、设置、
+│   │                   # 快捷键、状态、UI、更新、URL 提示）
+│   ├── hooks/          # 自定义 React Hooks（快捷键、画布交互）
+│   ├── lib/            # 工具函数（坐标、路由、终端注册表）
+│   ├── workers/        # Monaco/编辑器 Workers
+│   └── styles/         # Tailwind/全局样式
+└── shared/             # IPC 通道定义和共享 TypeScript 类型
+```
+
+### 技术栈
+
+- **Electron 41** ——桌面外壳（Chromium + Node.js）
+- **React 18** ——UI 框架，函数组件和 Hooks
+- **Zustand 5** ——轻量级状态管理（无 Redux/Context）
+- **Monaco Editor 0.52** ——代码编辑（VS Code 编辑器组件）
+- **xterm.js 5.5 + node-pty 1.0** ——终端模拟器，WebGL 渲染
+- **@earendil-works/pi 系列包** ——嵌入式编码代理运行时、提供商认证和扩展市场
+- **pdf.js + mammoth** ——原生 PDF 和 DOCX 文档渲染
+- **react-markdown + remark-gfm** ——Markdown 预览，GitHub 风格 Markdown
+- **simple-git 3.27** ——Git 操作
+- **chokidar 4.0** ——文件系统监视
+- **@phosphor-icons/react** ——应用图标
+- **Tailwind CSS 3.4** ——样式
+- **electron-vite 5.0** ——打包与 HMR
+- **electron-builder 26** ——打包和分发
+- **electron-updater 6.8** ——更新检查
+- **Sentry Electron 5** ——崩溃报告和诊断
+- **Playwright** ——端到端集成测试
+- **Vitest** ——单元测试运行器
+
+## 路线图
+
+Cate 正在积极开发中。有关每个版本的详细变更历史以及未来方向，请查看 [CHANGELOG](CHANGELOG.md)。
+
+## Star 趋势
+
+<a href="https://www.star-history.com/#0-AI-UG/cate&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+  </picture>
+</a>
+
+## 贡献
+
+请参阅 [CONTRIBUTING.md](CONTRIBUTING.md) 了解贡献指南。
+
+## 许可证
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Add language selector bar (English | Français | 简体中文 | Deutsch) to the main README header
- Create full translated README files: `README.fr.md`, `README.zh-CN.md`, `README.de.md`
- Non-English versions include a disclaimer noting they were auto-translated

## Test plan
- [ ] Verify language links in main README resolve to the correct files
- [ ] Confirm translated READMEs render correctly on GitHub