### PR TITLE
fix(panels): tint title text for parallel work, not the icon

### DIFF
--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -13,12 +13,16 @@ import { useDragStore, useTabSourceVisibility } from '../drag'
 import { PANEL_REGISTRY, getPanelDef } from '../panels/registry'
 import { useAppStore } from '../stores/appStore'
 import { useAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
+import { worktreeTitleStyle } from '../lib/worktreeTitleStyle'
 
 const AWAIT_COLOR = '#c08a5a'
 
 // Lookup: panelId → worktree color. Only returns a color when the panel's
 // workspace has 2+ worktrees (matches WorktreePill's visibility rule, so the
-// tab tint and the title-bar pill appear together or not at all).
+// tab title tint and the title-bar pill appear together or not at all). The
+// color is applied to the tab's title text, not its icon — the icon may be an
+// agent logo (an <img>, which ignores `color`), and tinting it would clash
+// with the per-agent icon swap.
 function useWorktreeColorByPanel(): Record<string, string> {
   return useAppStore(useShallow((s) => {
     const out: Record<string, string> = {}
@@ -220,8 +224,7 @@ export function DockTabBar(props: DockTabBarProps) {
               />
             )}
             <span
-              className={`shrink-0 ${worktreeColorByPanel[panelId] ? '' : isActive ? PANEL_TYPE_TINT[panelType] : 'text-muted'}`}
-              style={worktreeColorByPanel[panelId] ? { color: worktreeColorByPanel[panelId] } : undefined}
+              className={`shrink-0 ${isActive ? PANEL_TYPE_TINT[panelType] : 'text-muted'}`}
             >
               <TabIcon
                 type={panelType}
@@ -248,7 +251,8 @@ export function DockTabBar(props: DockTabBarProps) {
               />
             ) : (
               <span
-                className="truncate flex-1 min-w-0"
+                className={`truncate flex-1 min-w-0 ${agentInfoByPanel[panelId]?.state === 'running' ? 'cate-notif-pulse' : ''}`}
+                style={worktreeTitleStyle(worktreeColorByPanel[panelId], agentInfoByPanel[panelId]?.state === 'running')}
               >{getPanelTitle(panelId)}</span>
             )}
             {agentInfoByPanel[panelId]?.state === 'waitingForInput' && (

--- a/src/renderer/lib/worktreeTitleStyle.ts
+++ b/src/renderer/lib/worktreeTitleStyle.ts
@@ -1,0 +1,23 @@
+import type { CSSProperties } from 'react'
+
+// Title-text styling for a panel that belongs to a parallel-work worktree.
+// Parallel work tints the tab/row TITLE rather than the icon — the icon may be
+// an agent logo (an <img>, which ignores `color`), and tinting it would clash
+// with the per-agent icon swap.
+//
+// While the agent is running the title shimmers in the worktree hue: the caller
+// adds the `cate-notif-pulse` class and this returns the gradient stops as CSS
+// custom properties (--shimmer-dim/--shimmer-bright). When idle it returns a
+// steady color. Without a worktree color it returns undefined, so a running
+// non-worktree title falls back to the class's default muted->primary sweep.
+export function worktreeTitleStyle(
+  color: string | undefined,
+  isRunning: boolean,
+): CSSProperties | undefined {
+  if (!color) return undefined
+  if (!isRunning) return { color }
+  return {
+    '--shimmer-bright': color,
+    '--shimmer-dim': `color-mix(in srgb, ${color} 45%, var(--text-muted, #8a8479))`,
+  } as CSSProperties
+}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -12,6 +12,7 @@ import { findTabStack, findStackContainingPanel } from '../stores/dockTreeUtils'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import type { AgentState } from '../../shared/types'
 import { terminalRegistry } from '../lib/terminalRegistry'
+import { worktreeTitleStyle } from '../lib/worktreeTitleStyle'
 import { PANEL_REGISTRY } from '../panels/registry'
 import { useAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
 
@@ -165,10 +166,13 @@ export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, inden
         <Icon
           size={11}
           className="flex-shrink-0"
-          style={worktreeColor ? { color: worktreeColor, opacity: 0.95 } : { opacity: 0.6 }}
+          style={{ opacity: 0.6 }}
         />
       )}
-      <span className={`truncate min-w-0 flex-1 ${isRunning ? 'cate-notif-pulse' : ''}`}>
+      <span
+        className={`truncate min-w-0 flex-1 ${isRunning ? 'cate-notif-pulse' : ''}`}
+        style={worktreeTitleStyle(worktreeColor, isRunning)}
+      >
         {label}
       </span>
       {isAwaiting ? (

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -280,12 +280,30 @@
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
-/* "Active/running" text emphasis. Static (no sweep): the moving gradient
-   repainted the text every frame — a continuous cost wherever it appeared
-   (sidebar tabs + agent chat) — for a subtle cue. A steady bright color reads
-   as "active" without animating. */
+@keyframes cate-notif-sweep {
+  0%   { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+/* "Active/running" text shimmer — a slow gradient sweep that reads as "working".
+   Used by the agent chat (ChatThread) and by panel tab/row titles whose agent
+   is running. Callers gate it to running/streaming state only, so the per-frame
+   paint is transient, not perpetual (the concern #161 raised when it removed the
+   always-on variants). The two stops are themeable via --shimmer-dim/
+   --shimmer-bright, letting a parallel-work title shimmer in its worktree color;
+   unset, they fall back to muted->primary. */
 .cate-notif-pulse {
-  color: var(--text-primary, #e8e6e1);
+  background: linear-gradient(
+    90deg,
+    var(--shimmer-dim, var(--text-muted, #8a8479)) 40%,
+    var(--shimmer-bright, var(--text-primary, #e8e6e1)) 50%,
+    var(--shimmer-dim, var(--text-muted, #8a8479)) 60%
+  );
+  background-size: 300% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: cate-notif-sweep 2s ease-in-out infinite;
 }
 
 @keyframes cate-fade-in {


### PR DESCRIPTION
Agent panels swap the terminal icon to the running agent's logo (an `<img>`), so the parallel-work color we applied to the icon's wrapping span (`color`) had no effect once an agent was running. The two features were fighting over the same surface.

## Changes
- Parallel-work color now tints the **title text** (tab bar + workspace overview sidebar) instead of the icon. The icon is left alone for the agent logo.
- Restored the animated shimmer that #161 turned static. `cate-notif-pulse` sweeps again, themeable via `--shimmer-dim`/`--shimmer-bright`, so:
  - running titles shimmer in their worktree color (steady worktree color when idle),
  - the agent chat (ChatThread) shimmers again with the default sweep.
- Shimmer stays gated to running/streaming state, so the per-frame paint is transient, not the always-on cost #161 removed.
- New `worktreeTitleStyle()` helper shared by the tab bar and sidebar.

## Per-title behavior
- Running + worktree → shimmers in the worktree color
- Running, no worktree → default muted→white shimmer
- Idle + worktree → steady worktree color
- Idle, no worktree → normal tab/row text color

## Testing
- `tsc --noEmit` clean
- `WorkspaceTab.test.tsx` 6/6 pass