### PR TITLE
fix(terminal): deliver macOS line-editing chords to the shell

### DIFF
--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -315,14 +315,20 @@ export function useShortcuts(): void {
         const navOnly = action !== 'toolSelect' && action !== 'toolHand'
         if (navOnly && (ui.showNodeSwitcher || ui.showCommandPalette)) return
       }
-      // Context-aware guard: when a text surface (input, textarea, Monaco,
-      // xterm helper textarea, contenteditable) has focus, let clipboard and
-      // undo/redo fall through to it natively instead of the canvas.
-      // Terminals don't consume Cmd+Z/Y/Backspace, so let canvas handle them
-      // even when a terminal panel is focused. Only real text editors
-      // (Monaco, inputs, contenteditables) should swallow them.
-      if (action === 'undo' || action === 'redo' || action === 'deleteNode') {
+      // Context-aware guard: when a real text editor (Monaco, input, textarea,
+      // contenteditable) has focus, let Cmd+Z/Y fall through to it natively.
+      // Terminals don't consume Cmd+Z/Y, so the canvas still owns undo/redo when
+      // a terminal panel is focused.
+      if (action === 'undo' || action === 'redo') {
         if (!terminalHasFocus && isTextSurfaceFocused()) return
+      }
+      // Cmd+Backspace (deleteNode): a focused terminal must keep the chord so the
+      // shell can delete-to-line-start (translated to Ctrl+U in terminalRegistry),
+      // and a focused text editor must keep it to delete text. Panels stay
+      // closable via Cmd+W. Without this, the canvas would close the panel and
+      // the keystroke would never reach the shell (issue #172).
+      if (action === 'deleteNode') {
+        if (terminalHasFocus || isTextSurfaceFocused()) return
       }
 
       // Keyboard-only passthrough: when a browser panel is focused, let

--- a/src/renderer/lib/terminalKeymap.test.ts
+++ b/src/renderer/lib/terminalKeymap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveTerminalKeySequence, type TerminalKeyEvent } from './terminalKeymap'
+import { resolveTerminalKeySequence, MAC_TERMINAL_KEYMAP, type TerminalKeyEvent } from './terminalKeymap'
 
 function ev(partial: Partial<TerminalKeyEvent> & { key: string }): TerminalKeyEvent {
   return { metaKey: false, altKey: false, ctrlKey: false, shiftKey: false, ...partial }
@@ -44,5 +44,15 @@ describe('resolveTerminalKeySequence (macOS line-editing chords)', () => {
 
   it('leaves forward Delete with Cmd alone (only Option+Delete is mapped)', () => {
     expect(resolveTerminalKeySequence(ev({ key: 'Delete', metaKey: true }), true)).toBeNull()
+  })
+})
+
+describe('MAC_TERMINAL_KEYMAP table', () => {
+  it('has the 7 VS Code-parity chords, each with a non-empty send + label', () => {
+    expect(MAC_TERMINAL_KEYMAP).toHaveLength(7)
+    for (const entry of MAC_TERMINAL_KEYMAP) {
+      expect(entry.send.length).toBeGreaterThan(0)
+      expect(entry.label.length).toBeGreaterThan(0)
+    }
   })
 })

--- a/src/renderer/lib/terminalKeymap.test.ts
+++ b/src/renderer/lib/terminalKeymap.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { resolveTerminalKeySequence, type TerminalKeyEvent } from './terminalKeymap'
+
+function ev(partial: Partial<TerminalKeyEvent> & { key: string }): TerminalKeyEvent {
+  return { metaKey: false, altKey: false, ctrlKey: false, shiftKey: false, ...partial }
+}
+
+describe('resolveTerminalKeySequence (macOS line-editing chords)', () => {
+  const cases: Array<[string, TerminalKeyEvent, string]> = [
+    ['Cmd+Backspace → Ctrl+U', ev({ key: 'Backspace', metaKey: true }), '\x15'],
+    ['Option+Backspace → Ctrl+W', ev({ key: 'Backspace', altKey: true }), '\x17'],
+    ['Option+Delete → ESC d', ev({ key: 'Delete', altKey: true }), '\x1bd'],
+    ['Cmd+Left → Ctrl+A', ev({ key: 'ArrowLeft', metaKey: true }), '\x01'],
+    ['Cmd+Right → Ctrl+E', ev({ key: 'ArrowRight', metaKey: true }), '\x05'],
+    ['Option+Left → ESC b', ev({ key: 'ArrowLeft', altKey: true }), '\x1bb'],
+    ['Option+Right → ESC f', ev({ key: 'ArrowRight', altKey: true }), '\x1bf'],
+  ]
+
+  for (const [name, event, expected] of cases) {
+    it(name, () => {
+      expect(resolveTerminalKeySequence(event, true)).toBe(expected)
+    })
+  }
+
+  it('returns null on non-macOS for every chord', () => {
+    for (const [, event] of cases) {
+      expect(resolveTerminalKeySequence(event, false)).toBeNull()
+    }
+  })
+
+  it('ignores plain keys (no Cmd/Option modifier)', () => {
+    expect(resolveTerminalKeySequence(ev({ key: 'Backspace' }), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev({ key: 'ArrowLeft' }), true)).toBeNull()
+  })
+
+  it('does not fire when Ctrl or Shift is also held', () => {
+    expect(resolveTerminalKeySequence(ev({ key: 'Backspace', metaKey: true, ctrlKey: true }), true)).toBeNull()
+    expect(resolveTerminalKeySequence(ev({ key: 'Backspace', metaKey: true, shiftKey: true }), true)).toBeNull()
+  })
+
+  it('does not fire when both Cmd and Option are held (ambiguous)', () => {
+    expect(resolveTerminalKeySequence(ev({ key: 'Backspace', metaKey: true, altKey: true }), true)).toBeNull()
+  })
+
+  it('leaves forward Delete with Cmd alone (only Option+Delete is mapped)', () => {
+    expect(resolveTerminalKeySequence(ev({ key: 'Delete', metaKey: true }), true)).toBeNull()
+  })
+})

--- a/src/renderer/lib/terminalKeymap.ts
+++ b/src/renderer/lib/terminalKeymap.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// terminalKeymap — translate macOS line-editing chords into the literal control
+// bytes a shell's line editor (readline / zsh ZLE) understands.
+//
+// In a Cate terminal, chords like Cmd+Backspace ("delete to line start") must
+// behave the way they do in the VS Code / Cursor integrated terminal. xterm.js
+// doesn't translate them, and a CSI-u encoding (e.g. `\x1b[127;3u`) isn't
+// understood by a plain shell — so we map each chord to the exact byte sequence
+// VS Code sends via `workbench.action.terminal.sendSequence`.
+//
+// This module is pure (no DOM / xterm dependency) so it can be unit-tested and
+// later extended to Windows / Linux. The byte writing happens in the caller's
+// xterm customKeyEventHandler (see terminalRegistry.ts).
+// =============================================================================
+
+/** Minimal keyboard-event shape so this stays unit-testable without a real DOM. */
+export interface TerminalKeyEvent {
+  key: string
+  metaKey: boolean
+  altKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+}
+
+/**
+ * Resolve a macOS line-editing chord to the bytes to write to the PTY, or null
+ * when the event isn't one of the handled chords (the caller then falls back to
+ * its normal handling). Verified against VS Code's macOS terminal defaults:
+ *
+ *   Cmd+Backspace   → \x15 (Ctrl+U)  delete to line start
+ *   Option+Backspace→ \x17 (Ctrl+W)  delete word left
+ *   Option+Delete   → \x1bd (ESC d)  delete word right (forward)
+ *   Cmd+Left        → \x01 (Ctrl+A)  line start
+ *   Cmd+Right       → \x05 (Ctrl+E)  line end
+ *   Option+Left     → \x1bb (ESC b)  word left
+ *   Option+Right    → \x1bf (ESC f)  word right
+ *
+ * Only macOS is handled for now; on other platforms this always returns null so
+ * the standard xterm path is unchanged. Ctrl or Shift held disqualifies the
+ * chord (those are distinct, unbound combos — matching VS Code exactly).
+ */
+export function resolveTerminalKeySequence(e: TerminalKeyEvent, isMac: boolean): string | null {
+  if (!isMac) return null
+  if (e.ctrlKey || e.shiftKey) return null
+
+  const cmd = e.metaKey && !e.altKey
+  const opt = e.altKey && !e.metaKey
+  if (!cmd && !opt) return null
+
+  switch (e.key) {
+    case 'Backspace':
+      if (cmd) return '\x15' // delete to line start
+      if (opt) return '\x17' // delete word left
+      return null
+    case 'Delete': // forward delete (Fn+Delete / full-keyboard Del)
+      if (opt) return '\x1bd' // delete word right
+      return null
+    case 'ArrowLeft':
+      if (cmd) return '\x01' // line start
+      if (opt) return '\x1bb' // word left
+      return null
+    case 'ArrowRight':
+      if (cmd) return '\x05' // line end
+      if (opt) return '\x1bf' // word right
+      return null
+    default:
+      return null
+  }
+}

--- a/src/renderer/lib/terminalKeymap.ts
+++ b/src/renderer/lib/terminalKeymap.ts
@@ -6,14 +6,18 @@
 // behave the way they do in the VS Code / Cursor integrated terminal. xterm.js
 // doesn't translate them, and a CSI-u encoding (e.g. `\x1b[127;3u`) isn't
 // understood by a plain shell — so we map each chord to the exact byte sequence
-// VS Code sends via `workbench.action.terminal.sendSequence`.
+// VS Code sends via `workbench.action.terminal.sendSequence` (verified against
+// terminalContrib/sendSequence/.../terminal.sendSequence.contribution.ts).
 //
-// This module is pure (no DOM / xterm dependency) so it can be unit-tested and
-// later extended to Windows / Linux. The byte writing happens in the caller's
-// xterm customKeyEventHandler (see terminalRegistry.ts).
+// The mapping is a data-driven table so it's self-documenting (each row carries
+// a label for docs / a future settings UI) and extends to Windows / Linux by
+// adding rows later. This module is pure (no DOM / xterm dependency) so it can
+// be unit-tested; the byte writing happens in the caller's xterm
+// customKeyEventHandler (see terminalRegistry.ts).
 // =============================================================================
 
-/** Minimal keyboard-event shape so this stays unit-testable without a real DOM. */
+/** Minimal keyboard-event shape so this stays unit-testable without a real DOM.
+ *  A real `KeyboardEvent` is structurally assignable to this. */
 export interface TerminalKeyEvent {
   key: string
   metaKey: boolean
@@ -22,48 +26,50 @@ export interface TerminalKeyEvent {
   shiftKey: boolean
 }
 
+export interface TerminalKeymapEntry {
+  /** KeyboardEvent.key this row matches (e.g. 'Backspace', 'ArrowLeft', 'Delete'). */
+  key: string
+  /** Required Cmd (meta) state — matched exactly. */
+  meta: boolean
+  /** Required Option (alt) state — matched exactly. */
+  alt: boolean
+  /** Bytes written to the PTY when this row matches. */
+  send: string
+  /** Human-readable description (docs / future settings UI). */
+  label: string
+}
+
+const ESC = '\x1b'
+
+/** macOS terminal line-editing chords, mirroring VS Code's defaults. Ctrl and
+ *  Shift must both be absent for a row to match (enforced by the resolver). */
+export const MAC_TERMINAL_KEYMAP: readonly TerminalKeymapEntry[] = [
+  { key: 'Backspace', meta: true, alt: false, send: '\x15', label: 'Delete to line start' },
+  { key: 'Backspace', meta: false, alt: true, send: '\x17', label: 'Delete word left' },
+  { key: 'Delete', meta: false, alt: true, send: `${ESC}d`, label: 'Delete word right' },
+  { key: 'ArrowLeft', meta: true, alt: false, send: '\x01', label: 'Move to line start' },
+  { key: 'ArrowRight', meta: true, alt: false, send: '\x05', label: 'Move to line end' },
+  { key: 'ArrowLeft', meta: false, alt: true, send: `${ESC}b`, label: 'Move word left' },
+  { key: 'ArrowRight', meta: false, alt: true, send: `${ESC}f`, label: 'Move word right' },
+]
+
 /**
- * Resolve a macOS line-editing chord to the bytes to write to the PTY, or null
- * when the event isn't one of the handled chords (the caller then falls back to
- * its normal handling). Verified against VS Code's macOS terminal defaults:
+ * Resolve a keyboard event to the PTY byte sequence for a macOS line-editing
+ * chord, or null when no chord matches (the caller then falls back to its
+ * normal handling).
  *
- *   Cmd+Backspace   → \x15 (Ctrl+U)  delete to line start
- *   Option+Backspace→ \x17 (Ctrl+W)  delete word left
- *   Option+Delete   → \x1bd (ESC d)  delete word right (forward)
- *   Cmd+Left        → \x01 (Ctrl+A)  line start
- *   Cmd+Right       → \x05 (Ctrl+E)  line end
- *   Option+Left     → \x1bb (ESC b)  word left
- *   Option+Right    → \x1bf (ESC f)  word right
- *
- * Only macOS is handled for now; on other platforms this always returns null so
- * the standard xterm path is unchanged. Ctrl or Shift held disqualifies the
- * chord (those are distinct, unbound combos — matching VS Code exactly).
+ * Returns null on non-mac platforms so Windows/Linux keep their existing
+ * behaviour. Matching is exact on Cmd/Option, and Ctrl/Shift must be absent, so
+ * adjacent chords (Cmd+Shift+Backspace, Cmd+Ctrl+Backspace, Cmd+Option+Left, …)
+ * are never hijacked. Total function; never throws.
  */
 export function resolveTerminalKeySequence(e: TerminalKeyEvent, isMac: boolean): string | null {
   if (!isMac) return null
   if (e.ctrlKey || e.shiftKey) return null
-
-  const cmd = e.metaKey && !e.altKey
-  const opt = e.altKey && !e.metaKey
-  if (!cmd && !opt) return null
-
-  switch (e.key) {
-    case 'Backspace':
-      if (cmd) return '\x15' // delete to line start
-      if (opt) return '\x17' // delete word left
-      return null
-    case 'Delete': // forward delete (Fn+Delete / full-keyboard Del)
-      if (opt) return '\x1bd' // delete word right
-      return null
-    case 'ArrowLeft':
-      if (cmd) return '\x01' // line start
-      if (opt) return '\x1bb' // word left
-      return null
-    case 'ArrowRight':
-      if (cmd) return '\x05' // line end
-      if (opt) return '\x1bf' // word right
-      return null
-    default:
-      return null
+  for (const entry of MAC_TERMINAL_KEYMAP) {
+    if (e.key === entry.key && e.metaKey === entry.meta && e.altKey === entry.alt) {
+      return entry.send
+    }
   }
+  return null
 }

--- a/src/renderer/lib/terminalRegistry.ts
+++ b/src/renderer/lib/terminalRegistry.ts
@@ -19,6 +19,7 @@ import { extractAgentTitleSegment } from './agentTitleParser'
 import { titleIndicatesRunning, outputShowsBodySpinner } from './agentSpinner'
 import { noteAgentTitle, noteAgentSpinnerByte } from './agentScreenDetector'
 import { scanTerminalChunkForUrls, clearTerminalUrlBuffer } from './terminalUrlAutoOpen'
+import { resolveTerminalKeySequence } from './terminalKeymap'
 import { getActiveTheme, subscribeTheme } from './themeManager'
 import type { Theme } from '../../shared/types'
 
@@ -92,6 +93,68 @@ export function isTerminalCopyChord(
   return terminal.hasSelection()
 }
 
+// ---------------------------------------------------------------------------
+// xterm custom key-event handler
+//
+// One factory shared by getOrCreate() and reconnectTerminal() (previously two
+// copies). It covers, in order: paste/copy chords, macOS line-editing chords
+// (Cmd/Option + Backspace/Delete/Arrows → literal control bytes), and CSI-u
+// encoding for modified special keys (Ctrl+Enter, Shift+Tab, …) so shells and
+// TUIs can tell them apart. Returning false makes xterm skip the key; we only
+// preventDefault when we've written bytes ourselves.
+// ---------------------------------------------------------------------------
+
+/** Special keys xterm doesn't translate to distinct escape sequences — encoded
+ *  as CSI u (fixterms/kitty) so shells/TUIs can distinguish the combos. */
+const CSI_U_KEYS: Record<string, number> = {
+  Enter: 13,
+  Tab: 9,
+  Backspace: 127,
+  Escape: 27,
+  Space: 32,
+}
+
+function makeTerminalKeyEventHandler(
+  terminal: { hasSelection(): boolean },
+  ptyId: string,
+): (event: KeyboardEvent) => boolean {
+  return (event: KeyboardEvent) => {
+    if (event.type !== 'keydown') return true
+
+    // Skip without preventDefault so the browser still fires the native paste
+    // event into xterm's textarea (xterm then pastes exactly once).
+    if (isTerminalPasteChord(event)) return false
+    if (isTerminalCopyChord(event, terminal)) return false
+
+    // macOS line-editing chords → literal bytes the shell's line editor reads,
+    // matching VS Code / Cursor. Pure table lives in terminalKeymap.ts.
+    const seq = resolveTerminalKeySequence(event, isMacPlatform)
+    if (seq !== null) {
+      window.electronAPI.terminalWrite(ptyId, seq)
+      event.preventDefault()
+      return false
+    }
+
+    const keyCode = CSI_U_KEYS[event.key]
+    if (keyCode === undefined) return true // let xterm handle all other keys
+
+    // Build modifier param: 1 + (shift=1, alt=2, ctrl=4, meta=8)
+    let mod = 1
+    if (event.shiftKey) mod += 1
+    if (event.altKey) mod += 2
+    if (event.ctrlKey) mod += 4
+    if (event.metaKey) mod += 8
+
+    if (mod === 1) return true // no modifier — let xterm handle normally
+    if (event.key === 'Tab' && mod === 2) return true // Shift+Tab = reverse-tab
+    // Remaining Cmd+key combos are app shortcuts — let them propagate.
+    if (event.metaKey) return true
+
+    window.electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
+    event.preventDefault()
+    return false
+  }
+}
 
 /** Apply the active theme's terminal palette to every live terminal. Called
  *  whenever the unified theme changes. */
@@ -348,53 +411,9 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
     })
     cleanupListeners.push(() => titleDisposable.dispose())
 
-    // 8. Handle modified special keys that xterm.js doesn't translate to
-    //    distinct escape sequences (e.g. Ctrl+Enter, Shift+Enter, etc.).
-    //    We send CSI u (fixterms/kitty) encoded sequences directly to the PTY
-    //    so shells and TUI programs can distinguish these key combos.
-    const CSI_U_KEYS: Record<string, number> = {
-      Enter: 13,
-      Tab: 9,
-      Backspace: 127,
-      Escape: 27,
-      Space: 32,
-    }
-
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type !== 'keydown') return true
-
-      // Returning false makes xterm skip this key (no literal ^V) without
-      // calling preventDefault, so the browser still fires its paste event into
-      // xterm's textarea and xterm performs the paste once. Do NOT preventDefault
-      // here — that would also cancel the paste event and nothing would paste.
-      if (isTerminalPasteChord(event)) return false
-      if (isTerminalCopyChord(event, terminal)) return false
-
-      const keyCode = CSI_U_KEYS[event.key]
-      if (keyCode === undefined) return true // let xterm handle all other keys
-
-      // Build modifier param: 1 + (shift=1, alt=2, ctrl=4, meta=8)
-      let mod = 1
-      if (event.shiftKey) mod += 1
-      if (event.altKey) mod += 2
-      if (event.ctrlKey) mod += 4
-      if (event.metaKey) mod += 8
-
-      // No modifier — let xterm handle normally
-      if (mod === 1) return true
-
-      // Shift+Tab already handled by xterm as reverse-tab (\x1b[Z)
-      if (event.key === 'Tab' && mod === 2) return true
-
-      // Ctrl+Shift+C/V overlap — but those aren't special keys, so won't match.
-      // Cmd+key combos are app shortcuts — let them propagate to the shortcut handler.
-      if (event.metaKey) return true
-
-      // Send CSI u sequence: ESC [ keycode ; modifier u
-      electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
-      event.preventDefault()
-      return false
-    })
+    // 8. Modified special keys + macOS line-editing chords — see
+    //    makeTerminalKeyEventHandler().
+    terminal.attachCustomKeyEventHandler(makeTerminalKeyEventHandler(terminal, ptyId))
 
     // 8b. xterm -> PTY: keystrokes (standard path for all other input)
     const dataDisposable = terminal.onData((data) => {
@@ -533,28 +552,8 @@ async function reconnectTerminal(
   })
   cleanupListeners.push(() => titleDisposable.dispose())
 
-  // CSI u key handler (same as getOrCreate)
-  const CSI_U_KEYS: Record<string, number> = {
-    Enter: 13, Tab: 9, Backspace: 127, Escape: 27, Space: 32,
-  }
-  terminal.attachCustomKeyEventHandler((event) => {
-    if (event.type !== 'keydown') return true
-    if (isTerminalPasteChord(event)) return false
-    if (isTerminalCopyChord(event, terminal)) return false
-    const keyCode = CSI_U_KEYS[event.key]
-    if (keyCode === undefined) return true
-    let mod = 1
-    if (event.shiftKey) mod += 1
-    if (event.altKey) mod += 2
-    if (event.ctrlKey) mod += 4
-    if (event.metaKey) mod += 8
-    if (mod === 1) return true
-    if (event.key === 'Tab' && mod === 2) return true
-    if (event.metaKey) return true
-    electronAPI.terminalWrite(ptyId, `\x1b[${keyCode};${mod}u`)
-    event.preventDefault()
-    return false
-  })
+  // Modified special keys + macOS line-editing chords (shared with getOrCreate).
+  terminal.attachCustomKeyEventHandler(makeTerminalKeyEventHandler(terminal, ptyId))
 
   const dataDisposable = terminal.onData((data) => {
     electronAPI.terminalWrite(ptyId, data)


### PR DESCRIPTION
Closes #172.

## Problem

In a Cate terminal, **`Cmd+Backspace` does not delete to the start of the line** the way it does in the VS Code / Cursor integrated terminal, and other macOS line-editing chords are missing or wrong. Two layers both fail to deliver the chord to the shell:

1. **App layer eats it.** `deleteNode` is bound to `Cmd+Backspace`. The capture-phase keydown handler in `useShortcuts` ran `deleteNode` even when a terminal was focused, calling `preventDefault()`/`stopPropagation()` — so the keystroke never reached xterm (it closed the focused panel instead).
2. **Terminal layer never translated it.** xterm emitted a plain `\x7f` for `Cmd+Backspace`; `Option+Backspace` produced a CSI-u sequence (`\x1b[127;3u`) that a plain shell (readline / zsh) doesn't interpret as delete-word.

## Fix

- **New pure module `terminalKeymap.ts`** with a data-driven `resolveTerminalKeySequence(event, isMac)` mapping the 7 macOS chords to the exact bytes VS Code sends via `sendSequence`:

  | Chord | Bytes | Effect |
  |---|---|---|
  | `Cmd+Backspace` | `\x15` (Ctrl+U) | delete to line start |
  | `Option+Backspace` | `\x17` (Ctrl+W) | delete word left |
  | `Option+Delete` | `\x1bd` (ESC d) | delete word right |
  | `Cmd+Left` | `\x01` (Ctrl+A) | line start |
  | `Cmd+Right` | `\x05` (Ctrl+E) | line end |
  | `Option+Left` | `\x1bb` (ESC b) | word left |
  | `Option+Right` | `\x1bf` (ESC f) | word right |

- Translate in the xterm `customKeyEventHandler` (works for canvas, dock, **and** detached-window terminals). The duplicated handlers in `getOrCreate`/`reconnectTerminal` are extracted into one `makeTerminalKeyEventHandler` factory.
- `useShortcuts`: stop consuming `Cmd+Backspace` when a terminal or text editor is focused. Closing a focused panel stays on `Cmd+W`.

CSI-u disambiguation for `Enter`/`Tab`/`Escape`/`Space` is unchanged; non-macOS is unaffected (the resolver returns `null`).

## Test plan
- New `terminalKeymap.test.ts` (12 cases: all 7 chords, non-mac no-op, plain keys, Ctrl/Shift guard, Cmd+Option ambiguity).
- `npm run typecheck` ✅ · `npm run test:unit` ✅ (364 passed, 3 skipped) · `npm run build` ✅ · `npm run test:smoke:electron` ✅