### PR TITLE
fix: canvas/workspace DnD and empty-workspace note blink

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import log from './logger'
 import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session } from 'electron'
 import fs from 'fs'
 import path from 'path'
-import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, APP_OPEN_PATH } from '../shared/ipc-channels'
+import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, DIALOG_CONFIRM_IMPORT, APP_OPEN_PATH } from '../shared/ipc-channels'
 import {
   WINDOW_SET_TITLE,
   PANEL_TRANSFER, PANEL_RECEIVE, PANEL_TRANSFER_ACK,
@@ -616,6 +616,24 @@ function registerWindowAndDialogHandlers(): void {
       noLink: true,
     })
     return result.response === 0 ? 'with-contents' : result.response === 1 ? 'region-only' : 'cancel'
+  })
+
+  // Ask whether to copy or move external files/folders dropped onto the file
+  // explorer into a workspace directory.
+  ipcMain.handle(DIALOG_CONFIRM_IMPORT, async (event, payload: { count: number; destName: string }) => {
+    const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
+    const count = payload?.count ?? 0
+    const destName = payload?.destName ?? 'this folder'
+    const result = await dialog.showMessageBox(win!, {
+      type: 'question',
+      message: `Add ${count} ${count === 1 ? 'item' : 'items'} to "${destName}"?`,
+      detail: 'Copy keeps the originals where they are. Move removes them from their current location.',
+      buttons: ['Copy', 'Move', 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+    })
+    return result.response === 0 ? 'copy' : result.response === 1 ? 'move' : 'cancel'
   })
 
   // Capture page screenshot for panel previews

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest'
+
+// Capture the handlers registered via ipcMain.handle so we can invoke them
+// directly without a live Electron main process.
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, fn)
+    },
+  },
+}))
+
+vi.mock('../windowRegistry', () => ({
+  windowFromEvent: () => undefined,
+  sendToWindow: vi.fn(),
+}))
+
+const { registerHandlers } = await import('./filesystem')
+const { addAllowedRoot, removeAllowedRoot } = await import('./pathValidation')
+const { FS_IMPORT_ENTRIES } = await import('../../shared/ipc-channels')
+
+registerHandlers()
+const importEntries = handlers.get(FS_IMPORT_ENTRIES)!
+const fakeEvent = { sender: {} } as unknown
+
+// A throwaway event arg + helper to call the handler ergonomically.
+function callImport(sources: string[], destDir: string, mode: 'copy' | 'move') {
+  return importEntries(fakeEvent, sources, destDir, mode) as Promise<{ created: string[]; failed: number }>
+}
+
+describe('FS_IMPORT_ENTRIES', () => {
+  let root: string // workspace destination (an allowed root: lives under tmpdir)
+  let extern: string // "external" source location
+
+  beforeEach(async () => {
+    // realpath so the registered allowed root matches validatePathStrict's
+    // symlink-resolved comparison (e.g. /tmp → /private/tmp on macOS).
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'cate-import-dest-')))
+    extern = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'cate-import-src-')))
+    addAllowedRoot(root) // destination must be inside a workspace root; source need not be
+  })
+
+  afterEach(async () => {
+    removeAllowedRoot(root)
+    await fs.rm(root, { recursive: true, force: true })
+    await fs.rm(extern, { recursive: true, force: true })
+  })
+
+  test('copy leaves the original in place and creates a copy in the destination', async () => {
+    const src = path.join(extern, 'note.txt')
+    await fs.writeFile(src, 'hello', 'utf8')
+
+    const result = await callImport([src], root, 'copy')
+
+    expect(result.failed).toBe(0)
+    expect(result.created).toEqual([path.join(root, 'note.txt')])
+    expect(await fs.readFile(path.join(root, 'note.txt'), 'utf8')).toBe('hello')
+    // Original untouched.
+    expect(await fs.readFile(src, 'utf8')).toBe('hello')
+  })
+
+  test('move relocates the entry and removes the original', async () => {
+    const src = path.join(extern, 'data.bin')
+    await fs.writeFile(src, 'x', 'utf8')
+
+    const result = await callImport([src], root, 'move')
+
+    expect(result.failed).toBe(0)
+    expect(await fs.readFile(path.join(root, 'data.bin'), 'utf8')).toBe('x')
+    await expect(fs.lstat(src)).rejects.toThrow() // gone
+  })
+
+  test('copies a directory recursively', async () => {
+    const dir = path.join(extern, 'folder')
+    await fs.mkdir(path.join(dir, 'sub'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'sub', 'a.txt'), 'a', 'utf8')
+
+    const result = await callImport([dir], root, 'copy')
+
+    expect(result.failed).toBe(0)
+    expect(await fs.readFile(path.join(root, 'folder', 'sub', 'a.txt'), 'utf8')).toBe('a')
+  })
+
+  test('renames on name collision instead of overwriting', async () => {
+    await fs.writeFile(path.join(root, 'dup.txt'), 'existing', 'utf8')
+    const src = path.join(extern, 'dup.txt')
+    await fs.writeFile(src, 'incoming', 'utf8')
+
+    const result = await callImport([src], root, 'copy')
+
+    expect(result.failed).toBe(0)
+    // Existing file preserved; the import landed under a non-colliding name.
+    expect(await fs.readFile(path.join(root, 'dup.txt'), 'utf8')).toBe('existing')
+    expect(result.created).toHaveLength(1)
+    expect(result.created[0]).not.toBe(path.join(root, 'dup.txt'))
+    expect(await fs.readFile(result.created[0], 'utf8')).toBe('incoming')
+  })
+
+  test('refuses to import a folder into itself', async () => {
+    // destDir is inside the source folder → must be rejected.
+    const inner = path.join(root, 'child')
+    await fs.mkdir(inner)
+
+    const result = await callImport([root], inner, 'copy')
+
+    expect(result.created).toHaveLength(0)
+    expect(result.failed).toBe(1)
+  })
+})

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -20,6 +20,7 @@ import {
   FS_RENAME,
   FS_MKDIR,
   FS_COPY,
+  FS_IMPORT_ENTRIES,
   FS_SEARCH,
   FS_READ_BINARY,
 } from '../../shared/ipc-channels'
