### PR TITLE
fix(terminal): send macOS line-editing key sequences to the shell

### DIFF
--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -269,11 +269,19 @@ export function useShortcuts(): void {
       // Context-aware guard: when a text surface (input, textarea, Monaco,
       // xterm helper textarea, contenteditable) has focus, let clipboard and
       // undo/redo fall through to it natively instead of the canvas.
-      // Terminals don't consume Cmd+Z/Y/Backspace, so let canvas handle them
-      // even when a terminal panel is focused. Only real text editors
-      // (Monaco, inputs, contenteditables) should swallow them.
-      if (action === 'undo' || action === 'redo' || action === 'deleteNode') {
+      // Terminals don't consume Cmd+Z/Y, so the canvas handles undo/redo even
+      // when a terminal is focused — only real editors/inputs swallow them.
+      if (action === 'undo' || action === 'redo') {
         if (!terminalHasFocus && isTextSurfaceFocused()) return
+      }
+      // Cmd+Backspace (deleteNode): a focused terminal now owns it for line
+      // editing (kill-to-line-start, sent to the shell by the terminal's key
+      // handler), so never delete a focused terminal/editor/input panel with
+      // it. The xterm helper textarea counts as a text surface, so this covers
+      // canvas, docked, and detached-window terminals alike. Close a focused
+      // terminal panel with Cmd+W instead.
+      if (action === 'deleteNode') {
+        if (isTextSurfaceFocused()) return
       }
 
       // Keyboard-only passthrough: when a browser panel is focused, let

--- a/src/renderer/lib/terminalKeymap.test.ts
+++ b/src/renderer/lib/terminalKeymap.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+
+import { resolveTerminalKeySequence, MAC_TERMINAL_KEYMAP } from './terminalKeymap'
+
+/** Build a minimal KeyboardEvent-shaped object. The resolver only reads
+ *  key + the four modifier flags, so a plain literal is enough (no jsdom). */
+function ev(
+  key: string,
+  mods: Partial<Record<'metaKey' | 'altKey' | 'ctrlKey' | 'shiftKey', boolean>> = {},
+): KeyboardEvent {
+  return {
+    key,
+    metaKey: false,
+    altKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    ...mods,
+  } as unknown as KeyboardEvent
+}
+
+describe('resolveTerminalKeySequence — macOS line-editing chords (VS Code parity)', () => {
+  it('Cmd+Backspace → kill to line start (Ctrl+U)', () => {
+    expect(resolveTerminalKeySequence(ev('Backspace', { metaKey: true }), true)).toBe('\x15')
+  })
+
+  it('Option+Backspace → delete word left (Ctrl+W)', () => {
+    expect(resolveTerminalKeySequence(ev('Backspace', { altKey: true }), true)).toBe('\x17')
+  })
+
+  it('Option+Delete (forward) → delete word right (ESC d)', () => {
+    expect(resolveTerminalKeySequence(ev('Delete', { altKey: true }), true)).toBe('\x1bd')
+  })
+
+  it('Cmd+ArrowLeft → move to line start (Ctrl+A)', () => {
+    expect(resolveTerminalKeySequence(ev('ArrowLeft', { metaKey: true }), true)).toBe('\x01')
+  })
+
+  it('Cmd+ArrowRight → move to line end (Ctrl+E)', () => {
+    expect(resolveTerminalKeySequence(ev('ArrowRight', { metaKey: true }), true)).toBe('\x05')
+  })
+
+  it('Option+ArrowLeft → word left (ESC b)', () => {
+    expect(resolveTerminalKeySequence(ev('ArrowLeft', { altKey: true }), true)).toBe('\x1bb')
+  })
+
+  it('Option+ArrowRight → word right (ESC f)', () => {
+    expect(resolveTerminalKeySequence(ev('ArrowRight', { altKey: true }), true)).toBe('\x1bf')
+  })
+})
+
+describe('resolveTerminalKeySequence — non-matches return null', () => {
+  it('returns null on non-mac (Win/Linux unchanged)', () => {
+    expect(resolveTerminalKeySequence(ev('Backspace', { metaKey: true }), false)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('ArrowLeft', { altKey: true }), false)).toBeNull()
+  })
+
+  it('plain Backspace / arrows with no modifiers → null (xterm default)', () => {
+    expect(resolveTerminalKeySequence(ev('Backspace'), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('ArrowLeft'), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('ArrowRight'), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('Delete'), true)).toBeNull()
+  })
+
+  it('does not hijack adjacent chords with extra modifiers', () => {
+    // Cmd+Shift+Backspace stays free (e.g. for a future deleteNode rebind)
+    expect(resolveTerminalKeySequence(ev('Backspace', { metaKey: true, shiftKey: true }), true)).toBeNull()
+    // Cmd+Ctrl+Backspace
+    expect(resolveTerminalKeySequence(ev('Backspace', { metaKey: true, ctrlKey: true }), true)).toBeNull()
+    // Cmd+Option+ArrowLeft
+    expect(resolveTerminalKeySequence(ev('ArrowLeft', { metaKey: true, altKey: true }), true)).toBeNull()
+  })
+
+  it('Cmd+Delete (forward) has no mapping — only Option+Delete does', () => {
+    expect(resolveTerminalKeySequence(ev('Delete', { metaKey: true }), true)).toBeNull()
+  })
+
+  it('unrelated keys → null', () => {
+    expect(resolveTerminalKeySequence(ev('a', { metaKey: true }), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('Enter', { metaKey: true }), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev('ArrowUp', { altKey: true }), true)).toBeNull()
+  })
+})
+
+describe('MAC_TERMINAL_KEYMAP table', () => {
+  it('has the 7 VS Code-parity chords and every send sequence is non-empty', () => {
+    expect(MAC_TERMINAL_KEYMAP).toHaveLength(7)
+    for (const entry of MAC_TERMINAL_KEYMAP) {
+      expect(entry.send.length).toBeGreaterThan(0)
+      expect(entry.label.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/renderer/lib/terminalKeymap.ts
+++ b/src/renderer/lib/terminalKeymap.ts
@@ -1,0 +1,64 @@
+// =============================================================================
+// terminalKeymap — macOS line-editing key translation for terminals
+//
+// xterm.js does not emit readline-style control sequences for Cmd/Option
+// chords, so a plain shell never sees "delete to line start", "delete word",
+// or word/line navigation. This module maps those chords to the exact byte
+// sequences VS Code's integrated terminal sends (verified against
+// terminalContrib/sendSequence/.../terminal.sendSequence.contribution.ts), so
+// behaviour matches VS Code / Cursor.
+//
+// Pure + dependency-free (reads only the event's key + modifier flags) so it
+// is trivially unit-testable. The xterm customKeyEventHandler calls
+// resolveTerminalKeySequence() and writes the result to the PTY.
+//
+// macOS-only for now; the table is data-driven and extends to Win/Linux (Ctrl
+// chords) by adding rows later.
+// =============================================================================
+
+export interface TerminalKeymapEntry {
+  /** KeyboardEvent.key this row matches (e.g. 'Backspace', 'ArrowLeft', 'Delete'). */
+  key: string
+  /** Required Cmd (meta) state — matched exactly. */
+  meta: boolean
+  /** Required Option (alt) state — matched exactly. */
+  alt: boolean
+  /** Bytes written to the PTY when this row matches. */
+  send: string
+  /** Human-readable description (docs / future settings UI). */
+  label: string
+}
+
+const ESC = '\x1b'
+
+/** macOS terminal line-editing chords, mirroring VS Code's defaults.
+ *  Ctrl and Shift must both be absent for a row to match (see resolver). */
+export const MAC_TERMINAL_KEYMAP: readonly TerminalKeymapEntry[] = [
+  { key: 'Backspace', meta: true, alt: false, send: '\x15', label: 'Delete to line start' },
+  { key: 'Backspace', meta: false, alt: true, send: '\x17', label: 'Delete word left' },
+  { key: 'Delete', meta: false, alt: true, send: `${ESC}d`, label: 'Delete word right' },
+  { key: 'ArrowLeft', meta: true, alt: false, send: '\x01', label: 'Move to line start' },
+  { key: 'ArrowRight', meta: true, alt: false, send: '\x05', label: 'Move to line end' },
+  { key: 'ArrowLeft', meta: false, alt: true, send: `${ESC}b`, label: 'Move word left' },
+  { key: 'ArrowRight', meta: false, alt: true, send: `${ESC}f`, label: 'Move word right' },
+]
+
+/**
+ * Resolve a keyboard event to the PTY byte sequence for a macOS line-editing
+ * chord, or null when no chord matches.
+ *
+ * Returns null on non-mac platforms so Windows/Linux keep their existing
+ * behaviour. Matching is exact on all four modifiers — Ctrl and Shift must be
+ * absent — so adjacent chords (Cmd+Shift+Backspace, Cmd+Ctrl+Backspace, …) are
+ * never hijacked. Total function; never throws.
+ */
+export function resolveTerminalKeySequence(event: KeyboardEvent, isMac: boolean): string | null {
+  if (!isMac) return null
+  if (event.ctrlKey || event.shiftKey) return null
+  for (const entry of MAC_TERMINAL_KEYMAP) {
+    if (event.key === entry.key && event.metaKey === entry.meta && event.altKey === entry.alt) {
+      return entry.send
+    }
+  }
+  return null
+}

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -20,6 +20,7 @@ import { titleIndicatesRunning, outputShowsBodySpinner } from './agentSpinner'
 import { noteAgentTitle, noteAgentSpinnerByte } from './agentScreenDetector'
 import { scanTerminalChunkForUrls, clearTerminalUrlBuffer } from './terminalUrlAutoOpen'
 import { getResolvedTheme, subscribeTheme, type ResolvedTheme } from './themeManager'
+import { resolveTerminalKeySequence } from './terminalKeymap'
 
 /** Agent terminals show the clean detected agent name (e.g. "Codex", "Claude
  *  Code") as their tab title — set by useProcessMonitor — not the agent's raw
@@ -89,6 +90,77 @@ export function isTerminalCopyChord(
   if (event.type !== 'keydown' || !event.ctrlKey || event.altKey || event.metaKey) return false
   if (event.key !== 'c' && event.key !== 'C') return false
   return terminal.hasSelection()
+}
+
+// Modified special keys that xterm.js doesn't translate to distinct escape
+// sequences (e.g. Ctrl+Enter, Shift+Enter). We send CSI u (fixterms/kitty)
+// encoded sequences directly to the PTY so shells and TUI programs can
+// distinguish these key combos.
+const CSI_U_KEYS: Record<string, number> = {
+  Enter: 13,
+  Tab: 9,
+  Backspace: 127,
+  Escape: 27,
+  Space: 32,
+}
+
+/**
+ * Build the xterm customKeyEventHandler shared by the fresh-spawn and
+ * cross-window-reconnect paths (identical logic — kept here so they can't drift
+ * apart). Returns true to let xterm handle the key normally, false to suppress
+ * xterm's own handling.
+ */
+function createTerminalKeyEventHandler(
+  terminal: Terminal,
+  ptyId: string,
+): (event: KeyboardEvent) => boolean {
+  const { electronAPI } = window
+  return (event: KeyboardEvent): boolean => {
+    if (event.type !== 'keydown') return true
+
+    // Returning false makes xterm skip this key (no literal ^V) without calling
+    // preventDefault, so the browser still fires its paste event into xterm's
+    // textarea and xterm performs the paste once. Do NOT preventDefault here —
+    // that would also cancel the paste event and nothing would paste.
+    if (isTerminalPasteChord(event)) return false
+    if (isTerminalCopyChord(event, terminal)) return false
+
+    // macOS line-editing chords (Cmd/Option + Backspace/Delete/Arrows) →
+    // readline control sequences, matching VS Code's integrated terminal.
+    // Must run before the metaKey passthrough below, otherwise Cmd combos
+    // would fall through to xterm's default (a plain delete) or be ignored.
+    const macSeq = resolveTerminalKeySequence(event, isMacPlatform)
+    if (macSeq !== null) {
+      electronAPI.terminalWrite(ptyId, macSeq)
+      event.preventDefault()
+      return false
+    }
+
+    const keyCode = CSI_U_KEYS[event.key]
+    if (keyCode === undefined) return true // let xterm handle all other keys
+
+    // Build modifier param: 1 + (shift=1, alt=2, ctrl=4, meta=8)
+    let mod = 1
+    if (event.shiftKey) mod += 1
+    if (event.altKey) mod += 2
+    if (event.ctrlKey) mod += 4
+    if (event.metaKey) mod += 8
+
+    // No modifier — let xterm handle normally
+    if (mod === 1) return true
+
+    // Shift+Tab already handled by xterm as reverse-tab (\x1b[Z)
+    if (event.key === 'Tab' && mod === 2) return true
+
+    // Remaining Cmd combos are app shortcuts — let them propagate to the
+    // shortcut handler (line-editing Cmd chords were handled above).
+    if (event.metaKey) return true
+
+    // Send CSI u sequence: ESC [ keycode ; modifier u
+    electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
+    event.preventDefault()
+    return false
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -563,53 +635,9 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
     })
     cleanupListeners.push(() => titleDisposable.dispose())
 
-    // 8. Handle modified special keys that xterm.js doesn't translate to
-    //    distinct escape sequences (e.g. Ctrl+Enter, Shift+Enter, etc.).
-    //    We send CSI u (fixterms/kitty) encoded sequences directly to the PTY
-    //    so shells and TUI programs can distinguish these key combos.
-    const CSI_U_KEYS: Record<string, number> = {
-      Enter: 13,
-      Tab: 9,
-      Backspace: 127,
-      Escape: 27,
-      Space: 32,
-    }
-
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type !== 'keydown') return true
-
-      // Returning false makes xterm skip this key (no literal ^V) without
-      // calling preventDefault, so the browser still fires its paste event into
-      // xterm's textarea and xterm performs the paste once. Do NOT preventDefault
-      // here — that would also cancel the paste event and nothing would paste.
-      if (isTerminalPasteChord(event)) return false
-      if (isTerminalCopyChord(event, terminal)) return false
-
-      const keyCode = CSI_U_KEYS[event.key]
-      if (keyCode === undefined) return true // let xterm handle all other keys
-
-      // Build modifier param: 1 + (shift=1, alt=2, ctrl=4, meta=8)
-      let mod = 1
-      if (event.shiftKey) mod += 1
-      if (event.altKey) mod += 2
-      if (event.ctrlKey) mod += 4
-      if (event.metaKey) mod += 8
-
-      // No modifier — let xterm handle normally
-      if (mod === 1) return true
-
-      // Shift+Tab already handled by xterm as reverse-tab (\x1b[Z)
-      if (event.key === 'Tab' && mod === 2) return true
-
-      // Ctrl+Shift+C/V overlap — but those aren't special keys, so won't match.
-      // Cmd+key combos are app shortcuts — let them propagate to the shortcut handler.
-      if (event.metaKey) return true
-
-      // Send CSI u sequence: ESC [ keycode ; modifier u
-      electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
-      event.preventDefault()
-      return false
-    })
+    // 8. Custom key handling: macOS line-editing chords + CSI u for modified
+    //    special keys. See createTerminalKeyEventHandler.
+    terminal.attachCustomKeyEventHandler(createTerminalKeyEventHandler(terminal, ptyId))
 
     // 8b. xterm -> PTY: keystrokes (standard path for all other input)
     const dataDisposable = terminal.onData((data) => {
@@ -749,28 +777,8 @@ async function reconnectTerminal(
   })
   cleanupListeners.push(() => titleDisposable.dispose())
 
-  // CSI u key handler (same as getOrCreate)
-  const CSI_U_KEYS: Record<string, number> = {
-    Enter: 13, Tab: 9, Backspace: 127, Escape: 27, Space: 32,
-  }
-  terminal.attachCustomKeyEventHandler((event) => {
-    if (event.type !== 'keydown') return true
-    if (isTerminalPasteChord(event)) return false
-    if (isTerminalCopyChord(event, terminal)) return false
-    const keyCode = CSI_U_KEYS[event.key]
-    if (keyCode === undefined) return true
-    let mod = 1
-    if (event.shiftKey) mod += 1
-    if (event.altKey) mod += 2
-    if (event.ctrlKey) mod += 4
-    if (event.metaKey) mod += 8
-    if (mod === 1) return true
-    if (event.key === 'Tab' && mod === 2) return true
-    if (event.metaKey) return true
-    electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
-    event.preventDefault()
-    return false
-  })
+  // Custom key handler — same logic as getOrCreate (shared factory).
+  terminal.attachCustomKeyEventHandler(createTerminalKeyEventHandler(terminal, ptyId))
 
   const dataDisposable = terminal.onData((data) => {
     electronAPI.terminalWrite(ptyId, data)


### PR DESCRIPTION
## What & why

In Cate terminals, **`Cmd+Delete` (`Cmd+Backspace`) didn't delete to the start of the line**, and other macOS line-editing chords were missing/wrong — unlike the VS Code / Cursor integrated terminal. Two layers were at fault:

1. The app shortcut handler ran `deleteNode` on `Cmd+Backspace` even when a terminal was focused, calling `preventDefault()` before xterm saw the key.
2. The terminal's `customKeyEventHandler` returned `true` for any `Cmd` combo and never translated it to a readline control sequence.

## Changes

- **New `src/renderer/lib/terminalKeymap.ts`** — a pure, data-driven table + `resolveTerminalKeySequence(event, isMac)` mapping the macOS chords to the exact bytes VS Code's integrated terminal sends. macOS-only for now; extensible to Win/Linux by adding rows.
- **`terminalRegistry.ts`** — translate the chords in the xterm key handler (works for canvas, dock, and detached-window terminals). Extracted the duplicated handler from `getOrCreate`/`reconnectTerminal` into one shared `createTerminalKeyEventHandler` factory so they can't drift apart. The CSI-u path for `Enter`/`Tab`/`Escape`/`Space` is unchanged.
- **`useShortcuts.ts`** — `deleteNode` no longer fires when a text surface (incl. a focused terminal — xterm focuses its `.xterm-helper-textarea`) has focus, so `Cmd+Backspace` reaches the shell. A focused terminal panel is still closed with **`Cmd+W`**. `undo`/`redo` behaviour is unchanged.

### Chords (mac, VS Code parity)

| Chord | Bytes | Effect |
|---|---|---|
| `Cmd+Backspace` | `\x15` (Ctrl+U) | delete to line start |
| `Option+Backspace` | `\x17` (Ctrl+W) | delete word left |
| `Option+Delete` | `\x1bd` (ESC d) | delete word right |
| `Cmd+Left` / `Cmd+Right` | `\x01` / `\x05` | line start / end |
| `Option+Left` / `Option+Right` | `\x1bb` / `\x1bf` | word left / right |

## Testing

- New `terminalKeymap.test.ts` (13 cases): every chord → expected bytes, non-mac → null, plain/near-miss combos → null.
- Full suite: **333 passed, 3 skipped, 0 failed**. `npm run build` ✓. `tsc --noEmit` ✓.
- `useShortcuts` is a store-coupled hook with no existing unit tests; its change is a single guard branch, verified via build/typecheck.

Closes #172
