### PR TITLE
fix(agent): drive running state from PTY streaming + post-startup subprocesses (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ test-results/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# Local logo scratch dir
+_logos/

--- a/src/main/ipc/agentPidAge.test.ts
+++ b/src/main/ipc/agentPidAge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { STARTUP_GRACE_MS, __resetPidAges, recordPidFirstSeen, pruneStalePidAges } from './agentPidAge'
+
+describe('agent pid first-seen tracking', () => {
+  beforeEach(() => { __resetPidAges() })
+
+  it('records first sight and returns that timestamp', () => {
+    expect(recordPidFirstSeen(123, 1_000)).toBe(1_000)
+  })
+
+  it('returns the original timestamp on later calls (caller passes actual start time)', () => {
+    recordPidFirstSeen(123, 1_000)
+    expect(recordPidFirstSeen(123, 99_999)).toBe(1_000)
+  })
+
+  it('respects an explicit backdated first-seen for already-running PIDs', () => {
+    // simulates shell.ts passing the actual process start time on first sight
+    expect(recordPidFirstSeen(7, -50_000)).toBe(-50_000)
+  })
+
+  it('pruneStalePidAges drops pids missing from the cycle set', () => {
+    recordPidFirstSeen(1, 1_000)
+    recordPidFirstSeen(2, 1_000)
+    pruneStalePidAges(new Set([1]))
+    // pid 2 was pruned → re-records against a new timestamp
+    expect(recordPidFirstSeen(2, 5_000)).toBe(5_000)
+    // pid 1 was kept → original timestamp preserved
+    expect(recordPidFirstSeen(1, 9_999)).toBe(1_000)
+  })
+
+  it('startup grace covers helpers spawned right after the agent', () => {
+    const agentStartedAt = 0
+    const helperFirstSeen = recordPidFirstSeen(10, STARTUP_GRACE_MS - 1)
+    expect(helperFirstSeen - agentStartedAt).toBeLessThanOrEqual(STARTUP_GRACE_MS)
+  })
+
+  it('post-grace children fall outside the helper window', () => {
+    const agentStartedAt = 0
+    const toolFirstSeen = recordPidFirstSeen(20, STARTUP_GRACE_MS + 1)
+    expect(toolFirstSeen - agentStartedAt).toBeGreaterThan(STARTUP_GRACE_MS)
+  })
+})

--- a/src/main/ipc/agentPidAge.ts
+++ b/src/main/ipc/agentPidAge.ts
@@ -1,0 +1,35 @@
+// Agent-child PID first-seen tracking. Used by shell.ts to tell startup
+// helpers (MCP servers + the `bun`/`node` runtimes they share names with)
+// apart from tool subprocesses spawned later: anything observed within
+// STARTUP_GRACE_MS of the agent first appearing is treated as a helper,
+// later spawns are real tools regardless of how long they run.
+
+/** Children first seen within this window after the agent appears count as
+ *  startup helpers and are ignored. */
+export const STARTUP_GRACE_MS = 5_000
+
+const pidFirstSeen: Map<number, number> = new Map()
+
+/** Record (if new) and return the first-seen timestamp for this PID. Callers
+ *  should pass the process's *actual* start time when known so reattaching
+ *  to a long-running process doesn't shift its anchor forward. */
+export function recordPidFirstSeen(pid: number, firstSeen: number): number {
+  const existing = pidFirstSeen.get(pid)
+  if (existing != null) return existing
+  pidFirstSeen.set(pid, firstSeen)
+  return firstSeen
+}
+
+export function hasPidFirstSeen(pid: number): boolean {
+  return pidFirstSeen.has(pid)
+}
+
+export function pruneStalePidAges(seenThisCycle: Set<number>): void {
+  for (const pid of Array.from(pidFirstSeen.keys())) {
+    if (!seenThisCycle.has(pid)) pidFirstSeen.delete(pid)
+  }
+}
+
+export function __resetPidAges(): void {
+  pidFirstSeen.clear()
+}

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   computeRawState,
   applyHysteresis,
@@ -7,9 +7,48 @@ import {
   type DetectorSignals,
 } from '../../renderer/lib/agentScreenDetectorLogic'
 
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn(), on: vi.fn() } }))
+vi.mock('./pathValidation', () => ({ validateCwd: (p: string) => p }))
+vi.mock('./terminalLogger', () => ({
+  getOrCreateLogger: () => ({ append: () => {}, flush: () => {}, readAll: () => '' }),
+  removeLogger: () => {},
+  flushAll: () => {},
+  disposeAll: () => {},
+  TerminalLogger: { getLogDir: () => '' },
+}))
+vi.mock('../windowRegistry', () => ({
+  sendToWindow: () => {},
+  broadcastToAll: () => {},
+  windowFromEvent: () => null,
+}))
+vi.mock('../shellEnv', () => ({ getShellEnv: () => ({}) }))
+vi.mock('../shellResolver', () => ({ resolveShell: () => ({ path: '/bin/sh', fallback: false }) }))
+vi.mock('../logger', () => ({ default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} } }))
+vi.mock('../store', () => ({ getSettingSync: () => false }))
+
+import { __parseEtimeForTests } from './shell'
+
 function signals(overrides: Partial<DetectorSignals> = {}): DetectorSignals {
-  return { agentPresent: true, wasAgentPresent: true, subprocessActive: false, ...overrides }
+  return { agentPresent: true, wasAgentPresent: true, subprocessActive: false, isStreaming: false, ...overrides }
 }
