### PR TITLE
Scope pi agent config per workspace + accordion provider settings

### DIFF
--- a/src/agent/main/agentDir.ts
+++ b/src/agent/main/agentDir.ts
@@ -1,0 +1,124 @@
+// =============================================================================
+// agentDir — per-workspace home for the embedded pi coding agent.
+//
+// Pi resolves its entire config dir (extensions, sessions, settings.json,
+// auth.json) from PI_CODING_AGENT_DIR when set, else ~/.pi/agent. We point it
+// per-workspace at <cwd>/.cate/pi-agent so each project is self-contained and
+// cate stops seeding state into the user's global pi install.
+//
+// Auth is the one exception: provider logins are not project-specific, so we
+// keep a single shared auth.json in cate's userData and mirror it into each
+// workspace dir with a copy-on-spawn + watch-and-copy-back scheme. This is
+// uniform across Windows/macOS/Linux (no symlinks, no privileges, any volume).
+// =============================================================================
+
+import fs from 'fs'
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { app } from 'electron'
+import { watch, type FSWatcher } from 'chokidar'
+import log from '../../main/logger'
+
+const CATE_DIR = '.cate'
+const PI_AGENT_DIR = 'pi-agent'
+
+/** Per-workspace pi config dir. Pi honours this via PI_CODING_AGENT_DIR. */
+export function agentDirFor(cwd: string): string {
+  return path.join(cwd, CATE_DIR, PI_AGENT_DIR)
+}
+
+/** The single shared auth.json — source of truth for provider credentials. */
+export function sharedAuthPath(): string {
+  return path.join(app.getPath('userData'), PI_AGENT_DIR, 'auth.json')
+}
+
+function workspaceAuthPath(cwd: string): string {
+  return path.join(agentDirFor(cwd), 'auth.json')
+}
+
+/** Legacy global pi auth, used once to seed the shared file so existing users
+ *  aren't logged out by the cut-over to per-workspace dirs. */
+function legacyGlobalAuthPath(): string {
+  return path.join(os.homedir(), '.pi', 'agent', 'auth.json')
+}
+
+async function readFileOrNull(p: string): Promise<string | null> {
+  try { return await fsp.readFile(p, 'utf-8') }
+  catch { return null }
+}
+
+// Serialize writes to the shared auth file so two workspaces refreshing tokens
+// at the same moment can't interleave on it.
+let sharedWriteQueue: Promise<void> = Promise.resolve()
+function queueSharedWrite(fn: () => Promise<void>): Promise<void> {
+  sharedWriteQueue = sharedWriteQueue.then(fn, fn)
+  return sharedWriteQueue
+}
+
+async function ensureSharedAuth(): Promise<void> {
+  const shared = sharedAuthPath()
+  if (fs.existsSync(shared)) return
+  await fsp.mkdir(path.dirname(shared), { recursive: true, mode: 0o700 })
+  // One-time seed from the user's old global pi auth so logins carry over.
+  const legacy = await readFileOrNull(legacyGlobalAuthPath())
+  await fsp.writeFile(shared, legacy ?? '{}\n', 'utf-8')
+  try { await fsp.chmod(shared, 0o600) } catch { /* no file modes on this platform */ }
+}
+
+async function copyAuth(from: string, to: string): Promise<void> {
+  const data = await readFileOrNull(from)
+  if (data == null) return
+  await fsp.mkdir(path.dirname(to), { recursive: true })
+  await fsp.writeFile(to, data, 'utf-8')
+  try { await fsp.chmod(to, 0o600) } catch { /* */ }
+}
+
+/** Create the workspace's pi-agent dir, seed its auth.json from the shared
+ *  file, and keep the dir out of version control. Returns the agent dir. */
+export async function prepareAgentDir(cwd: string): Promise<string> {
+  const dir = agentDirFor(cwd)
+  await fsp.mkdir(dir, { recursive: true })
+  await ensureSharedAuth()
+  await copyAuth(sharedAuthPath(), workspaceAuthPath(cwd))
+  // Sessions, settings, and the auth copy must never be committed.
+  try { await fsp.writeFile(path.join(dir, '.gitignore'), '*\n', { flag: 'wx' }) }
+  catch { /* already exists — leave the user's copy */ }
+  return dir
+}
+
+/** Push the shared auth into a workspace copy. Called when cate's own UI changes
+ *  auth so live pi processes pick up new credentials. The watcher's content
+ *  check (see syncBack) absorbs the echo this write produces. */
+export async function pushSharedToWorkspace(cwd: string): Promise<void> {
+  await copyAuth(sharedAuthPath(), workspaceAuthPath(cwd))
+}
+
+async function syncBack(file: string): Promise<void> {
+  await queueSharedWrite(async () => {
+    const wsData = await readFileOrNull(file)
+    if (wsData == null) return
+    const sharedData = await readFileOrNull(sharedAuthPath())
+    if (wsData === sharedData) return // echo of our own push, or no real change
+    await fsp.mkdir(path.dirname(sharedAuthPath()), { recursive: true, mode: 0o700 })
+    await fsp.writeFile(sharedAuthPath(), wsData, 'utf-8')
+    try { await fsp.chmod(sharedAuthPath(), 0o600) } catch { /* */ }
+    log.info('[agentDir] synced workspace auth back to shared')
+  })
+}
+
+/** Watch a workspace's auth.json; when pi rewrites it (e.g. an OAuth token
+ *  refresh) copy the change back to the shared file. Returns a disposer. */
+export function watchWorkspaceAuth(cwd: string): () => void {
+  const file = workspaceAuthPath(cwd)
+  let watcher: FSWatcher | null = null
+  try {
+    watcher = watch(file, { ignoreInitial: true })
+    const onChange = (): void => { void syncBack(file) }
+    watcher.on('change', onChange)
+    watcher.on('add', onChange)
+  } catch (err) {
+    log.warn('[agentDir] failed to watch %s: %O', file, err)
+  }
+  return () => { if (watcher) void watcher.close() }
+}

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -11,7 +11,6 @@
 // agent-shaped that wants changing belongs upstream in pi.
 // =============================================================================
 
