### PR TITLE
chore: gitignore local .cate session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test-results/
 
 # Local logo scratch dir
 _logos/
+
+# Cate local session state
+.cate/


### PR DESCRIPTION
Adds `.cate/` to `.gitignore` so Cate's local session/workspace scratch state (`.cate/session.json`, `workspace.json`, etc.) is no longer tracked or surfaced as untracked noise in `git status`.