### PR TITLE
fix(editor): reset markdown preview when switching files

### DIFF
--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -694,6 +694,19 @@ export default function EditorPanel({
   }, [])
 
   // ---------------------------------------------------------------------------
+  // Reset preview when the file changes
+  // ---------------------------------------------------------------------------
+
+  // A single EditorPanel instance is reused across dock tabs — renderPanelComponent
+  // creates the element without a `key`, so switching tabs swaps the `filePath`
+  // prop on the same mount rather than remounting. Without resetting here the
+  // markdown preview toggle would leak from one file to the next (turning preview
+  // on for one tab would show every other markdown tab in preview too).
+  useEffect(() => {
+    setMarkdownPreview(false)
+  }, [filePath])
+
+  // ---------------------------------------------------------------------------
   // Sync markdown content when preview is toggled on
   // ---------------------------------------------------------------------------
 

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -326,12 +326,22 @@ export default function EditorPanel({
   // path we just learned and the next Cmd+S would re-open Save-As.
   if (filePath !== undefined) filePathRef.current = filePath
 
-  const [markdownPreview, setMarkdownPreview] = useState(false)
   const [markdownContent, setMarkdownContent] = useState('')
 
   const workspaces = useAppStore((s) => s.workspaces)
   const ws = workspaces.find((w) => w.id === workspaceId)
   const diffMode = ws?.panels[panelId]?.diffMode
+  // Preview mode is kept per-panel in the store rather than as local state: a
+  // single EditorPanel mount is reused across dock tabs (renderPanelComponent
+  // creates the element without a key), so local state would leak the toggle
+  // from one markdown file to the next. Keying it by panelId also keeps each
+  // tab's choice independent across canvas switches.
+  const markdownPreview = !!ws?.panels[panelId]?.markdownPreview
+  const setMarkdownPreview = useCallback(
+    (next: boolean) =>
+      useAppStore.getState().setPanelMarkdownPreview(workspaceId, panelId, next),
+    [workspaceId, panelId],
+  )
   const rootPath = ws?.rootPath
   const isMarkdown = !!filePath && /\.mdx?$/i.test(filePath)
 
@@ -694,19 +704,6 @@ export default function EditorPanel({
   }, [])
 
   // ---------------------------------------------------------------------------
-  // Reset preview when the file changes
-  // ---------------------------------------------------------------------------
-
-  // A single EditorPanel instance is reused across dock tabs — renderPanelComponent
-  // creates the element without a `key`, so switching tabs swaps the `filePath`
-  // prop on the same mount rather than remounting. Without resetting here the
-  // markdown preview toggle would leak from one file to the next (turning preview
-  // on for one tab would show every other markdown tab in preview too).
-  useEffect(() => {
-    setMarkdownPreview(false)
-  }, [filePath])
-
-  // ---------------------------------------------------------------------------
   // Sync markdown content when preview is toggled on
   // ---------------------------------------------------------------------------
 
@@ -745,7 +742,7 @@ export default function EditorPanel({
     <div className="w-full h-full relative">
       {isMarkdown && !diffMode && (
         <button
-          onClick={() => setMarkdownPreview((v) => !v)}
+          onClick={() => setMarkdownPreview(!markdownPreview)}
           className={`absolute top-2 right-5 z-10 px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
             markdownPreview
               ? 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30'

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -323,6 +323,7 @@ interface AppStoreActions {
   updatePanelUrl: (workspaceId: string, panelId: string, url: string) => void
   updatePanelFilePath: (workspaceId: string, panelId: string, filePath: string) => void
   setPanelDirty: (workspaceId: string, panelId: string, dirty: boolean) => void
+  setPanelMarkdownPreview: (workspaceId: string, panelId: string, preview: boolean) => void
   setPanelUnsavedContent: (workspaceId: string, panelId: string, content: string | undefined) => void
   addPanel: (workspaceId: string, panel: PanelState) => void
 
@@ -937,6 +938,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   setPanelDirty(workspaceId, panelId, dirty) {
     setPanelField(set, workspaceId, panelId, (panel) => ({ ...panel, isDirty: dirty }))
+  },
+
+  setPanelMarkdownPreview(workspaceId, panelId, preview) {
+    set((state) => ({
+      workspaces: state.workspaces.map((ws) => {
+        if (ws.id !== workspaceId) return ws
+        const panel = ws.panels[panelId]
+        if (!panel) return ws
+        return {
+          ...ws,
+          panels: { ...ws.panels, [panelId]: { ...panel, markdownPreview: preview } },
+        }
+      }),
+    }))
   },
 
   setPanelUnsavedContent(workspaceId, panelId, content) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,10 @@ export interface PanelState {
   url?: string
   /** When set, EditorPanel renders as a Monaco diff editor. */
   diffMode?: 'staged' | 'working'
+  /** Editor panels with a markdown file only: render the rendered preview
+   *  instead of the source. Kept per-panel (not local component state) because
+   *  a single EditorPanel mount is reused across dock tabs. */
+  markdownPreview?: boolean
   /** Unsaved buffer content for scratch (no-filePath) editors. Persisted so
    *  content survives canvas switches and app restarts. */
   unsavedContent?: string


### PR DESCRIPTION
Switching to preview mode for one markdown file flipped every other markdown tab into preview too.

A single EditorPanel instance is reused across dock tabs (renderPanelComponent creates the element without a key), so switching tabs swaps the filePath prop on the same mount rather than remounting. The markdownPreview toggle was local component state, so it leaked from one file to the next.

Fix: move the toggle onto PanelState, keyed by panelId, with a setPanelMarkdownPreview store action. Each tab now independently remembers source vs preview. (A simpler "reset on file change" was rejected because it would force every markdown tab back to source on each switch, losing the user's choice.)