### PR TITLE
working draft / idea: Overview — global view of all workspaces

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,6 +26,7 @@ import { renderPanelComponent, PANEL_REGISTRY } from './panels/registry'
 const CanvasPanel = PANEL_REGISTRY.canvas.Component
 import { NodeSwitcher } from './ui/NodeSwitcher'
 import { CommandPalette } from './ui/CommandPalette'
+import OverviewMode from './overview/OverviewMode'
 import { SettingsWindow } from './settings/SettingsWindow'
 import { SavedLayoutsDialog } from './dialogs/SavedLayoutsDialog'
 import { PostUpdateFeedbackDialog } from './dialogs/PostUpdateFeedbackDialog'
@@ -115,6 +116,7 @@ function MainApp() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
   const showNodeSwitcher = useUIStore((s) => s.showNodeSwitcher)
   const showCommandPalette = useUIStore((s) => s.showCommandPalette)
+  const showOverview = useUIStore((s) => s.showOverview)
 
   // Theme — apply on mount and re-apply whenever appearanceMode changes
   const appearanceMode = useSettingsStore((s) => s.appearanceMode)
@@ -487,6 +489,7 @@ function MainApp() {
       {/* Modal overlays */}
       {showNodeSwitcher && <NodeSwitcher />}
       {showCommandPalette && <CommandPalette />}
+      {showOverview && <OverviewMode />}
       {showSettings && (
         <SettingsWindow isOpen={showSettings} onClose={closeSettings} initialTab={settingsInitialTab ?? undefined} />
       )}

--- a/src/renderer/hooks/useAgentPanelInfo.ts
+++ b/src/renderer/hooks/useAgentPanelInfo.ts
@@ -24,7 +24,7 @@ function resolvePanelId(key: string): string {
   return terminalRegistry.panelIdForPty(key) ?? key
 }
 
-function selectAgentInfoByPanel(
+export function selectAgentInfoByPanel(
   s: StatusStore,
   workspaceId: string | undefined,
 ): Record<string, AgentPanelInfo> {

--- a/src/renderer/overview/OverviewCard.tsx
+++ b/src/renderer/overview/OverviewCard.tsx
@@ -1,0 +1,85 @@
+// =============================================================================
+// OverviewCard — one schematic window card in the Overview overlay. Title bar
+// (icon + title), big centered type logo, and a short snippet. No live panel
+// content (that is Phase 2, on zoom-in).
+// =============================================================================
+
+import React, { useCallback } from 'react'
+import { getPanelDef } from '../panels/registry'
+import { navigateToNode } from './navigate'
+import type { OverviewWindow } from './collectOverview'
+
+/** Fixed card geometry — shared with WorkspaceBox/OverviewMode for layout math. */
+export const CARD_W = 220
+export const CARD_H = 140
+export const CARD_GAP = 16
+
+const OverviewCard: React.FC<{ win: OverviewWindow }> = ({ win }) => {
+  const def = getPanelDef(win.panelType)
+  const Icon = def.icon
+  const color = def.brandColor
+  // Agent brand logo (Claude Code / Codex / …) for terminals running a
+  // detected agent; resolved in collectOverview from live status + title.
+  const agentLogo = win.logo
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation() // don't trigger the workspace-box click
+      void navigateToNode(win.workspaceId, win.nodeId)
+    },
+    [win.workspaceId, win.nodeId],
+  )
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      title={win.title}
+      className="flex flex-col rounded-lg overflow-hidden bg-surface-3 border border-white/10 shadow-sm cursor-pointer transition-transform hover:scale-[1.02] hover:border-white/25"
+      style={{ width: CARD_W, height: CARD_H }}
+    >
+      {/* Title bar */}
+      <div
+        className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-primary"
+        style={{ backgroundColor: `color-mix(in srgb, ${color} 22%, transparent)` }}
+      >
+        {agentLogo ? (
+          <img
+            src={agentLogo}
+            alt={win.title}
+            width={14}
+            height={14}
+            style={{ objectFit: 'contain', display: 'block' }}
+            draggable={false}
+            className="flex-shrink-0"
+          />
+        ) : (
+          <Icon size={13} weight="bold" style={{ color }} className="flex-shrink-0" />
+        )}
+        <span className="truncate">{win.title}</span>
+      </div>
+
+      {/* Body: big agent logo (terminals) or type logo + optional snippet */}
+      <div className="relative flex-1 flex flex-col items-center justify-center gap-1.5 min-h-0">
+        {agentLogo ? (
+          <img
+            src={agentLogo}
+            alt={win.title}
+            width={40}
+            height={40}
+            style={{ objectFit: 'contain', display: 'block' }}
+            draggable={false}
+          />
+        ) : (
+          <Icon size={40} weight="duotone" style={{ color, opacity: 0.55 }} />
+        )}
+        {win.snippet && (
+          <span className="px-2 max-w-full truncate text-[11px] text-muted">{win.snippet}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OverviewCard

--- a/src/renderer/overview/OverviewMode.tsx
+++ b/src/renderer/overview/OverviewMode.tsx
@@ -1,0 +1,133 @@
+// =============================================================================
+// OverviewMode — full-screen overlay showing every workspace's windows as
+// schematic cards in a zoom/pan-able space. Mirrors the CommandPalette overlay
+// pattern (conditional-rendered from App.tsx on uiStore.showOverview).
+// =============================================================================
+
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { X } from '@phosphor-icons/react'
+import { useUIStore } from '../stores/uiStore'
+import { collectOverview, type OverviewWorkspace } from './collectOverview'
+import WorkspaceBox from './WorkspaceBox'
+
+const ZOOM_MIN = 0.1
+const ZOOM_MAX = 2
+const FIT_PADDING = 64
+
+interface View {
+  scale: number
+  offset: { x: number; y: number }
+}
+
+const OverviewMode: React.FC = () => {
+  const setShowOverview = useUIStore((s) => s.setShowOverview)
+  const close = useCallback(() => setShowOverview(false), [setShowOverview])
+
+  // Collect in an effect, not during render: collectOverview() flushes the
+  // active canvas into appStore (a store mutation), which must not run in the
+  // render phase.
+  const [data, setData] = useState<OverviewWorkspace[]>([])
+  useEffect(() => {
+    setData(collectOverview())
+  }, [])
+
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const worldRef = useRef<HTMLDivElement>(null)
+  const [view, setView] = useState<View>({ scale: 1, offset: { x: 0, y: 0 } })
+  const fittedRef = useRef(false)
+
+  // Fit-to-screen once the content has been laid out.
+  useLayoutEffect(() => {
+    if (fittedRef.current || data.length === 0 || !worldRef.current) return
+    const w = worldRef.current.offsetWidth
+    const h = worldRef.current.offsetHeight
+    if (w === 0 || h === 0) return
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const scale = Math.min((vw - FIT_PADDING * 2) / w, (vh - FIT_PADDING * 2) / h, 1)
+    const safeScale = Math.max(scale, ZOOM_MIN)
+    setView({
+      scale: safeScale,
+      offset: { x: (vw - w * safeScale) / 2, y: Math.max(FIT_PADDING, (vh - h * safeScale) / 2) },
+    })
+    fittedRef.current = true
+  }, [data])
+
+  // Esc closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        close()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [close])
+
+  // Cmd/Ctrl + wheel = zoom around cursor; plain wheel / two-finger = pan.
+  // Attached as a native non-passive listener so preventDefault() actually
+  // suppresses the browser's pinch-zoom / scroll (React's onWheel is passive).
+  useEffect(() => {
+    const el = overlayRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      if (e.metaKey || e.ctrlKey) {
+        const factor = Math.exp(-e.deltaY * 0.01)
+        setView((prev) => {
+          const next = Math.min(Math.max(prev.scale * factor, ZOOM_MIN), ZOOM_MAX)
+          const cx = e.clientX
+          const cy = e.clientY
+          const contentX = (cx - prev.offset.x) / prev.scale
+          const contentY = (cy - prev.offset.y) / prev.scale
+          return { scale: next, offset: { x: cx - contentX * next, y: cy - contentY * next } }
+        })
+      } else {
+        setView((prev) => ({ scale: prev.scale, offset: { x: prev.offset.x - e.deltaX, y: prev.offset.y - e.deltaY } }))
+      }
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
+
+  const boxes = useMemo(
+    () => data.map((ws) => <WorkspaceBox key={ws.id} workspace={ws} />),
+    [data],
+  )
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 overflow-hidden backdrop-blur-sm"
+      style={{ backgroundColor: 'color-mix(in srgb, var(--canvas-bg) 95%, transparent)' }}
+    >
+      {/* Header */}
+      <div className="absolute top-0 inset-x-0 z-10 flex items-center justify-between px-4 py-3 pointer-events-none">
+        <span className="text-sm font-semibold text-secondary pointer-events-auto">Übersicht</span>
+        <button
+          type="button"
+          onClick={close}
+          title="Schließen (Esc)"
+          className="flex items-center justify-center w-8 h-8 rounded text-muted hover:text-primary hover:bg-hover transition-colors pointer-events-auto"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Zoom/pan world */}
+      <div
+        ref={worldRef}
+        className="absolute top-0 left-0 flex flex-col gap-8 p-8"
+        style={{
+          transform: `translate(${view.offset.x}px, ${view.offset.y}px) scale(${view.scale})`,
+          transformOrigin: '0 0',
+        }}
+      >
+        {boxes}
+      </div>
+    </div>
+  )
+}
+
+export default OverviewMode

--- a/src/renderer/overview/WorkspaceBox.tsx
+++ b/src/renderer/overview/WorkspaceBox.tsx
@@ -1,0 +1,69 @@
+// =============================================================================
+// WorkspaceBox — one workspace section in the Overview overlay: a label plus a
+// tinted box (workspace color) holding all of that workspace's windows tiled at
+// uniform size. Clicking the box background (not a card) switches workspaces.
+// =============================================================================
+
+import React, { useCallback } from 'react'
+import OverviewCard, { CARD_W, CARD_H, CARD_GAP } from './OverviewCard'
+import { navigateToWorkspace } from './navigate'
+import type { OverviewWorkspace } from './collectOverview'
+
+const BOX_PADDING = 16
+const MAX_COLUMNS = 4
+
+const WorkspaceBox: React.FC<{ workspace: OverviewWorkspace }> = ({ workspace }) => {
+  const { name, color, windows, deferred } = workspace
+
+  const columns = Math.max(1, Math.min(windows.length || 1, MAX_COLUMNS))
+  const boxWidth = columns * CARD_W + (columns - 1) * CARD_GAP + BOX_PADDING * 2
+
+  const handleClick = useCallback(() => {
+    void navigateToWorkspace(workspace.id)
+  }, [workspace.id])
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2 text-sm font-semibold text-secondary">
+        <span>{name}</span>
+        {deferred && <span className="text-[10px] text-muted font-normal">(nicht geladen)</span>}
+      </div>
+
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={handleClick}
+        title={`Zu ${name} wechseln`}
+        className="rounded-xl border border-white/10 cursor-pointer transition-colors hover:border-white/25"
+        style={{
+          width: boxWidth,
+          padding: BOX_PADDING,
+          backgroundColor: `color-mix(in srgb, ${color} 14%, var(--surface-1))`,
+        }}
+      >
+        {windows.length === 0 ? (
+          <div
+            className="flex items-center justify-center text-xs text-muted"
+            style={{ height: CARD_H }}
+          >
+            Keine Fenster
+          </div>
+        ) : (
+          <div
+            className="grid"
+            style={{
+              gridTemplateColumns: `repeat(${columns}, ${CARD_W}px)`,
+              gap: CARD_GAP,
+            }}
+          >
+            {windows.map((win) => (
+              <OverviewCard key={`${win.workspaceId}:${win.nodeId ?? win.panelId}`} win={win} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default WorkspaceBox

--- a/src/renderer/overview/collectOverview.ts
+++ b/src/renderer/overview/collectOverview.ts
@@ -1,0 +1,191 @@
+// =============================================================================
+// collectOverview — flattens every workspace into a uniform list of "windows"
+// for the global Overview overlay.
+//
+// Two data sources have to be unioned because inactive workspaces are NOT fully
+// hydrated in memory:
+//   1. Visited / active workspaces — `ws.canvasNodes` (geometry + stable node
+//      ids) joined against `ws.panels` (type/title/filePath/url/cwd).
+//   2. Deferred workspaces (never switched to this session) — `ws.canvasNodes`
+//      is empty; the data lives in the lazy `deferredSnapshots` map as
+//      `NodeSnapshot[]`, which already carries type/title/filePath/url/
+//      workingDirectory directly (no panel join).
+//
+// Node/panel ids are regenerated when a deferred workspace is restored, so a
+// snapshot node has no id that survives the round-trip. Therefore `nodeId` is
+// populated only for visited workspaces; deferred windows navigate to the
+// workspace without focusing a specific node.
+// =============================================================================
+
+import { useAppStore } from '../stores/appStore'
+import { useStatusStore } from '../stores/statusStore'
+import { selectAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
+import { getAgentLogo } from '../lib/agentLogos'
+import { deferredSnapshots } from '../lib/session'
+import type { PanelType, PanelState, NodeSnapshot, CanvasNodeState } from '../../shared/types'
+
+export interface OverviewWindow {
+  workspaceId: string
+  panelId: string
+  /** Stable canvas-node id — only known for visited workspaces (null otherwise). */
+  nodeId: string | null
+  panelType: PanelType
+  title: string
+  /** Short secondary line: editor→file, terminal→cwd, browser→url. */
+  snippet: string
+  /** Agent brand logo URL (Claude Code / Codex / …) when this is a terminal
+   *  running a detected agent; null otherwise (falls back to the type icon). */
+  logo: string | null
+}
+
+export interface OverviewWorkspace {
+  id: string
+  name: string
+  color: string
+  /** True when the data came from a deferred snapshot (no stable node ids). */
+  deferred: boolean
+  windows: OverviewWindow[]
+}
+
+/** Last path segment, for compact file/dir snippets. */
+function basename(p: string): string {
+  const trimmed = p.replace(/[/\\]+$/, '')
+  const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed
+}
+
+/** Strip protocol + trailing slash so URLs read as host/path. */
+function shortUrl(url: string): string {
+  return url.replace(/^[a-z]+:\/\//i, '').replace(/\/$/, '')
+}
+
+function snippetFromPanel(panel: PanelState): string {
+  switch (panel.type) {
+    case 'editor':
+      return panel.filePath ? basename(panel.filePath) : 'Untitled'
+    case 'terminal':
+      return panel.cwd ? basename(panel.cwd) : ''
+    case 'browser':
+      return panel.url ? shortUrl(panel.url) : ''
+    default:
+      return ''
+  }
+}
+
+function snippetFromSnapshot(node: NodeSnapshot): string {
+  switch (node.panelType) {
+    case 'editor':
+      return node.filePath ? basename(node.filePath) : 'Untitled'
+    case 'terminal':
+      return node.workingDirectory ? basename(node.workingDirectory) : ''
+    case 'browser':
+      return node.url ? shortUrl(node.url) : ''
+    default:
+      return ''
+  }
+}
+
+/** Canvas panels never live on a canvas; nothing else is filtered. */
+function isCanvasWindow(type: string): boolean {
+  return type === 'canvas'
+}
+
+/** Live agent logo for a terminal panel, falling back to a title match (the
+ *  panel title is the agent display name and survives persistence). */
+function resolveLogo(
+  type: PanelType,
+  title: string,
+  agentLogoByPanel: Record<string, string | null>,
+  panelId: string,
+): string | null {
+  if (type !== 'terminal') return null
+  return agentLogoByPanel[panelId] ?? getAgentLogo(title)
+}
+
+function windowsFromVisited(
+  workspaceId: string,
+  canvasNodes: Record<string, CanvasNodeState>,
+  panels: Record<string, PanelState>,
+  agentLogoByPanel: Record<string, string | null>,
+): OverviewWindow[] {
+  const out: OverviewWindow[] = []
+  for (const node of Object.values(canvasNodes)) {
+    const panel = panels[node.panelId]
+    if (!panel || isCanvasWindow(panel.type)) continue
+    out.push({
+      workspaceId,
+      panelId: node.panelId,
+      nodeId: node.id,
+      panelType: panel.type,
+      title: panel.title,
+      snippet: snippetFromPanel(panel),
+      logo: resolveLogo(panel.type, panel.title, agentLogoByPanel, node.panelId),
+    })
+  }
+  return out
+}
+
+function windowsFromSnapshot(workspaceId: string, nodes: NodeSnapshot[]): OverviewWindow[] {
+  const out: OverviewWindow[] = []
+  for (const node of nodes) {
+    if (isCanvasWindow(node.panelType)) continue
+    const type = node.panelType as PanelType
+    out.push({
+      workspaceId,
+      panelId: node.panelId,
+      nodeId: null,
+      panelType: type,
+      title: node.title,
+      // No live process for deferred workspaces — title match only.
+      snippet: snippetFromSnapshot(node),
+      logo: type === 'terminal' ? getAgentLogo(node.title) : null,
+    })
+  }
+  return out
+}
+
+/**
+ * Snapshot every workspace's windows for the Overview overlay. Flushes the
+ * active workspace's live canvas into its WorkspaceState first so positions and
+ * panels are current.
+ */
+export function collectOverview(): OverviewWorkspace[] {
+  const app = useAppStore.getState()
+  // Flush live canvas → active workspace state so we don't read stale data.
+  app.syncCanvasToWorkspace(app.selectedWorkspaceId)
+
+  // Re-read after the sync mutated the store.
+  const workspaces = useAppStore.getState().workspaces
+  const status = useStatusStore.getState()
+
+  return workspaces.map((ws): OverviewWorkspace => {
+    const hasLiveNodes = Object.keys(ws.canvasNodes).length > 0
+    if (hasLiveNodes) {
+      // Live agent name/logo keyed by panelId (gated on the process running).
+      const agentInfo = selectAgentInfoByPanel(status, ws.id)
+      const logoByPanel: Record<string, string | null> = {}
+      for (const [panelId, info] of Object.entries(agentInfo)) logoByPanel[panelId] = info.logo
+      return {
+        id: ws.id,
+        name: ws.name,
+        color: ws.color,
+        deferred: false,
+        windows: windowsFromVisited(ws.id, ws.canvasNodes, ws.panels, logoByPanel),
+      }
+    }
+
+    const snapshot = deferredSnapshots.get(ws.id)
+    if (snapshot) {
+      return {
+        id: ws.id,
+        name: ws.name,
+        color: ws.color,
+        deferred: true,
+        windows: windowsFromSnapshot(ws.id, snapshot.nodes),
+      }
+    }
+
+    // Empty workspace — still shown as a labeled box with no windows.
+    return { id: ws.id, name: ws.name, color: ws.color, deferred: false, windows: [] }
+  })
+}

--- a/src/renderer/overview/navigate.ts
+++ b/src/renderer/overview/navigate.ts
@@ -1,0 +1,45 @@
+// =============================================================================
+// Overview navigation — switch workspaces (and optionally focus a node) from
+// the Overview overlay. Reuses the NodeSwitcher center-on-node pattern.
+// =============================================================================
+
+import { useAppStore, getWorkspaceCanvasStore } from '../stores/appStore'
+import { useUIStore } from '../stores/uiStore'
+
+/** Switch to a workspace and close the overlay. */
+export async function navigateToWorkspace(workspaceId: string): Promise<void> {
+  useUIStore.getState().setShowOverview(false)
+  await useAppStore.getState().selectWorkspace(workspaceId)
+}
+
+/**
+ * Center the viewport on a node in the (already-selected) workspace's canvas
+ * store and focus it. The store may not be mounted on the same tick the
+ * workspace was selected, so retry across a few animation frames before giving
+ * up silently.
+ */
+function focusNodeWhenReady(workspaceId: string, nodeId: string, attempt = 0): void {
+  const store = getWorkspaceCanvasStore(workspaceId)
+  const node = store?.getState().nodes[nodeId]
+  if (!store || !node) {
+    if (attempt < 10) requestAnimationFrame(() => focusNodeWhenReady(workspaceId, nodeId, attempt + 1))
+    return
+  }
+  const state = store.getState()
+  state.focusNode(nodeId)
+  const zoom = state.zoomLevel
+  state.setViewportOffset({
+    x: window.innerWidth / 2 - (node.origin.x + node.size.width / 2) * zoom,
+    y: window.innerHeight / 2 - (node.origin.y + node.size.height / 2) * zoom,
+  })
+}
+
+/**
+ * Switch to a workspace, close the overlay, and focus a node. `nodeId` is only
+ * stable for visited workspaces; pass null for deferred ones (switch only).
+ */
+export async function navigateToNode(workspaceId: string, nodeId: string | null): Promise<void> {
+  useUIStore.getState().setShowOverview(false)
+  await useAppStore.getState().selectWorkspace(workspaceId)
+  if (nodeId) requestAnimationFrame(() => focusNodeWhenReady(workspaceId, nodeId))
+}

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   Gear,
   MagnifyingGlass,
+  SquaresFour,
   type Icon as PhosphorIcon,
 } from '@phosphor-icons/react'
 import pkg from '../../../package.json'
@@ -309,6 +310,18 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
         })}
         {isDragActive && views.length === 0 && dropIndicator !== null && (
           <div className="w-7 h-[2px] my-0.5 bg-blue-400 rounded-full pointer-events-none" />
+        )}
+        {side === 'left' && (
+          <div className="relative w-full flex items-center justify-center">
+            <button
+              type="button"
+              className="flex items-center justify-center w-8 h-8 my-1 rounded text-muted hover:text-secondary transition-colors"
+              onClick={() => useUIStore.getState().setShowOverview(true)}
+              title="Übersicht — alle Workspaces"
+            >
+              <SquaresFour size={16} className="pointer-events-none" />
+            </button>
+          </div>
         )}
       </div>
       {side === 'left' && (

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -51,6 +51,8 @@ interface UIStoreState {
   showNodeSwitcher: boolean
   showCommandPalette: boolean
   showLayoutsDialog: boolean
+  /** Whether the global Overview overlay (all workspaces) is open. */
+  showOverview: boolean
   /** Whether the minimap is currently expanded. */
   minimapOpen: boolean
   showSettings: boolean
@@ -73,6 +75,7 @@ interface UIStoreActions {
   setShowNodeSwitcher: (show: boolean) => void
   setShowCommandPalette: (show: boolean) => void
   setShowLayoutsDialog: (show: boolean) => void
+  setShowOverview: (show: boolean) => void
   setMinimapOpen: (open: boolean) => void
   toggleMinimapOpen: () => void
   openSettings: (initialTab?: string) => void
@@ -98,6 +101,7 @@ export const useUIStore = create<UIStore>((set, get) => ({
   showNodeSwitcher: false,
   showCommandPalette: false,
   showLayoutsDialog: false,
+  showOverview: false,
   minimapOpen: false,
   showSettings: false,
   settingsInitialTab: null,
@@ -120,6 +124,10 @@ export const useUIStore = create<UIStore>((set, get) => ({
 
   setShowLayoutsDialog(show) {
     set({ showLayoutsDialog: show })
+  },
+
+  setShowOverview(show) {
+    set({ showOverview: show })
   },
 
   setMinimapOpen(open) {


### PR DESCRIPTION

<img width="1621" height="960" alt="Bildschirmfoto 2026-05-29 um 09 55 41" src="https://github.com/user-attachments/assets/d332aa44-f03b-4642-b366-a256bf0ba215" />

<img width="302" height="212" alt="Bildschirmfoto 2026-05-29 um 10 06 57" src="https://github.com/user-attachments/assets/513ccf82-c5c8-46f5-a863-ab784e86fbe9" />




> **Draft / idea — work in progress.** Not ready for review yet.

Just to check acceptance / idea. 

Would be nice to have an overview. Screenshot attached. 

Working -> but just a shot, needs polishing, code hardening, styling, attention needed marker, rendering on zoom in, content preview.  etc.etc 

jumps to - and mounts terminal on click, overview is able to pan / zoom etc, sorted by workspace.


## What

A full-screen **Overview** overlay that shows every workspace at once: each workspace as a labeled, tinted box with all of its windows tiled at uniform size, in a zoom/pan-able space. Reachable from a new rail button below the workspace icon group.

Goal: a spatial bird's-eye over all workspaces + fast navigation (click a window → jump there).

## How it works (MVP)

- **Schematic cards**, no live panel mount: each window = title bar (icon + title), big centered logo, short snippet (editor→file, terminal→cwd, browser→url).
- **Agent logos**: terminal cards running a detected agent show the agent brand logo (Claude Code, Codex, …), from live agent status with a title fallback.
- **Two data sources** so inactive workspaces render too: visited workspaces from in-memory `canvasNodes`+`panels`; deferred (never-opened) ones from the lazy session snapshot.
- **Navigation**: click a card → switch workspace + focus/center the node (visited only — ids regenerate on deferred restore); click the box background → switch workspace only.
- **Zoom + pan**: Cmd+scroll = zoom, two-finger = pan, Esc closes. Initial fit-to-screen.

## Out of scope (phase 2)

Live panel content on zoom-in (real terminal/editor) — needs a `renderPanelContent` refactor (currently bound to the active workspace) + WebGL context limits.

## Files

- New: `src/renderer/overview/{collectOverview,navigate}.ts`, `{OverviewMode,WorkspaceBox,OverviewCard}.tsx`
- Wiring: `uiStore.showOverview`, `App.tsx`, rail button in `Sidebar.tsx`, `selectAgentInfoByPanel` exported from `useAgentPanelInfo`

## Status

Typecheck + build clean; existing test suite green (minus the documented env-only git tests). Manually clicked through locally. No tests for the new feature yet.



###  Feedback

what do you think about this ?