### PR TITLE
feat(browser): widen resize hit area and add device size presets

### DIFF
--- a/src/renderer/hooks/useNodeResize.ts
+++ b/src/renderer/hooks/useNodeResize.ts
@@ -58,7 +58,11 @@ interface UseNodeResizeReturn {
 // Edge detection (exported for use by CanvasNode)
 // -----------------------------------------------------------------------------
 
-const RESIZE_THRESHOLD = 6
+// Edge / corner detection band. Wider than the original 6px to give a more
+// comfortable hit target — especially important for the browser panel where the
+// <webview> captures pointer events and the usable resize strip is the band
+// between the node's outer edge and the webview's edge. See issue #147.
+const RESIZE_THRESHOLD = 10
 
 /**
  * Detect if a mouse position (relative to the node's top-left) is near an

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -5,14 +5,25 @@
 // =============================================================================
 
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { Globe, ArrowLeft, ArrowRight, ArrowClockwise, Camera, MagnifyingGlass } from '@phosphor-icons/react'
+import { Globe, ArrowLeft, ArrowRight, ArrowClockwise, Camera, MagnifyingGlass, Devices, Check } from '@phosphor-icons/react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
-import { SEARCH_ENGINE_URLS } from '../../shared/types'
+import { SEARCH_ENGINE_URLS, PANEL_MINIMUM_SIZES } from '../../shared/types'
 import type { BrowserPanelProps } from './types'
 import { portalRegistry } from '../lib/portalRegistry'
 import { isUrl, normalizeUrl } from './browserUrl'
+
+// Common device viewport presets. Width × height in CSS pixels; reasonable
+// defaults for previewing responsive sites. "Custom" sits at the bottom.
+const SIZE_PRESETS: ReadonlyArray<{ label: string; width: number; height: number; hint?: string }> = [
+  { label: 'Mobile', width: 375, height: 667, hint: 'iPhone SE' },
+  { label: 'Mobile L', width: 414, height: 896, hint: 'iPhone 11 Pro Max' },
+  { label: 'Tablet', width: 768, height: 1024, hint: 'iPad' },
+  { label: 'Tablet L', width: 1024, height: 1366, hint: 'iPad Pro' },
+  { label: 'Laptop', width: 1280, height: 800 },
+  { label: 'Desktop', width: 1920, height: 1080 },
+]
 
 // -----------------------------------------------------------------------------
 // Type declarations for Electron's <webview> element
@@ -51,6 +62,10 @@ export default function BrowserPanel({
   const updatePanelUrl = useAppStore((s) => s.updatePanelUrl)
 
   const isFocused = useCanvasStoreContext((s) => s.focusedNodeId === nodeId)
+  const resizeNode = useCanvasStoreContext((s) => s.resizeNode)
+  const currentSize = useCanvasStoreContext((s) =>
+    nodeId ? s.nodes[nodeId]?.size : undefined,
+  )
 
   const rawInitialUrl = url || browserHomepage || 'https://www.google.com'
   const initialUrl = rawInitialUrl.startsWith('about:') ? rawInitialUrl : normalizeUrl(rawInitialUrl)
@@ -68,6 +83,8 @@ export default function BrowserPanel({
   const [loadError, setLoadError] = useState<string | null>(null)
   const [screenshot, setScreenshot] = useState<{ dataUrl: string; filePath: string } | null>(null)
   const screenshotTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [isSizeMenuOpen, setIsSizeMenuOpen] = useState(false)
+  const sizeMenuRef = useRef<HTMLDivElement>(null)
 
   // -------------------------------------------------------------------------
   // Navigation helpers
@@ -155,6 +172,40 @@ export default function BrowserPanel({
     if (screenshotTimerRef.current) clearTimeout(screenshotTimerRef.current)
     setScreenshot(null)
   }, [])
+
+  // -------------------------------------------------------------------------
+  // Device size presets
+  // -------------------------------------------------------------------------
+
+  const applyPresetSize = useCallback((width: number, height: number) => {
+    if (!nodeId) return
+    // The size we apply is the *node* size, which includes the URL bar.
+    // Add the chrome height so the visible viewport matches the preset.
+    const URL_BAR_HEIGHT = 40
+    const minSize = PANEL_MINIMUM_SIZES.browser
+    const finalWidth = Math.max(width, minSize.width)
+    const finalHeight = Math.max(height + URL_BAR_HEIGHT, minSize.height)
+    resizeNode(nodeId, { width: finalWidth, height: finalHeight })
+    setIsSizeMenuOpen(false)
+  }, [nodeId, resizeNode])
+
+  // Close the menu when clicking outside.
+  useEffect(() => {
+    if (!isSizeMenuOpen) return
+    const onClickOutside = (e: MouseEvent) => {
+      if (sizeMenuRef.current && !sizeMenuRef.current.contains(e.target as Node)) {
+        setIsSizeMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [isSizeMenuOpen])
+
+  // Match a preset to the current viewport (chrome subtracted) for the checkmark.
+  const URL_BAR_HEIGHT = 40
+  const matchedPreset = currentSize ? SIZE_PRESETS.find(
+    (p) => p.width === currentSize.width && p.height + URL_BAR_HEIGHT === currentSize.height,
+  ) : undefined
 
   const handleUrlBarKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -335,6 +386,43 @@ export default function BrowserPanel({
           />
         </div>
 
+        {/* Size presets */}
+        <div ref={sizeMenuRef} className="relative">
+          <button
+            onClick={() => setIsSizeMenuOpen((v) => !v)}
+            className="w-7 h-7 flex items-center justify-center rounded-full border border-subtle bg-surface-5 hover:bg-hover text-primary transition-colors"
+            title={matchedPreset ? `Size: ${matchedPreset.label} (${matchedPreset.width}×${matchedPreset.height})` : 'Resize to device preset'}
+          >
+            <Devices size={13} />
+          </button>
+          {isSizeMenuOpen && (
+            <div
+              className="absolute right-0 top-9 z-30 min-w-[200px] rounded-lg border border-subtle bg-surface-5 shadow-xl py-1"
+              role="menu"
+            >
+              {SIZE_PRESETS.map((p) => {
+                const active = matchedPreset?.label === p.label
+                return (
+                  <button
+                    key={p.label}
+                    onClick={() => applyPresetSize(p.width, p.height)}
+                    className="w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-hover text-primary transition-colors"
+                    role="menuitem"
+                  >
+                    <span className="w-3 shrink-0 flex items-center justify-center">
+                      {active && <Check size={11} />}
+                    </span>
+                    <span className="flex-1">{p.label}</span>
+                    <span className="text-muted tabular-nums">
+                      {p.width}×{p.height}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
         {/* Screenshot tool */}
         <button
           onClick={handleScreenshot}
@@ -369,6 +457,21 @@ export default function BrowserPanel({
           className={`w-full h-full ${loadError ? 'hidden' : ''}`}
           partition={`persist:browser-${panelId}`}
         />
+
+        {/* Resize edge guards — invisible strips that sit on top of the
+            webview's outer pixels so mouse events reach CanvasNode's resize
+            handler instead of being captured by the <webview>. Match the
+            RESIZE_THRESHOLD (10px) of useNodeResize so the visible cursor
+            change aligns with the clickable area. Corners use diagonal
+            cursors; pointer-events propagate up to the canvas node. */}
+        <div aria-hidden="true" className="absolute left-3 right-3 top-0 h-[10px] cursor-ns-resize z-10" />
+        <div aria-hidden="true" className="absolute left-3 right-3 bottom-0 h-[10px] cursor-ns-resize z-10" />
+        <div aria-hidden="true" className="absolute top-3 bottom-3 left-0 w-[10px] cursor-ew-resize z-10" />
+        <div aria-hidden="true" className="absolute top-3 bottom-3 right-0 w-[10px] cursor-ew-resize z-10" />
+        <div aria-hidden="true" className="absolute top-0 left-0 w-3 h-3 cursor-nwse-resize z-10" />
+        <div aria-hidden="true" className="absolute top-0 right-0 w-3 h-3 cursor-nesw-resize z-10" />
+        <div aria-hidden="true" className="absolute bottom-0 left-0 w-3 h-3 cursor-nesw-resize z-10" />
+        <div aria-hidden="true" className="absolute bottom-0 right-0 w-3 h-3 cursor-nwse-resize z-10" />
 
         {/* Screenshot thumbnail */}
         {screenshot && (


### PR DESCRIPTION
Closes #147.

## What

Two small UX improvements to the browser panel resize, requested in issue #147.

### 1. Wider resize hit area (6 → 10 px)

The `RESIZE_THRESHOLD` constant in `useNodeResize.ts` is bumped from 6 to 10 pixels. The 6px band was uncomfortably small in general and especially around the browser panel: the `<webview>` captures pointer events, shrinking the usable edge to whatever sits between the node's outer border and the webview's edge.

### 2. Edge guards over the webview

Transparent overlay divs are placed on top of the webview's borders and corners. They forward `mousedown` to the CanvasNode resize handler (events would otherwise be captured by the webview) and set the correct resize cursor for that side/corner. Together with the wider threshold, the browser panel now feels as easy to resize from any edge as the other panels.

### 3. Device size presets

A new "Devices" button is added next to the Screenshot button in the URL bar. It opens a small menu with these presets:

| Label    | Size       | Hint              |
| -------- | ---------- | ----------------- |
| Mobile   | 375×667    | iPhone SE         |
| Mobile L | 414×896    | iPhone 11 Pro Max |
| Tablet   | 768×1024   | iPad              |
| Tablet L | 1024×1366  | iPad Pro          |
| Laptop   | 1280×800   |                   |
| Desktop  | 1920×1080  |                   |

Selecting a preset calls `canvasStore.resizeNode` and accounts for the URL bar height so the visible viewport matches the preset exactly. The active preset is marked with a check.

## Why

Both pieces of feedback come from #147 — the small hit area was frustrating in normal use and made browser resize harder than for other panels, and there was no quick way to test responsive layouts at common viewport sizes without manually dragging to approximate dimensions.

## Test

- `npm run build` passes locally.
- Verified manually with `npm run dev` on macOS (arm64): resize feels comfortable on all four edges and all four corners; preset menu opens/closes correctly; selecting a preset resizes the node exactly to the requested viewport (URL bar accounted for); the active preset shows a check mark; clicking outside closes the menu.

## Notes

- No new dependencies. `Devices` and `Check` icons are already in `@phosphor-icons/react` (already used elsewhere in BrowserPanel).
- The threshold change is global (affects all panels), which I think is a net improvement but happy to scope it to the browser if maintainers prefer.
- Screenshots can be added if useful — let me know.