@@ -477,6 +478,34 @@ export function stopWatchersForWindow(windowId: number): void {
   }
 }
 
+/**
+ * Find a non-colliding entry name for `baseName` inside `destDir`. When the item
+ * is landing in the directory it already lives in (`intoSameDir`), the first
+ * candidate gets a " copy" suffix so it doesn't clobber the original; otherwise
+ * the original name is kept. Further collisions add an incrementing counter.
+ */
+async function nextAvailableName(
+  destDir: string,
+  baseName: string,
+  intoSameDir: boolean,
+): Promise<string> {
+  const ext = path.extname(baseName)
+  const stem = ext ? baseName.slice(0, -ext.length) : baseName
+  let candidate = intoSameDir ? `${stem} copy${ext}` : baseName
+  let n = 2
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await fs.lstat(path.join(destDir, candidate))
+    } catch {
+      // ENOENT — safe to use
+      return candidate
+    }
+    candidate = intoSameDir ? `${stem} copy ${n}${ext}` : `${stem} (${n})${ext}`
+    n++
+  }
+}
+
 export function registerHandlers(): void {
   ipcMain.handle(FS_READ_FILE, async (event, filePath: string) => {
     try {
@@ -595,32 +624,8 @@ export function registerHandlers(): void {
       const safeSrc = await validatePathStrict(srcPath)
       const safeDestDir = await validatePathStrict(destDir)
 
-      // If copying into the same parent, append "copy" suffix so we don't
-      // collide with the original. Otherwise keep the source name.
-      const srcParent = path.dirname(safeSrc)
-      const baseName = path.basename(safeSrc)
-      const ext = path.extname(baseName)
-      const stem = ext ? baseName.slice(0, -ext.length) : baseName
-
-      const intoSameDir = srcParent === safeDestDir
-      let candidate = intoSameDir ? `${stem} copy${ext}` : baseName
-      let n = 2
-      // Find a non-existing destination name in destDir.
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const target = path.join(safeDestDir, candidate)
-        try {
-          await fs.lstat(target)
-        } catch {
-          // ENOENT — safe to use
-          break
-        }
-        candidate = intoSameDir
-          ? `${stem} copy ${n}${ext}`
-          : `${stem} (${n})${ext}`
-        n++
-      }
-
+      const intoSameDir = path.dirname(safeSrc) === safeDestDir
+      const candidate = await nextAvailableName(safeDestDir, path.basename(safeSrc), intoSameDir)
       const finalDest = await validatePathForCreation(path.join(safeDestDir, candidate))
 
       // Refuse to copy a directory into itself or one of its descendants.
@@ -635,6 +640,62 @@ export function registerHandlers(): void {
       throw error instanceof Error ? error : new Error(String(error))
     }
   })
+
+  // Import external files/folders (dragged in from the OS file manager) into a
+  // workspace directory. The security boundary is the DESTINATION: `destDir`
+  // must resolve inside an allowed workspace root. The SOURCE paths originate
+  // from a user-initiated OS drag (webUtils.getPathForFile) and may live
+  // anywhere — they are only read server-side to copy/move into `destDir`, and
+  // their contents are never returned to the renderer. This mirrors the
+  // explicit per-window grant model used by the native Open/Save dialogs.
+  ipcMain.handle(
+    FS_IMPORT_ENTRIES,
+    async (event, sources: string[], destDir: string, mode: 'copy' | 'move') => {
+      const win = windowFromEvent(event)
+      const safeDestDir = await validatePathStrict(destDir, win?.id)
+      const created: string[] = []
+      let failed = 0
+
+      for (const src of Array.isArray(sources) ? sources : []) {
+        try {
+          // Resolve the real source (also proves it exists). Deliberately not
+          // restricted to allowed roots — this is an explicit user drag.
+          const realSrc = await fs.realpath(src)
+
+          // Never import a folder into itself or one of its own descendants.
+          if (safeDestDir === realSrc || safeDestDir.startsWith(realSrc + path.sep)) {
+            throw new Error('Cannot import a folder into itself')
+          }
+
+          const intoSameDir = path.dirname(realSrc) === safeDestDir
+          const candidate = await nextAvailableName(safeDestDir, path.basename(realSrc), intoSameDir)
+          const finalDest = await validatePathForCreation(path.join(safeDestDir, candidate), win?.id)
+
+          if (mode === 'move') {
+            try {
+              await fs.rename(realSrc, finalDest)
+            } catch (err) {
+              // rename can't cross filesystems/volumes — fall back to copy+delete.
+              if ((err as NodeJS.ErrnoException)?.code === 'EXDEV') {
+                await fs.cp(realSrc, finalDest, { recursive: true, errorOnExist: true, force: false })
+                await fs.rm(realSrc, { recursive: true, force: true })
+              } else {
+                throw err
+              }
+            }
+          } else {
+            await fs.cp(realSrc, finalDest, { recursive: true, errorOnExist: true, force: false })
+          }
+          created.push(finalDest)
+        } catch (error) {
+          failed++
+          log.error(`[${FS_IMPORT_ENTRIES}]`, src, error)
+        }
+      }
+
+      return { created, failed }
+    },
+  )
 
   ipcMain.handle(FS_MKDIR, async (_event, dirPath: string) => {
     try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,6 +74,7 @@ import {
   DIALOG_CONFIRM_UNSAVED,
   DIALOG_CONFIRM_CLOSE_CANVAS,
   DIALOG_CONFIRM_DELETE_REGION,
+  DIALOG_CONFIRM_IMPORT,
   RECENT_PROJECTS_GET,
   RECENT_PROJECTS_ADD,
   LAYOUT_SAVE,
@@ -84,6 +85,7 @@ import {
   FS_RENAME,
   FS_MKDIR,
   FS_COPY,
+  FS_IMPORT_ENTRIES,
   FS_SEARCH,
   SHELL_SHOW_IN_FOLDER,
   NOTIFY_OS,
@@ -636,6 +638,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(DIALOG_CONFIRM_DELETE_REGION, payload)
   },
 
+  confirmImportEntries(payload: { count: number; destName: string }): Promise<'copy' | 'move' | 'cancel'> {
+    return ipcRenderer.invoke(DIALOG_CONFIRM_IMPORT, payload)
+  },
+
   // ---------------------------------------------------------------------------
   // Recent Projects
   // ---------------------------------------------------------------------------
@@ -698,6 +704,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   fsCopy(srcPath: string, destDir: string): Promise<string> {
     return ipcRenderer.invoke(FS_COPY, srcPath, destDir)
+  },
+
+  fsImportEntries(
+    sources: string[],
+    destDir: string,
+    mode: 'copy' | 'move',
+  ): Promise<{ created: string[]; failed: number }> {
+    return ipcRenderer.invoke(FS_IMPORT_ENTRIES, sources, destDir, mode)
   },
 
   shellShowInFolder(filePath: string): Promise<void> {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -357,24 +357,19 @@ function MainApp() {
   }, [])
 
   // ---------------------------------------------------------------------------
-  // Drag-and-drop folder from Finder
+  // Swallow stray external file drops on the app background. Dropping files onto
+  // the file explorer is handled there (copy/move into a directory); anywhere
+  // else we only preventDefault so Chromium doesn't navigate to the file:// URL.
+  // We deliberately do NOT re-root the workspace on drop.
   // ---------------------------------------------------------------------------
   const handleFileDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault()
-    e.dataTransfer.dropEffect = 'copy'
+    e.dataTransfer.dropEffect = 'none'
   }, [])
 
-  const handleFileDrop = useCallback(async (e: React.DragEvent) => {
+  const handleFileDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault()
-    const files = Array.from(e.dataTransfer.files)
-    if (files.length === 0) return
-    for (const file of files) {
-      const filePath = window.electronAPI.getPathForFile(file)
-      if (!filePath) continue
-      useAppStore.getState().setWorkspaceRootPath(selectedWorkspaceId, filePath)
-      break
-    }
-  }, [selectedWorkspaceId])
+  }, [])
 
   // ---------------------------------------------------------------------------
   // Dock zone panel helpers

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -43,6 +43,7 @@ import { applyCanvasChildPanels } from './lib/applyCanvasChildPanels'
 import { applyTheme } from './lib/themeManager'
 import { confirmCloseDirtyPanels } from './lib/confirmCloseDirty'
 import { confirmCloseCanvas } from './lib/confirmCloseCanvas'
+import { isExternalFileDrag } from './lib/importExternalEntries'
 import pkg from '../../package.json'
 
 // -----------------------------------------------------------------------------
@@ -357,17 +358,24 @@ function MainApp() {
   }, [])
 
   // ---------------------------------------------------------------------------
