### PR TITLE
fix(canvas,sidebar): square top-level cards, de-blue + soften pane glow

### DIFF
--- a/src/renderer/canvas/useCanvasNodeStyle.ts
+++ b/src/renderer/canvas/useCanvasNodeStyle.ts
@@ -10,9 +10,10 @@ import type { CanvasNodeState, NodeActivityState } from '../../shared/types'
 
 const CORNER_RADIUS = 8
 
-const SHADOW_UNFOCUSED = `0 20px 60px -12px rgba(0,0,0,0.35), 0 6px 16px -4px rgba(0,0,0,0.2)`
-const SHADOW_HOVERED = `${SHADOW_UNFOCUSED}, 0 0 32px rgba(255,255,255,0.03)`
-const FOCUS_GLOW = `0 0 100px 8px rgba(74,158,255,0.09), 0 0 40px rgba(74,158,255,0.07)`
+const SHADOW_UNFOCUSED = `0 12px 36px -14px rgba(0,0,0,0.28), 0 4px 10px -5px rgba(0,0,0,0.16)`
+const SHADOW_HOVERED = `${SHADOW_UNFOCUSED}, 0 0 18px rgba(255,255,255,0.015)`
+// Active/focused pane: a very faint bright (white) halo — no blue tint.
+const FOCUS_GLOW = `0 0 20px 1px rgba(255,255,255,0.025), 0 0 8px rgba(255,255,255,0.02)`
 
 function boxShadow(hovered: boolean): string {
   if (hovered) return SHADOW_HOVERED

--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -316,7 +316,7 @@ const WorktreeCard: React.FC<{
     <div>
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-1 h-8 px-1.5 rounded-sm text-secondary hover:text-primary hover:bg-hover transition-colors outline-none"
+        className="w-full flex items-center gap-1 h-8 px-1.5 text-secondary hover:text-primary hover:bg-hover transition-colors outline-none"
         title={worktree.path}
       >
         <CaretRight

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -404,7 +404,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     }
     return (
       <div
-        className={`group flex items-center gap-2 h-8 px-2 rounded-sm cursor-pointer text-muted hover:text-secondary hover:bg-hover transition-colors outline-none ${
+        className={`group flex items-center gap-2 h-8 px-2 cursor-pointer text-muted hover:text-secondary hover:bg-hover transition-colors outline-none ${
           isContextActive ? 'ring-1 ring-strong' : ''
         } ${isSelected ? 'bg-surface-6' : ''}`}
         onClick={handlePickFolder}
@@ -504,7 +504,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     <div onContextMenu={handleContextMenu}>
       {/* Project row */}
       <div
-        className={`group flex items-center gap-1 h-8 px-1.5 rounded-sm cursor-pointer transition-colors outline-none ${
+        className={`group flex items-center gap-1 h-8 px-1.5 cursor-pointer transition-colors outline-none ${
           isContextActive ? 'ring-1 ring-strong' : ''
         } ${
           isMultiSelected


### PR DESCRIPTION
## Summary

Further UI polish on the sidebar + canvas, following #179.

- **Fully square sidebar** — removed border radius from the remaining top-level cards (workspace project row, empty "Add Workspace" row, and the parallel-work worktree card). Combined with #179's square nested rows, the entire sidebar is now blocky and edge-to-edge.
- **De-blued, much subtler active-pane glow** — the focused canvas node's glow was a blue halo (`rgba(74,158,255,...)`) with a large 100px spread. It's now a very faint white halo (`rgba(255,255,255,0.025)` / `0.02`, 20px/8px), no blue tint.
- **Lighter non-active shadow + hover sheen** — reduced the unfocused pane drop shadow (shallower offset, smaller blur, lower opacity) and halved the hover white sheen, so panes sit flatter and the hierarchy is gentle across unfocused / hover / active.

## Testing

- `tsc --noEmit` clean
- CSS/className + inline-style constant changes only; no logic touched
- Verified live via `pnpm dev` (HMR)