### PR TITLE
fix: unpack all node_modules so pi's transitive deps resolve in packaged app

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,10 +2,17 @@ appId: com.cate.app
 productName: Cate
 directories:
   output: release
+# The pi coding agent (@earendil-works/pi-coding-agent) is loaded as ESM
+# directly from the unpacked location, so Node resolves all of its transitive
+# dependencies against the real filesystem rather than reading them from the
+# asar. Its dependency closure is large (~130 packages) and npm's hoisting
+# layout varies between installs, so an explicit allowlist silently breaks
+# whenever a dependency moves between nested and hoisted positions (issue #150:
+# cross-spawn was hoisted to node_modules/cross-spawn in CI and left inside the
+# asar). Unpack the whole node_modules tree so every dependency pi needs is
+# present on disk regardless of hoisting.
 asarUnpack:
-  - "node_modules/@earendil-works/**"
-  - "node_modules/.bin/pi"
-  - "node_modules/.bin/pi.cmd"
+  - "node_modules/**"
 extraResources:
   # Ship bundled pi extensions (e.g. cate-plan-mode) into the packaged app so
   # installPlanModeExtension can copy them into ~/.pi/agent/extensions/ on


### PR DESCRIPTION
## Summary

Fixes #150 — installing an extension in the packaged app crashes with `ERR_MODULE_NOT_FOUND: Cannot find package 'cross-spawn'`.

`@earendil-works/pi-coding-agent` is loaded as ESM directly from the `app.asar.unpacked` location, so Node resolves all of its transitive dependencies against the real filesystem. The old `asarUnpack` allowlist only covered `node_modules/@earendil-works/**`, so any transitive dep that npm hoisted to the top-level `node_modules` (like `cross-spawn`) stayed inside the asar and failed to resolve.

The dependency closure is ~130 packages and npm's hoisting layout differs between installs (locally `cross-spawn` is nested under pi; in CI it gets hoisted to the root), so a hand-maintained allowlist is fragile and would break again on the next pi update. This unpacks the whole `node_modules` tree instead, which has no functional downside since asar is only a packaging optimization (native modules are already unpacked).

## Test plan

- [ ] `npm run build` produces a packaged app
- [ ] Install an extension from the Skills/Extensions tab in the packaged build and confirm no `ERR_MODULE_NOT_FOUND`