### PR TITLE
feat(ci): nightly build channel via curated nightly branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,174 @@
+name: Nightly
+
+# Builds the `nightly` branch and publishes prerelease artifacts under the
+# `nightly` electron-updater channel. App users who opt into nightly builds
+# via Settings receive these as auto-updates; everyone else stays on the
+# `latest` channel (driven by tag-based `release.yml`).
+#
+# Branching model: `nightly` is the active development branch — PRs land
+# here. Maintainers cherry-pick / merge stable changes from `nightly` into
+# `main`, then tag a stable release on `main` which triggers `release.yml`.
+# Nightly users therefore see changes earlier; stable users wait for the
+# next merge into `main` + tag.
+#
+# Trigger model:
+#   - push to `nightly`        → build + publish
+#   - manual workflow_dispatch → ad-hoc rebuild
+
+on:
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute nightly version
+        id: bump
+        run: |
+          base=$(node -p "require('./package.json').version")
+          # Drop any existing -nightly suffix from main so we don't end up with
+          # "0.5.0-nightly.X-nightly.Y" when bumping a nightly branch.
+          base_clean=${base%%-*}
+          short_sha=$(git rev-parse --short HEAD)
+          date=$(date -u +%Y%m%d)
+          version="${base_clean}-nightly.${date}-${short_sha}"
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Nightly version: ${version}"
+
+      - name: Create draft prerelease (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping creation"
+          else
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --title "$TAG" \
+              --draft \
+              --prerelease \
+              --generate-notes
+          fi
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: mac
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: win
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install setuptools (needed by node-gyp)
+        run: pip install setuptools
+
+      - name: Delete lockfile
+        run: node -e "try{require('fs').unlinkSync('package-lock.json')}catch{}"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate icons
+        run: npm run icons
+
+      - name: Pin nightly version in package.json
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.version=process.env.NIGHTLY_VERSION; fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\n')"
+          echo "Pinned package.json version to ${NIGHTLY_VERSION}"
+
+      - name: Build app
+        run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      - name: Package (macOS)
+        if: matrix.platform == 'mac'
+        run: npx electron-builder --mac --config.publish.channel=nightly --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Package (Linux)
+        if: matrix.platform == 'linux'
+        run: npx electron-builder --linux --config.publish.channel=nightly --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package (Windows)
+        if: matrix.platform == 'win'
+        run: npx electron-builder --win --config.publish.channel=nightly --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("$file")
+          done < <(find release -maxdepth 1 -type f \
+            ! -name 'builder-debug.yml' \
+            ! -name 'builder-effective-config.yaml' \
+            -print0)
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No top-level release artifacts found in $(pwd)/release"
+            exit 1
+          fi
+
+          gh release upload "$TAG" "${files[@]}" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish prerelease (remove draft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: gh release edit "$TAG" --repo "${{ github.repository }}" --draft=false --prerelease

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -24,6 +24,7 @@ import {
 } from '../shared/ipc-channels'
 import { getWindowType } from './windowRegistry'
 import { sendEvent } from './analytics'
+import { getSettingSync } from './store'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -35,6 +36,26 @@ const API_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_RE
 
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = false
+
+/** Sync electron-updater's channel + prerelease flag with the current setting.
+ *  Called at init and again whenever the renderer toggles `useNightlyBuilds`. */
+function applyChannelFromSettings(): void {
+  const nightly = getSettingSync('useNightlyBuilds') === true
+  autoUpdater.channel = nightly ? 'nightly' : 'latest'
+  autoUpdater.allowPrerelease = nightly
+}
+applyChannelFromSettings()
+
+/** Reapply the channel and trigger a fresh update check. Exported so the
+ *  settings IPC handler can flip channels without an app relaunch. */
+export function applyChannelFromSettingsAndRecheck(): void {
+  applyChannelFromSettings()
+  if (!app.isPackaged) return
+  log.info('[auto-updater] Channel switched to %s', autoUpdater.channel)
+  autoUpdater.checkForUpdates().catch((err) => {
+    log.warn('[auto-updater] post-channel-switch check failed:', err)
+  })
+}
 
 /** True after the user clicked "Update & Restart". The will-quit handler in
  *  src/main/index.ts reads this to skip its `process.reallyExit(0)` fallback —

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -59,6 +59,7 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   notifyOnlyWhenUnfocused: 'boolean',
   crashReportingEnabled: 'boolean',
   usageAnalyticsEnabled: 'boolean',
+  useNightlyBuilds: 'boolean',
 }
 
 /** Safely merge only known, type-correct keys from a parsed object into the settings cache. */
@@ -317,6 +318,16 @@ export function registerHandlers(): void {
           setCrashReportingEnabled(value !== false)
         } catch (err) {
           log.warn('Sentry live-toggle failed: %O', err)
+        }
+      }
+      // Live-switch the auto-updater channel so the user doesn't have to
+      // relaunch after opting in/out of nightly builds.
+      if (key === 'useNightlyBuilds') {
+        try {
+          const { applyChannelFromSettingsAndRecheck } = await import('./auto-updater')
+          applyChannelFromSettingsAndRecheck()
+        } catch (err) {
+          log.warn('Auto-updater channel live-switch failed: %O', err)
         }
       }
     },