+
+describe('parseEtime', () => {
+  it('parses MM:SS', () => {
+    expect(__parseEtimeForTests('00:42')).toBe(42)
+    expect(__parseEtimeForTests('01:30')).toBe(90)
+  })
+  it('parses HH:MM:SS', () => {
+    expect(__parseEtimeForTests('1:02:03')).toBe(3_723)
+  })
+  it('parses DD-HH:MM:SS', () => {
+    expect(__parseEtimeForTests('2-03:04:05')).toBe(2 * 86_400 + 3 * 3_600 + 4 * 60 + 5)
+  })
+  it('returns null for empty / garbage', () => {
+    expect(__parseEtimeForTests('')).toBeNull()
+    expect(__parseEtimeForTests('not a duration')).toBeNull()
+  })
+})
 
 describe('computeRawState', () => {
   it('not present, never was → notRunning', () => {
@@ -20,11 +59,15 @@ describe('computeRawState', () => {
     expect(computeRawState(signals({ agentPresent: false, wasAgentPresent: true }))).toBe('finished')
   })
 
-  it('subprocess active → running', () => {
+  it('streaming → running', () => {
+    expect(computeRawState(signals({ isStreaming: true }))).toBe('running')
+  })
+
+  it('recently-spawned subprocess (no streaming yet) → running', () => {
     expect(computeRawState(signals({ subprocessActive: true }))).toBe('running')
   })
 
-  it('present, no subprocess → waitingForInput', () => {
+  it('present, nothing active → waitingForInput', () => {
     expect(computeRawState(signals())).toBe('waitingForInput')
   })
 })
@@ -59,13 +102,13 @@ describe('lifecycle', () => {
     let s = applyHysteresis(computeRawState(signals()), h, 0)
     h.lastReported = s; states.push(s)
 
-    s = applyHysteresis(computeRawState(signals({ subprocessActive: true })), h, 100)
+    s = applyHysteresis(computeRawState(signals({ isStreaming: true })), h, 100)
     h.lastReported = s; states.push(s)
 
-    s = applyHysteresis(computeRawState(signals({ subprocessActive: false })), h, 200)
+    s = applyHysteresis(computeRawState(signals({ isStreaming: false })), h, 200)
     h.lastReported = s; states.push(s) // held by hysteresis
 
-    s = applyHysteresis(computeRawState(signals({ subprocessActive: false })), h, 200 + RUNNING_HOLD_MS)
+    s = applyHysteresis(computeRawState(signals({ isStreaming: false })), h, 200 + RUNNING_HOLD_MS)
     h.lastReported = s; states.push(s)
 
     s = applyHysteresis(computeRawState(signals({ agentPresent: false, wasAgentPresent: true })), h, 200 + RUNNING_HOLD_MS + 1000)

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -14,7 +14,8 @@ import {
   SHELL_CWD_UPDATE,
   SHELL_AGENT_SCREEN_STATE,
 } from '../../shared/ipc-channels'
-import { terminalPids } from './terminal'
+import { getTotalPtyBytes, terminalPids } from './terminal'
+import { hasPidFirstSeen, recordPidFirstSeen, pruneStalePidAges, STARTUP_GRACE_MS } from './agentPidAge'
 import { sendToWindow, windowFromEvent, broadcastToAll } from '../windowRegistry'
 import { getShellEnv } from '../shellEnv'
 import type { TerminalActivity } from '../../shared/types'
@@ -37,7 +38,21 @@ interface ScanResult {
   subprocessActive: boolean
   agentPresent: boolean
   previouslyHadAgent: boolean
+  isStreaming: boolean
 }
+
+/** Bytes/s above which the agent counts as actively streaming. Tuned to
+ *  pass model output and the thinking spinner while ignoring cursor blinks. */
+const STREAMING_BYTES_PER_INTERVAL = 200
+
+interface BytesSample {
+  total: number
+  sampledAt: number
+}
+
+/** Last sampled cumulative PTY byte count per terminal, used to compute a
+ *  per-interval delta in `scanTerminal`. */
+const bytesSamples: Map<string, BytesSample> = new Map()
 
 // Concurrency limiter — caps simultaneous execFile calls across all terminals
 function createLimit(max: number) {
@@ -97,6 +112,52 @@ function getChildPids(pid: number): Promise<number[]> {
  * Get the process name (command basename) for a given PID.
  * Runs: ps -o comm= -p <pid>
  */
+/** Parse BSD `ps -o etime` output (`[[DD-]HH:]MM:SS`) to seconds. Returns
+ *  null when the format isn't recognised. */
+function parseEtime(raw: string): number | null {
+  const s = raw.trim()
+  if (!s) return null
+  // optional days separated by `-`
+  let days = 0
+  let rest = s
+  const dashIdx = s.indexOf('-')
+  if (dashIdx >= 0) {
+    const d = parseInt(s.slice(0, dashIdx), 10)
+    if (!Number.isFinite(d)) return null
+    days = d
+    rest = s.slice(dashIdx + 1)
+  }
+  const parts = rest.split(':').map((p) => parseInt(p, 10))
+  if (parts.some((n) => !Number.isFinite(n))) return null
+  let h = 0, m = 0, sec = 0
+  if (parts.length === 3) [h, m, sec] = parts
+  else if (parts.length === 2) [m, sec] = parts
+  else return null
+  return days * 86_400 + h * 3_600 + m * 60 + sec
+}
+
+/** Wall-clock timestamp (ms) the process was started. Reads BSD `etime`
+ *  (macOS) and falls through to it on Linux too (Linux ps supports it).
+ *  Returns null on Windows or when the lookup fails — the caller should
+ *  fall back to `Date.now()`. */
+function getProcessStartedAt(pid: number): Promise<number | null> {
+  if (!pid || pid <= 0) return Promise.resolve(null)
+  if (process.platform === 'win32') return Promise.resolve(null)
+  return limit(() => new Promise((resolve) => {
+    execFile('ps', ['-o', 'etime=', '-p', `${pid}`], {
+      encoding: 'utf-8',
+      timeout: 2000,
+    }, (err, stdout) => {
+      if (err || !stdout) { resolve(null); return }
+      const secs = parseEtime(stdout)
+      if (secs == null) { resolve(null); return }
+      resolve(Date.now() - secs * 1000)
+    })
+  }))
+}
+
+export { parseEtime as __parseEtimeForTests }
+
 function getProcessName(pid: number): Promise<string | null> {
   if (!pid || pid <= 0) return Promise.resolve(null)
   return limit(() => new Promise((resolve) => {
@@ -180,26 +241,71 @@ function isShellProcess(name: string): boolean {
  */
 const IDLE_AGENT_HELPERS = new Set(['caffeinate', 'pmset'])
 
-/**
- * True if the agent has a child process that's *actually doing something* —
- * a non-helper, non-idle-shell descendant. Used as a "definitely running"
- * signal that overrides the renderer's buffer-stability reading.
- */
-async function agentIsActive(agentPid: number): Promise<boolean> {
+/** MCP servers (`<name>-mcp`) and other long-lived helpers don't count as
+ *  active tool execution. */
+function isAgentHelper(name: string): boolean {
+  if (IDLE_AGENT_HELPERS.has(name)) return true
+  if (name.endsWith('-mcp') || name.startsWith('mcp-')) return true
+  return false
+}
+
+/** Carries each terminal's last observed PIDs across a skipped/errored
+ *  scan so `pruneStalePidAges` doesn't reset the first-seen entries for
+ *  those processes on the next successful scan. */
+const lastSeenPidsByTerminal: Map<string, number[]> = new Map()
+
+/** When the current agent instance was first observed in each terminal —
+ *  the reference point for the startup-grace helper window. */
+const agentFirstSeenAt: Map<string, number> = new Map()
+
+/** Returns the actual process start time on first sight (so reattach
+ *  doesn't shift the anchor), or `now` if the lookup fails. */
+async function childFirstSeenAt(pid: number, now: number): Promise<number> {
+  if (hasPidFirstSeen(pid)) return recordPidFirstSeen(pid, now)
+  const started = await getProcessStartedAt(pid)
+  return recordPidFirstSeen(pid, started ?? now)
+}
+
+/** True iff this PID was started after the agent's startup-grace window
+ *  ended — i.e. it's a tool, not a startup helper. */
+async function isPostStartupChild(pid: number, now: number, agentStartedAt: number): Promise<boolean> {
+  const firstSeen = await childFirstSeenAt(pid, now)
+  return firstSeen - agentStartedAt > STARTUP_GRACE_MS
+}
+
+/** True if the agent has a child it spawned for real work, not a startup
+ *  helper. Startup helpers (MCP servers + their `bun`/`node` runtimes) all
+ *  appear within `STARTUP_GRACE_MS` of the agent itself appearing; later
+ *  children are tools regardless of how long they run silently. */
+async function agentIsActive(
+  agentPid: number,
+  terminalId: string,
+  seenThisCycle: Set<number>,
+): Promise<boolean> {
   const children = await getChildPids(agentPid)
+  const now = Date.now()
+  const agentStartedAt = agentFirstSeenAt.get(terminalId) ?? now
+  let active = false
   for (const childPid of children) {
+    seenThisCycle.add(childPid)
     const name = await getProcessName(childPid)
     if (!name) continue
     const lower = name.toLowerCase()
-    if (IDLE_AGENT_HELPERS.has(lower)) continue
+    if (isAgentHelper(lower)) continue
     if (isShellProcess(lower)) {
+      // Shells only count as active when they have a post-startup subcommand
+      // running under them. A bare idle shell — even one spawned post-grace
+      // — isn't doing work.
       const subchildren = await getChildPids(childPid)
-      if (subchildren.length > 0) return true
+      for (const sub of subchildren) seenThisCycle.add(sub)
+      for (const sub of subchildren) {
+        if (await isPostStartupChild(sub, now, agentStartedAt)) { active = true; break }
+      }
       continue
     }
-    return true
+    if (await isPostStartupChild(childPid, now, agentStartedAt)) active = true
   }
-  return false
+  return active
 }
 
 
@@ -294,7 +400,11 @@ function getProcessCwd(pid: number): Promise<string | null> {
  * Scan a single terminal's process tree to detect activity and Claude state.
  * Ported from ProcessMonitor.scanProcesses(for:) in Swift.
  */
-async function scanTerminal(terminalId: string, info: TerminalRegistration): Promise<ScanResult> {
+async function scanTerminal(
+  terminalId: string,
+  info: TerminalRegistration,
+  seenThisCycle: Set<number>,
+): Promise<ScanResult> {
   const prev = previousStates.get(terminalId) || {
     previousAgentName: null,
     previouslyHadAgent: false,
@@ -307,6 +417,7 @@ async function scanTerminal(terminalId: string, info: TerminalRegistration): Pro
   let firstChildName: string | null = null
 
   for (const childPid of childrenToScan) {
+    seenThisCycle.add(childPid)
     const name = await getProcessName(childPid)
     if (name) {
       if (firstChildName === null && !isShellProcess(name)) {
@@ -322,8 +433,39 @@ async function scanTerminal(terminalId: string, info: TerminalRegistration): Pro
     }
   }
 
-  const subprocessActive = foundAgentPid != null ? await agentIsActive(foundAgentPid) : false
   const agentPresent = foundAgentName != null
+  // Anchor the startup-grace window to the agent process's actual start
+  // time so re-attaching to a long-running agent (cross-window reconnect,
+  // session restore) doesn't shift the window into the future and
+  // misclassify its already-running tools as helpers.
+  if (agentPresent && !prev.previouslyHadAgent) {
+    const startedAt = foundAgentPid != null ? await getProcessStartedAt(foundAgentPid) : null
+    agentFirstSeenAt.set(terminalId, startedAt ?? Date.now())
+  } else if (!agentPresent) {
+    agentFirstSeenAt.delete(terminalId)
+  }
+  const subprocessActive = foundAgentPid != null
+    ? await agentIsActive(foundAgentPid, terminalId, seenThisCycle)
+    : false
+
+  // Diff PTY bytes since last scan, normalised to 1s, against the streaming
+  // threshold. Filters out low-rate TUI redraws (cursor blink, status line).
+  const now = Date.now()
+  const totalBytes = getTotalPtyBytes(terminalId)
+  let isStreaming = false
+  if (agentPresent && totalBytes != null) {
+    const prev = bytesSamples.get(terminalId)
+    if (prev) {
+      const elapsed = Math.max(now - prev.sampledAt, 1)
+      const bytesPerInterval = (totalBytes - prev.total) * (1000 / elapsed)
+      isStreaming = bytesPerInterval >= STREAMING_BYTES_PER_INTERVAL
+    }
+    bytesSamples.set(terminalId, { total: totalBytes, sampledAt: now })
+  } else {
+    // Drop the baseline once the agent is gone so a restart doesn't diff
+    // against bytes accumulated while no agent was around.
+    bytesSamples.delete(terminalId)
+  }
 
   const terminalActivity: TerminalActivity =
     firstChildName != null
@@ -344,11 +486,12 @@ async function scanTerminal(terminalId: string, info: TerminalRegistration): Pro
     subprocessActive,
     agentPresent,
     previouslyHadAgent,
+    isStreaming,
   }
 }
 
 /**
- * Start polling all registered terminals every 2 seconds.
+ * Start polling all registered terminals every 1 second.
  * Emits SHELL_ACTIVITY_UPDATE IPC events to the owning window.
  */
 function startPolling(): void {
@@ -362,21 +505,34 @@ function startPolling(): void {
       // Scan all terminals concurrently
       const entries = Array.from(registeredTerminals.entries())
       if (entries.length === 0) return
+      const seenThisCycle = new Set<number>()
       const scanResults = await Promise.all(
         entries.map(async ([terminalId, info]) => {
           if (skipNextScan.has(terminalId)) {
             skipNextScan.delete(terminalId)
+            // Carry the last successful scan's PIDs forward so the prune
+            // below doesn't wipe their age entries.
+            for (const pid of lastSeenPidsByTerminal.get(terminalId) ?? []) {
+              seenThisCycle.add(pid)
+            }
             return null
           }
+          const localSeen = new Set<number>()
           try {
-            const result = await scanTerminal(terminalId, info)
+            const result = await scanTerminal(terminalId, info, localSeen)
+            for (const pid of localSeen) seenThisCycle.add(pid)
+            lastSeenPidsByTerminal.set(terminalId, Array.from(localSeen))
             return { terminalId, info, result }
           } catch (e) {
             skipNextScan.add(terminalId)
+            for (const pid of lastSeenPidsByTerminal.get(terminalId) ?? []) {
+              seenThisCycle.add(pid)
+            }
             return null
           }
         })
       )
+      pruneStalePidAges(seenThisCycle)
 
       for (const entry of scanResults) {
         if (!entry) continue
@@ -394,6 +550,7 @@ function startPolling(): void {
           result.agentName,
           result.subprocessActive,
           result.agentPresent,
+          result.isStreaming,
         )
       }
 
@@ -454,6 +611,9 @@ export function unregisterTerminalsForWindow(windowId: number): void {
       registeredTerminals.delete(terminalId)
       previousStates.delete(terminalId)
       skipNextScan.delete(terminalId)
+      bytesSamples.delete(terminalId)
+      lastSeenPidsByTerminal.delete(terminalId)
+      agentFirstSeenAt.delete(terminalId)
     }
   }
   if (registeredTerminals.size === 0) {
@@ -505,6 +665,9 @@ export function registerHandlers(): void {
     registeredTerminals.delete(terminalId)
     previousStates.delete(terminalId)
     skipNextScan.delete(terminalId)
+    bytesSamples.delete(terminalId)
+    lastSeenPidsByTerminal.delete(terminalId)
+    agentFirstSeenAt.delete(terminalId)
     if (registeredTerminals.size === 0) {
       stopPolling()
     }

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -195,6 +195,12 @@ const AGENT_DEFINITIONS: { displayName: string; match: (name: string) => boolean
     match: (n) => n === 'codex',
   },
   {
+    // Successor to Gemini CLI.
+    displayName: 'Antigravity',
+    match: (n) => n === 'antigravity',
+  },
+  {
+    // Kept for legacy installs; Google's coding CLI moved to Antigravity.
     displayName: 'Gemini CLI',
     match: (n) => n === 'gemini',
   },
@@ -205,6 +211,11 @@ const AGENT_DEFINITIONS: { displayName: string; match: (name: string) => boolean
   {
     displayName: 'OpenCode',
     match: (n) => n === 'opencode',
+  },
+  {
+    // forgecode.dev — installs as the `forge` binary.
+    displayName: 'Forge Code',
+    match: (n) => n === 'forge' || n === 'forgecode',
   },
   {
     // @mariozechner/pi-coding-agent — installs as the `pi` binary.

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -200,7 +200,9 @@ const AGENT_DEFINITIONS: { displayName: string; match: (name: string) => boolean
     match: (n) => n === 'antigravity',
   },
   {
-    // Kept for legacy installs; Google's coding CLI moved to Antigravity.
+    // Deprecated in favor of Antigravity CLI:
+    // https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/
+    // Kept for legacy installs.
     displayName: 'Gemini CLI',
     match: (n) => n === 'gemini',
   },

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -181,6 +181,45 @@ function getProcessName(pid: number): Promise<string | null> {
   }))
 }
 
+/** Full command line for a PID via `ps -o args=`. Used to identify agents
+ *  that ship as `#!/usr/bin/env node` scripts (Gemini CLI, etc.) where
+ *  `comm=` returns `node`. */
+function getProcessArgs(pid: number): Promise<string | null> {
+  if (!pid || pid <= 0) return Promise.resolve(null)
+  return limit(() => new Promise((resolve) => {
+    execFile('ps', ['-o', 'args=', '-p', `${pid}`], {
+      encoding: 'utf-8',
+      timeout: 2000,
+    }, (err, stdout) => {
+      if (err || !stdout) { resolve(null); return }
+      const out = stdout.trim()
+      resolve(out.length === 0 ? null : out)
+    })
+  }))
+}
+
+/** Interpreter names that frequently host an agent CLI as a script. When
+ *  `getProcessName()` returns one of these we fall back to args-based
+ *  matching on the script basename. */
+const INTERPRETER_NAMES = new Set(['node', 'bun', 'deno', 'python', 'python3'])
+
+/** Extract a likely script basename from a `ps -o args=` line. Skips flags
+ *  (`-`/`--`-prefixed tokens) and the interpreter itself. Returns the
+ *  basename of the first plausible script-path argument. */
+function scriptBasenameFromArgs(args: string): string | null {
+  // Split on whitespace; the first token is the interpreter path.
+  const tokens = args.split(/\s+/).filter(Boolean)
+  for (let i = 1; i < tokens.length; i++) {
+    const tok = tokens[i]
+    if (tok.startsWith('-')) continue
+    const slash = tok.lastIndexOf('/')
+    const base = slash === -1 ? tok : tok.slice(slash + 1)
+    if (!base) continue
+    return base.toLowerCase()
+  }
+  return null
+}
+
 /**
  * Agent CLI definitions. Each entry maps process name patterns to a display name.
  * The matcher checks if the process basename (lowercased) matches any pattern.
@@ -437,7 +476,16 @@ async function scanTerminal(
         firstChildName = name
       }
       if (!foundAgentName) {
-        const agentMatch = matchAgentProcess(name)
+        let agentMatch = matchAgentProcess(name)
+        // Node/bun/deno scripts: comm= returns the interpreter, so probe the
+        // arg vector for the script basename (gemini ships as `#!/usr/bin/env node`).
+        if (!agentMatch && INTERPRETER_NAMES.has(name.toLowerCase())) {
+          const args = await getProcessArgs(childPid)
+          if (args) {
+            const script = scriptBasenameFromArgs(args)
+            if (script) agentMatch = matchAgentProcess(script)
+          }
+        }
         if (agentMatch) {
           foundAgentName = agentMatch
           foundAgentPid = childPid

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -48,12 +48,20 @@ const terminalOwners: Map<string, number> = new Map()
 // =============================================================================
 
 interface TerminalIdleState {
+  /** Idle-suspend timer. Reset on resume — not a pure PTY-output timestamp. */
   lastOutputAt: number
+  /** Cumulative PTY bytes, only ever incremented in `onData`. shell.ts diffs
+   *  this against the previous sample for the streaming signal. */
+  totalPtyBytes: number
   visible: boolean
   suspended: boolean
 }
 
 const idleState: Map<string, TerminalIdleState> = new Map()
+
+export function getTotalPtyBytes(terminalId: string): number | undefined {
+  return idleState.get(terminalId)?.totalPtyBytes
+}
 const IDLE_SUSPEND_MS = 2 * 60_000
 const IDLE_CHECK_INTERVAL_MS = 20_000
 let idleScanner: ReturnType<typeof setInterval> | null = null
@@ -236,7 +244,7 @@ function createTerminal(
   terminals.set(id, ptyProcess)
   terminalPids.set(id, ptyProcess.pid)
   terminalOwners.set(id, ownerWindowId)
-  idleState.set(id, { lastOutputAt: Date.now(), visible: true, suspended: false })
+  idleState.set(id, { lastOutputAt: Date.now(), totalPtyBytes: 0, visible: true, suspended: false })
   ensureIdleScanner()
 
   // Surface fallback details inside the terminal — otherwise users only see
@@ -265,7 +273,10 @@ function createTerminal(
   ptyProcess.onData((data: string) => {
     if (shuttingDown) return
     const state = idleState.get(id)
-    if (state) state.lastOutputAt = Date.now()
+    if (state) {
+      state.lastOutputAt = Date.now()
+      state.totalPtyBytes += data.length
+    }
     // Log to disk for session restore
     const logger = getOrCreateLogger(id)
     logger.append(data)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -461,6 +461,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       agentName: unknown,
       subprocessActive: unknown,
       agentPresent: unknown,
+      isStreaming: unknown,
     ) => void,
   ): () => void {
     const listener = (
@@ -470,8 +471,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       agentName: unknown,
       subprocessActive: unknown,
       agentPresent: unknown,
+      isStreaming: unknown,
     ): void => {
-      callback(terminalId, activity, agentName, subprocessActive, agentPresent)
+      callback(terminalId, activity, agentName, subprocessActive, agentPresent, isStreaming)
     }
     ipcRenderer.on(SHELL_ACTIVITY_UPDATE, listener)
     return () => {

--- a/src/renderer/hooks/useProcessMonitor.ts
+++ b/src/renderer/hooks/useProcessMonitor.ts
@@ -17,11 +17,13 @@ export function useProcessMonitor(workspaceId: string): void {
         agentNameRaw: unknown,
         subprocessActiveRaw: unknown,
         agentPresentRaw: unknown,
+        isStreamingRaw: unknown,
       ) => {
         const terminalActivity = activityRaw as TerminalActivity
         const agentName = (agentNameRaw as string | null) ?? null
         const subprocessActive = subprocessActiveRaw === true
         const agentPresent = agentPresentRaw === true
+        const isStreaming = isStreamingRaw === true
 
         const actualWorkspaceId =
           useStatusStore.getState().terminalWorkspaceMap[terminalId] ?? workspaceId
@@ -30,6 +32,7 @@ export function useProcessMonitor(workspaceId: string): void {
         store().setSubprocessActive(actualWorkspaceId, terminalId, subprocessActive)
         store().setAgentPresent(actualWorkspaceId, terminalId, agentPresent)
         store().setAgentName(actualWorkspaceId, terminalId, agentName)
+        store().setAgentStreaming(actualWorkspaceId, terminalId, isStreaming)
       },
     )
 

--- a/src/renderer/lib/agentScreenDetector.test.ts
+++ b/src/renderer/lib/agentScreenDetector.test.ts
@@ -15,10 +15,11 @@ function resetStore(): void {
   useStatusStore.setState({ workspaces: {}, _clearTimers: {}, terminalWorkspaceMap: {}, gitInfo: {} })
 }
 
-function setup(agentPresent: boolean, subprocessActive = false): void {
+function setup(agentPresent: boolean, subprocessActive = false, isStreaming = false): void {
   const s = useStatusStore.getState()
   s.setAgentPresent(WS, PTY, agentPresent)
   s.setSubprocessActive(WS, PTY, subprocessActive)
+  s.setAgentStreaming(WS, PTY, isStreaming)
   if (agentPresent) s.setAgentState(WS, PTY, 'notRunning', 'Claude Code')
 }
 
@@ -28,6 +29,7 @@ function tick(wasAgentPresent: boolean, h: HysteresisState, now: number): AgentS
     agentPresent: ws?.agentPresent[PTY] === true,
     wasAgentPresent,
     subprocessActive: ws?.subprocessActive[PTY] === true,
+    isStreaming: ws?.agentStreaming[PTY] === true,
   })
   const state = applyHysteresis(raw, h, now)
   if (h.lastReported !== state) {
@@ -52,20 +54,27 @@ describe('agent detection', () => {
     expect(displayed()).toBe('waitingForInput')
   })
 
-  it('subprocess → running', () => {
+  it('recent subprocess alone (no streaming) → running', () => {
     setup(true, true)
     const h: HysteresisState = { lastReported: null, pendingWaitingSince: null }
     tick(false, h, 0)
     expect(displayed()).toBe('running')
   })
 
-  it('subprocess ends → waitingForInput after hold', () => {
-    setup(true, true)
+  it('streaming output (no subprocess) → running', () => {
+    setup(true, false, true)
+    const h: HysteresisState = { lastReported: null, pendingWaitingSince: null }
+    tick(false, h, 0)
+    expect(displayed()).toBe('running')
+  })
+
+  it('streaming stops (no subprocess) → waitingForInput after hold', () => {
+    setup(true, false, true)
     const h: HysteresisState = { lastReported: null, pendingWaitingSince: null }
     tick(false, h, 0)
     expect(displayed()).toBe('running')
 
-    useStatusStore.getState().setSubprocessActive(WS, PTY, false)
+    useStatusStore.getState().setAgentStreaming(WS, PTY, false)
     tick(true, h, 100)
     expect(displayed()).toBe('running') // held
 

--- a/src/renderer/lib/agentScreenDetector.ts
+++ b/src/renderer/lib/agentScreenDetector.ts
@@ -70,10 +70,12 @@ function tick(): void {
     const t = trackerFor(ptyId)
 
     const subprocessActive = ws.subprocessActive[ptyId] === true
+    const isStreaming = ws.agentStreaming[ptyId] === true
     const rawState = computeRawState({
       agentPresent,
       wasAgentPresent: t.wasAgentPresent,
       subprocessActive,
+      isStreaming,
     })
 
     t.wasAgentPresent = agentPresent
@@ -99,12 +101,8 @@ function tick(): void {
         action,
       })
     } else if (kind === 'finished') {
+      // Agent exit is intentional — only cancel any pending input prompt.
       waitingDebouncer?.cancel(ptyId)
-      sendOsNotification({
-        title: 'Task complete',
-        body: `${displayName} has finished running.`,
-        action,
-      })
     } else if (state !== 'waitingForInput' && prevState === 'waitingForInput') {
       waitingDebouncer?.cancel(ptyId)
     }

--- a/src/renderer/lib/agentScreenDetectorLogic.ts
+++ b/src/renderer/lib/agentScreenDetectorLogic.ts
@@ -7,7 +7,11 @@ export const NEVER = -1e9
 export interface DetectorSignals {
   agentPresent: boolean
   wasAgentPresent: boolean
+  /** Age-filtered subprocess signal from `shell.ts` — covers quiet tools. */
   subprocessActive: boolean
+  /** PTY bytes/s above the streaming threshold — covers model output and the
+   *  thinking spinner. */
+  isStreaming: boolean
 }
 
 export interface HysteresisState {
@@ -18,7 +22,7 @@ export interface HysteresisState {
 export function computeRawState(s: DetectorSignals): AgentState {
   if (!s.agentPresent && s.wasAgentPresent) return 'finished'
   if (!s.agentPresent) return 'notRunning'
-  if (s.subprocessActive) return 'running'
+  if (s.isStreaming || s.subprocessActive) return 'running'
   return 'waitingForInput'
 }
 

--- a/src/renderer/stores/statusStore.ts
+++ b/src/renderer/stores/statusStore.ts
@@ -25,6 +25,9 @@ interface WorkspaceStatusState {
   subprocessActive: Record<string, boolean>
   /** terminalId → whether main's process-tree scan found a known agent CLI. */
   agentPresent: Record<string, boolean>
+  /** terminalId → whether the PTY produced output inside the streaming window
+   *  (proxy for "the agent is thinking or streaming a response"). */
+  agentStreaming: Record<string, boolean>
   nodeActivity: Record<CanvasNodeId, NodeActivityState>
   terminalTitles: Record<string, string>
   listeningPorts: Record<string, number[]>      // terminalId → ports
@@ -51,6 +54,7 @@ interface StatusStoreActions {
   setAgentName: (workspaceId: string, terminalId: string, name: string | null) => void
   setSubprocessActive: (workspaceId: string, terminalId: string, active: boolean) => void
   setAgentPresent: (workspaceId: string, terminalId: string, present: boolean) => void
+  setAgentStreaming: (workspaceId: string, terminalId: string, streaming: boolean) => void
   setNodeActivity: (nodeId: CanvasNodeId, state: NodeActivityState) => void
   clearNodeActivity: (nodeId: CanvasNodeId) => void
   setTerminalTitle: (terminalId: string, title: string) => void
@@ -90,6 +94,7 @@ function emptyWorkspaceStatus(): WorkspaceStatusState {
     agentName: {},
     subprocessActive: {},
     agentPresent: {},
+    agentStreaming: {},
     nodeActivity: {},
     terminalTitles: {},
     listeningPorts: {},
@@ -221,6 +226,23 @@ export const useStatusStore = create<StatusStore>((set, get) => ({
           [workspaceId]: {
             ...ws,
             agentPresent: { ...ws.agentPresent, [terminalId]: present },
+          },
+        },
+      }
+    })
+  },
+
+  setAgentStreaming(workspaceId, terminalId, streaming) {
+    get().ensureWorkspace(workspaceId)
+    set((state) => {
+      const ws = state.workspaces[workspaceId] ?? emptyWorkspaceStatus()
+      if (ws.agentStreaming[terminalId] === streaming) return state
+      return {
+        workspaces: {
+          ...state.workspaces,
+          [workspaceId]: {
+            ...ws,
+            agentStreaming: { ...ws.agentStreaming, [terminalId]: streaming },
           },
         },
       }
@@ -408,6 +430,7 @@ export const useStatusStore = create<StatusStore>((set, get) => ({
         const { [terminalId]: _an, ...remainingAgentName } = ws.agentName
         const { [terminalId]: _sa, ...remainingSubprocess } = ws.subprocessActive
         const { [terminalId]: _ap, ...remainingAgentPresent } = ws.agentPresent
+        const { [terminalId]: _as, ...remainingAgentStreaming } = ws.agentStreaming
         const { [terminalId]: _t, ...remainingTitles } = ws.terminalTitles
         updatedWorkspaces[workspaceId] = {
           ...ws,
@@ -418,6 +441,7 @@ export const useStatusStore = create<StatusStore>((set, get) => ({
           agentName: remainingAgentName,
           subprocessActive: remainingSubprocess,
           agentPresent: remainingAgentPresent,
+          agentStreaming: remainingAgentStreaming,
           terminalTitles: remainingTitles,
         }
       }

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -237,6 +237,7 @@ export interface ElectronAPI {
       agentName: string | null,
       subprocessActive: boolean,
       agentPresent: boolean,
+      isStreaming: boolean,
     ) => void,
   ): () => void
 


### PR DESCRIPTION
Fixes #140.

## Problem

Sidebar "agent running" shimmer was unreliable:

- **Original bug:** dropped to `waitingForInput` mid-stream because the detector only tracked `subprocessActive` (presence of a child PID), and during pure model output / thinking there is *no* subprocess — just bytes flowing through the PTY.
- **MCP regression after the first fix:** users running `claude` with MCP servers (e.g. `context7-mcp`, `bun`-based MCP runtimes) had `subprocessActive=true` forever, so the shimmer never stopped even when the agent was idle waiting for input.

## Fix

Two independent activity signals, OR'd in `computeRawState`:

1. **`isStreaming`** — PTY bytes/s above a threshold (`STREAMING_BYTES_PER_INTERVAL = 200`).
   Catches model output and the thinking spinner without depending on a subprocess. Uses a cumulative byte counter (`totalPtyBytes`) on `TerminalIdleState` so resume-from-idle does *not* reset the baseline.
2. **`subprocessActive`** (age-filtered) — true only for children spawned **after** a startup grace window.
   MCP servers + their `bun`/`node` runtimes appear within the first few seconds after the agent process and are filtered out; tools spawned later (silent or noisy) count.

State machine unchanged otherwise; 3 s hysteresis still holds `running → waitingForInput` to avoid flicker.

## Agent detection

Detects `claude` / `claude-code`, `codex`, `antigravity`, `cursor` / `cursor-agent`, `opencode`, `forge` / `forgecode`, `pi`, and `gemini` (legacy).

> **Note:** Gemini CLI is **deprecated in favor of Antigravity CLI**. See [Google's announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/). The `gemini` entry is kept for legacy installs.

## How the helper filter works

`src/main/ipc/agentPidAge.ts` tracks first-seen timestamps per child PID.

- On **first sight** of a child, `shell.ts` calls `ps -o etime=` to read the child's real start time and uses that as `firstSeen` — important when reattaching to an already-running agent, otherwise startup helpers would look "fresh" and get classified as tools.
- `parseEtime()` handles BSD `etime` format (`MM:SS` / `HH:MM:SS` / `DD-HH:MM:SS`) for macOS portability. Linux `etimes` (seconds) is not portable across the two.
- A child first-seen ≤ `agentStartedAt + STARTUP_GRACE_MS` (5 s) is a helper. Anything later is a tool, regardless of how long it then lives.
- Name-pattern filter (`*-mcp`, `mcp-*`, known idle helpers) catches the obvious cases too.

`bytesSamples` is dropped per terminal when the agent disappears so a restart starts with a clean baseline. `lastSeenPidsByTerminal` carries pids across skipped/errored scan cycles so the prune step doesn't wipe valid entries.

## Tradeoff

This is a heuristic, not a guarantee. Thresholds (200 B/s, 5 s grace window) are empirical and may need tuning for edge cases (slow streams, slow-starting MCPs, bursty long-running tools). We measure *symptoms* (bytes, subprocesses), not agent state.

The only truly reliable solution would be **hooks** — an explicit protocol where each agent CLI emits lifecycle events (`thinking`, `awaiting_input`, `tool_invoked`, `done`). That doesn't exist across agents today. If it ever does, it should replace this heuristic entirely.

Good enough for daily use right now; not a final answer.

## Files of interest

- `src/main/ipc/shell.ts` — main detection logic, `agentIsActive(terminalId)`, `childFirstSeenAt`, `isPostStartupChild`, `parseEtime`, `AGENT_DEFINITIONS`.
- `src/main/ipc/agentPidAge.ts` (new) — PID first-seen map + prune.
- `src/main/ipc/terminal.ts` — `totalPtyBytes` cumulative counter, `getTotalPtyBytes()`.
- `src/renderer/lib/agentScreenDetectorLogic.ts` — `DetectorSignals` with `isStreaming` + `subprocessActive`.
- `src/renderer/lib/agentScreenDetector.ts` — drops `finished`-state notification.
- `src/renderer/stores/statusStore.ts`, `src/renderer/hooks/useProcessMonitor.ts`, `src/preload/index.ts`, `src/shared/electron-api.d.ts` — plumb `isStreaming` through IPC.

## Test plan

- [x] `npm test` — 328 pass (2 pre-existing git-env failures, environmental)
- [x] Manual dev: `claude` with MCPs → shimmer on while streaming/thinking → stops within hysteresis window after response → dot + "waiting for input" notification → no notification on agent exit
- [x] Manual dev: `codex` — same behavior
- [x] Reattach to long-running agent (close+reopen window) — verify helpers still classified as helpers via `etime` backdating
