### PR TITLE
fix(sidebar): square nested rows, soften active tab + terminal highlights

### DIFF
--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -188,7 +188,7 @@ export function DockTabBar(props: DockTabBarProps) {
               group relative flex items-center gap-1.5 whitespace-nowrap
               cursor-grab select-none min-w-0 flex-1 max-w-[200px]
               ${compact ? 'pl-2 pr-1.5 text-[11px]' : 'pl-3 pr-2 text-xs'}
-              ${isActive ? 'text-primary font-medium' : 'text-secondary hover:text-primary'}
+              ${isActive ? 'text-secondary font-medium' : 'text-muted hover:text-secondary'}
             `}
             onClick={() => onTabClick(i)}
             onMouseDown={(e) => onTabMouseDown(e, panelId)}

--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -291,7 +291,7 @@ const ChildAction: React.FC<{
 }> = ({ icon, label, onClick, destructive }) => (
   <button
     onClick={onClick}
-    className={`group/action flex items-center gap-1.5 h-7 pl-7 pr-2 rounded text-[13px] text-secondary hover:bg-hover hover:text-primary text-left min-w-0 focus:outline-none transition-colors ${
+    className={`group/action flex items-center gap-1.5 h-7 pl-7 pr-2 text-[13px] text-secondary hover:bg-hover hover:text-primary text-left min-w-0 focus:outline-none transition-colors ${
       destructive ? 'hover:text-red-400' : ''
     }`}
   >

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -146,7 +146,7 @@ export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, inden
 
   return (
     <button
-      className={`group/panel flex items-center gap-1.5 h-7 pr-2 rounded text-[13px] hover:bg-hover text-left min-w-0 focus:outline-none ${
+      className={`group/panel flex items-center gap-1.5 h-7 pr-2 text-[13px] hover:bg-hover text-left min-w-0 focus:outline-none ${
         indent ? 'pl-10' : 'pl-7'
       } ${isAwaiting ? 'text-primary' : 'text-muted hover:text-primary'}`}
       onClick={onClick}
@@ -485,7 +485,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     return (
       <button
         key={p.id}
-        className={`group/panel flex items-center gap-1.5 h-7 pr-2 rounded text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 focus:outline-none ${
+        className={`group/panel flex items-center gap-1.5 h-7 pr-2 text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 focus:outline-none ${
           indent ? 'pl-10' : 'pl-7'
         }`}
         onClick={(e) => handlePanelClick(e, p.id)}

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -149,9 +149,9 @@
 .cate-notif-pulse {
   background: linear-gradient(
     90deg,
-    var(--shimmer-dim, var(--text-muted, #8a8479)) 40%,
-    var(--shimmer-bright, var(--text-primary, #e8e6e1)) 50%,
-    var(--shimmer-dim, var(--text-muted, #8a8479)) 60%
+    var(--shimmer-dim, var(--text-muted, #6b6762)) 40%,
+    var(--shimmer-bright, var(--text-secondary, #a8a49e)) 50%,
+    var(--shimmer-dim, var(--text-muted, #6b6762)) 60%
   );
   background-size: 300% 100%;
   background-clip: text;


### PR DESCRIPTION
## Summary

Follow-up UI polish to the sidebar/theming work, completing the "blocky, edge-to-edge, subtle highlight" direction.

- **Square nested rows** — removed border radius from the workspace and parallel-work sub-element rows (Canvas/Terminal panel rows, worktree child actions) so nested rows match the blocky, edge-to-edge file-explorer treatment. (Top-level cards stay at `rounded-sm`.)
- **Softer active dock-tab title** — the active tab title was hardcoded to bright white (`text-primary font-medium`); now `text-secondary font-medium`, with inactive dropped to `text-muted`. Preserves the active/inactive hierarchy without the white glow.
- **Calmer running-terminal shimmer** — the non-colored `cate-notif-pulse` fallback now sweeps muted → `text-secondary` instead of muted → near-white, so an active terminal title no longer flashes a bright band. Worktree-colored titles keep their own hue (they supply their own shimmer stops).

## Notes

The companion changes (workspace card `bg-surface-6`/`rounded-sm`, edge-to-edge `ProjectList` container, overlay drop indicator) already landed on `main` via #174; this PR carries the remaining tweaks.

## Testing

- `tsc --noEmit` clean
- CSS/className-only changes; no logic touched