-  // Swallow stray external file drops on the app background. Dropping files onto
-  // the file explorer is handled there (copy/move into a directory); anywhere
-  // else we only preventDefault so Chromium doesn't navigate to the file:// URL.
-  // We deliberately do NOT re-root the workspace on drop.
+  // Swallow stray EXTERNAL (OS) file drops on the app background so Chromium
+  // doesn't navigate to the file:// URL. The file explorer handles its own
+  // external drops (copy/move into a directory) and stops propagation, so those
+  // never reach here. We deliberately do NOT re-root the workspace on drop.
+  //
+  // Crucially, this only engages for external file drags. Internal drags
+  // (workspace reorder, file-tree moves, sidebar/panel drags) bubble up to this
+  // root element too — touching their dropEffect here would override the inner
+  // handler's effect and make the browser reject the drop (onDrop never fires).
   // ---------------------------------------------------------------------------
   const handleFileDragOver = useCallback((e: React.DragEvent) => {
+    if (!isExternalFileDrag(e)) return
     e.preventDefault()
     e.dataTransfer.dropEffect = 'none'
   }, [])
 
   const handleFileDrop = useCallback((e: React.DragEvent) => {
+    if (!isExternalFileDrag(e)) return
     e.preventDefault()
   }, [])
 

--- a/src/renderer/lib/importExternalEntries.ts
+++ b/src/renderer/lib/importExternalEntries.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// importExternalEntries — handle files/folders dragged into Cate from the OS
+// file manager (Finder, Explorer, …). Prompts copy/move and imports them into a
+// target workspace directory via the privileged fsImportEntries IPC.
+//
+// The caller is responsible for the synchronous preventDefault()/stopPropagation()
+// inside the drop event handler (so the drop doesn't bubble to the app-root
+// handler or make Chromium navigate to the file://). This module only covers
+// detection, the dialog, and the import itself.
+// =============================================================================
+
+import log from './logger'
+
+/** True when the drag carries OS files (an external drop), not an internal
+ *  Cate panel/file drag. */
+export function isExternalFileDrag(e: React.DragEvent): boolean {
+  return Array.from(e.dataTransfer.types).includes('Files')
+}
+
+/**
+ * Resolve dropped File objects to absolute OS paths, ask the user whether to
+ * copy or move them, and import them into `destDir`. `destName` is the
+ * human-readable label shown in the dialog (defaults to the destination's
+ * basename). Returns true if any entry was imported.
+ */
+export async function importDroppedEntries(
+  files: FileList,
+  destDir: string,
+  destName?: string,
+): Promise<boolean> {
+  const api = window.electronAPI
+  if (!api || !destDir) return false
+
+  try {
+    const sources = Array.from(files)
+      .map((f) => api.getPathForFile(f))
+      .filter((p): p is string => !!p)
+    if (sources.length === 0) return false
+
+    const label = destName ?? destDir.split('/').filter(Boolean).pop() ?? destDir
+    const choice = await api.confirmImportEntries({ count: sources.length, destName: label })
+    if (choice === 'cancel') return false
+
+    const result = await api.fsImportEntries(sources, destDir, choice)
+    if (result.failed > 0) {
+      log.warn(`[file-explorer] ${result.failed} of ${sources.length} item(s) failed to import`)
+    }
+    return result.created.length > 0
+  } catch (err) {
+    log.error('[file-explorer] import failed:', err)
+    return false
+  }
+}

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -12,6 +12,7 @@ import { getClipboard, hasClipboard } from './fileClipboard'
 import { useAppStore } from '../stores/appStore'
 import { useDockStore } from '../stores/dockStore'
 import { openFileAsPanel } from '../lib/fileRouting'
