### PR TITLE
feat(theme): theme-aware native window chrome + Dark Cold default

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import log from './logger'
-import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, shell, nativeImage, screen, webContents, session, nativeTheme } from 'electron'
 import fs from 'fs'
 import path from 'path'
 import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_DELETE_REGION, DIALOG_CONFIRM_IMPORT, DIALOG_CONFIRM_RELOAD_WORKSPACE, DIALOG_TERMINAL_LINK_OPEN, APP_OPEN_PATH } from '../shared/ipc-channels'
@@ -107,6 +107,14 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   const bootSnap = windowType === 'main' ? readBootSnapshot() : null
   const snapGeom = bootSnap?.geometry
   const snapBg = bootSnap?.backgroundColor
+
+  // Apply the active theme's native appearance before the window exists so the
+  // macOS native title bar (native-tabs mode) paints with the right dark/light
+  // material on the first frame. themeSource is app-wide, so we only need it
+  // once from the main window's snapshot; the renderer keeps it in sync after.
+  if (windowType === 'main' && bootSnap?.appearance) {
+    try { nativeTheme.themeSource = bootSnap.appearance } catch { /* noop */ }
+  }
 
   // Snapshot native-tabs state at window creation. The renderer reads this via
   // the URL query so that the React TitlebarStrip matches the actual

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -3,7 +3,7 @@
 // electron-store v10 is ESM-only, so we use dynamic import()
 // =============================================================================
 
-import { ipcMain, app, BrowserWindow } from 'electron'
+import { ipcMain, app, BrowserWindow, nativeTheme } from 'electron'
 import log from './logger'
 import fs from 'fs/promises'
 import fsSync from 'fs'
@@ -134,6 +134,10 @@ export interface BootSnapshot {
   geometry?: { x: number; y: number; width: number; height: number }
   theme?: string
   backgroundColor?: string
+  // Desired native window appearance for the active theme. Drives
+  // nativeTheme.themeSource so the macOS native title bar (native-tabs mode)
+  // matches the theme's dark/light instead of the OS. 'system' tracks the OS.
+  appearance?: 'dark' | 'light' | 'system'
   nativeTabs?: boolean
   lastWorkspaceId?: string
 }
@@ -261,6 +265,16 @@ export function registerHandlers(): void {
         BrowserWindow.fromWebContents(event.sender)?.setBackgroundColor(partial.backgroundColor)
       } catch (err) {
         log.warn('Live window background update failed: %O', err)
+      }
+    }
+    // Drive the app-wide native appearance from the active theme so the macOS
+    // native title bar (native-tabs mode) follows the theme's dark/light. It's
+    // global (NSApplication.appearance), so one assignment covers every window.
+    if (partial.appearance === 'dark' || partial.appearance === 'light' || partial.appearance === 'system') {
+      try {
+        nativeTheme.themeSource = partial.appearance
+      } catch (err) {
+        log.warn('Native appearance update failed: %O', err)
       }
     }
   })

--- a/src/renderer/lib/themeManager.ts
+++ b/src/renderer/lib/themeManager.ts
@@ -116,13 +116,23 @@ function applyResolved(theme: Theme): void {
   notify(theme)
 
   // Persist resolved theme id + exact background to the boot snapshot so the
-  // next cold launch constructs the BrowserWindow with the right color.
+  // next cold launch constructs the BrowserWindow with the right color, and
+  // (on macOS) drive the native window appearance.
   try {
     const bg = theme.bootBackground ?? mergedAppVars(theme)['surface-0']
+    // macOS draws the native title bar itself when native tabs are on
+    // (titleBarStyle 'default') — it can't take an arbitrary color, only a
+    // dark/light system material. Send the desired appearance so the native bar
+    // tracks the theme's dark/light (for built-in AND user-generated themes)
+    // instead of blindly following the OS. While the selection is 'system' we
+    // keep it on 'system' so `prefers-color-scheme` — and thus the system-theme
+    // resolution above — stays bound to the real OS appearance.
+    const appearance: 'dark' | 'light' | 'system' =
+      currentSelection === 'system' ? 'system' : theme.type
     const api = (window as unknown as {
       electronAPI?: { bootSnapshotWrite?: (p: Record<string, unknown>) => Promise<void> }
     }).electronAPI
-    api?.bootSnapshotWrite?.({ theme: theme.id, backgroundColor: bg }).catch(() => { /* noop */ })
+    api?.bootSnapshotWrite?.({ theme: theme.id, backgroundColor: bg, appearance }).catch(() => { /* noop */ })
   } catch { /* noop */ }
 }
 