-import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import { app, type WebContents } from 'electron'
@@ -41,6 +40,7 @@ import type {
 import { AGENT_EVENT } from '../../shared/ipc-channels'
 import { installSubagentExtension } from './installSubagents'
 import { installPlanModeExtension } from './installPlanMode'
+import { agentDirFor, prepareAgentDir, watchWorkspaceAuth, pushSharedToWorkspace } from './agentDir'
 import type { AuthManager } from './authManager'
 
 function resolvePiCliPath(): string {
@@ -86,8 +86,11 @@ function ensureElectronNodeShim(): string {
   return dir
 }
 
-function buildAgentEnv(): Record<string, string> {
+function buildAgentEnv(cwd: string): Record<string, string> {
   const env = { ...getShellEnv() }
+  // Scope pi's entire config (extensions, sessions, settings, auth) to this
+  // workspace instead of the user's global ~/.pi/agent.
+  env.PI_CODING_AGENT_DIR = agentDirFor(cwd)
   const needsShim = app.isPackaged || !nodeExistsOnPath(env)
   if (needsShim) {
     const shimDir = ensureElectronNodeShim()
@@ -101,9 +104,11 @@ function buildAgentEnv(): Record<string, string> {
 
 interface AgentSession {
   panelId: string
+  cwd: string
   client: RpcClient
   sender: WebContents
   unsubscribeEvents: () => void
+  disposeAuthWatcher: () => void
   modelRef: AgentModelRef | null
 }
 
@@ -139,6 +144,18 @@ export class AgentManager {
 
   constructor(authManager: AuthManager) {
     this.authManager = authManager
+    // When the user changes credentials in cate's UI, mirror the shared
+    // auth.json into every open workspace so their pi processes see it.
+    authManager.setOnChange(() => this.syncAuthToOpenSessions())
+  }
+
+  /** Push the shared auth.json into every live session's workspace dir. */
+  private syncAuthToOpenSessions(): void {
+    for (const session of this.sessions.values()) {
+      void pushSharedToWorkspace(session.cwd).catch((err) => {
+        log.warn('[agentManager] auth sync failed for %s: %O', session.panelId, err)
+      })
+    }
   }
 
   private withLock<T>(panelId: string, fn: () => Promise<T>): Promise<T> {
@@ -155,10 +172,12 @@ export class AgentManager {
         await this.disposeInternal(opts.panelId)
       }
 
-      // One-shot: drop pi's official subagent extension into ~/.pi/agent/ so it
-      // is auto-discovered the first time pi spins up.
-      await installSubagentExtension()
-      await installPlanModeExtension()
+      // Create <cwd>/.cate/pi-agent, seed its auth.json from the shared file,
+      // and drop pi's official subagent + plan-mode extensions in so they are
+      // auto-discovered the first time pi spins up in this workspace.
+      await prepareAgentDir(opts.cwd)
+      await installSubagentExtension(opts.cwd)
+      await installPlanModeExtension(opts.cwd)
 
       const extraArgs: string[] = []
       if (opts.sessionFile) extraArgs.push('--session', opts.sessionFile)
@@ -169,7 +188,7 @@ export class AgentManager {
         provider: opts.model?.provider,
         model: opts.model?.model,
         args: extraArgs.length > 0 ? extraArgs : undefined,
-        env: buildAgentEnv(),
+        env: buildAgentEnv(opts.cwd),
       })
 
       try {
@@ -194,11 +213,17 @@ export class AgentManager {
         }
       })
 
+      // Watch this workspace's auth.json so OAuth token refreshes written by pi
+      // propagate back to the shared file.
+      const disposeAuthWatcher = watchWorkspaceAuth(opts.cwd)
+
       this.sessions.set(opts.panelId, {
         panelId: opts.panelId,
+        cwd: opts.cwd,
         client,
         sender,
         unsubscribeEvents,
+        disposeAuthWatcher,
         modelRef: opts.model ?? null,
       })
       log.info(
@@ -278,6 +303,7 @@ export class AgentManager {
     const session = this.sessions.get(panelId)
     if (!session) return
     try { session.unsubscribeEvents() } catch { /* noop */ }
+    try { session.disposeAuthWatcher() } catch { /* noop */ }
     // RpcClient.pendingRequests is a Map<string, { resolve, reject }>. When we
     // kill the child, those promises will never resolve — so reject them now.
     const pending = (session.client as unknown as {
@@ -480,7 +506,7 @@ export class AgentManager {
     if (!session) return []
     try {
       const commands = await session.client.getCommands()
-      const homeAgent = path.join(os.homedir(), '.pi', 'agent') + path.sep
+      const homeAgent = agentDirFor(session.cwd) + path.sep
       return commands.map((c) => {
         const filePath = (c as { sourceInfo?: { path?: string; scope?: 'user' | 'project' | 'temporary' } }).sourceInfo?.path
         const scope = (c as { sourceInfo?: { scope?: 'user' | 'project' | 'temporary' } }).sourceInfo?.scope

--- a/src/agent/main/authManager.ts
+++ b/src/agent/main/authManager.ts
@@ -1,10 +1,14 @@
 // =============================================================================
 // AuthManager — provider auth for the embedded pi coding agent.
 //
-// Two provider kinds, both persisted to ~/.pi/agent/auth.json (the same file
-// pi reads from), so credentials work seamlessly in the spawned pi RPC process:
+// Two provider kinds, both persisted to the shared auth.json (the same file
+// each workspace's pi RPC process reads, mirrored in by agentDir):
 //   - OAuth (anthropic, openai-codex, github-copilot) — { type: 'oauth', ... }
 //   - API-key (openai, google, groq, etc.) — { type: 'api_key', key }
+//
+// Provider logins are not project-specific, so this file is global: one shared
+// auth.json under cate's userData (see agentDir.sharedAuthPath). After any write
+// we fire `onChange` so AgentManager can push the update into open workspaces.
 //
 // NOTE: This module imports from pi-ai (pure ESM). electron-vite should handle
 // this for us — if it can't, the import line below is the place to look.
@@ -12,7 +16,6 @@
 
 import { shell, type WebContents } from 'electron'
 import fsp from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import {
   findEnvKeys,
@@ -20,6 +23,7 @@ import {
   type OAuthLoginCallbacks,
 } from '@earendil-works/pi-ai'
 import { getOAuthProvider, getOAuthProviders } from '@earendil-works/pi-ai/oauth'
+import { sharedAuthPath } from './agentDir'
 import log from '../../main/logger'
 import type {
   AuthProviderDescriptor,
@@ -38,9 +42,10 @@ type AuthCredentialOnDisk =
 
 type AuthStorageData = Record<string, AuthCredentialOnDisk>
 
-/** Shared with the pi coding-agent CLI we spawn over RPC. */
+/** Shared with the pi coding-agent CLI we spawn over RPC (mirrored into each
+ *  workspace's pi-agent dir by agentDir). */
 function authJsonPath(): string {
-  return path.join(os.homedir(), '.pi', 'agent', 'auth.json')
+  return sharedAuthPath()
 }
 
 async function readAuthJson(): Promise<AuthStorageData> {
@@ -64,6 +69,10 @@ function serializeWrite(fn: () => Promise<void>): Promise<void> {
   return writeQueue
 }
 
+// Fired after every successful write so AgentManager can mirror the shared
+// auth.json into open workspaces' pi-agent dirs.
+let onAuthChange: (() => void) | null = null
+
 async function writeAuthJson(data: AuthStorageData): Promise<void> {
   await serializeWrite(async () => {
     const p = authJsonPath()
@@ -73,6 +82,7 @@ async function writeAuthJson(data: AuthStorageData): Promise<void> {
     try { await fsp.chmod(tmp, 0o600) } catch { /* noop on platforms without modes */ }
     await fsp.rename(tmp, p)
   })
+  try { onAuthChange?.() } catch (err) { log.warn('[authManager] onChange hook failed: %O', err) }
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +133,12 @@ export class AuthManager {
   private activeFlows = new Set<string>()
   /** Per-providerId connectedAt timestamps (iso). */
   private connectedAt = new Map<string, string>()
+
+  /** Register a callback fired after any credential write — used by
+   *  AgentManager to push the shared auth.json into open workspaces. */
+  setOnChange(fn: () => void): void {
+    onAuthChange = fn
+  }
 
   async listProviders(): Promise<AuthProviderDescriptor[]> {
     const oauth: AuthProviderDescriptor[] = []

--- a/src/agent/main/installPlanMode.ts
+++ b/src/agent/main/installPlanMode.ts
@@ -1,6 +1,6 @@
 // =============================================================================
-// installPlanMode — copy the bundled cate-plan-mode extension into
-// ~/.pi/agent/extensions/ on first use, where pi auto-discovers it.
+// installPlanMode — copy the bundled cate-plan-mode extension into a
+// workspace's pi-agent extensions dir on first use, where pi auto-discovers it.
 //
 // Source lives in our own tree at src/agent/extensions/cate-plan-mode/. Pi
 // loads .ts directly via jiti, so we just ship the raw .ts and .json files.
@@ -15,14 +15,10 @@
 
 import fs from 'fs'
 import fsp from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import { app } from 'electron'
 import log from '../../main/logger'
-
-function agentDir(): string {
-  return path.join(os.homedir(), '.pi', 'agent')
-}
+import { agentDirFor } from './agentDir'
 
 /** Source dir of the bundled extension. Tries dev path first (src/ on disk),
  *  then production extraResources copy. */
@@ -47,19 +43,20 @@ async function copyIfMissing(src: string, dest: string): Promise<void> {
   log.info('[installPlanMode] installed %s', dest)
 }
 
-let installed = false
+const installed = new Set<string>()
 
 /** Idempotent — safe to call from AgentManager.create() on every session. */
-export async function installPlanModeExtension(): Promise<void> {
-  if (installed) return
-  installed = true
+export async function installPlanModeExtension(cwd: string): Promise<void> {
+  const home = agentDirFor(cwd)
+  if (installed.has(home)) return
+  installed.add(home)
   try {
     const src = sourceDir()
     if (!src) {
       log.warn('[installPlanMode] source dir not found — plan mode extension not installed')
       return
     }
-    const destDir = path.join(agentDir(), 'extensions', 'cate-plan-mode')
+    const destDir = path.join(home, 'extensions', 'cate-plan-mode')
     await copyIfMissing(path.join(src, 'index.ts'), path.join(destDir, 'index.ts'))
     await copyIfMissing(path.join(src, 'package.json'), path.join(destDir, 'package.json'))
   } catch (err) {

--- a/src/agent/main/installSubagents.ts
+++ b/src/agent/main/installSubagents.ts
@@ -1,29 +1,25 @@
 // =============================================================================
 // installSubagents — one-shot install of pi's official subagent extension into
-// ~/.pi/agent/ on first use. Pi auto-discovers extensions from this directory
-// when its RPC process starts; no further wiring is needed on our side.
+// a workspace's pi-agent dir on first use. Pi auto-discovers extensions from
+// this directory when its RPC process starts; no further wiring is needed.
 //
 // The extension itself lives inside the @earendil-works/pi-coding-agent npm
-// package (examples/extensions/subagent). We copy three things:
-//   - extensions/subagent/{index.ts,agents.ts}  → ~/.pi/agent/extensions/subagent/
+// package (examples/extensions/subagent). We copy three things (relative to
+// <cwd>/.cate/pi-agent/):
+//   - extensions/subagent/{index.ts,agents.ts}
 //   - agents/*.md (scout, planner, reviewer, worker, plus our additions)
-//                                               → ~/.pi/agent/agents/
-//   - prompts/*.md (implement, scout-and-plan, ...) → ~/.pi/agent/prompts/
+//   - prompts/*.md (implement, scout-and-plan, ...)
 //
 // All copies are skip-if-exists so the user's own modifications survive.
 // =============================================================================
 
 import fs from 'fs'
 import fsp from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import { app } from 'electron'
 import log from '../../main/logger'
 import { addAllowedRoot } from '../../main/ipc/pathValidation'
-
-function agentDir(): string {
-  return path.join(os.homedir(), '.pi', 'agent')
-}
+import { agentDirFor } from './agentDir'
 
 function piPackageDir(): string {
   const base = app.getAppPath()
@@ -83,22 +79,22 @@ async function stripPinnedModels(agentsDir: string): Promise<void> {
   }
 }
 
-let installed = false
+const installed = new Set<string>()
 
 /** Idempotent — safe to call from AgentManager.create() on every session. */
-export async function installSubagentExtension(): Promise<void> {
-  // Whitelist ~/.pi/agent on every call so EditorPanel can read skill/agent
-  // .md files via fs:readFile, even on app restarts.
-  try { addAllowedRoot(agentDir()) } catch { /* */ }
-  if (installed) return
-  installed = true
+export async function installSubagentExtension(cwd: string): Promise<void> {
+  const home = agentDirFor(cwd)
+  // Whitelist the workspace's pi-agent dir on every call so EditorPanel can
+  // read skill/agent .md files via fs:readFile, even on app restarts.
+  try { addAllowedRoot(home) } catch { /* */ }
+  if (installed.has(home)) return
+  installed.add(home)
   try {
     const examples = path.join(piPackageDir(), 'examples', 'extensions', 'subagent')
     if (!fs.existsSync(examples)) {
       log.warn('[installSubagents] subagent extension examples not found at %s — skipping', examples)
       return
     }
-    const home = agentDir()
     await copyIfMissing(
       path.join(examples, 'index.ts'),
       path.join(home, 'extensions', 'subagent', 'index.ts'),

--- a/src/agent/main/ipcAgent.ts
+++ b/src/agent/main/ipcAgent.ts
@@ -2,7 +2,6 @@
 // IPC handlers for AGENT_* channels — thin wrappers around AgentManager.
 // =============================================================================
 
-import os from 'os'
 import path from 'path'
 import fs from 'fs/promises'
 import { ipcMain, shell } from 'electron'
@@ -59,6 +58,7 @@ import {
   type MarketplaceSort,
 } from './marketplace'
 import { deleteSession, listSessions, loadSessionTranscript } from './sessionFiles'
+import { agentDirFor } from './agentDir'
 import log from '../../main/logger'
 import type {
   AgentCreateOptions,
@@ -250,7 +250,8 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
     agentManager.uiResponse(panelId, response)
   })
 
-  // Disk-backed pi session index — read straight from ~/.pi/agent/sessions/.
+  // Disk-backed pi session index — read straight from the workspace's
+  // .cate/pi-agent/sessions/ dir.
   ipcMain.handle(AGENT_LIST_SESSIONS, async (_event, cwd: string) => {
     if (!cwd) return []
     return listSessions(cwd)
@@ -287,21 +288,19 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
     }
   })
 
-  const agentRoot = (): string => path.join(os.homedir(), '.pi', 'agent')
-
-  const isUserAgentPath = (target: string): boolean => {
-    const root = agentRoot() + path.sep
+  const isUserAgentPath = (cwd: string, target: string): boolean => {
+    const root = agentDirFor(cwd) + path.sep
     return path.resolve(target).startsWith(root)
   }
 
-  ipcMain.handle(AGENT_OPEN_SKILLS_FOLDER, async (_event, kind: 'agents' | 'prompts' | 'skills') => {
-    const dir = path.join(agentRoot(), kind)
+  ipcMain.handle(AGENT_OPEN_SKILLS_FOLDER, async (_event, cwd: string, kind: 'agents' | 'prompts' | 'skills') => {
+    const dir = path.join(agentDirFor(cwd), kind)
     try { await fs.mkdir(dir, { recursive: true }) } catch { /* */ }
     await shell.openPath(dir)
   })
 
-  ipcMain.handle(AGENT_LIST_SKILL_FILES, async (_event, kind: 'agents' | 'prompts' | 'skills') => {
-    const dir = path.join(agentRoot(), kind)
+  ipcMain.handle(AGENT_LIST_SKILL_FILES, async (_event, cwd: string, kind: 'agents' | 'prompts' | 'skills') => {
+    const dir = path.join(agentDirFor(cwd), kind)
     try { await fs.mkdir(dir, { recursive: true }) } catch { /* */ }
     let entries: import('fs').Dirent[]
     try { entries = await fs.readdir(dir, { withFileTypes: true }) }
@@ -338,19 +337,19 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
     await shell.openPath(filePath)
   })
 
-  ipcMain.handle(AGENT_DELETE_SKILL_FILE, async (_event, filePath: string) => {
-    if (!filePath || !isUserAgentPath(filePath)) {
-      throw new Error('Refusing to delete file outside ~/.pi/agent')
+  ipcMain.handle(AGENT_DELETE_SKILL_FILE, async (_event, cwd: string, filePath: string) => {
+    if (!filePath || !isUserAgentPath(cwd, filePath)) {
+      throw new Error("Refusing to delete file outside the workspace's pi-agent dir")
     }
     await fs.unlink(filePath)
   })
 
   ipcMain.handle(
     AGENT_CREATE_SKILL,
-    async (_event, kind: 'agents' | 'prompts' | 'skills', name: string) => {
+    async (_event, cwd: string, kind: 'agents' | 'prompts' | 'skills', name: string) => {
       const safe = name.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '')
       if (!safe) throw new Error('Invalid name')
-      const dir = path.join(agentRoot(), kind)
+      const dir = path.join(agentDirFor(cwd), kind)
       await fs.mkdir(dir, { recursive: true })
       const target = path.join(dir, `${safe}.md`)
       try { await fs.access(target); throw new Error(`${safe}.md already exists`) }
@@ -383,21 +382,21 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
     },
   )
 
-  ipcMain.handle(AGENT_MARKETPLACE_LIST_INSTALLED, async () => {
+  ipcMain.handle(AGENT_MARKETPLACE_LIST_INSTALLED, async (_event, cwd: string) => {
     try {
-      return await listInstalled()
+      return await listInstalled(cwd)
     } catch (err) {
       log.warn('[ipc.agent] marketplaceListInstalled failed: %O', err)
       return []
     }
   })
 
-  ipcMain.handle(AGENT_MARKETPLACE_INSTALL, async (_event, name: string) => {
-    return installExtension(name)
+  ipcMain.handle(AGENT_MARKETPLACE_INSTALL, async (_event, cwd: string, name: string) => {
+    return installExtension(cwd, name)
   })
 
-  ipcMain.handle(AGENT_MARKETPLACE_UNINSTALL, async (_event, name: string) => {
-    return uninstallExtension(name)
+  ipcMain.handle(AGENT_MARKETPLACE_UNINSTALL, async (_event, cwd: string, name: string) => {
+    return uninstallExtension(cwd, name)
   })
 
   ipcMain.handle(

--- a/src/agent/main/marketplace.ts
+++ b/src/agent/main/marketplace.ts
@@ -8,17 +8,17 @@
 //
 // Install/uninstall shells out to the pi CLI at node_modules/.bin/pi (anchored
 // on app.getAppPath() so it works both in dev and once packaged via
-// electron-builder). Pi installs to ~/.pi/agent/extensions/<name>/ which is
-// also where it auto-discovers them.
+// electron-builder), with PI_CODING_AGENT_DIR pointed at the workspace's
+// pi-agent dir so installs are scoped per workspace.
 // =============================================================================
 
 import fs from 'fs'
 import fsp from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import { spawn } from 'child_process'
 import { app } from 'electron'
 import log from '../../main/logger'
+import { agentDirFor } from './agentDir'
 
 export interface MarketplaceEntry {
   name: string
@@ -37,21 +37,17 @@ export interface InstalledExtension {
   path: string
 }
 
-function piAgentRoot(): string {
-  return path.join(os.homedir(), '.pi', 'agent')
+function extensionsDir(cwd: string): string {
+  return path.join(agentDirFor(cwd), 'extensions')
 }
 
-function extensionsDir(): string {
-  return path.join(piAgentRoot(), 'extensions')
+function npmModulesDir(cwd: string): string {
+  // Pi 0.x installs packages into <agentDir>/npm/node_modules/<name>/
+  return path.join(agentDirFor(cwd), 'npm', 'node_modules')
 }
 
-function npmModulesDir(): string {
-  // Pi 0.x installs packages into ~/.pi/agent/npm/node_modules/<name>/
-  return path.join(piAgentRoot(), 'npm', 'node_modules')
-}
-
-function settingsPath(): string {
-  return path.join(piAgentRoot(), 'settings.json')
+function settingsPath(cwd: string): string {
+  return path.join(agentDirFor(cwd), 'settings.json')
 }
 
 function piBinaryPath(): string {
@@ -307,8 +303,8 @@ async function buildEntry(name: string, dirPath: string): Promise<InstalledExten
   }
 }
 
-async function scanExtensionsDir(): Promise<InstalledExtension[]> {
-  const dir = extensionsDir()
+async function scanExtensionsDir(cwd: string): Promise<InstalledExtension[]> {
+  const dir = extensionsDir(cwd)
   if (!fs.existsSync(dir)) return []
   const out: InstalledExtension[] = []
   const entries = await fsp.readdir(dir, { withFileTypes: true })
@@ -333,20 +329,20 @@ async function scanExtensionsDir(): Promise<InstalledExtension[]> {
   return out
 }
 
-async function scanInstalledPackages(): Promise<InstalledExtension[]> {
+async function scanInstalledPackages(cwd: string): Promise<InstalledExtension[]> {
   // Pi 0.x records `pi install`-ed packages in settings.json -> packages[],
-  // and unpacks them into ~/.pi/agent/npm/node_modules/<name>/. The two
-  // locations (~/.pi/agent/extensions and ~/.pi/agent/npm/node_modules) are
+  // and unpacks them into <agentDir>/npm/node_modules/<name>/. The two
+  // locations (<agentDir>/extensions and <agentDir>/npm/node_modules) are
   // disjoint — the first is for hand-placed extensions like our bundled
   // subagent, the second is for everything `pi install` puts on disk.
   let raw: string
-  try { raw = await fsp.readFile(settingsPath(), 'utf-8') }
+  try { raw = await fsp.readFile(settingsPath(cwd), 'utf-8') }
   catch { return [] }
   let parsed: { packages?: string[] } = {}
   try { parsed = JSON.parse(raw) }
   catch { return [] }
   const refs = parsed.packages ?? []
-  const modulesRoot = npmModulesDir()
+  const modulesRoot = npmModulesDir(cwd)
   const out: InstalledExtension[] = []
   for (const ref of refs) {
     // Refs look like "npm:<name>" or "git:<url>" or "https://..." — we only
@@ -361,8 +357,8 @@ async function scanInstalledPackages(): Promise<InstalledExtension[]> {
   return out
 }
 
-export async function listInstalled(): Promise<InstalledExtension[]> {
-  const [a, b] = await Promise.all([scanExtensionsDir(), scanInstalledPackages()])
+export async function listInstalled(cwd: string): Promise<InstalledExtension[]> {
+  const [a, b] = await Promise.all([scanExtensionsDir(cwd), scanInstalledPackages(cwd)])
   const seen = new Set<string>()
   const out: InstalledExtension[] = []
   for (const e of [...a, ...b]) {
@@ -373,7 +369,7 @@ export async function listInstalled(): Promise<InstalledExtension[]> {
   return out.sort((a, b) => a.name.localeCompare(b.name))
 }
 
-function runPi(args: string[]): Promise<{ ok: true } | { ok: false; error: string }> {
+function runPi(cwd: string, args: string[]): Promise<{ ok: true } | { ok: false; error: string }> {
   return new Promise((resolve) => {
     const bin = piBinaryPath()
     if (!fs.existsSync(bin)) {
@@ -383,7 +379,12 @@ function runPi(args: string[]): Promise<{ ok: true } | { ok: false; error: strin
     const spawnBin = bin.endsWith('.js') ? process.execPath : bin
     const spawnArgs = bin.endsWith('.js') ? [bin, ...args] : args
     const child = spawn(spawnBin, spawnArgs, {
-      env: { ...process.env, PI_OFFLINE: process.env.PI_OFFLINE ?? '0', ELECTRON_RUN_AS_NODE: '1' },
+      env: {
+        ...process.env,
+        PI_OFFLINE: process.env.PI_OFFLINE ?? '0',
+        ELECTRON_RUN_AS_NODE: '1',
+        PI_CODING_AGENT_DIR: agentDirFor(cwd),
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
     let stdout = ''
@@ -413,17 +414,17 @@ function runPi(args: string[]): Promise<{ ok: true } | { ok: false; error: strin
   })
 }
 
-export async function installExtension(name: string): Promise<{ ok: true } | { ok: false; error: string }> {
+export async function installExtension(cwd: string, name: string): Promise<{ ok: true } | { ok: false; error: string }> {
   if (!name || /[\s;|&`$<>]/.test(name)) {
     return { ok: false, error: 'Invalid package name' }
   }
-  return runPi(['install', `npm:${name}`])
+  return runPi(cwd, ['install', `npm:${name}`])
 }
 
-export async function uninstallExtension(name: string): Promise<{ ok: true } | { ok: false; error: string }> {
+export async function uninstallExtension(cwd: string, name: string): Promise<{ ok: true } | { ok: false; error: string }> {
   if (!name || /[\s;|&`$<>]/.test(name)) {
     return { ok: false, error: 'Invalid package name' }
   }
   // `pi remove` is documented; `uninstall` is an alias.
-  return runPi(['remove', `npm:${name}`])
+  return runPi(cwd, ['remove', `npm:${name}`])
 }

--- a/src/agent/main/sessionFiles.ts
+++ b/src/agent/main/sessionFiles.ts
@@ -1,8 +1,8 @@
 // =============================================================================
 // sessionFiles — read-only access to pi's on-disk session store. Pi writes
-// every conversation to:
+// every conversation to (PI_CODING_AGENT_DIR points at <cwd>/.cate/pi-agent):
 //
-//   ~/.pi/agent/sessions/--<cwd-with-/-as-dashes>--/<timestamp>_<uuid>.jsonl
+//   <cwd>/.cate/pi-agent/sessions/--<cwd-with-/-as-dashes>--/<timestamp>_<uuid>.jsonl
 //
 // Each line is a JSON entry. The first line is the session header; subsequent
 // lines are either `message`, `session_info` (name), `model_change`,
@@ -15,9 +15,9 @@
 // =============================================================================
 
 import fs from 'fs/promises'
-import os from 'os'
 import path from 'path'
 import log from '../../main/logger'
+import { agentDirFor } from './agentDir'
 import type { AgentSessionListEntry } from '../../shared/types'
 
 /** Encode a cwd to pi's directory naming. Pi maps `/Users/anton/Dev/cate` to
@@ -28,13 +28,14 @@ function encodeCwd(cwd: string): string {
   return `-${dashed}--`
 }
 
-function sessionsRoot(): string {
-  return path.join(os.homedir(), '.pi', 'agent', 'sessions')
+function sessionsDirFor(cwd: string): string {
+  return path.join(agentDirFor(cwd), 'sessions', encodeCwd(cwd))
 }
 
-function sessionsDirFor(cwd: string): string {
-  return path.join(sessionsRoot(), encodeCwd(cwd))
-}
+// Pi nests sessions under <agentDir>/sessions/<encoded-cwd>/. The agent dir is
+// now per-workspace, so we validate file ops by this path segment rather than a
+// single global root.
+const SESSIONS_SEGMENT = `${path.sep}${path.join('.cate', 'pi-agent', 'sessions')}${path.sep}`
 
 interface ParsedHeader {
   id: string
@@ -143,16 +144,15 @@ export async function listSessions(cwd: string): Promise<AgentSessionListEntry[]
   return entries
 }
 
-/** Refuse to touch anything outside the pi sessions root — guards delete. */
-function isInsideSessionsRoot(filePath: string): boolean {
-  const root = sessionsRoot() + path.sep
+/** Refuse to touch anything that isn't a pi session file — guards delete/read. */
+function isSessionFile(filePath: string): boolean {
   const resolved = path.resolve(filePath)
-  return resolved.startsWith(root)
+  return resolved.includes(SESSIONS_SEGMENT) && resolved.endsWith('.jsonl')
 }
 
 export async function deleteSession(filePath: string): Promise<void> {
-  if (!isInsideSessionsRoot(filePath)) {
-    throw new Error(`Refusing to delete ${filePath} — not inside pi sessions root`)
+  if (!isSessionFile(filePath)) {
+    throw new Error(`Refusing to delete ${filePath} — not a pi session file`)
   }
   await fs.unlink(filePath)
 }
@@ -194,8 +194,8 @@ let counter = 0
 const nid = (): string => { counter += 1; return `s${counter}` }
 
 export async function loadSessionTranscript(filePath: string): Promise<RendererMessage[]> {
-  if (!isInsideSessionsRoot(filePath)) {
-    throw new Error(`Refusing to read ${filePath} — not inside pi sessions root`)
+  if (!isSessionFile(filePath)) {
+    throw new Error(`Refusing to read ${filePath} — not a pi session file`)
   }
   const raw = await fs.readFile(filePath, 'utf-8')
   const out: RendererMessage[] = []

--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -13,7 +13,7 @@
 // replaces the main column; the only way out is its back arrow — no double
 // close paths.
 //
-// Chats are pi's own session files on disk (~/.pi/agent/sessions/<cwd>/*.jsonl).
+// Chats are pi's own session files on disk (<cwd>/.cate/pi-agent/sessions/<cwd>/*.jsonl).
 // The sidebar reads them via AGENT_LIST_SESSIONS; opening a row resumes that
 // session by spawning pi with `--session <path>`. New chat = dispose + create
 // without a session file, then pick up pi's freshly-written file from getState.
@@ -907,6 +907,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
           <SettingsView
             commands={commands}
             workspaceId={workspaceId}
+            cwd={cwd}
             scopedProviderId={settingsScopedTo}
             availableModels={availableModels}
             onBack={() => setView('chat')}
@@ -1742,6 +1743,7 @@ function SlashPopup({
 function SettingsView({
   commands,
   workspaceId,
+  cwd,
   scopedProviderId,
   availableModels,
   onBack,
@@ -1749,6 +1751,7 @@ function SettingsView({
 }: {
   commands: AgentSlashCommand[]
   workspaceId: string
+  cwd: string
   scopedProviderId?: string
   availableModels: Array<{ provider: string; model: string; label?: string }>
   onBack: () => void
@@ -1797,13 +1800,13 @@ function SettingsView({
   const refreshAllFiles = useCallback(async () => {
     try {
       const [a, p, s] = await Promise.all([
-        window.electronAPI.agentListSkillFiles('agents'),
-        window.electronAPI.agentListSkillFiles('prompts'),
-        window.electronAPI.agentListSkillFiles('skills'),
+        window.electronAPI.agentListSkillFiles(cwd, 'agents'),
+        window.electronAPI.agentListSkillFiles(cwd, 'prompts'),
+        window.electronAPI.agentListSkillFiles(cwd, 'skills'),
       ])
       setAgentFiles(a); setPromptFiles(p); setSkillFiles(s)
     } catch (err) { log.warn('[SettingsView] list failed', err) }
-  }, [])
+  }, [cwd])
 
   useEffect(() => { void refreshAllFiles() }, [refreshAllFiles])
 
@@ -1815,7 +1818,7 @@ function SettingsView({
   const handleCreate = async (kind: 'agents' | 'prompts' | 'skills'): Promise<void> => {
     setError(null)
     try {
-      const created = await window.electronAPI.agentCreateSkill(kind, newName)
+      const created = await window.electronAPI.agentCreateSkill(cwd, kind, newName)
       setNewName(''); setCreating(null)
       await refreshAllFiles()
       onRefresh()
@@ -1834,7 +1837,7 @@ function SettingsView({
     if (!filePath) return
     if (!window.confirm(`Delete this ${kind.slice(0, -1)}?`)) return
     try {
-      await window.electronAPI.agentDeleteSkillFile(filePath)
+      await window.electronAPI.agentDeleteSkillFile(cwd, filePath)
       await refreshAllFiles()
       onRefresh()
     } catch (err) {
@@ -1861,7 +1864,7 @@ function SettingsView({
           </button>
         )}
         <button
-          onClick={() => window.electronAPI.agentOpenSkillsFolder(kind).catch(() => {})}
+          onClick={() => window.electronAPI.agentOpenSkillsFolder(cwd, kind).catch(() => {})}
           className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
         >
           <FolderOpen size={11} /> Open folder
@@ -1991,7 +1994,7 @@ function SettingsView({
               <ArrowsClockwise size={12} />
             </button>
           </div>
-          <ExtensionsTab refreshNonce={refreshNonce} />
+          <ExtensionsTab cwd={cwd} refreshNonce={refreshNonce} />
         </div>
       </div>
     </div>
@@ -2024,7 +2027,7 @@ const TERMINAL_TOOLTIP =
 
 type MarketplaceSortValue = 'downloads' | 'recent' | 'name'
 
-function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
+function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: number }) {
   const [catalog, setCatalog] = useState<MarketplaceCatalogEntry[]>([])
   const [installed, setInstalled] = useState<InstalledExtensionEntry[]>([])
   const [queryInput, setQueryInput] = useState('')
@@ -2039,12 +2042,12 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
 
   const refreshInstalled = useCallback(async () => {
     try {
-      const list = await window.electronAPI.agentMarketplaceListInstalled()
+      const list = await window.electronAPI.agentMarketplaceListInstalled(cwd)
       setInstalled(list)
     } catch (err) {
       log.warn('[ExtensionsTab] listInstalled failed', err)
     }
-  }, [])
+  }, [cwd])
 
   // Debounce the search input: typing waits 300ms before triggering a fetch.
   useEffect(() => {
@@ -2106,7 +2109,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
     setError(null)
     setRowPending(name, 'install')
     try {
-      const res = await window.electronAPI.agentMarketplaceInstall(name)
+      const res = await window.electronAPI.agentMarketplaceInstall(cwd, name)
       if (!res.ok) {
         setError(res.error ?? `Failed to install ${name}`)
       }
@@ -2123,7 +2126,7 @@ function ExtensionsTab({ refreshNonce = 0 }: { refreshNonce?: number }) {
     setError(null)
     setRowPending(name, 'uninstall')
     try {
-      const res = await window.electronAPI.agentMarketplaceUninstall(name)
+      const res = await window.electronAPI.agentMarketplaceUninstall(cwd, name)
       if (!res.ok) {
         setError(res.error ?? `Failed to uninstall ${name}`)
       }

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -1,9 +1,9 @@
 // =============================================================================
 // ProvidersView — in-panel UI for managing pi agent provider authentication.
 //
-// Single-column push navigation: list → detail → back to list, then back to
-// chat. The back arrow is the only way out: from the detail it pops to the
-// list, and from the list it returns to the chat.
+// Accordion: the full provider list is always visible; clicking a row expands
+// its sign-in / API-key form inline beneath it (at most one open at a time).
+// When embedded in Settings the parent owns the surrounding chrome.
 //
 // Only pi's built-in providers are supported. Custom OpenAI-compatible
 // endpoints would belong in pi's models.json — out of scope here.
@@ -48,8 +48,9 @@ interface ProvidersViewProps {
 export function ProvidersView({ onBack, scopedProviderId, embedded = false, availableModels }: ProvidersViewProps) {
   const [providers, setProviders] = useState<AuthProviderDescriptor[]>([])
   const [statuses, setStatuses] = useState<AuthProviderStatus[]>([])
-  const [detailId, setDetailId] = useState<string | null>(null)
-  const [detailKind, setDetailKind] = useState<'oauth' | 'apiKey' | null>(null)
+  // Accordion: at most one provider expanded at a time. Keyed by `${kind}-${id}`
+  // because the same provider id can appear as both an OAuth and an API-key entry.
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     try {
@@ -67,8 +68,13 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false, avai
   useEffect(() => { refresh() }, [refresh])
 
   useEffect(() => {
-    if (scopedProviderId) setDetailId(scopedProviderId)
-  }, [scopedProviderId])
+    if (!scopedProviderId) return
+    // Prefer the OAuth entry when a provider id exists in both groups.
+    const match =
+      providers.find((p) => p.kind === 'oauth' && p.id === scopedProviderId) ??
+      providers.find((p) => p.id === scopedProviderId)
+    if (match) setExpandedKey(`${match.kind}-${match.id}`)
+  }, [scopedProviderId, providers])
 
   const statusFor = useCallback(
     (id: string): AuthProviderStatus | undefined => statuses.find((s) => s.id === id),
@@ -85,71 +91,59 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false, avai
     return { oauth, apiKey }
   }, [providers])
 
-  const selectedProvider = useMemo(
-    () => (detailId ? providers.find((p) => p.id === detailId && (!detailKind || p.kind === detailKind)) ?? null : null),
-    [providers, detailId, detailKind],
-  )
-
-  const headerTitle = selectedProvider?.name ?? 'Providers'
-
-  const handleBack = useCallback(() => {
-    if (detailId) { setDetailId(null); setDetailKind(null) }
-    else onBack?.()
-  }, [detailId, onBack])
+  const toggle = useCallback((key: string) => {
+    setExpandedKey((prev) => (prev === key ? null : key))
+  }, [])
 
   return (
-    <div className="flex-1 flex flex-col bg-surface-4 text-primary min-h-0">
-      {(!embedded || detailId) && (
+    <div className="flex-1 flex flex-col text-primary min-h-0">
+      {!embedded && (
         <div className="flex items-center gap-2 px-3 h-9 border-b border-subtle shrink-0">
           <button
-            onClick={handleBack}
+            onClick={() => onBack?.()}
             className="p-1 -ml-1 rounded-md text-muted hover:text-primary hover:bg-white/5"
-            title={detailId ? 'Back to providers' : 'Back to chat'}
-            disabled={embedded && !detailId}
+            title="Back to chat"
           >
             <ArrowLeft size={14} />
           </button>
-          <div className="text-[12px] font-medium text-primary truncate flex-1 min-w-0">{headerTitle}</div>
-          {selectedProvider && (
-            <StatusPill status={statusFor(selectedProvider.id)} />
-          )}
+          <div className="text-[12px] font-medium text-primary truncate flex-1 min-w-0">Providers</div>
         </div>
       )}
 
       <div className="flex-1 overflow-y-auto min-h-0">
-        {!selectedProvider ? (
-          <div className="px-3 py-3 space-y-4">
-            <DefaultModelSection models={availableModels ?? []} />
-            <Section label="Sign in">
-              {grouped.oauth.map((p) => (
-                <ProviderListRow
-                  key={`oauth-${p.id}`}
-                  name={p.name}
+        <div className="px-3 py-3 space-y-4">
+          <DefaultModelSection models={availableModels ?? []} />
+          <Section label="Sign in">
+            {grouped.oauth.map((p) => {
+              const key = `oauth-${p.id}`
+              return (
+                <ProviderAccordionRow
+                  key={key}
+                  provider={p}
                   status={statusFor(p.id)}
-                  onClick={() => { setDetailId(p.id); setDetailKind('oauth') }}
+                  expanded={expandedKey === key}
+                  onToggle={() => toggle(key)}
+                  onRefresh={refresh}
                 />
-              ))}
-            </Section>
-            <Section label="API key">
-              {grouped.apiKey.map((p) => (
-                <ProviderListRow
-                  key={`apiKey-${p.id}`}
-                  name={p.name}
+              )
+            })}
+          </Section>
+          <Section label="API key">
+            {grouped.apiKey.map((p) => {
+              const key = `apiKey-${p.id}`
+              return (
+                <ProviderAccordionRow
+                  key={key}
+                  provider={p}
                   status={statusFor(p.id)}
-                  onClick={() => { setDetailId(p.id); setDetailKind('apiKey') }}
+                  expanded={expandedKey === key}
+                  onToggle={() => toggle(key)}
+                  onRefresh={refresh}
                 />
-              ))}
-            </Section>
-          </div>
-        ) : (
-          <div className="px-4 py-4">
-            <ProviderDetail
-              provider={selectedProvider}
-              status={statusFor(selectedProvider.id)}
-              onRefresh={refresh}
-            />
-          </div>
-        )}
+              )
+            })}
+          </Section>
+        </div>
       </div>
     </div>
   )
@@ -172,48 +166,45 @@ function Section({ label, children }: { label: string; children: React.ReactNode
   )
 }
 
-function ProviderListRow({
-  name,
+function ProviderAccordionRow({
+  provider,
   status,
-  onClick,
+  expanded,
+  onToggle,
+  onRefresh,
 }: {
-  name: string
+  provider: AuthProviderDescriptor
   status?: AuthProviderStatus
-  onClick: () => void
+  expanded: boolean
+  onToggle: () => void
+  onRefresh: () => Promise<void>
 }) {
   const connected = !!status?.connected
   return (
-    <button
-      onClick={onClick}
-      className="w-full flex items-center gap-2 px-2.5 py-2 text-left border-b border-white/5 last:border-0 hover:bg-white/[0.04]"
-    >
-      <span className="flex-1 truncate text-[12.5px] text-primary">{name}</span>
-      {connected ? (
-        <span className="inline-flex items-center gap-1 text-[10px] text-agent-light/90">
-          <CheckCircle size={10} weight="fill" /> Connected
-        </span>
-      ) : (
-        <CircleDashed size={11} className="text-muted/60" />
+    <div className="border-b border-white/5 last:border-0">
+      <button
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-white/[0.04]"
+      >
+        <span className="flex-1 truncate text-[12.5px] text-primary">{provider.name}</span>
+        {connected ? (
+          <span className="inline-flex items-center gap-1 text-[10px] text-agent-light/90">
+            <CheckCircle size={10} weight="fill" /> Connected
+          </span>
+        ) : (
+          <CircleDashed size={11} className="text-muted/60" />
+        )}
+        {expanded
+          ? <CaretDown size={10} className="text-muted/60" />
+          : <CaretRight size={10} className="text-muted/60" />}
+      </button>
+      {expanded && (
+        <div className="p-2.5 border-t border-white/5 bg-black/10">
+          <ProviderDetail provider={provider} status={status} onRefresh={onRefresh} />
+        </div>
       )}
-      <CaretRight size={10} className="text-muted/60" />
-    </button>
-  )
-}
-
-function StatusPill({ status }: { status?: AuthProviderStatus }) {
-  if (status?.connected) {
-    return (
-      <span className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full bg-agent/15 text-agent-light">
-        <CheckCircle size={10} weight="fill" />
-        Connected
-      </span>
-    )
-  }
-  return (
-    <span className="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full bg-white/5 text-muted">
-      <CircleDashed size={10} />
-      Not connected
-    </span>
+    </div>
   )
 }
 
@@ -312,17 +303,17 @@ function OAuthForm({
   }, [provider.id, onRefresh])
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {phase.type === 'idle' && !status?.connected && (
         <button
           onClick={handleStart}
-          className="w-full px-3 py-2.5 rounded-lg bg-agent hover:bg-agent-light text-white text-[13px] font-medium"
+          className="w-full px-3 py-2 rounded-md bg-agent hover:bg-agent-light text-white text-[12px] font-medium"
         >
           Sign in with {provider.name}
         </button>
       )}
       {phase.type === 'idle' && status?.connected && (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           <button
             onClick={handleStart}
             className="flex-1 px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
@@ -331,7 +322,7 @@ function OAuthForm({
           </button>
           <button
             onClick={handleDisconnect}
-            className="px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-[12px] text-rose-300 hover:text-rose-200"
+            className="shrink-0 px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-[12px] text-rose-300 hover:text-rose-200"
           >
             Disconnect
           </button>
@@ -343,7 +334,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'deviceCode' && (
-        <div className="space-y-3 rounded-lg border border-white/10 bg-black/10 p-3">
+        <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
           <div className="text-[12px] text-primary">
             Enter this code in your browser at{' '}
             <a href={phase.verificationUri} target="_blank" rel="noreferrer" className="underline text-agent-light">
@@ -379,7 +370,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'prompt' && (
-        <div className="space-y-2 rounded-lg border border-white/10 bg-black/10 p-3">
+        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <input
             type="text"
@@ -403,7 +394,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'select' && (
-        <div className="space-y-2 rounded-lg border border-white/10 bg-black/10 p-3">
+        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <div className="flex flex-col gap-1">
             {phase.options.map((opt) => (
@@ -420,7 +411,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'manualCode' && (
-        <div className="space-y-2 rounded-lg border border-white/10 bg-black/10 p-3">
+        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
           <div className="text-[12px] text-primary">
             Sign in completes automatically when the browser callback fires.
             If it doesn't, paste the code (or full redirect URL) here:
@@ -452,7 +443,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'error' && (
-        <div className="space-y-2 rounded-lg border border-white/10 bg-white/5 p-3">
+        <div className="space-y-2 rounded-md border border-white/10 bg-white/5 p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <button
             onClick={handleStart}
@@ -468,7 +459,7 @@ function OAuthForm({
 
 function AuthUrlCard({ url, instructions }: { url: string; instructions?: string }) {
   return (
-    <div className="space-y-3 rounded-lg border border-white/10 bg-black/10 p-3">
+    <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
       <div className="flex items-center gap-2 text-[12px] text-primary">
         <CloudArrowUp size={14} className="text-agent-light" />
         Browser opened for sign in.
@@ -544,9 +535,9 @@ function ApiKeyForm({
   }, [provider.id, onRefresh])
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1 min-w-0">
           <input
             type={reveal ? 'text' : 'password'}
             value={value}
@@ -555,43 +546,40 @@ function ApiKeyForm({
             autoComplete="off"
             spellCheck={false}
             placeholder={status?.connected ? '••••••••••••' : `Paste your ${provider.name} key`}
-            className="flex-1 min-w-0 bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+            className="w-full bg-surface-3 border border-white/10 rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
           />
           <button
             type="button"
             onClick={() => setReveal((r) => !r)}
-            className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-white/5"
+            className="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded text-muted hover:text-primary"
             title={reveal ? 'Hide' : 'Show'}
           >
             {reveal ? <EyeSlash size={14} /> : <Eye size={14} />}
           </button>
         </div>
-      </div>
-
-      {error && <div className="text-[12px] text-primary">{error}</div>}
-      {savedAt && !error && (
-        <div className="text-[12px] text-agent-light flex items-center gap-1">
-          <CheckCircle size={12} weight="fill" /> Saved.
-        </div>
-      )}
-
-      <div className="flex items-center gap-2 pt-2">
         <button
           disabled={saving || !value.trim()}
           onClick={handleSave}
-          className="px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
+          className="shrink-0 px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
-        {status?.connected && (
-          <button
-            onClick={handleDisconnect}
-            className="px-3 py-1.5 rounded-md text-muted hover:text-primary hover:bg-white/5 text-[12px]"
-          >
-            Disconnect
-          </button>
-        )}
       </div>
+
+      {error && <div className="text-[11px] text-rose-300">{error}</div>}
+      {savedAt && !error && (
+        <div className="flex items-center gap-1 text-[11px] text-agent-light">
+          <CheckCircle size={12} weight="fill" /> Saved.
+        </div>
+      )}
+      {status?.connected && (
+        <button
+          onClick={handleDisconnect}
+          className="text-[11px] text-muted hover:text-rose-200"
+        >
+          Disconnect
+        </button>
+      )}
     </div>
   )
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1107,24 +1107,24 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(AGENT_TOOL_DECISION, panelId, toolCallId, decision, reason)
   },
 
-  agentOpenSkillsFolder(kind: 'agents' | 'prompts' | 'skills'): Promise<void> {
-    return ipcRenderer.invoke(AGENT_OPEN_SKILLS_FOLDER, kind)
+  agentOpenSkillsFolder(cwd: string, kind: 'agents' | 'prompts' | 'skills'): Promise<void> {
+    return ipcRenderer.invoke(AGENT_OPEN_SKILLS_FOLDER, cwd, kind)
   },
 
   agentOpenSkillFile(filePath: string): Promise<void> {
     return ipcRenderer.invoke(AGENT_OPEN_SKILL_FILE, filePath)
   },
 
-  agentDeleteSkillFile(filePath: string): Promise<void> {
-    return ipcRenderer.invoke(AGENT_DELETE_SKILL_FILE, filePath)
+  agentDeleteSkillFile(cwd: string, filePath: string): Promise<void> {
+    return ipcRenderer.invoke(AGENT_DELETE_SKILL_FILE, cwd, filePath)
   },
 
-  agentCreateSkill(kind: 'agents' | 'prompts' | 'skills', name: string): Promise<string> {
-    return ipcRenderer.invoke(AGENT_CREATE_SKILL, kind, name)
+  agentCreateSkill(cwd: string, kind: 'agents' | 'prompts' | 'skills', name: string): Promise<string> {
+    return ipcRenderer.invoke(AGENT_CREATE_SKILL, cwd, kind, name)
   },
 
-  agentListSkillFiles(kind: 'agents' | 'prompts' | 'skills'): Promise<Array<{ name: string; description?: string; path: string }>> {
-    return ipcRenderer.invoke(AGENT_LIST_SKILL_FILES, kind)
+  agentListSkillFiles(cwd: string, kind: 'agents' | 'prompts' | 'skills'): Promise<Array<{ name: string; description?: string; path: string }>> {
+    return ipcRenderer.invoke(AGENT_LIST_SKILL_FILES, cwd, kind)
   },
 
   agentMarketplaceList(
@@ -1133,16 +1133,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(AGENT_MARKETPLACE_LIST, params)
   },
 
-  agentMarketplaceListInstalled(): Promise<unknown[]> {
-    return ipcRenderer.invoke(AGENT_MARKETPLACE_LIST_INSTALLED)
+  agentMarketplaceListInstalled(cwd: string): Promise<unknown[]> {
+    return ipcRenderer.invoke(AGENT_MARKETPLACE_LIST_INSTALLED, cwd)
   },
 
-  agentMarketplaceInstall(name: string): Promise<{ ok: boolean; error?: string }> {
-    return ipcRenderer.invoke(AGENT_MARKETPLACE_INSTALL, name)
+  agentMarketplaceInstall(cwd: string, name: string): Promise<{ ok: boolean; error?: string }> {
+    return ipcRenderer.invoke(AGENT_MARKETPLACE_INSTALL, cwd, name)
   },
 
-  agentMarketplaceUninstall(name: string): Promise<{ ok: boolean; error?: string }> {
-    return ipcRenderer.invoke(AGENT_MARKETPLACE_UNINSTALL, name)
+  agentMarketplaceUninstall(cwd: string, name: string): Promise<{ ok: boolean; error?: string }> {
+    return ipcRenderer.invoke(AGENT_MARKETPLACE_UNINSTALL, cwd, name)
   },
 
   onAgentEvent(callback: (envelope: unknown) => void): () => void {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -683,20 +683,20 @@ export interface ElectronAPI {
   /** Approve or deny a pending tool call. */
   agentToolDecision(panelId: string, toolCallId: string, decision: 'allow' | 'deny', reason?: string): Promise<void>
 
-  /** Open ~/.pi/agent/{agents|prompts} in the OS file manager. */
-  agentOpenSkillsFolder(kind: 'agents' | 'prompts' | 'skills'): Promise<void>
+  /** Open <cwd>/.cate/pi-agent/{agents|prompts} in the OS file manager. */
+  agentOpenSkillsFolder(cwd: string, kind: 'agents' | 'prompts' | 'skills'): Promise<void>
 
   /** Open a single skill/prompt/agent file in the OS default editor. */
   agentOpenSkillFile(filePath: string): Promise<void>
 
-  /** Delete a skill/prompt/agent file. Only allowed under ~/.pi/agent. */
-  agentDeleteSkillFile(filePath: string): Promise<void>
+  /** Delete a skill/prompt/agent file. Only allowed under the workspace's pi-agent dir. */
+  agentDeleteSkillFile(cwd: string, filePath: string): Promise<void>
 
   /** Create a new skill/prompt file from a template, then open it. */
-  agentCreateSkill(kind: 'agents' | 'prompts' | 'skills', name: string): Promise<string>
+  agentCreateSkill(cwd: string, kind: 'agents' | 'prompts' | 'skills', name: string): Promise<string>
 
-  /** List user files under ~/.pi/agent/{agents|prompts}. */
-  agentListSkillFiles(kind: 'agents' | 'prompts' | 'skills'): Promise<Array<{ name: string; description?: string; path: string }>>
+  /** List user files under <cwd>/.cate/pi-agent/{agents|prompts}. */
+  agentListSkillFiles(cwd: string, kind: 'agents' | 'prompts' | 'skills'): Promise<Array<{ name: string; description?: string; path: string }>>
 
   /** Browse-able marketplace catalog backed by a live scrape of pi.dev/packages
    *  (~2.9k entries, paginated). Returns an empty list when pi.dev is
@@ -719,8 +719,8 @@ export interface ElectronAPI {
     page: number
   }>
 
-  /** List extensions currently present in ~/.pi/agent/extensions/. */
-  agentMarketplaceListInstalled(): Promise<Array<{
+  /** List extensions currently present in <cwd>/.cate/pi-agent/extensions/. */
+  agentMarketplaceListInstalled(cwd: string): Promise<Array<{
     name: string
     description?: string
     requiresTerminal: boolean
@@ -728,10 +728,10 @@ export interface ElectronAPI {
   }>>
 
   /** Install an extension via `pi install npm:<name>`. Streams output to the log. */
-  agentMarketplaceInstall(name: string): Promise<{ ok: boolean; error?: string }>
+  agentMarketplaceInstall(cwd: string, name: string): Promise<{ ok: boolean; error?: string }>
 
   /** Uninstall an extension via `pi remove npm:<name>`. */
-  agentMarketplaceUninstall(name: string): Promise<{ ok: boolean; error?: string }>
+  agentMarketplaceUninstall(cwd: string, name: string): Promise<{ ok: boolean; error?: string }>
 
   /** Stream of agent events forwarded from the main process. */
   onAgentEvent(callback: (envelope: AgentEventEnvelope) => void): () => void


### PR DESCRIPTION
## What

Two things:

**Per-workspace pi config.** Sets `PI_CODING_AGENT_DIR` to `<workspace>/.cate/pi-agent` so pi's extensions, sessions and settings live per project instead of in the user's global `~/.pi/agent`. Cate no longer seeds its subagent/plan-mode extensions into your personal pi install.

Auth is the exception, kept shared so you don't re-login per project: one `auth.json` under cate's userData, copied into each workspace on spawn and watched (chokidar) so pi's OAuth token refreshes sync back. No symlinks/hardlinks/privileged calls, so it behaves the same on Windows/macOS/Linux. Existing `~/.pi/agent/auth.json` is seeded forward once so current users stay logged in.

**Accordion provider settings.** Clicking a provider used to swap the whole providers view for one detail form (leftover from the old tabbed settings). Now it expands inline under the row. Input and Save are on one line, padding is uniform across the sign-in, API-key and connected states.

## Notes

Clean cut: existing global sessions and marketplace extensions won't appear in workspaces (intended). Two workspaces open at once share auth with a small lag only if both refresh simultaneously.

## Test

`npm run typecheck` and `npm test` (315 pass) green. Manual: open the agent panel, confirm `<ws>/.cate/pi-agent/` is created and gitignored, a second workspace has its own history but is already authed, and installing an extension in one workspace doesn't leak to the other.