+import { isExternalFileDrag, importDroppedEntries } from '../lib/importExternalEntries'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
 import type { DockLayoutNode } from '../../shared/types'
 
@@ -366,7 +367,30 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   // ---------------------------------------------------------------------------
 
   return (
-    <div className="flex flex-col h-full">
+    <div
+      className="flex flex-col h-full"
+      // External (OS) file/folder drops anywhere in the panel import into the
+      // workspace root. stopPropagation keeps the drop from bubbling to the
+      // app-root handler (which would otherwise re-root the workspace).
+      onDragOver={(e) => {
+        if (!isExternalFileDrag(e)) return
+        e.preventDefault()
+        // Stop the bubble to the app-root dragover handler, which forces
+        // dropEffect='none' (to swallow stray canvas drops) and would otherwise
+        // override our 'copy' and make the browser reject the drop.
+        e.stopPropagation()
+        e.dataTransfer.dropEffect = 'copy'
+      }}
+      onDrop={(e) => {
+        if (!isExternalFileDrag(e)) return
+        e.preventDefault()
+        e.stopPropagation()
+        const files = e.dataTransfer.files
+        void importDroppedEntries(files, rootPath, folderName).then((ok) => {
+          if (ok) handleReload()
+        })
+      }}
+    >
       <SidebarSectionHeader
         title="Explorer"
         subtitle={folderName}

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -18,6 +18,7 @@ import {
   Image as ImageIcon,
 } from '@phosphor-icons/react'
 import log from '../lib/logger'
+import { isExternalFileDrag, importDroppedEntries } from '../lib/importExternalEntries'
 import type { FileTreeNode as FileTreeNodeType } from '../../shared/types'
 import { getClipboard, hasClipboard, setClipboard } from './fileClipboard'
 
@@ -392,13 +393,21 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   const dropTargetDir = node.isDirectory ? node.path : parentDir
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (isExternalFileDrag(e)) {
+      e.preventDefault()
+      // Stop the bubble to the app-root handler (which forces dropEffect='none')
+      // so the browser keeps our 'copy' and allows the drop.
+      e.stopPropagation()
+      e.dataTransfer.dropEffect = 'copy'
+      return
+    }
     if (!e.dataTransfer.types.includes('application/cate-file')) return
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
   }, [])
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes('application/cate-file')) return
+    if (!isExternalFileDrag(e) && !e.dataTransfer.types.includes('application/cate-file')) return
     e.preventDefault()
     dragCounterRef.current++
     setIsDragOver(true)