--- a/src/renderer/settings/GeneralSettings.tsx
+++ b/src/renderer/settings/GeneralSettings.tsx
@@ -25,7 +25,7 @@ export function GeneralSettings() {
               {NATIVE_TABS_BOOT && (
                 <p className="flex items-center gap-1 text-xs text-muted">
                   <InfoIcon size={12} />
-                  Title bar follows macOS appearance and ignores the app theme while tabs are enabled.
+                  Title bar matches your theme's dark/light, but macOS can't tint it the exact theme color while tabs are enabled.
                 </p>
               )}
               {nativeTabsPending && (

--- a/src/shared/themes/index.ts
+++ b/src/shared/themes/index.ts
@@ -14,11 +14,11 @@ import { tokyoNight } from './tokyoNight'
 
 export { BASE_DARK, BASE_LIGHT } from './base'
 
-/** Shipped themes, in catalog order. */
+/** Shipped themes, in catalog order. Dark Cold leads as the standard theme. */
 export const BUILT_IN_THEMES: Theme[] = [
+  darkCold,
   darkWarm,
   lightSubtle,
-  darkCold,
   dracula,
   nord,
   solarizedDark,
@@ -30,5 +30,5 @@ export const BUILT_IN_BY_ID: Record<string, Theme> = Object.fromEntries(
 )
 
 /** Default dark / light themes used for `system` mode and as fallbacks. */
-export const DEFAULT_DARK_THEME_ID = 'dark-warm'
+export const DEFAULT_DARK_THEME_ID = 'dark-cold'
 export const DEFAULT_LIGHT_THEME_ID = 'light-subtle'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -875,7 +875,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // Appearance
   activeThemeId: 'system',
   systemLightThemeId: 'light-subtle',
-  systemDarkThemeId: 'dark-warm',
+  systemDarkThemeId: 'dark-cold',
   customThemes: [],
   editorFontSize: 12,
 


### PR DESCRIPTION
## Summary

Makes the OS-level window chrome follow the active theme, switches the standard theme to **Dark Cold**, and refreshes the README demo gif.

### Theme-aware native window chrome
The native macOS title bar and window backdrop only updated on the next cold launch (via the boot snapshot), so switching themes at runtime left them on the old color.
- Live-apply `backgroundColor` to the `BrowserWindow` on theme change so the backdrop tracks any theme (built-in, new, or user-generated) without a relaunch.
- Drive `nativeTheme.themeSource` from the theme's dark/light `type` so the native title bar in native-tabs mode matches the theme instead of following the OS. `system` selection stays `system` so `prefers-color-scheme` keeps resolving the system theme.
- Set appearance from the boot snapshot before window creation (correct first frame on cold launch).
- Updated the native-tabs settings hint.

> macOS note: a native title bar (native-tabs mode) can only be dark/light, not an arbitrary hex — exact theme color requires native tabs off, where Cate draws its own themed strip.

### Dark Cold default
- `DEFAULT_DARK_THEME_ID` and the default `systemDarkThemeId` are now `dark-cold`; Dark Cold leads the catalog. `BASE_DARK`/`:root` are unchanged (Dark Warm inherits from them).

### README demo gif
- Newer capture, trimmed 1s and re-encoded with an optimized palette (900px wide to match display width).

## Test plan
- `npm run typecheck` passes; theme test suite (23) passes.
- Switching themes recolors the window chrome live; Dark Cold is the default for new configs / system-dark.