--- a/src/renderer/settings/GeneralSettings.tsx
+++ b/src/renderer/settings/GeneralSettings.tsx
@@ -52,6 +52,12 @@ export function GeneralSettings() {
       >
         <Toggle checked={store.usageAnalyticsEnabled} onChange={(v) => store.setSetting('usageAnalyticsEnabled', v)} />
       </SettingRow>
+      <SettingRow
+        label="Receive nightly builds"
+        description="Auto-update from the curated `nightly` release channel instead of stable. Nightlies can be broken — opt in only if you want to test upcoming changes early."
+      >
+        <Toggle checked={store.useNightlyBuilds} onChange={(v) => store.setSetting('useNightlyBuilds', v)} />
+      </SettingRow>
     </div>
   )
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -757,6 +757,11 @@ export interface AppSettings {
   /** Send anonymous usage data (app starts, version upgrades, feedback) to the
    *  cero-analytics endpoint. No personal data, no file paths, no project info. */
   usageAnalyticsEnabled: boolean
+
+  // Updates
+  /** When true, the auto-updater follows the `nightly` release channel and
+   *  accepts prereleases. Off by default so regular users stay on stable. */
+  useNightlyBuilds: boolean
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -804,6 +809,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // Privacy
   crashReportingEnabled: true,
   usageAnalyticsEnabled: true,
+
+  // Updates
+  useNightlyBuilds: false,
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an opt-in nightly release channel. So we can have a build always ready with the actual pr's merged. 

-> main branch is still protected and maintainer can merge / cherry pick from nightly. 
-> easy testing, faster feedback, stops branch drifts while developing
-> contributors can work on up to date branch
-> manual setting of allowed users on nightly branch



**Branching model:** `nightly` is the active development branch — PRs land here. Maintainer cherry-picks / merges from `nightly` into `main` when ready, then tags `v*` → existing `release.yml` builds + publishes stable. Two layers: `nightly` branch (what gets built) + `nightly` electron-updater channel (who receives it via opt-in setting).

```mermaid
flowchart LR
    contrib([Contributors]) -->|PR| nightly[nightly branch]
    nightly -->|push trigger| nworkflow[nightly.yml]
    nworkflow -->|signed prerelease| ghr1[(GitHub Release<br/>X.Y.Z-nightly.date-sha)]
    ghr1 --> nightlyusers([Nightly users<br/>useNightlyBuilds=on])

    nightly -->|maintainer<br/>cherry-pick / merge| main[main branch]
    main -->|tag v*| rworkflow[release.yml]
    rworkflow -->|signed release| ghr2[(GitHub Release<br/>vX.Y.Z)]
    ghr2 --> stableusers([Stable users<br/>useNightlyBuilds=off])
```

## Workflow

`.github/workflows/nightly.yml`:
- Triggers on push to `nightly` + `workflow_dispatch`.
- Version: `X.Y.Z-nightly.YYYYMMDD-<short_sha>`.
- Mac / Win / Linux build (mac signed + notarized, same secrets as `release.yml`).
- electron-builder with `--config.publish.channel=nightly` → writes `nightly-<platform>.yml` next to artifacts.
- Drafts a GitHub prerelease, uploads, publishes (un-drafts).

## App-side

- New `useNightlyBuilds: boolean` setting (default `false`).
- `auto-updater.ts` reads at init + on every `SETTINGS_SET`. When on: `autoUpdater.channel = 'nightly'` + `allowPrerelease = true`. Switches live, no relaunch needed.
- Toggle added to General Settings.

---

## Manual steps required on GitHub after merging this PR

The PR adds the workflow + app wiring. Channel can't go live until these one-time GitHub settings are done by a repo admin:

### 1. Create the `nightly` branch

```bash
git checkout main
git pull
git checkout -b nightly
git push -u origin nightly
```

Or via UI: **Branches → New branch from `main` → name `nightly`**.

### 2. Configure branch protection on `nightly`

GitHub repo → **Settings → Branches → Add branch protection rule**:

- **Branch name pattern:** `nightly`
- **Restrict who can push to matching branches:** ✓ — add maintainers + the GitHub Actions app (`github-actions[bot]`) so the workflow can push artifacts via `gh release upload`. Without the bot in the allowlist, the workflow's upload step fails.

### 3. Update default branch + contribution guide

If new contributor PRs should target `nightly` instead of `main`: **Settings → Branches → Default branch** → switch to `nightly`. Update CONTRIBUTING.md / README to mention the model.

### 4. Verify the channel end-to-end

After steps 1-3:

1. Push a trivial commit to `nightly` (or run `workflow_dispatch`).
2. Wait for the workflow to complete (~15 min incl. macOS notarization).
3. GitHub Releases: a prerelease tagged `v<base>-nightly.<date>-<sha>` should appear with `Cate-<version>-arm64.dmg`, `nightly-mac.yml`, `nightly.yml`, `nightly-linux.yml`, etc.
4. Build the app from this branch locally, flip "Receive nightly builds" in Settings → trigger an update check → app should pick up the prerelease.


---

## Cost notes

Mac signing + notarization runs on every nightly build (~10-15 min). Cash cost: $0 — Apple Dev Program already paid for stable; public-repo CI minutes are unlimited. If push frequency becomes a problem the trigger can be downgraded to `schedule: cron` later without breaking the channel.

## Test plan

- [x] `npm test` passes
- [x] `npx tsc --noEmit` clean
- [ ] First nightly build after manual setup (steps 1-2)
- [ ] Toggle "Receive nightly builds" in packaged build — `autoUpdater.channel` flips + recheck fires
- [ ] Stable user unaffected — `latest-*.yml` still drives stable channel