@@ -413,6 +422,19 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   }, [])
 
   const handleDrop = useCallback(async (e: React.DragEvent) => {
+    // External (OS) file/folder drop onto a folder → import into that folder.
+    // stopPropagation keeps it from also triggering the panel-root import.
+    if (isExternalFileDrag(e)) {
+      e.preventDefault()
+      e.stopPropagation()
+      dragCounterRef.current = 0
+      setIsDragOver(false)
+      const files = e.dataTransfer.files
+      const ok = await importDroppedEntries(files, dropTargetDir, node.name)
+      if (ok) onTreeChanged?.()
+      return
+    }
+
     e.preventDefault()
     e.stopPropagation()
     dragCounterRef.current = 0
@@ -437,7 +459,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       }
     }
     onTreeChanged?.()
-  }, [dropTargetDir, node.isDirectory, onTreeChanged])
+  }, [dropTargetDir, node.isDirectory, node.name, onTreeChanged])
 
   // ---------------------------------------------------------------------------
   // Render

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -87,9 +87,14 @@ export const ProjectList: React.FC = () => {
     setMultiSelected(new Set())
   }, [addWorkspace, selectWorkspace])
 
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  // Insertion slot the drop would land in: 0..N where N is "after the last
+  // row". Derived from which half of a row the cursor is over, so the bottom
+  // slot (below the last workspace) is reachable.
+  const [insertIndex, setInsertIndex] = useState<number | null>(null)
 
   const displayWorkspaces = workspaces
