### PR TITLE
Configure the IDE from the .cate skill + reload-from-disk

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import log from './logger'
 import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session } from 'electron'
 import fs from 'fs'
 import path from 'path'
-import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, DIALOG_CONFIRM_IMPORT, APP_OPEN_PATH } from '../shared/ipc-channels'
+import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, DIALOG_CONFIRM_IMPORT, DIALOG_CONFIRM_RELOAD_WORKSPACE, APP_OPEN_PATH } from '../shared/ipc-channels'
 import {
   WINDOW_SET_TITLE,
   PANEL_TRANSFER, PANEL_RECEIVE, PANEL_TRANSFER_ACK,
@@ -634,6 +634,23 @@ function registerWindowAndDialogHandlers(): void {
       noLink: true,
     })
     return result.response === 0 ? 'copy' : result.response === 1 ? 'move' : 'cancel'
+  })
+
+  // Confirm reloading the canvas after the workspace.json file changed on disk
+  // (edited externally, e.g. by an agent following the .cate skill).
+  ipcMain.handle(DIALOG_CONFIRM_RELOAD_WORKSPACE, async (event, payload: { name?: string }) => {
+    const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
+    const name = payload?.name?.trim()
+    const result = await dialog.showMessageBox(win!, {
+      type: 'question',
+      message: 'Reload workspace from disk?',
+      detail: `The workspace file${name ? ` for "${name}"` : ''} changed on disk. Reload to apply it? This rebuilds the canvas and restarts terminals; the current in-app layout will be discarded.`,
+      buttons: ['Reload', 'Keep Current'],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+    })
+    return result.response === 0 ? 'reload' : 'cancel'
   })
 
   // Capture page screenshot for panel previews

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -101,6 +101,7 @@ export function buildApplicationMenu(): void {
         { label: 'New Browser', accelerator: 'CmdOrCtrl+Shift+B', click: dispatch('newBrowser') },
         { type: 'separator' },
         { label: 'Open Folder...', accelerator: 'CmdOrCtrl+O', click: dispatch('openFolder') },
+        { label: 'Reload Workspace from Disk', click: dispatch('reloadWorkspace') },
         { type: 'separator' },
         { label: 'Save', accelerator: 'CmdOrCtrl+S', click: dispatch('saveFile') },
         { type: 'separator' },

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -1,14 +1,18 @@
 import { ipcMain, app } from 'electron'
 import fs from 'fs/promises'
 import fsSync from 'fs'
+import crypto from 'crypto'
 import path from 'path'
 import log from './logger'
 import {
   PROJECT_STATE_SAVE,
   PROJECT_STATE_LOAD,
+  WORKSPACE_EXTERNAL_EDIT,
+  WORKSPACE_EXTERNAL_EDIT_DISMISS,
 } from '../shared/ipc-channels'
 import type { ProjectWorkspaceFile, ProjectSessionFile, MultiWorkspaceSession, SessionSnapshot, DockLayoutNode, WindowDockState } from '../shared/types'
 import { toRelativePath } from '../shared/pathUtils'
+import { broadcastToAll } from './windowRegistry'
 
 const CATE_DIR = '.cate'
 const WORKSPACE_FILE = 'workspace.json'
@@ -24,6 +28,55 @@ function workspacePath(rootPath: string): string {
 
 function sessionPath(rootPath: string): string {
   return path.join(rootPath, CATE_DIR, SESSION_FILE)
+}
+
+// ---------------------------------------------------------------------------
+// External-edit guard for workspace.json
+//
+// workspace.json is committable and meant to be hand- or agent-edited (e.g. via
+// the .cate skill) to reconfigure the canvas. But the renderer also autosaves
+// the live layout back over it (~30s + on quit), which would clobber any edit
+// made while the app is running. To prevent that, we remember the hash of the
+// content we last wrote/read per project; before any autosave overwrite we
+// compare it against what's on disk. A mismatch means the file was edited
+// behind our back, so we skip the overwrite and preserve the edit until the
+// user reloads the workspace from disk.
+// ---------------------------------------------------------------------------
+
+const lastWrittenWorkspaceHash = new Map<string, string>()
+
+function hashContent(content: string): string {
+  return crypto.createHash('sha1').update(content).digest('hex')
+}
+
+/** Record the hash of the exact content now living on disk for this project. */
+function rememberWorkspaceContent(rootPath: string, content: string): void {
+  lastWrittenWorkspaceHash.set(rootPath, hashContent(content))
+}
+
+/**
+ * True iff the on-disk workspace.json differs from what we last wrote/read —
+ * i.e. it was edited externally and an autosave would clobber that edit. When
+ * we've never tracked this project, or the file is gone, returns false (nothing
+ * to protect, let the write proceed).
+ */
+function workspaceEditedExternallyAsync(rootPath: string): Promise<boolean> {
+  const known = lastWrittenWorkspaceHash.get(rootPath)
+  if (known === undefined) return Promise.resolve(false)
+  return fs
+    .readFile(workspacePath(rootPath), 'utf-8')
+    .then((current) => hashContent(current) !== known)
+    .catch(() => false)
+}
+
+function workspaceEditedExternallySync(rootPath: string): boolean {
+  const known = lastWrittenWorkspaceHash.get(rootPath)
+  if (known === undefined) return false
+  try {
+    return hashContent(fsSync.readFileSync(workspacePath(rootPath), 'utf-8')) !== known
+  } catch {
+    return false
+  }
 }
 
 async function atomicWrite(filePath: string, json: string): Promise<void> {
@@ -106,6 +159,13 @@ export async function loadProjectState(rootPath: string): Promise<{
 } | null> {
   const ws = await tryReadWithFallback<ProjectWorkspaceFile>(workspacePath(rootPath))
   if (!ws || !isValidWorkspace(ws)) return null
+  // Track the on-disk content so a later autosave can tell our own writes apart
+  // from an external edit. Hash the raw file (not a re-serialization) so the
+  // comparison is byte-exact.
+  await fs
+    .readFile(workspacePath(rootPath), 'utf-8')
+    .then((raw) => rememberWorkspaceContent(rootPath, raw))
+    .catch(() => {})
   const sess = await tryReadWithFallback<ProjectSessionFile>(sessionPath(rootPath))
   return {
     workspace: ws,
@@ -119,8 +179,13 @@ let lastSavedProjectStates: Map<string, { workspace: string; session: string }> 
 export function saveProjectStateSync(): void {
   for (const [rootPath, { workspace, session }] of lastSavedProjectStates) {
     try {
-      atomicWriteSync(workspacePath(rootPath), workspace)
       atomicWriteSync(sessionPath(rootPath), session)
+      if (workspaceEditedExternallySync(rootPath)) {
+        log.info('Skipping workspace.json sync overwrite for %s — edited externally', cateDir(rootPath))
+      } else {
+        atomicWriteSync(workspacePath(rootPath), workspace)
+        rememberWorkspaceContent(rootPath, workspace)
+      }
     } catch (err) {
       log.warn('Sync project state save failed for %s: %O', rootPath, err)
     }
@@ -314,10 +379,17 @@ export function registerProjectStateHandlers(): void {
       const wsJson = JSON.stringify(workspace, null, 2)
       const sessJson = JSON.stringify(session, null, 2)
       lastSavedProjectStates.set(rootPath, { workspace: wsJson, session: sessJson })
-      await Promise.all([
-        atomicWrite(workspacePath(rootPath), wsJson),
-        atomicWrite(sessionPath(rootPath), sessJson),
-      ])
+      // session.json is machine-local and never hand-edited, so always write it.
+      const writes: Promise<void>[] = [atomicWrite(sessionPath(rootPath), sessJson)]
+      if (await workspaceEditedExternallyAsync(rootPath)) {
+        // Hold the overwrite and ask the renderer to prompt for a reload. The
+        // file stays steady until the user reloads or dismisses the prompt.
+        log.info('Skipping workspace.json overwrite for %s — edited externally; prompting reload', cateDir(rootPath))
+        broadcastToAll(WORKSPACE_EXTERNAL_EDIT, { rootPath })
+      } else {
+        writes.push(atomicWrite(workspacePath(rootPath), wsJson).then(() => rememberWorkspaceContent(rootPath, wsJson)))
+      }
+      await Promise.all(writes)
       seedSkillFile(rootPath).catch(() => {})
       log.debug('Project state saved to %s', cateDir(rootPath))
     },
@@ -325,5 +397,12 @@ export function registerProjectStateHandlers(): void {
 
   ipcMain.handle(PROJECT_STATE_LOAD, async (_event, rootPath: string) => {
     return loadProjectState(rootPath)
+  })
+
+  // User dismissed the "reload?" prompt (chose to keep the in-app layout).
+  // Drop the tracked hash so the next autosave overwrites the external edit —
+  // i.e. resume normal saving with the current canvas winning.
+  ipcMain.handle(WORKSPACE_EXTERNAL_EDIT_DISMISS, async (_event, rootPath: string) => {
+    lastWrittenWorkspaceHash.delete(rootPath)
   })
 }

--- a/src/main/templates/skillTemplate.ts
+++ b/src/main/templates/skillTemplate.ts
@@ -1,42 +1,82 @@
 export const SKILL_TEMPLATE = `# Cate Workspace Skill
 
-Read and write \`.cate/workspace.json\` to control the Cate canvas layout for this project. Changes are picked up on next app launch or workspace switch.
+Cate is the desktop IDE the user is running. Its UI is an infinite zoomable
+canvas where editor, terminal, browser, agent, and other panels float at fixed
+positions. **You configure that IDE by editing one file: \`.cate/workspace.json\`
+at the project root.** Writing this file is how you open files for the user,
+arrange panels, group them into labelled regions, and lay out their workspace.
+
+Use this skill whenever the user asks you to set up, arrange, open, lay out, or
+reorganise their Cate workspace (e.g. "open the auth files side by side", "set
+up a debugging layout", "put a terminal next to server.ts").
+
+## How changes take effect (read this first)
+
+- **If Cate is running:** it detects your edit (within a second or two) and asks
+  the user **"Reload workspace from disk?"**. If they accept, the canvas rebuilds
+  from your file (terminals restart). If they decline, Cate keeps the current
+  in-app layout and overwrites your edit on its next save — so the change is
+  lost. The user can also reload anytime via "Reload Workspace from Disk" in the
+  Command Palette (⌘K, search "reload") or the File menu.
+- **If Cate is closed:** just edit the file; it loads on next launch.
+
+So after you write the file, tell the user to expect (or trigger) the reload —
+and that declining the prompt discards the change. Only edit when the user
+actually wants a layout change, since a reload restarts terminals.
+
+## Workflow
+
+1. **Read the existing file** at \`<project-root>/.cate/workspace.json\` if it
+   exists. Edit it in place: preserve the existing \`name\`, \`color\`,
+   \`zoomLevel\`, \`viewportOffset\`, and any \`dockState\`/\`dockPanels\` keys you
+   don't understand. Only change \`canvas.nodes\` / \`canvas.regions\` unless the
+   user asks otherwise.
+2. **If the file is absent**, create \`.cate/workspace.json\` from scratch using
+   the full schema below (\`version\` MUST be \`1\`).
+3. **Make your edits** — add/remove/move nodes, set \`filePath\` on editors, etc.
+   Generate a fresh UUID for every new panel's \`panelId\`. Keep existing
+   \`panelId\`s when you're repositioning a panel that's already there.
+4. **Write valid JSON** (no comments, no trailing commas). Then tell the user
+   the change is written and to run "Reload Workspace from Disk" (or relaunch
+   if Cate is closed) to apply it — see "How changes take effect" above.
+
+Never edit \`.cate/session.json\` — it's ephemeral, gitignored, machine-local
+runtime state (PTYs, scroll, unsaved buffers). Touching it can corrupt the
+session. Only \`workspace.json\` is yours to edit, and it's safe to commit.
 
 ## File location
 
 \`\`\`
-<project-root>/.cate/workspace.json   # layout (committable)
-<project-root>/.cate/session.json     # ephemeral runtime state (gitignored)
+<project-root>/.cate/workspace.json   # layout — you edit this, committable
+<project-root>/.cate/session.json     # ephemeral runtime state — never touch
 \`\`\`
-
-Only edit \`workspace.json\`. Never touch \`session.json\`.
 
 ## Schema
 
 \`\`\`jsonc
 {
-  "version": 1,
-  "name": "My Project",           // workspace display name
-  "color": "",                     // accent color (hex or empty)
+  "version": 1,                        // MUST be 1
+  "name": "My Project",                // workspace display name
+  "color": "",                         // accent color (hex like "#4A9EFF" or empty)
   "canvas": {
-    "zoomLevel": 1,                // 0.3 – 3.0
-    "viewportOffset": { "x": 0, "y": 0 },
+    "zoomLevel": 1,                    // 0.3 – 3.0 (1 = 100%)
+    "viewportOffset": { "x": 0, "y": 0 }, // canvas pan; {0,0} shows around origin
     "nodes": [
       {
-        "panelId": "unique-id",    // stable UUID — generate one per panel
-        "panelType": "editor",     // see panel types below
-        "title": "main.ts",
-        "origin": { "x": 0, "y": 0 },
+        "panelId": "unique-uuid",      // stable UUID v4 — one per panel, never reused
+        "panelType": "editor",         // see panel types below
+        "title": "main.ts",            // tab/title-bar label
+        "origin": { "x": 0, "y": 0 },  // top-left corner, canvas-space px
         "size": { "width": 600, "height": 500 },
-        "filePath": "src/main.ts", // relative to project root (editors only)
-        "url": null,               // browsers only
-        "regionId": null,          // ID of containing region, if any
-        "documentType": null       // "pdf" | "docx" | "image" (document panels only)
+        "filePath": "src/main.ts",     // editors only; relative to project root
+        "url": null,                   // browsers only (e.g. "https://...")
+        "regionId": null,              // id of containing region, or null
+        "documentType": null           // document panels only: "pdf"|"docx"|"image"
       }
     ],
     "regions": [
       {
-        "id": "region-id",
+        "id": "region-id",             // referenced by node.regionId
         "origin": { "x": -20, "y": -20 },
         "size": { "width": 1300, "height": 500 },
         "label": "Frontend",
@@ -45,29 +85,41 @@ Only edit \`workspace.json\`. Never touch \`session.json\`.
       }
     ]
   }
+  // dockState / dockPanels may also be present — leave them as you found them.
 }
 \`\`\`
 
 ## Panel types and default sizes
 
-| type           | use for                        | default size  |
-|----------------|--------------------------------|---------------|
-| \`terminal\`     | shell / command runner         | 640 x 400     |
-| \`editor\`       | code file (set \`filePath\`)     | 600 x 500     |
-| \`browser\`      | embedded web view (set \`url\`)  | 800 x 600     |
-| \`agent\`        | AI agent chat                  | 760 x 480     |
-| \`document\`     | PDF / docx / image viewer      | 700 x 500     |
-| \`git\`          | git status / diff panel        | 500 x 600     |
-| \`fileExplorer\` | file tree sidebar              | 300 x 500     |
+| \`panelType\`    | use for                          | default size | min size  |
+|----------------|----------------------------------|--------------|-----------|
+| \`editor\`       | a code file — set \`filePath\`     | 600 x 500    | 300 x 250 |
+| \`terminal\`     | shell / command runner           | 640 x 400    | 320 x 200 |
+| \`browser\`      | embedded web view — set \`url\`    | 800 x 600    | 400 x 300 |
+| \`agent\`        | Claude-Code agent chat           | 760 x 480    | 360 x 320 |
+| \`document\`     | PDF / docx / image — set \`documentType\` + \`filePath\` | 700 x 500 | 300 x 250 |
+| \`git\`          | git status / diff panel          | 500 x 600    | 350 x 300 |
+| \`fileExplorer\` | git-aware file tree              | 300 x 500    | 180 x 200 |
 
-## Rules
+(\`projectList\` and \`canvas\` panel types also exist but are rarely placed by hand.)
 
-- All \`filePath\` values are relative to the project root, forward-slash separated.
-- Every \`panelId\` must be a unique UUID.
-- Coordinates are in canvas-space pixels. Positive x = right, positive y = down.
-- Place nodes so they don't overlap. Leave ~20px gaps.
-- Regions are visual group containers. Set \`regionId\` on nodes to place them inside a region.
-- Omit fields you don't need (\`url\`, \`filePath\`, \`regionId\`, \`documentType\`).
+## Layout rules
+
+- **Coordinates are canvas-space pixels.** Origin \`{0,0}\` is the natural center
+  of a fresh view. Positive x = right, positive y = down. Lay new content out
+  starting near \`{0,0}\`.
+- **Don't overlap nodes.** Leave a ~20px gap. To place a panel to the right of
+  one at \`x=0, width=600\`, start the next at \`x=620\`.
+- **Use the default sizes** from the table unless the user wants something
+  specific. Never go below the min size.
+- **\`filePath\` is always relative to the project root**, forward-slash
+  separated (\`src/lib/auth.ts\`, never an absolute or Windows-backslash path).
+- **Every \`panelId\` is a unique UUID v4.** Generate a new one per new panel.
+- **Regions are visual group boxes.** To put nodes in a region, give the region
+  an \`id\` and set each member node's \`regionId\` to it. Size the region to
+  enclose its members with padding (extend origin up/left by ~20–40px).
+- **Omit** \`filePath\` / \`url\` / \`documentType\` when not applicable (or set
+  \`null\`); set \`regionId\` to \`null\` for ungrouped nodes.
 
 ## Examples
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,8 @@ import {
   SESSION_FLUSH_SAVE_DONE,
   PROJECT_STATE_SAVE,
   PROJECT_STATE_LOAD,
+  WORKSPACE_EXTERNAL_EDIT,
+  WORKSPACE_EXTERNAL_EDIT_DISMISS,
   BOOT_SNAPSHOT_WRITE,
   APP_OPEN_PATH,
   MENU_OPEN_SETTINGS,
@@ -73,6 +75,7 @@ import {
   DIALOG_SAVE_FILE,
   DIALOG_CONFIRM_UNSAVED,
   DIALOG_CONFIRM_CLOSE_CANVAS,
+  DIALOG_CONFIRM_RELOAD_WORKSPACE,
   DIALOG_CONFIRM_DELETE_REGION,
   DIALOG_CONFIRM_IMPORT,
   RECENT_PROJECTS_GET,
@@ -634,6 +637,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(DIALOG_CONFIRM_CLOSE_CANVAS, payload)
   },
 
+  confirmReloadWorkspace(payload: { name?: string }): Promise<'reload' | 'cancel'> {
+    return ipcRenderer.invoke(DIALOG_CONFIRM_RELOAD_WORKSPACE, payload)
+  },
+
   confirmDeleteRegion(payload: { panelCount: number }): Promise<'with-contents' | 'region-only' | 'cancel'> {
     return ipcRenderer.invoke(DIALOG_CONFIRM_DELETE_REGION, payload)
   },
@@ -820,6 +827,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
     ipcRenderer.on(WINDOW_FULLSCREEN_STATE, listener)
     return () => { ipcRenderer.removeListener(WINDOW_FULLSCREEN_STATE, listener) }
+  },
+
+  /** Subscribe to workspace.json external-edit state. Fires whenever a project's
+   *  on-disk workspace file diverges from what Cate last wrote (edited
+   *  externally) or comes back in sync after a reload. */
+  onWorkspaceExternalEdit(callback: (payload: { rootPath: string }) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, payload: { rootPath: string }): void => {
+      callback(payload)
+    }
+    ipcRenderer.on(WORKSPACE_EXTERNAL_EDIT, listener)
+    return () => { ipcRenderer.removeListener(WORKSPACE_EXTERNAL_EDIT, listener) }
+  },
+
+  /** Tell main the user declined the reload prompt — resume saving so the
+   *  current in-app layout overwrites the external edit. */
+  dismissWorkspaceExternalEdit(rootPath: string): Promise<void> {
+    return ipcRenderer.invoke(WORKSPACE_EXTERNAL_EDIT_DISMISS, rootPath)
   },
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -109,6 +109,8 @@ function MainApp() {
   const closeSettings = useUIStore((s) => s.closeSettings)
   const [initializing, setInitializing] = useState(true)
   const initializedRef = useRef(false)
+  // Guards against stacking reload-confirm dialogs when the detector re-fires.
+  const reloadPromptOpenRef = useRef(false)
 
 
   // Store state
@@ -160,6 +162,35 @@ function MainApp() {
     const api = (window as unknown as { electronAPI?: { windowSetTitle?: (t: string) => Promise<void> } }).electronAPI
     api?.windowSetTitle?.(title).catch(() => { /* noop */ })
   }, [currentWorkspace?.name])
+
+  // When the active workspace's workspace.json is detected to have changed on
+  // disk (edited externally, e.g. by an agent following the .cate skill), prompt
+  // to reload the canvas. The detector (main's autosave guard) fires once per
+  // change via WORKSPACE_EXTERNAL_EDIT.
+  useEffect(() => {
+    return window.electronAPI.onWorkspaceExternalEdit?.(async ({ rootPath }) => {
+      if (reloadPromptOpenRef.current) return
+      const app = useAppStore.getState()
+      const active = app.workspaces.find((w) => w.id === app.selectedWorkspaceId)
+      // Only prompt for the workspace whose canvas is currently shown.
+      if (!active?.rootPath || active.rootPath !== rootPath) return
+
+      reloadPromptOpenRef.current = true
+      try {
+        const choice = await window.electronAPI.confirmReloadWorkspace?.({ name: active.name })
+        if (choice === 'reload') {
+          const { reloadActiveWorkspaceFromDisk } = await import('./lib/session')
+          await reloadActiveWorkspaceFromDisk()
+        } else {
+          // Declined — resume normal saving so the current canvas overwrites the
+          // external edit (the file was held steady only while the prompt was up).
+          await window.electronAPI.dismissWorkspaceExternalEdit?.(rootPath)
+        }
+      } finally {
+        reloadPromptOpenRef.current = false
+      }
+    })
+  }, [])
 
   // ---------------------------------------------------------------------------
   // Initialization — load settings, create first terminal

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -60,6 +60,11 @@ export function useShortcuts(): void {
         }
         return
       }
+      if (action === 'reloadWorkspace') {
+        const { reloadActiveWorkspaceFromDisk } = await import('../lib/session')
+        await reloadActiveWorkspaceFromDisk()
+        return
+      }
 
       switch (action as ShortcutAction) {
         case 'newTerminal': {

--- a/src/renderer/lib/session.ts
+++ b/src/renderer/lib/session.ts
@@ -26,8 +26,10 @@ import type {
   ProjectCanvasRegion,
   ProjectPanelRef,
   ProjectSessionNode,
+  CanvasRegion,
+  PanelState,
 } from '../../shared/types'
-import { toRelativePath } from '../../shared/pathUtils'
+import { toRelativePath, toAbsolutePath } from '../../shared/pathUtils'
 import { useDockStore } from '../stores/dockStore'
 import { terminalRegistry } from './terminalRegistry'
 import { mark } from './perfMarks'
@@ -387,9 +389,74 @@ export async function loadSession(): Promise<MultiWorkspaceSession | null> {
   return loadFromProjectFiles()
 }
 
-async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
-  const { toAbsolutePath } = await import('../../shared/pathUtils')
+/**
+ * Convert an on-disk workspace.json (+ optional session.json) into the in-memory
+ * SessionSnapshot used to rebuild a workspace. Shared by initial load and the
+ * "Reload Workspace from Disk" command so the two paths can't drift.
+ */
+export function projectFilesToSnapshot(
+  ws: ProjectWorkspaceFile,
+  sess: ProjectSessionFile | null,
+  rootPath: string,
+): SessionSnapshot {
+  const nodes: NodeSnapshot[] = ws.canvas.nodes.map((pn) => {
+    const ephemeral = sess?.nodes?.[pn.panelId]
+    return {
+      panelId: pn.panelId,
+      panelType: pn.panelType,
+      title: pn.title,
+      origin: pn.origin,
+      size: pn.size,
+      filePath: pn.filePath ? toAbsolutePath(pn.filePath, rootPath) : undefined,
+      url: pn.url,
+      regionId: pn.regionId,
+      documentType: pn.documentType,
+      ptyId: ephemeral?.ptyId,
+      workingDirectory: ephemeral?.workingDirectory,
+      unsavedContent: ephemeral?.unsavedContent,
+    }
+  })
 
+  const regions: Record<string, CanvasRegion> = {}
+  for (const r of ws.canvas.regions) {
+    regions[r.id] = {
+      id: r.id,
+      origin: r.origin,
+      size: r.size,
+      label: r.label,
+      color: r.color,
+      zOrder: r.zOrder,
+    }
+  }
+
+  let snapshotDockPanels: Record<string, PanelState> | undefined
+  if (ws.dockPanels) {
+    snapshotDockPanels = {}
+    for (const [id, ref] of Object.entries(ws.dockPanels)) {
+      snapshotDockPanels[id] = {
+        id,
+        type: ref.type as PanelType,
+        title: ref.title,
+        isDirty: false,
+        filePath: ref.filePath ? toAbsolutePath(ref.filePath, rootPath) : undefined,
+        url: ref.url,
+      }
+    }
+  }
+
+  return {
+    workspaceName: ws.name,
+    rootPath,
+    zoomLevel: ws.canvas.zoomLevel,
+    viewportOffset: ws.canvas.viewportOffset,
+    nodes,
+    regions: Object.keys(regions).length > 0 ? regions : undefined,
+    dockState: ws.dockState,
+    dockPanels: snapshotDockPanels,
+  }
+}
+
+async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
   let recentProjects: string[] = []
   try {
     recentProjects = (await window.electronAPI.recentProjectsGet()) ?? []
@@ -405,69 +472,15 @@ async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
   for (const rootPath of recentProjects) {
     try {
       const projectState = await window.electronAPI.projectStateLoad(rootPath) as {
-        workspace: import('../../shared/types').ProjectWorkspaceFile
-        session: import('../../shared/types').ProjectSessionFile | null
+        workspace: ProjectWorkspaceFile
+        session: ProjectSessionFile | null
       } | null
       if (!projectState?.workspace) continue
 
       const ws = projectState.workspace
       const sess = projectState.session
 
-      const nodes: NodeSnapshot[] = ws.canvas.nodes.map((pn) => {
-        const ephemeral = sess?.nodes?.[pn.panelId]
-        return {
-          panelId: pn.panelId,
-          panelType: pn.panelType,
-          title: pn.title,
-          origin: pn.origin,
-          size: pn.size,
-          filePath: pn.filePath ? toAbsolutePath(pn.filePath, rootPath) : undefined,
-          url: pn.url,
-          regionId: pn.regionId,
-          documentType: pn.documentType,
-          ptyId: ephemeral?.ptyId,
-          workingDirectory: ephemeral?.workingDirectory,
-          unsavedContent: ephemeral?.unsavedContent,
-        }
-      })
-
-      const regions: Record<string, import('../../shared/types').CanvasRegion> = {}
-      for (const r of ws.canvas.regions) {
-        regions[r.id] = {
-          id: r.id,
-          origin: r.origin,
-          size: r.size,
-          label: r.label,
-          color: r.color,
-          zOrder: r.zOrder,
-        }
-      }
-
-      let snapshotDockPanels: Record<string, import('../../shared/types').PanelState> | undefined
-      if (ws.dockPanels) {
-        snapshotDockPanels = {}
-        for (const [id, ref] of Object.entries(ws.dockPanels)) {
-          snapshotDockPanels[id] = {
-            id,
-            type: ref.type as PanelType,
-            title: ref.title,
-            isDirty: false,
-            filePath: ref.filePath ? toAbsolutePath(ref.filePath, rootPath) : undefined,
-            url: ref.url,
-          }
-        }
-      }
-
-      snapshots.push({
-        workspaceName: ws.name,
-        rootPath,
-        zoomLevel: ws.canvas.zoomLevel,
-        viewportOffset: ws.canvas.viewportOffset,
-        nodes,
-        regions: Object.keys(regions).length > 0 ? regions : undefined,
-        dockState: ws.dockState,
-        dockPanels: snapshotDockPanels,
-      })
+      snapshots.push(projectFilesToSnapshot(ws, sess, rootPath))
 
       if (sess?.panelWindows) panelWindows.push(...sess.panelWindows)
       if (sess?.dockWindows) dockWindows.push(...sess.dockWindows)
@@ -485,6 +498,42 @@ async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
     panelWindows: panelWindows.length > 0 ? panelWindows : undefined,
     dockWindows: dockWindows.length > 0 ? dockWindows : undefined,
   }
+}
+
+/**
+ * Re-read the active workspace's .cate/workspace.json from disk and rebuild the
+ * canvas from it, discarding the current in-memory layout. This is how an
+ * external edit (e.g. an agent following the .cate skill) is applied without
+ * quitting the app — the autosave guard in main keeps the edit from being
+ * clobbered until this runs.
+ *
+ * Tears down current panels (disposing terminals) then replays the on-disk
+ * snapshot through the same restore path used at launch.
+ */
+export async function reloadActiveWorkspaceFromDisk(): Promise<void> {
+  const appStore = useAppStore.getState()
+  const wsId = appStore.selectedWorkspaceId
+  const ws = appStore.workspaces.find((w) => w.id === wsId)
+  if (!ws?.rootPath) return
+
+  const projectState = (await window.electronAPI.projectStateLoad(ws.rootPath)) as {
+    workspace: ProjectWorkspaceFile
+    session: ProjectSessionFile | null
+  } | null
+  if (!projectState?.workspace) return
+
+  const snapshot = projectFilesToSnapshot(projectState.workspace, projectState.session, ws.rootPath)
+
+  // Keep the workspace's display name/color in sync with the file.
+  if (projectState.workspace.name) appStore.renameWorkspace(wsId, projectState.workspace.name)
+  if (typeof projectState.workspace.color === 'string') {
+    appStore.setWorkspaceColor(wsId, projectState.workspace.color)
+  }
+
+  // Discard the live layout, then rebuild from the file via the launch path.
+  appStore.closeAllPanels(wsId)
+  await restoreSession(snapshot)
+  log.info('[session] reloaded workspace %s from disk (%d nodes)', wsId, snapshot.nodes.length)
 }
 
 // -----------------------------------------------------------------------------

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -19,6 +19,7 @@ import {
   Square,
   FloppyDisk,
   GitBranch,
+  ArrowsClockwise,
 } from '@phosphor-icons/react'
 import type { PanelType } from '../../shared/types'
 import { CateLogo } from './CateLogo'
@@ -55,6 +56,7 @@ const ZoomResetIcon = () => <MagnifyingGlass size={ICON_SIZE} />
 const ZoomToFitIcon = () => <ArrowsOutSimple size={ICON_SIZE} />
 const RectangleIcon = () => <Square size={ICON_SIZE} />
 const SaveIcon = () => <FloppyDisk size={ICON_SIZE} />
+const ReloadIcon = () => <ArrowsClockwise size={ICON_SIZE} />
 const AgentIcon = () => <CateLogo size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
@@ -208,6 +210,15 @@ export const CommandPalette: React.FC = () => {
         shortcutText: '',
         icon: <SaveIcon />,
         action: () => useUIStore.getState().setShowLayoutsDialog(true),
+      },
+      {
+        id: 'reloadWorkspace',
+        title: 'Reload Workspace from Disk',
+        shortcutText: '',
+        icon: <ReloadIcon />,
+        action: () => {
+          void import('../lib/session').then((m) => m.reloadActiveWorkspaceFromDisk())
+        },
       },
     ],
     [

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -342,6 +342,9 @@ export interface ElectronAPI {
    *  Otherwise returns 'close' | 'cancel'. */
   confirmCloseCanvas(payload: { panelCount: number; isLast: boolean }): Promise<'move' | 'delete' | 'close' | 'cancel'>
 
+  /** Confirm reloading the canvas after workspace.json changed on disk. */
+  confirmReloadWorkspace(payload: { name?: string }): Promise<'reload' | 'cancel'>
+
   /** Native confirmation shown when deleting a region that has panels inside.
    *  Returns 'with-contents' (delete region + contents), 'region-only' (keep
    *  contents, just remove the region around them), or 'cancel'. */
@@ -468,6 +471,15 @@ export interface ElectronAPI {
   /** Subscribe to native-fullscreen state changes. Fires with the new boolean
    *  whenever any Cate window enters or leaves macOS native fullscreen. */
   onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void
+
+  /** Subscribe to external edits of a project's workspace.json. Fires when the
+   *  on-disk file is found to differ from what Cate last wrote (i.e. a reload
+   *  should be offered). */
+  onWorkspaceExternalEdit(callback: (payload: { rootPath: string }) => void): () => void
+
+  /** Tell main the user declined the reload prompt — resume normal saving so
+   *  the current in-app layout overwrites the external edit. */
+  dismissWorkspaceExternalEdit(rootPath: string): Promise<void>
 
   // ---------------------------------------------------------------------------
   // Dock window management

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -86,6 +86,12 @@ export const SESSION_FLUSH_SAVE_DONE = 'session:flushSaveDone' // renderer -> ma
 // Project-local workspace persistence (.cate/)
 export const PROJECT_STATE_SAVE = 'project:stateSave'     // renderer -> main
 export const PROJECT_STATE_LOAD = 'project:stateLoad'     // renderer -> main
+// Fired when a project's workspace.json is found to differ on disk from what
+// Cate last wrote (edited externally) — or back in sync after a reload.
+export const WORKSPACE_EXTERNAL_EDIT = 'project:externalEdit' // main -> renderer
+// Renderer tells main the user declined the reload prompt — resume saving so
+// the current in-app layout overwrites the external edit.
+export const WORKSPACE_EXTERNAL_EDIT_DISMISS = 'project:externalEditDismiss' // renderer -> main
 
 // Boot snapshot — a tiny JSON file (geometry, theme, last workspace id, native
 // tabs flag) written by the renderer whenever the relevant settings change.
@@ -139,6 +145,7 @@ export const DIALOG_CONFIRM_UNSAVED = 'dialog:confirmUnsaved'
 export const DIALOG_CONFIRM_CLOSE_CANVAS = 'dialog:confirmCloseCanvas'
 export const DIALOG_CONFIRM_DELETE_REGION = 'dialog:confirmDeleteRegion'
 export const DIALOG_CONFIRM_IMPORT = 'dialog:confirmImport'
+export const DIALOG_CONFIRM_RELOAD_WORKSPACE = 'dialog:confirmReloadWorkspace'
 
 // Panel window: renderer pushes an updated PanelState snapshot to main so
 // the windowRegistry's panel meta (used by session persistence and the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -435,7 +435,7 @@ export type ShortcutAction =
 /** Actions the native menu can dispatch into the renderer. Superset of
  *  ShortcutAction — includes a few menu-only items that have no keyboard
  *  binding. */
-export type MenuActionId = ShortcutAction | 'openFolder'
+export type MenuActionId = ShortcutAction | 'openFolder' | 'reloadWorkspace'
 
 export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   'newTerminal',


### PR DESCRIPTION
## What

- Rewrites the seeded `.cate/skill.md` so an agent knows it configures Cate by editing `workspace.json`, with the workflow and how edits take effect.
- Adds "Reload Workspace from Disk" (Command Palette + File menu) that re-reads `workspace.json` and rebuilds the canvas.
- Detects external edits to `workspace.json`: the autosave holds the overwrite and prompts the user to reload. Reload applies the file; declining resumes normal saving so the current canvas wins.

## Why

The skill existed but didn't tell the agent how to edit the workspace file. And a running Cate would silently overwrite any hand or agent edit on its next autosave, so edits never applied.

## Notes

- The detector and dialog live in main/preload, so the app must be restarted to pick them up.
- Existing projects keep their old `skill.md` (seeding skips when the file exists); only fresh projects get the rewrite.

## Test

`npm run build` and `npm test` (315 pass) green. Reload + guard verified manually in the running app.