+  const INDICATOR = '2px solid rgba(74, 158, 255, 0.6)'
+  const RESERVED = '2px solid transparent'
 
   return (
     <div
@@ -110,43 +115,57 @@ export const ProjectList: React.FC = () => {
       {/* Scrollable workspace list */}
       <div className="flex-1 overflow-y-auto px-1 py-1">
         <div className="flex flex-col">
-          {displayWorkspaces.map((ws, index) => (
-            <div
-              key={ws.id}
-              draggable={multiSelected.size === 0}
-              onDragStart={(e) => {
-                e.dataTransfer.setData('text/plain', String(index))
-                e.dataTransfer.effectAllowed = 'move'
-              }}
-              onDragOver={(e) => {
-                e.preventDefault()
-                e.dataTransfer.dropEffect = 'move'
-                setDragOverIndex(index)
-              }}
-              onDragLeave={() => setDragOverIndex(null)}
-              onDrop={(e) => {
-                e.preventDefault()
-                const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10)
-                if (!isNaN(fromIndex) && fromIndex !== index) {
-                  useAppStore.getState().reorderWorkspaces(fromIndex, index)
-                }
-                setDragOverIndex(null)
-              }}
-              style={{
-                borderTop: dragOverIndex === index ? '2px solid rgba(74, 158, 255, 0.6)' : '2px solid transparent',
-                transition: 'border-color 0.15s',
-              }}
-            >
-              <WorkspaceTab
-                workspace={ws}
-                isSelected={ws.id === selectedWorkspaceId}
-                isMultiSelected={multiSelected.has(ws.id)}
-                onClick={(e) => handleWorkspaceClick(index, ws.id, e)}
-                onClose={() => removeWorkspace(ws.id)}
-                onBulkContextMenu={(e) => handleBulkContextMenu(e, ws.id)}
-              />
-            </div>
-          ))}
+          {displayWorkspaces.map((ws, index) => {
+            const isLast = index === displayWorkspaces.length - 1
+            return (
+              <div
+                key={ws.id}
+                draggable={multiSelected.size === 0}
+                onDragStart={(e) => {
+                  e.dataTransfer.setData('text/plain', String(index))
+                  e.dataTransfer.effectAllowed = 'move'
+                }}
+                onDragOver={(e) => {
+                  e.preventDefault()
+                  e.dataTransfer.dropEffect = 'move'
+                  // Top half → insert before this row; bottom half → after it.
+                  // The bottom half of the last row targets the final slot.
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  const after = e.clientY > rect.top + rect.height / 2
+                  setInsertIndex(after ? index + 1 : index)
+                }}
+                onDrop={(e) => {
+                  e.preventDefault()
+                  const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10)
+                  // Recompute the target slot from the drop position rather than
+                  // reading insertIndex state, which can be stale in this closure.
+                  const rect = e.currentTarget.getBoundingClientRect()
+                  const to = e.clientY > rect.top + rect.height / 2 ? index + 1 : index
+                  setInsertIndex(null)
+                  if (!isNaN(fromIndex)) {
+                    useAppStore.getState().reorderWorkspaces(fromIndex, to)
+                  }
+                }}
+                onDragEnd={() => setInsertIndex(null)}
+                style={{
+                  borderTop: insertIndex === index ? INDICATOR : RESERVED,
+                  // Only the last row reserves a bottom border, so it can show
+                  // the "drop at the end" indicator without shifting other rows.
+                  borderBottom: isLast ? (insertIndex === index + 1 ? INDICATOR : RESERVED) : undefined,
+                  transition: 'border-color 0.15s',
+                }}
+              >
+                <WorkspaceTab
+                  workspace={ws}
+                  isSelected={ws.id === selectedWorkspaceId}
+                  isMultiSelected={multiSelected.has(ws.id)}
+                  onClick={(e) => handleWorkspaceClick(index, ws.id, e)}
+                  onClose={() => removeWorkspace(ws.id)}
+                  onBulkContextMenu={(e) => handleBulkContextMenu(e, ws.id)}
+                />
+              </div>
+            )
+          })}
         </div>
       </div>
     </div>

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -1309,9 +1309,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   reorderWorkspaces(fromIndex, toIndex) {
     set((state) => {
+      if (fromIndex === toIndex) return state
       const workspaces = [...state.workspaces]
       const [moved] = workspaces.splice(fromIndex, 1)
-      workspaces.splice(toIndex, 0, moved)
+      // The drop indicator is a top border on the target row ("insert before this
+      // row"). Removing the dragged item first shifts every later index down by one,
+      // so for downward drags we must compensate to land before the target row.
+      const insertAt = fromIndex < toIndex ? toIndex - 1 : toIndex
+      workspaces.splice(insertAt, 0, moved)
       return { workspaces }
     })
   },

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -1308,13 +1308,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   reorderWorkspaces(fromIndex, toIndex) {
+    // `toIndex` is an insertion slot in [0, length]: 0 = before the first row,
+    // length = after the last. Dropping at the item's own slot or the one just
+    // after it leaves the order unchanged.
     set((state) => {
-      if (fromIndex === toIndex) return state
+      if (toIndex === fromIndex || toIndex === fromIndex + 1) return state
       const workspaces = [...state.workspaces]
       const [moved] = workspaces.splice(fromIndex, 1)
-      // The drop indicator is a top border on the target row ("insert before this
-      // row"). Removing the dragged item first shifts every later index down by one,
-      // so for downward drags we must compensate to land before the target row.
+      // Removing the dragged item first shifts every later slot down by one, so
+      // for downward moves the insertion slot is one less than requested.
       const insertAt = fromIndex < toIndex ? toIndex - 1 : toIndex
       workspaces.splice(insertAt, 0, moved)
       return { workspaces }

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -500,6 +500,32 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // a brand new workspace was created before any canvas panel existed yet,
       // or where a restored dock layout references no canvas-type panel.
       get().ensureCenterCanvas(id)
+
+      // ensureCenterCanvas may have just minted a brand-new canvas panel (empty
+      // or freshly created workspace). Its store can momentarily alias the
+      // legacy singleton, which still holds the previous workspace's nodes — so
+      // the freshly mounted CanvasPanel briefly renders a stale node before it
+      // settles, visible as an empty note blinking in then vanishing. Re-resolve
+      // the now-authoritative canvas store and load this workspace's state into
+      // it to clear any leftover nodes immediately.
+      const finalCanvasPanelId = getWorkspaceCanvasPanelId(id)
+      if (finalCanvasPanelId && finalCanvasPanelId !== canvasPanelId) {
+        setActiveCanvasPanelId(finalCanvasPanelId)
+        const wsFinal = get().workspaces.find((w) => w.id === id)
+        if (wsFinal) {
+          try {
+            getWorkspaceCanvasStore(id)?.getState().loadWorkspaceCanvas(
+              wsFinal.canvasNodes,
+              wsFinal.viewportOffset,
+              wsFinal.zoomLevel,
+              wsFinal.focusedNodeId,
+              wsFinal.regions,
+            )
+          } catch (error) {
+            log.error('Failed to load canvas for workspace:', error)
+          }
+        }
+      }
     }
   },
 

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -382,6 +382,34 @@ export const CommandPalette: React.FC = () => {
     [close],
   )
 
+  // Focus an open panel by id: pan/center the canvas node if it lives on the
+  // canvas, otherwise reveal it in its dock zone. Shared by the "Open Panels"
+  // click + Enter handlers and the panel search results.
+  const focusPanelById = useCallback(
+    (panelId: string) => {
+      const cs = canvasApi.getState()
+      const node = Object.values(cs.nodes).find((n) => n.panelId === panelId)
+      if (node) {
+        cs.focusAndCenter(node.id)
+        return
+      }
+      const dock = useDockStore.getState()
+      const loc = dock.getPanelLocation(panelId)
+      if (loc && loc.type === 'dock') {
+        const zone = dock.zones[loc.zone]
+        if (!zone.visible) dock.toggleZone(loc.zone)
+        if (zone.layout) {
+          const stack = findTabStack(zone.layout, loc.stackId)
+          if (stack) {
+            const idx = stack.panelIds.indexOf(panelId)
+            if (idx >= 0) dock.setActiveTab(loc.stackId, idx)
+          }
+        }
+      }
+    },
+    [canvasApi],
+  )
+
   const selectSearchResult = useCallback(
     async (result: SearchResult) => {
       const appStore = useAppStore.getState()
@@ -405,24 +433,12 @@ export const CommandPalette: React.FC = () => {
         if (result.nodeId) {
           canvasApi.getState().focusAndCenter(result.nodeId)
         } else if (result.panelId) {
-          const dock = useDockStore.getState()
-          const loc = dock.getPanelLocation(result.panelId)
-          if (loc && loc.type === 'dock') {
-            const zone = dock.zones[loc.zone]
-            if (!zone.visible) dock.toggleZone(loc.zone)
-            if (zone.layout) {
-              const stack = findTabStack(zone.layout, loc.stackId)
-              if (stack) {
-                const idx = stack.panelIds.indexOf(result.panelId)
-                if (idx >= 0) dock.setActiveTab(loc.stackId, idx)
-              }
-            }
-          }
+          focusPanelById(result.panelId)
         }
       }
       close()
     },
-    [canvasApi, close],
+    [canvasApi, close, focusPanelById],
   )
 
   // Keyboard navigation
@@ -449,9 +465,7 @@ export const CommandPalette: React.FC = () => {
             if (selectedIndex < recommendedPanels.length) {
               const panel = recommendedPanels[selectedIndex]
               if (panel) {
-                const cs = canvasApi.getState()
-                const nodeEntry = Object.values(cs.nodes).find((n) => n.panelId === panel.id)
-                if (nodeEntry) cs.focusNode(nodeEntry.id)
+                focusPanelById(panel.id)
                 close()
               }
             } else {
@@ -479,7 +493,7 @@ export const CommandPalette: React.FC = () => {
     document.addEventListener('keydown', handleKey, { capture: true })
     return () =>
       document.removeEventListener('keydown', handleKey, { capture: true })
-  }, [showCommandPalette, filteredCommands, searchResults, recommendedPanels, showRecommended, selectedIndex, totalItems, executeCommand, selectSearchResult, close, canvasApi])
+  }, [showCommandPalette, filteredCommands, searchResults, recommendedPanels, showRecommended, selectedIndex, totalItems, executeCommand, selectSearchResult, close, canvasApi, focusPanelById])
 
   if (!showCommandPalette) return null
 
@@ -547,9 +561,7 @@ export const CommandPalette: React.FC = () => {
                           isSelected ? 'bg-blue-600/30' : 'hover:bg-white/5'
                         }`}
                         onClick={() => {
-                          const cs = canvasApi.getState()
-                          const nodeEntry = Object.values(cs.nodes).find((n) => n.panelId === panel.id)
-                          if (nodeEntry) cs.focusNode(nodeEntry.id)
+                          focusPanelById(panel.id)
                           close()
                         }}
                         onMouseEnter={() => setSelectedIndex(i)}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -347,6 +347,11 @@ export interface ElectronAPI {
    *  contents, just remove the region around them), or 'cancel'. */
   confirmDeleteRegion(payload: { panelCount: number }): Promise<'with-contents' | 'region-only' | 'cancel'>
 
+  /** Native confirmation shown when external files/folders are dropped onto the
+   *  file explorer. Returns 'copy' (duplicate into the directory), 'move'
+   *  (relocate into the directory, removing the originals), or 'cancel'. */
+  confirmImportEntries(payload: { count: number; destName: string }): Promise<'copy' | 'move' | 'cancel'>
+
   // ---------------------------------------------------------------------------
   // Recent Projects
   // ---------------------------------------------------------------------------
@@ -390,6 +395,10 @@ export interface ElectronAPI {
   fsRename(oldPath: string, newPath: string): Promise<void>
   fsMkdir(dirPath: string): Promise<void>
   fsCopy(srcPath: string, destDir: string): Promise<string>
+  /** Import external files/folders (dragged in from the OS) into `destDir`,
+   *  which must resolve inside a workspace root. `mode` is 'copy' or 'move'.
+   *  Returns the created destination paths and a count of entries that failed. */
+  fsImportEntries(sources: string[], destDir: string, mode: 'copy' | 'move'): Promise<{ created: string[]; failed: number }>
   shellShowInFolder(filePath: string): Promise<void>
 
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -26,6 +26,7 @@ export const FS_DELETE = 'fs:delete'
 export const FS_RENAME = 'fs:rename'
 export const FS_MKDIR = 'fs:mkdir'
 export const FS_COPY = 'fs:copy'
+export const FS_IMPORT_ENTRIES = 'fs:import-entries'
 export const FS_SEARCH = 'fs:search'
 export const FS_READ_BINARY = 'fs:readBinary'
 
@@ -137,6 +138,7 @@ export const DIALOG_SAVE_FILE = 'dialog:saveFile'
 export const DIALOG_CONFIRM_UNSAVED = 'dialog:confirmUnsaved'
 export const DIALOG_CONFIRM_CLOSE_CANVAS = 'dialog:confirmCloseCanvas'
 export const DIALOG_CONFIRM_DELETE_REGION = 'dialog:confirmDeleteRegion'
+export const DIALOG_CONFIRM_IMPORT = 'dialog:confirmImport'
 
 // Panel window: renderer pushes an updated PanelState snapshot to main so
 // the windowRegistry's panel meta (used by session persistence and the


### PR DESCRIPTION
## Summary

Bundles a set of related canvas/workspace and DnD fixes on this branch.

## Changes

- **fix(explorer): copy/move external file drops instead of re-rooting the workspace** *(existing)*
- **fix(workspace): correct reorder index when dragging a workspace downward** *(existing)*
- **fix(workspace): reachable bottom slot for workspace reorder** — track the insertion slot from which half of a row the cursor is over, so the slot below the last workspace is now droppable; `reorderWorkspaces` treats `toIndex` as an insertion slot.
- **fix(workspace): stop empty note blink when switching to empty workspace** — loading an empty workspace's canvas into the singleton store before the real canvas panel was minted left a stale node rendering for a frame (the blinking "Empty" placeholder). Now reloads the authoritative store after `ensureCenterCanvas`.
- **fix(dnd): only intercept external file drops on the app background** — guard background dragover/drop with `isExternalFileDrag` so internal drags (workspace reorder, file-tree moves) aren't rejected.
- **refactor(command-palette): centralize open-panel focus** — shared `focusPanelById` for search results and Open Panels, with canvas-node pan + dock-zone reveal.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — 320 passed, 3 skipped
