### PR TITLE
Tighten README and sync translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -15,16 +15,12 @@
 > **Hinweis:** Diese Übersetzung wurde automatisch erstellt und kann Ungenauigkeiten enthalten.
 
 <p align="center">
-  Eine räumliche Desktop-IDE mit unendlicher Leinwand für Code, Terminals, Browser, Dokumente, KI-Agenten und Git.
-</p>
-
-<p align="center">
-  <strong>Aktuelle Quellversion:</strong> v1.1.0
+  Eine unendliche Arbeitsfläche für Code, Terminals, Browser, Dokumente und KI-Agenten.
 </p>
 
 <p align="center">
   <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT-Lizenz" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT License" /></a>
   <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
   <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Downloads" /></a>
 </p>
@@ -32,225 +28,94 @@
 ---
 
 <p align="center">
-  <img src="assets/demo.gif" alt="Cate Demo" width="900" />
+  <img src="assets/demo.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate ist eine Electron-Desktop-Anwendung zum Anordnen von Entwicklungswerkzeugen im freien Raum. Kombinieren Sie schwebende Canvas-Panels mit angedockten Tabs und Splits, lösen Sie Panels in eigenständige Fenster heraus und halten Sie mehrere Arbeitsbereiche sitzungsübergreifend synchron.
+Cate ist eine Desktop-IDE auf einer unendlichen Arbeitsfläche. Statt Fenster und Tabs zu stapeln, verteilen Sie Editoren, Terminals, Browser, Dokumente und KI-Agenten im freien Raum und ordnen sie so an, wie Sie über das Projekt denken. Lassen Sie Panels auf der Fläche schweben, docken Sie sie als Tabs und Splits an oder lösen Sie sie in eigene Fenster. Cate stellt alles wieder her, wenn Sie den Ordner erneut öffnen.
 
 ## Erste Schritte
 
-Öffnen Sie einen beliebigen Ordner, um einen Arbeitsbereich zu erstellen — Cate stellt Ihr Canvas-Layout, die Panel-Positionen und geöffnete Terminals bei jedem Neustart wieder her. Klicken Sie mit der rechten Maustaste auf die Leinwand, um Panels hinzuzufügen, drücken Sie `Cmd+K` für die Befehlspalette oder ziehen Sie Panels in das Dock, um Tabs und Splits zu erstellen.
+Öffnen Sie einen Ordner. Cate macht daraus einen Arbeitsbereich und stellt bei jeder Rückkehr Ihr Layout, die Panel-Positionen und die Terminals wieder her. Rechtsklick auf die Fläche fügt Panels hinzu, `Cmd+K` öffnet die Befehlspalette, und das Ziehen von Panels auf das Dock erzeugt Tabs und Splits. Es sind keine Konfigurationsdateien einzurichten.
 
-Keine Konfigurationsdateien, keine Projekteinrichtung — richten Sie Cate einfach auf ein Verzeichnis und beginnen Sie zu arbeiten.
+## Warum eine Arbeitsfläche?
 
-## Warum Cate?
+Alt-Tab reicht, bis Sie ein Dutzend Terminals, sechs offene Dateien, Dokumentation in einem anderen Fenster und über mehrere Desktops verstreute Notizen haben. Ab da wird das Finden des richtigen Fensters zum Engpass.
 
-Alt-Tab funktioniert gut — bis Sie 12 Terminals, 6 offene Dateien, Dokumentation in einem anderen Fenster und Notizen über verschiedene Desktops verstreut haben. Ab diesem Punkt wird das Fensterwechseln zum eigentlichen Engpass.
+Cate gibt jedem Projekt eine Arbeitsfläche, die sich merkt, wo Sie die Dinge gelassen haben. Das ist kein Fenstermanager. Tiling-WMs wie Hyprland, Niri und GlazeWM ordnen die Fenster von allem an, was Sie starten; Cate ordnet die Werkzeuge eines einzelnen Projekts an, näher an Figma als an einem WM.
 
-Cate ersetzt diesen Fensterstapel durch **eine persistente Leinwand pro Projekt**. Terminals, Editoren, Browser und Notizen bleiben dort, wo Sie sie platziert haben, gruppiert nach Ihrer Denkweise, und sie sind immer noch da, wenn Sie am nächsten Tag zurückkommen.
+## Was drinsteckt
 
-> Cate ist **kein Ersatz für einen Fenstermanager**. Kachel-/Scroll-WMs (Hyprland, Niri, GlazeWM, KDE) sind großartig, wenn Sie hauptsächlich Betriebssystemfenster anordnen möchten. Cate ist eine räumliche Leinwand um die Werkzeuge eines einzelnen Projekts — näher an Figmas unendlicher Leinwand als an einem WM.
+**Arbeitsfläche und Layout.** Zoomen und verschieben Sie eine unendliche Fläche, docken Sie Panels als Tabs und Splits in vier Zonen an, lösen Sie Panels in separate Fenster und speichern Sie benannte Layouts. Halten Sie mehrere Projekte offen und stellen Sie sie beim Neustart wieder her.
 
-## Funktionen
+**Editoren und Terminals.** Monaco-Editor-Panels mit Syntaxhervorhebung, Multi-Cursor, Suchen/Ersetzen, Diffs und Markdown-Vorschau. Native xterm.js-Terminals auf Basis von `node-pty`, im Arbeitsbereich verwurzelt, mit automatischer Shell-Erkennung. Dokument-Panels zeigen PDFs, DOCX und Bilder.
 
-### 🎨 Leinwand & Layout
+**Git.** Ein git-bewusster Dateibaum mit Live-Überwachung und Suche, dazu eine Versionsverwaltungs-Seitenleiste für Staging, Branches, Worktrees, Verlauf und Inline-Diffs. Volltextsuche im Projekt.
 
-- **Unendliche Leinwand** — zoomen, schwenken und Panels überall im freien Raum anordnen. Schwenken mit Zwei-Finger-Drag oder Rechtsklick-Drag; Zoomen mit `Cmd+Scroll` oder den Leinwand-Steuerelementen.
-- **Dock-System** — ziehen Sie schwebende Panels in das Dock, um Tabs und Splits zu erstellen. Jede Dock-Zone (Mitte, Links, Rechts, Unten) kann mehrere Tabs mit typfarbigen Icons aufnehmen.
-- **Abgelöste Fenster** — lösen Sie Panels oder vollständige Dock-Layouts in separate Betriebssystemfenster heraus.
-- **Gespeicherte Layouts** — benennen, speichern, laden und löschen Sie Leinwand-Anordnungen (Knoten und Regionen) über ein In-App-Modal (`Cmd+K → "Gespeicherte Layouts…"`).
-- **Multi-Arbeitsbereich-Sitzungen** — halten Sie mehrere Projekte offen und stellen Sie sie beim Neustart wieder her. Wechseln Sie zwischen Arbeitsbereichen über die Seitenleiste.
+**KI-Agenten.** Führen Sie einen integrierten Coding-Agenten (Pi) mit Chat-Threads und Modellgedächtnis pro Thread aus. Verbinden Sie Anthropic, OpenAI Codex, GitHub Copilot, Gemini, OpenRouter, Groq, Mistral, DeepSeek und weitere per OAuth oder API-Key. Installieren Sie Erweiterungen aus dem Marktplatz.
 
-### 💻 Code, Dokumente & Terminals
-
-- **Monaco-Editor-Panels** — vollwertiges VS-Code-Editing mit Syntaxhervorhebung, Multi-Cursor, Suchen/Ersetzen, Diff-Unterstützung und Markdown-Vorschau/Quellmodus mit GFM-Rendering. Scratch-Editoren behalten ungespeicherte Inhalte sitzungsübergreifend bei.
-- **Persistente Editor-Puffer** — dateibasierte Modelle werden panelübergreifend wiederverwendet, und Scratch-Editor-Inhalte bleiben mit der Sitzung erhalten.
-- **Dokumenten-Panels** — native Canvas-Viewer für PDFs, DOCX-Dateien und Bilder mit Dateityperkennung basierend auf Magic-Byte-Prüfungen.
-- **Native Terminals** — xterm.js mit WebGL-Rendering, unterstützt durch `node-pty`-PTYs, verwurzelt im aktiven Arbeitsbereich. Automatische Shell-Erkennung mit elegantem Fallback, wenn die konfigurierte Shell nicht verfügbar ist.
-- **Browser-Panels** — eingebettete Webview-Panels zur Vorschau von Dokumentation, Entwicklungsservern oder beliebigen URLs. Kontextisoliert mit gehärteten Sicherheitseinstellungen.
-
-### 🔧 Git & Quellcodeverwaltung
-
-- **Git-fähiger Dateibrowser** — Dateibaum mit Live-Dateisystemüberwachung, Dimmen von verfolgten/nicht verfolgten Dateien, Suche und Kopieren/Einfügen für Dateien und Ordner mit kollisionssicherer Umbenennung.
-- **Quellcodeverwaltungs-Seitenleiste** — Stage/Unstage, Branch-Verwaltung, Worktrees, Commit-Verlauf und Inline-Diff-Ansichten. Der Git-Monitor fragt ab und zeigt Änderungen automatisch an.
-- **Projektweite Suche** — Volltextsuche über Arbeitsbereichsdateien mit sofortigen Ergebnissen.
-
-### 🤖 KI-Agent
-
-- **Pi-Agent-Panel** — führen Sie einen In-App-Coding-Agenten aus, der von `@earendil-works/pi-agent-core` angetrieben wird, mit Chat-Threads, modellbezogener Wiederherstellung pro Chat und arbeitsbereichsbewusster Panel-Platzierung.
-- **Anbieter-Authentifizierung & Modelle** — verbinden Sie OAuth-Anbieter wie Anthropic, OpenAI Codex und GitHub Copilot oder API-Key-Anbieter wie OpenAI, Google Gemini, OpenRouter, Groq, Mistral, DeepSeek und mehr.
-- **Marketplace & Planmodus** — installieren Sie Pi-Erweiterungen aus dem Marketplace und nutzen Sie Cates integrierten Planmodus-Helfer für agentengeführte Implementierungsplanung.
-
-### 🔍 Suche & Navigation
-
-- **Leinwandweite Suche** (`Cmd+Shift+F`) — Spotlight-artiges Overlay, das Arbeitsbereichsdateien, Live-Terminal-Scrollback und geöffnete Panel-Titel/Pfade an einem Ort durchsucht. Ergebnisse nach letztem Fokus sortiert mit typfarbigen Icons.
-- **Panel-Umschalter** (`Ctrl+Space`) — kompaktes Tastatur-Overlay zum Springen zwischen geöffneten Canvas-Panels und Zentrieren des ausgewählten Knotens.
-- **Befehlspalette** (`Cmd+K`) — schneller Zugriff auf Befehle, geöffnete Panels und Arbeitsbereichsdateien. Einheitliches Spotlight-artiges Design über alle Overlays.
-
-### 🖥️ Desktop-Feinschliff
-
-- **Automatisches Speichern & Sitzungswiederherstellung** — alle Panel-Zustände, Positionen und geöffnete Dateien werden automatisch gespeichert.
-- **Optionale native macOS-Fenster-Tabs** — gruppieren Sie Cate-Fenster in der System-Tab-Leiste.
-- **Automatische Update-Prüfungen** — prüft GitHub-Releases und benachrichtigt, wenn eine neue Version verfügbar ist.
-- **Absturz-Resilienz** — Sentry-Diagnosen, Sitzungswiederherstellungs-Validierung, Shell-Fallback-Banner im PTY und geschützte Update/Neustart-Abläufe helfen, laute oder sich wiederholende Absturzzustände zu vermeiden.
+**Navigation.** Flächenweite Suche über Dateien, Terminal-Verlauf und Panel-Titel (`Cmd+Shift+F`). Panel-Umschalter (`Ctrl+Space`). Befehlspalette (`Cmd+K`).
 
 ## Installation
 
-Wenn Sie Cate einfach nur verwenden möchten, laden Sie ein vorgefertigtes Release herunter — kompilieren Sie nicht aus dem Quellcode. Dieses Repository zielt derzeit auf **v1.1.0** ab.
+Laden Sie eine vorgefertigte Version herunter. Bauen Sie für den täglichen Gebrauch nicht aus dem Quellcode.
 
 | Plattform | Formate | Link |
-|-----------|---------|------|
+|----------|---------|------|
 | macOS | DMG, ZIP (`arm64`, `x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
 | Windows | NSIS-Installer, ZIP (`x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
 | Linux | AppImage, DEB, `tar.gz` (`x64`) | [Neueste Version](https://github.com/0-AI-UG/cate/releases/latest) |
 
-> **macOS-Hinweis:** Release-Builds sind notarisiert und für gehärtete Laufzeit konfiguriert. Unsignierte lokale oder Test-Builds erfordern möglicherweise:
-> ```bash
-> xattr -cr /Applications/Cate.app
-> ```
+> **macOS:** Veröffentlichte Builds sind notariell beglaubigt. Unsignierte lokale Builds benötigen ggf. `xattr -cr /Applications/Cate.app`.
 
-> **Linux-Hinweis:** Auf dem Steam Deck oder anderen Distributionen mit schreibgeschütztem Root-Verzeichnis bevorzugen Sie den portablen `tar.gz`-Build. Wenn das AppImage nicht startet, versuchen Sie `--no-sandbox` als Fallback (z.B. `./Cate.AppImage --no-sandbox`).
+> **Linux:** Auf dem Steam Deck oder Distributionen mit schreibgeschütztem Root nutzen Sie den `tar.gz`-Build. Startet das AppImage nicht, versuchen Sie `./Cate.AppImage --no-sandbox`.
 
-## Aus dem Quellcode kompilieren
+## Aus dem Quellcode bauen
 
-> Die folgenden Schritte sind für **Mitwirkende** — verwenden Sie das vorgefertigte Release oben für den täglichen Gebrauch.
+Für Mitwirkende. Andernfalls die Version oben nutzen.
 
-### Voraussetzungen
-
-- [Node.js](https://nodejs.org/) 20 oder 22 LTS (siehe `.nvmrc`). Node 23+ wird nicht unterstützt; `node-pty` hat keine Prebuilds und die native Kompilierung wird fehlschlagen.
+**Voraussetzungen:**
+- [Node.js](https://nodejs.org/) 20 oder 22 LTS (siehe `.nvmrc`). Node 23+ schlägt fehl: `node-pty` hat keine Prebuilds, die native Kompilierung bricht ab.
 - npm >= 9
-- Python 3 und ein C++-Compiler (für das native `node-pty`-Modul)
-  - macOS: Xcode Command Line Tools (`xcode-select --install`)
+- Python 3 und ein C++-Compiler für `node-pty`:
+  - macOS: `xcode-select --install`
   - Debian/Ubuntu: `sudo apt install build-essential python3`
   - Fedora/RHEL: `sudo dnf install @development-tools gcc-c++ make python3`
   - Arch: `sudo pacman -S base-devel python`
-  - Windows: [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (wählen Sie die Workload „Desktopentwicklung mit C++")
-
-### Einrichtung
+  - Windows: [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) mit dem Workload „Desktopentwicklung mit C++"
 
 ```bash
 git clone https://github.com/0-AI-UG/cate.git
 cd cate
 npm install
-```
 
-### Entwicklung
-
-```bash
-npm run dev
-```
-
-Dies startet die Electron-App mit Hot Reload über electron-vite.
-
-### Qualitätsprüfungen
-
-```bash
+npm run dev          # Dev-Server mit Hot Reload
 npm run typecheck
-npm test            # Unit-Tests (vitest)
-npm run test:e2e    # Playwright-Integrationstests
+npm test             # Unit-Tests (vitest)
+npm run test:e2e     # Playwright-Integrationstests
+npm run build        # Produktions-Build
+npm run package      # Paketierung für Distribution (:mac, :win, :linux)
 ```
 
-Für den Electron-Smoke-Test:
-
-```bash
-npm run test:smoke:electron
-```
-
-### Produktions-Build
-
-```bash
-npm run build
-```
-
-### Paketierung für die Verteilung
-
-```bash
-npm run package
-# oder eine Plattform gezielt ansteuern:
-npm run package:mac
-npm run package:win
-npm run package:linux
-```
-
-Die paketierten Binärdateien befinden sich im Verzeichnis `release/`.
-
-## Sicherheit & Paketierung
-
-Cate verwendet eine kontextisolierte Preload-Brücke für die gesamte IPC-Kommunikation. Der Dateisystemzugriff ist auf registrierte Arbeitsbereich-Stammverzeichnisse beschränkt, Browser-Panels verwenden gehärtete Webview-Einstellungen mit deaktivierter Node-Integration, und der Updater öffnet als Fallback die GitHub-Release-Seite, wenn kein verifizierter Installer-Pfad verfügbar ist. Die arbeitsbereichsbezogene `allowedRoots`-Validierung verhindert, dass Terminals außerhalb genehmigter Verzeichnisse gestartet werden.
+Die paketierten Binärdateien landen in `release/`.
 
 ## Architektur
 
 ```text
 src/
-├── agent/              # Eingebettete Pi-Coding-Agent-Integration
-│   ├── main/           # Agent-Prozessmanager, Auth, Marketplace, Sitzungsdateien
-│   ├── renderer/       # Agent-Panel-UI, Chat-Thread, Anbieter, Modellpräferenzen
-│   └── extensions/     # Cate-gebündelte Planmodus-Pi-Erweiterung
-├── main/               # Electron-Hauptprozess
-│   ├── ipc/            # IPC-Handler (Dateisystem, Git, Terminal, Menü, Drag)
-│   ├── analytics       # Update/App-Event-Analytics-Helfer
-│   ├── appContext      # Geteilter Hauptprozess-App-Zustand
-│   ├── featureFlags    # Laufzeit-Feature-Flags
-│   ├── shellEnv        # Login-Shell-Umgebungserfassung
-│   ├── shellResolver   # Shell-Pfadauflösung mit Fallback-Kette
-│   ├── workspaceManager# Arbeitsbereich-Lebenszyklus und Sitzungspersistenz
-│   ├── workspaceRoots  # Registrierung und Validierung erlaubter Stammverzeichnisse
-│   ├── windowRegistry  # Fensterverwaltung (Haupt-, Dock-, abgelöste Fenster)
-│   ├── webSecurity     # Webview-Härtung und CSP
-│   ├── auto-updater    # Update-Prüfungen und Release-Abruf
-│   ├── sentry          # Sentry-Integration
-│   ├── store           # electron-store-Persistenz
-│   ├── jsonFileStore   # JSON-Datei-Persistenz-Helfer
-│   ├── menu            # Anwendungsmenü
-│   └── sessionTrust    # Sitzungswiederherstellungs-Validierung
-├── preload/            # Kontextisolierte Brücke zum Renderer
-├── renderer/           # React 18 Anwendung
-│   ├── assets/         # Renderer-Bilder und Asset-Deklarationen
-│   ├── canvas/         # Unendliche Leinwand — Rendering, Drag, Resize, Platzierung
-│   ├── docking/        # Tabs, Splits, abgelöste Dock-Fenster, Drag & Drop
-│   ├── drag/           # Fensterübergreifende Drag-and-Drop-Laufzeit und -Zustand
-│   ├── panels/         # Terminal, Editor, Browser, Dokument, Git, Explorer,
-│   │                   # Projekte, Canvas-Panel-Registry/Komponenten
-│   ├── sidebar/        # Arbeitsbereich, Dateibrowser, Quellcodeverwaltung,
-│   │                   # Parallele Arbeit, Projektliste, Datei-Zwischenablage
-│   ├── dialogs/        # Gespeicherte Layouts und Post-Update-Feedback-Dialoge
-│   ├── settings/       # Einstellungsfenster-Bereiche und Shortcut-Recorder
-│   ├── ui/             # Befehlspalette, Globale Suche, Knotenumschalter,
-│   │                   # Willkommensseite, Shortcut-Hinweis-Overlay
-│   ├── shells/         # Haupt-, Panel- und Dock-Fenster-Shells
-│   ├── stores/         # Zustand-Stores (Canvas, App, Dock, Einstellungen,
-│   │                   # Shortcut, Status, UI, Update, URL-Prompt)
-│   ├── hooks/          # Benutzerdefinierte React-Hooks (Shortcuts, Canvas-Interaktion)
-│   ├── lib/            # Hilfsprogramme (Koordinaten, Routing, Terminal-Registry)
-│   ├── workers/        # Monaco/Editor-Worker
-│   └── styles/         # Tailwind/globale Styles
-└── shared/             # IPC-Kanaldefinitionen und geteilte TypeScript-Typen
+├── agent/      # Eingebetteter Pi-Coding-Agent: Prozessmanager, Auth, Marktplatz, Panel-UI
+├── main/       # Electron-Hauptprozess: IPC, Arbeitsbereiche, Fenster, Updater, Sicherheit
+├── preload/    # Kontextisolierte IPC-Brücke
+├── renderer/   # React-18-App: Arbeitsfläche, Docking, Panels, Seitenleiste, Stores, Hooks
+└── shared/     # IPC-Kanäle und gemeinsame Typen
 ```
 
-### Technologie-Stack
+Cate leitet sämtliches IPC über eine kontextisolierte Preload-Brücke. Der Dateisystemzugriff ist auf registrierte Arbeitsbereichs-Wurzeln beschränkt, Browser-Panels deaktivieren die Node-Integration, und Terminals können nicht außerhalb genehmigter Verzeichnisse starten.
 
-- **Electron 41** — Desktop-Shell (Chromium + Node.js)
-- **React 18** — UI-Framework mit funktionalen Komponenten und Hooks
-- **Zustand 5** — leichtgewichtige Zustandsverwaltung (kein Redux/Context)
-- **Monaco Editor 0.52** — Code-Bearbeitung (VS Codes Editor-Komponente)
-- **xterm.js 5.5 + node-pty 1.0** — Terminal-Emulator mit WebGL-Renderer
-- **@earendil-works/pi-Pakete** — eingebettete Coding-Agent-Laufzeit, Anbieter-Auth und Erweiterungs-Marketplace
-- **pdf.js + mammoth** — natives PDF- und DOCX-Dokument-Rendering
-- **react-markdown + remark-gfm** — Markdown-Vorschau mit GitHub Flavored Markdown
-- **simple-git 3.27** — Git-Operationen
-- **chokidar 4.0** — Dateisystemüberwachung
-- **@phosphor-icons/react** — App-Ikonografie
-- **Tailwind CSS 3.4** — Styling
-- **electron-vite 5.0** — Bundling mit HMR
-- **electron-builder 26** — Paketierung und Verteilung
-- **electron-updater 6.8** — Update-Prüfungen
-- **Sentry Electron 5** — Absturzmeldungen und Diagnosen
-- **Playwright** — End-to-End-Integrationstests
-- **Vitest** — Unit-Test-Runner
+**Stack:** Electron 41, React 18, Zustand 5, Monaco 0.52, xterm.js 5.5 + node-pty 1.0, Tailwind 3.4, electron-vite, electron-builder, electron-updater, Sentry. PDFs und DOCX über pdf.js und mammoth, Git über simple-git, Dateiüberwachung über chokidar. Die Agent-Laufzeit ist `@earendil-works/pi`.
 
-## Roadmap
+## Mitwirken
 
-Cate wird aktiv weiterentwickelt. Einen detaillierten Verlauf der Änderungen in jeder Version und einen Ausblick finden Sie im [CHANGELOG](CHANGELOG.md).
+Siehe [CONTRIBUTING.md](CONTRIBUTING.md). Die Historie Version für Version steht im [CHANGELOG](CHANGELOG.md).
 
 ## Star-Verlauf
 
@@ -258,13 +123,9 @@ Cate wird aktiv weiterentwickelt. Einen detaillierten Verlauf der Änderungen in
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
-    <img alt="Star-Verlaufsdiagramm" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
   </picture>
 </a>
-
-## Mitwirken
-
-Siehe [CONTRIBUTING.md](CONTRIBUTING.md) für Richtlinien.
 
 ## Lizenz
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -15,256 +15,117 @@
 > **Note :** Cette traduction a été générée automatiquement et peut contenir des inexactitudes.
 
 <p align="center">
-  Un IDE de bureau spatial avec un canevas infini pour le code, les terminaux, les navigateurs, les documents, les agents IA et git.
-</p>
-
-<p align="center">
-  <strong>Version source actuelle :</strong> v1.1.0
+  Un canevas infini pour votre code, vos terminaux, vos navigateurs, vos documents et vos agents IA.
 </p>
 
 <p align="center">
   <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="Licence MIT" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT License" /></a>
   <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
-  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Téléchargements" /></a>
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Downloads" /></a>
 </p>
 
 ---
 
 <p align="center">
-  <img src="assets/demo.gif" alt="Démo Cate" width="900" />
+  <img src="assets/demo.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate est une application de bureau Electron pour organiser les outils de développement dans un espace libre. Mélangez des panneaux flottants sur le canevas avec des onglets et des divisions ancrés, détachez des panneaux dans des fenêtres autonomes et gardez plusieurs espaces de travail synchronisés entre les sessions.
+Cate est un IDE de bureau construit sur un canevas infini. Au lieu d'empiler des fenêtres et des onglets, vous répartissez éditeurs, terminaux, navigateurs, documents et agents IA dans un espace libre et les disposez comme vous pensez le projet. Faites flotter les panneaux sur le canevas, ancrez-les en onglets et en divisions, ou détachez-les dans leurs propres fenêtres. Cate restaure tout à la réouverture du dossier.
 
-## Premiers pas
+## Démarrage
 
-Ouvrez n'importe quel dossier pour créer un espace de travail — Cate restaure la disposition de votre canevas, les positions des panneaux et les terminaux ouverts à chaque fois que vous revenez. Faites un clic droit sur le canevas pour ajouter des panneaux, appuyez sur `Cmd+K` pour la palette de commandes, ou faites glisser les panneaux vers le dock pour créer des onglets et des divisions.
+Ouvrez un dossier. Cate en fait un espace de travail et rétablit votre disposition, la position des panneaux et les terminaux à chaque retour. Cliquez droit sur le canevas pour ajouter des panneaux, appuyez sur `Cmd+K` pour la palette de commandes, et glissez des panneaux sur le dock pour créer onglets et divisions. Aucun fichier de configuration à préparer.
 
-Pas de fichiers de configuration, pas de configuration de projet — pointez simplement Cate vers un répertoire et commencez à travailler.
+## Pourquoi un canevas ?
 
-## Pourquoi Cate ?
+Alt-tab suffit jusqu'à ce que vous ayez une douzaine de terminaux, six fichiers ouverts, de la documentation dans une autre fenêtre et des notes éparpillées sur plusieurs bureaux. Passé ce point, retrouver la bonne fenêtre devient le goulot d'étranglement.
 
-Alt-tab fonctionne bien — jusqu'à ce que vous ayez 12 terminaux, 6 fichiers ouverts, de la documentation dans une autre fenêtre et des notes éparpillées sur les bureaux. À ce stade, changer de fenêtre devient le véritable goulot d'étranglement.
+Cate donne à chaque projet un canevas qui se souvient de l'endroit où vous avez laissé les choses. Ce n'est pas un gestionnaire de fenêtres. Les WM en tuiles comme Hyprland, Niri et GlazeWM organisent les fenêtres de tout ce que vous lancez ; Cate organise les outils d'un seul projet, plus proche de Figma que d'un WM.
 
-Cate remplace cette pile de fenêtres par **un canevas persistant par projet**. Les terminaux, éditeurs, navigateurs et notes restent là où vous les avez placés, groupés comme vous les concevez, et ils sont toujours là quand vous revenez le lendemain.
+## Ce qu'il contient
 
-> Cate **n'est pas un remplacement de gestionnaire de fenêtres**. Les WM à tuiles/défilement (Hyprland, Niri, GlazeWM, KDE) sont excellents si vous souhaitez principalement organiser les fenêtres de l'OS. Cate est un canevas spatial autour des outils d'un seul projet — plus proche du canevas infini de Figma qu'un WM.
+**Canevas et disposition.** Zoomez et déplacez un canevas infini, ancrez des panneaux en onglets et divisions sur quatre zones, détachez des panneaux dans des fenêtres séparées et enregistrez des dispositions nommées. Gardez plusieurs projets ouverts et restaurez-les au redémarrage.
 
-## Fonctionnalités
+**Éditeurs et terminaux.** Panneaux d'éditeur Monaco avec coloration syntaxique, multi-curseur, recherche/remplacement, diffs et aperçu Markdown. Terminaux natifs xterm.js basés sur `node-pty`, ancrés dans l'espace de travail avec détection automatique du shell. Les panneaux de document affichent les PDF, DOCX et images.
 
-### 🎨 Canevas et disposition
+**Git.** Une arborescence de fichiers consciente de git avec suivi en direct et recherche, plus une barre latérale de contrôle de source pour l'index, les branches, les worktrees, l'historique et les diffs en ligne. Recherche plein texte dans le projet.
 
-- **Canevas infini** — zoomez, faites défiler et organisez les panneaux n'importe où dans l'espace libre. Défilement avec deux doigts ou clic droit ; zoom avec `Cmd+scroll` ou les contrôles du canevas.
-- **Système de dock** — glissez les panneaux flottants vers le dock pour créer des onglets et des divisions. Chaque zone de dock (centre, gauche, droite, bas) peut contenir plusieurs onglets avec des icônes colorées par type.
-- **Fenêtres détachées** — extrayez des panneaux ou des dispositions de dock complètes dans des fenêtres OS séparées.
-- **Dispositions sauvegardées** — nommez, sauvegardez, chargez et supprimez des arrangements de canevas (nœuds et régions) depuis une modale intégrée (`Cmd+K → "Dispositions sauvegardées…"`).
-- **Sessions multi-espaces de travail** — gardez plusieurs projets ouverts et restaurez-les au redémarrage. Basculez entre les espaces de travail depuis la barre latérale.
+**Agents IA.** Lancez un agent de code intégré (Pi) avec fils de discussion et mémoire de modèle par fil. Connectez Anthropic, OpenAI Codex, GitHub Copilot, Gemini, OpenRouter, Groq, Mistral, DeepSeek et d'autres via OAuth ou clé API. Installez des extensions depuis la marketplace.
 
-### 💻 Code, Documents et Terminaux
-
-- **Panneaux Monaco Editor** — édition complète de qualité VS Code avec coloration syntaxique, multi-curseur, rechercher/remplacer, support diff et mode Aperçu/Source Markdown avec rendu GFM. Les éditeurs brouillon conservent le contenu non sauvegardé entre les sessions.
-- **Tampons d'éditeur persistants** — les modèles basés sur fichiers sont réutilisés entre les panneaux, et le contenu des éditeurs brouillon persiste avec la session.
-- **Panneaux de documents** — visualiseurs natifs sur le canevas pour les PDF, fichiers DOCX et images, avec détection de type de fichier basée sur les octets magiques.
-- **Terminaux natifs** — xterm.js avec rendu WebGL, supporté par des PTY `node-pty` enracinés dans l'espace de travail actif. Détection automatique du shell avec repli gracieux si le shell configuré n'est pas disponible.
-- **Panneaux navigateur** — panneaux webview intégrés pour prévisualiser la documentation, les serveurs de développement ou toute URL. Isolés avec des paramètres de sécurité renforcés.
-
-### 🔧 Git et Contrôle de Source
-
-- **Explorateur de fichiers compatible git** — arborescence de fichiers avec surveillance en temps réel du système de fichiers, estompage des fichiers suivis/non suivis, recherche, et copier/coller pour les fichiers et dossiers avec renommage sans collision.
-- **Barre latérale de contrôle de source** — stage/unstage, gestion des branches, worktrees, historique des commits et vues diff inline. Le moniteur Git interroge et fait remonter les changements automatiquement.
-- **Recherche à l'échelle du projet** — recherche en texte intégral dans les fichiers de l'espace de travail avec résultats instantanés.
-
-### 🤖 Agent IA
-
-- **Panneau Pi Agent** — exécutez un agent de codage intégré alimenté par `@earendil-works/pi-agent-core`, avec des fils de discussion, restauration du modèle par discussion et placement de panneaux compatible avec l'espace de travail.
-- **Authentification des fournisseurs et modèles** — connectez des fournisseurs OAuth tels qu'Anthropic, OpenAI Codex et GitHub Copilot, ou des fournisseurs par clé API tels qu'OpenAI, Google Gemini, OpenRouter, Groq, Mistral, DeepSeek, et plus encore.
-- **Marketplace et mode plan** — installez des extensions Pi depuis le marketplace et utilisez l'assistant de mode plan intégré de Cate pour la planification d'implémentation guidée par agent.
-
-### 🔍 Recherche et Navigation
-
-- **Recherche à l'échelle du canevas** (`Cmd+Shift+F`) — overlay de type Spotlight qui recherche les fichiers de l'espace de travail, le scrollback des terminaux en direct et les titres/chemins des panneaux ouverts en un seul endroit. Résultats classés par focus récent avec icônes colorées par type.
-- **Sélecteur de panneaux** (`Ctrl+Space`) — overlay clavier compact pour naviguer entre les panneaux ouverts du canevas et centrer le nœud sélectionné.
-- **Palette de commandes** (`Cmd+K`) — accès rapide aux commandes, panneaux ouverts et fichiers de l'espace de travail. Chrome unifié de type Spotlight pour tous les overlays.
-
-### 🖥️ Finitions Bureau
-
-- **Sauvegarde automatique et restauration de session** — tout l'état des panneaux, positions et fichiers ouverts persiste automatiquement.
-- **Onglets natifs macOS optionnels** — groupez les fenêtres Cate dans la barre d'onglets système.
-- **Vérifications automatiques des mises à jour** — vérifie les releases GitHub et notifie quand une nouvelle version est disponible.
-- **Résilience aux pannes** — diagnostics Sentry, validation de restauration de session, bannières de repli shell dans le PTY et flux de mise à jour/redémarrage protégés aident à prévenir les états de crash bruyants ou en boucle.
+**Navigation.** Recherche sur tout le canevas dans les fichiers, le défilement des terminaux et les titres de panneaux (`Cmd+Shift+F`). Sélecteur de panneaux (`Ctrl+Space`). Palette de commandes (`Cmd+K`).
 
 ## Installation
 
-Si vous souhaitez simplement utiliser Cate, téléchargez une version précompilée — ne compilez pas depuis les sources. Ce dépôt cible actuellement la **v1.1.0**.
+Téléchargez une version précompilée. Ne compilez pas depuis les sources pour un usage quotidien.
 
 | Plateforme | Formats | Lien |
-|------------|---------|------|
+|----------|---------|------|
 | macOS | DMG, ZIP (`arm64`, `x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
-| Windows | Installateur NSIS, ZIP (`x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
+| Windows | Installeur NSIS, ZIP (`x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
 | Linux | AppImage, DEB, `tar.gz` (`x64`) | [Dernière version](https://github.com/0-AI-UG/cate/releases/latest) |
 
-> **Note macOS :** les builds de release sont notariés et configurés pour un runtime renforcé. Les builds locaux ou de test non signés peuvent nécessiter :
-> ```bash
-> xattr -cr /Applications/Cate.app
-> ```
+> **macOS :** les versions publiées sont notariées. Les builds locaux non signés peuvent nécessiter `xattr -cr /Applications/Cate.app`.
 
-> **Note Linux :** sur Steam Deck ou d'autres distributions avec racine en lecture seule, préférez le build portable `tar.gz`. Si l'AppImage ne se lance pas, essayez `--no-sandbox` comme solution de repli (ex. `./Cate.AppImage --no-sandbox`).
+> **Linux :** sur Steam Deck ou les distributions à racine en lecture seule, utilisez le build `tar.gz`. Si l'AppImage ne démarre pas, essayez `./Cate.AppImage --no-sandbox`.
 
-## Compiler depuis les Sources
+## Compiler depuis les sources
 
-> Les étapes ci-dessous sont pour les **contributeurs** — utilisez la version précompilée ci-dessus pour un usage quotidien.
+Pour les contributeurs. Sinon, utilisez la version ci-dessus.
 
-### Prérequis
-
-- [Node.js](https://nodejs.org/) 20 ou 22 LTS (voir `.nvmrc`). Node 23+ n'est pas supporté ; `node-pty` n'a pas de prebuilds et la compilation native échouera.
+**Prérequis :**
+- [Node.js](https://nodejs.org/) 20 ou 22 LTS (voir `.nvmrc`). Node 23+ échoue : `node-pty` n'a pas de prebuilds et la compilation native casse.
 - npm >= 9
-- Python 3 et un compilateur C++ (pour le module natif `node-pty`)
-  - macOS : Xcode Command Line Tools (`xcode-select --install`)
+- Python 3 et un compilateur C++ pour `node-pty` :
+  - macOS : `xcode-select --install`
   - Debian/Ubuntu : `sudo apt install build-essential python3`
   - Fedora/RHEL : `sudo dnf install @development-tools gcc-c++ make python3`
   - Arch : `sudo pacman -S base-devel python`
-  - Windows : [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (sélectionnez la charge de travail « Développement Desktop avec C++ »)
-
-### Configuration
+  - Windows : [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) avec la charge de travail « Développement Desktop en C++ »
 
 ```bash
 git clone https://github.com/0-AI-UG/cate.git
 cd cate
 npm install
-```
 
-### Développement
-
-```bash
-npm run dev
-```
-
-Cela démarre l'application Electron avec rechargement à chaud via electron-vite.
-
-### Vérifications de qualité
-
-```bash
+npm run dev          # serveur de dev avec rechargement à chaud
 npm run typecheck
-npm test            # tests unitaires (vitest)
-npm run test:e2e    # tests d'intégration Playwright
+npm test             # tests unitaires (vitest)
+npm run test:e2e     # tests d'intégration Playwright
+npm run build        # build de production
+npm run package      # packaging pour distribution (:mac, :win, :linux)
 ```
 
-Pour le harnais de test Electron :
-
-```bash
-npm run test:smoke:electron
-```
-
-### Build de Production
-
-```bash
-npm run build
-```
-
-### Empaquetage pour la Distribution
-
-```bash
-npm run package
-# ou cibler une plateforme :
-npm run package:mac
-npm run package:win
-npm run package:linux
-```
-
-Les binaires empaquetés seront dans le répertoire `release/`.
-
-## Sécurité et Empaquetage
-
-Cate utilise un pont preload isolé par contexte pour toute communication IPC. L'accès au système de fichiers est limité aux racines d'espace de travail enregistrées, les panneaux navigateur utilisent des paramètres webview renforcés avec intégration Node désactivée, et l'outil de mise à jour replie vers l'ouverture de la page de release GitHub lorsqu'un chemin d'installateur vérifié n'est pas disponible. La validation `allowedRoots` à portée d'espace de travail empêche les terminaux de démarrer en dehors des répertoires approuvés.
+Les binaires packagés se retrouvent dans `release/`.
 
 ## Architecture
 
 ```text
 src/
-├── agent/              # Intégration de l'agent de codage Pi intégré
-│   ├── main/           # Gestionnaire de processus agent, auth, marketplace, fichiers de session
-│   ├── renderer/       # UI du panneau agent, fil de discussion, fournisseurs, préférences de modèle
-│   └── extensions/     # Extension Pi de mode plan intégrée à Cate
-├── main/               # Processus principal Electron
-│   ├── ipc/            # Gestionnaires IPC (système de fichiers, git, terminal, menu, glisser)
-│   ├── analytics       # Helpers d'analytics d'événements mise à jour/app
-│   ├── appContext      # État partagé du processus principal
-│   ├── featureFlags    # Drapeaux de fonctionnalités à l'exécution
-│   ├── shellEnv        # Capture de l'environnement shell de connexion
-│   ├── shellResolver   # Résolution de chemin shell avec chaîne de repli
-│   ├── workspaceManager# Cycle de vie de l'espace de travail et persistance de session
-│   ├── workspaceRoots  # Enregistrement et validation des racines autorisées
-│   ├── windowRegistry  # Gestion des fenêtres (principale, dock, détachée)
-│   ├── webSecurity     # Renforcement webview et CSP
-│   ├── auto-updater    # Vérifications de mise à jour et récupération de release
-│   ├── sentry          # Intégration Sentry
-│   ├── store           # Persistance electron-store
-│   ├── jsonFileStore   # Helpers de persistance de fichiers JSON
-│   ├── menu            # Menu de l'application
-│   └── sessionTrust    # Validation de restauration de session
-├── preload/            # Pont isolé par contexte exposé au renderer
-├── renderer/           # Application React 18
-│   ├── assets/         # Images et déclarations d'assets du renderer
-│   ├── canvas/         # Rendu du canevas infini, glisser, redimensionner, placement
-│   ├── docking/        # Onglets, divisions, fenêtres dock détachées, glisser-déposer
-│   ├── drag/           # Runtime et état du glisser-déposer inter-fenêtres
-│   ├── panels/         # Terminal, Éditeur, Navigateur, Document, Git, Explorateur,
-│   │                   # Projets, registre/composants de panneaux Canvas
-│   ├── sidebar/        # Espace de travail, Explorateur de fichiers, Contrôle de source,
-│   │                   # Travail parallèle, Liste de projets, presse-papiers de fichiers
-│   ├── dialogs/        # Dispositions sauvegardées et dialogues de retour post-mise à jour
-│   ├── settings/       # Sections de la fenêtre de paramètres et enregistreur de raccourcis
-│   ├── ui/             # Palette de commandes, Recherche globale, Sélecteur de nœuds,
-│   │                   # Page d'accueil, Overlay d'indices de raccourcis
-│   ├── shells/         # Shells de fenêtres principale, panneau et dock
-│   ├── stores/         # Stores Zustand (canevas, app, dock, paramètres,
-│   │                   # raccourci, statut, ui, mise à jour, invite url)
-│   ├── hooks/          # Hooks React personnalisés (raccourcis, interaction canevas)
-│   ├── lib/            # Utilitaires (coordonnées, routage, registre de terminaux)
-│   ├── workers/        # Workers Monaco/éditeur
-│   └── styles/         # Styles Tailwind/globaux
-└── shared/             # Définitions de canaux IPC et types TypeScript partagés
+├── agent/      # Agent de code Pi intégré : gestionnaire de processus, auth, marketplace, UI du panneau
+├── main/       # Processus principal Electron : IPC, espaces de travail, fenêtres, updater, sécurité
+├── preload/    # Pont IPC à isolation de contexte
+├── renderer/   # App React 18 : canevas, docking, panneaux, barre latérale, stores, hooks
+└── shared/     # Canaux IPC et types partagés
 ```
 
-### Stack Technique
+Cate fait passer toute l'IPC par un pont preload à isolation de contexte. L'accès au système de fichiers est limité aux racines d'espace de travail enregistrées, les panneaux navigateur désactivent l'intégration Node, et les terminaux ne peuvent pas s'ouvrir hors des répertoires approuvés.
 
-- **Electron 41** — shell de bureau (Chromium + Node.js)
-- **React 18** — framework UI avec composants fonctionnels et hooks
-- **Zustand 5** — gestion d'état légère (sans Redux/Context)
-- **Monaco Editor 0.52** — édition de code (composant éditeur de VS Code)
-- **xterm.js 5.5 + node-pty 1.0** — émulateur de terminal avec rendu WebGL
-- **Packages @earendil-works/pi** — runtime d'agent de codage intégré, auth fournisseur et marketplace d'extensions
-- **pdf.js + mammoth** — rendu natif de documents PDF et DOCX
-- **react-markdown + remark-gfm** — aperçu Markdown avec GitHub Flavored Markdown
-- **simple-git 3.27** — opérations git
-- **chokidar 4.0** — surveillance du système de fichiers
-- **@phosphor-icons/react** — iconographie de l'application
-- **Tailwind CSS 3.4** — stylisation
-- **electron-vite 5.0** — bundling avec HMR
-- **electron-builder 26** — empaquetage et distribution
-- **electron-updater 6.8** — vérification des mises à jour
-- **Sentry Electron 5** — rapports de crash et diagnostics
-- **Playwright** — tests d'intégration de bout en bout
-- **Vitest** — exécuteur de tests unitaires
+**Stack :** Electron 41, React 18, Zustand 5, Monaco 0.52, xterm.js 5.5 + node-pty 1.0, Tailwind 3.4, electron-vite, electron-builder, electron-updater, Sentry. PDF et DOCX via pdf.js et mammoth, git via simple-git, surveillance des fichiers via chokidar. Le runtime de l'agent est `@earendil-works/pi`.
 
-## Feuille de Route
+## Contribuer
 
-Cate est en développement actif. Pour un historique détaillé de ce qui a changé dans chaque version et un aperçu de la direction, consultez le [CHANGELOG](CHANGELOG.md).
+Voir [CONTRIBUTING.md](CONTRIBUTING.md). L'historique version par version se trouve dans le [CHANGELOG](CHANGELOG.md).
 
-## Historique des Étoiles
+## Historique des étoiles
 
 <a href="https://www.star-history.com/#0-AI-UG/cate&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
-    <img alt="Graphique de l'historique des étoiles" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
   </picture>
 </a>
-
-## Contribuer
-
-Consultez [CONTRIBUTING.md](CONTRIBUTING.md) pour les directives.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@
 </p>
 
 <p align="center">
-  A spatial desktop IDE with an infinite canvas for code, terminals, browsers, documents, AI agents, and git.
-</p>
-
-<p align="center">
-  <strong>Current source version:</strong> v1.1.0
+  An infinite canvas for your code, terminals, browsers, docs, and AI agents.
 </p>
 
 <p align="center">
@@ -33,68 +29,33 @@
   <img src="assets/demo.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate is an Electron desktop app for arranging development tools in freeform space. Mix floating canvas panels with docked tabs and splits, detach panels into standalone windows, and keep multiple workspaces synced across sessions.
+Cate is a desktop IDE built on an infinite canvas. Instead of stacking windows and tabs, you spread editors, terminals, browsers, documents, and AI agents across freeform space and arrange them however you think about the project. Float panels on the canvas, dock them into tabs and splits, or detach them into their own OS windows. Cate restores everything when you reopen the folder.
 
-## Getting Started
+## Getting started
 
-Open any folder to create a workspace — Cate restores your canvas layout, panel positions, and open terminals every time you come back. Right-click the canvas to add panels, press `Cmd+K` for the command palette, or drag panels onto the dock to create tabs and splits.
+Open a folder. Cate makes it a workspace and brings back your layout, panel positions, and terminals each time you return. Right-click the canvas to add panels, press `Cmd+K` for the command palette, and drag panels onto the dock to build tabs and splits. There are no config files to set up.
 
-No configuration files, no project setup — just point Cate at a directory and start working.
+## Why a canvas?
 
-## Why Cate?
+Alt-tab is fine until you have a dozen terminals, six open files, docs in another window, and notes spread across desktops. Past that point, finding the right window is the bottleneck.
 
-Alt-tab works fine — until you have 12 terminals, 6 files open, docs in another window, and notes scattered across desktops. At that point switching windows becomes the actual bottleneck.
+Cate gives each project one canvas that remembers where you left things. This is not a window manager. Tiling WMs like Hyprland, Niri, and GlazeWM arrange OS windows for everything you run; Cate arranges the tools for a single project, closer to Figma than to a WM.
 
-Cate replaces that pile of windows with **one persistent canvas per project**. Terminals, editors, browsers, and notes sit where you put them, grouped how you think about them, and they're still there when you come back the next day.
+## What's inside
 
-> Cate is **not a window manager replacement**. Tiling/scrolling WMs (Hyprland, Niri, GlazeWM, KDE) are great if you mainly want to arrange OS windows. Cate is a spatial canvas around a single project's tools — closer to Figma's infinite canvas than to a WM.
+**Canvas and layout.** Zoom and pan an infinite canvas, dock panels into tabs and splits across four zones, detach panels into separate windows, and save named layouts. Keep several projects open and restore them on restart.
 
-## Features
+**Editors and terminals.** Monaco editor panels with syntax highlighting, multi-cursor, find/replace, diffs, and Markdown preview. Native xterm.js terminals backed by `node-pty`, rooted in the workspace with shell auto-detection. Document panels render PDFs, DOCX, and images.
 
-### 🎨 Canvas & Layout
+**Git.** A git-aware file tree with live watching and search, plus a source-control sidebar for staging, branches, worktrees, history, and inline diffs. Full-text project search.
 
-- **Infinite canvas** — zoom, pan, and arrange panels anywhere in freeform space. Pan with two-finger drag or right-click drag; zoom with `Cmd+scroll` or the canvas controls.
-- **Dock system** — drag floating panels onto the dock to create tabs and splits. Each dock zone (center, left, right, bottom) can hold multiple tabs with type-colored icons.
-- **Detached windows** — pull panels or full dock layouts into separate OS windows.
-- **Saved layouts** — name, save, load, and delete canvas arrangements (nodes and regions) from an in-app modal (`Cmd+K → "Saved Layouts…"`).
-- **Multi-workspace sessions** — keep several projects open and restore them on restart. Switch between workspaces from the sidebar.
+**AI agents.** Run an in-app coding agent (Pi) with chat threads and per-chat model memory. Connect Anthropic, OpenAI Codex, GitHub Copilot, Gemini, OpenRouter, Groq, Mistral, DeepSeek, and others via OAuth or API key. Install extensions from the marketplace.
 
-### 💻 Code, Docs & Terminals
-
-- **Monaco Editor panels** — full VS Code-grade editing with syntax highlighting, multi-cursor, find/replace, diff support, and Markdown Preview/Source mode with GFM rendering. Scratch editors persist unsaved content across sessions.
-- **Persistent editor buffers** — file-backed models are reused across panels, and scratch editor content persists with the session.
-- **Document panels** — native canvas viewers for PDFs, DOCX files, and images, with file type detection backed by magic-byte checks.
-- **Native terminals** — xterm.js with WebGL rendering, backed by `node-pty` PTYs rooted in the active workspace. Shell auto-detection with graceful fallback if the configured shell is unavailable.
-- **Browser panels** — embedded webview panels for previewing documentation, dev servers, or any URL. Context-isolated with hardened security settings.
-
-### 🔧 Git & Source Control
-
-- **Git-aware file explorer** — file tree with live filesystem watching, tracked/untracked dimming, search, and copy/paste for files and folders with collision-safe renaming.
-- **Source control sidebar** — stage/unstage, branch management, worktrees, commit history, and inline diff views. Git monitor polls and surfaces changes automatically.
-- **Project-wide search** — full-text search across workspace files with instant results.
-
-### 🤖 AI Agent
-
-- **Pi Agent panel** — run an in-app coding agent powered by `@earendil-works/pi-agent-core`, with chat threads, per-chat model restore, and workspace-aware panel placement.
-- **Provider auth & models** — connect OAuth providers such as Anthropic, OpenAI Codex, and GitHub Copilot, or API-key providers such as OpenAI, Google Gemini, OpenRouter, Groq, Mistral, DeepSeek, and more.
-- **Marketplace & plan mode** — install Pi extensions from the marketplace and use Cate's bundled plan-mode helper for agent-guided implementation planning.
-
-### 🔍 Search & Navigation
-
-- **Canvas-wide search** (`Cmd+Shift+F`) — Spotlight-style overlay that searches workspace files, live terminal scrollback, and open panel titles/paths in one place. Recent-focus ranked results with colored type-tile icons.
-- **Panel switcher** (`Ctrl+Space`) — compact keyboard overlay for jumping between open canvas panels and centering the selected node.
-- **Command palette** (`Cmd+K`) — quick access to commands, open panels, and workspace files. Unified Spotlight-style chrome across all overlays.
-
-### 🖥️ Desktop Polish
-
-- **Auto-save & session restore** — all panel state, positions, and open files persist automatically.
-- **Optional macOS native window tabs** — group Cate windows in the system tab bar.
-- **Auto-update checks** — checks GitHub releases and notifies when a new version is available.
-- **Crash resilience** — Sentry diagnostics, session restore validation, shell fallback banners in the PTY, and guarded update/restart flows help prevent noisy or looping crash states.
+**Navigation.** Canvas-wide search across files, terminal scrollback, and panel titles (`Cmd+Shift+F`). Panel switcher (`Ctrl+Space`). Command palette (`Cmd+K`).
 
 ## Install
 
-If you just want to use Cate, download a prebuilt release — don't build from source. This repository currently targets **v1.1.0**.
+Download a prebuilt release. Don't build from source for daily use.
 
 | Platform | Formats | Link |
 |----------|---------|------|
@@ -102,155 +63,59 @@ If you just want to use Cate, download a prebuilt release — don't build from s
 | Windows | NSIS installer, ZIP (`x64`) | [Latest release](https://github.com/0-AI-UG/cate/releases/latest) |
 | Linux | AppImage, DEB, `tar.gz` (`x64`) | [Latest release](https://github.com/0-AI-UG/cate/releases/latest) |
 
-> **macOS note:** release builds are notarized and configured for hardened runtime. Unsigned local or test builds may require:
-> ```bash
-> xattr -cr /Applications/Cate.app
-> ```
+> **macOS:** release builds are notarized. Unsigned local builds may need `xattr -cr /Applications/Cate.app`.
 
-> **Linux note:** on Steam Deck or other read-only-root distros, prefer the `tar.gz` portable build. If the AppImage fails to launch, try `--no-sandbox` as a fallback (e.g. `./Cate.AppImage --no-sandbox`).
+> **Linux:** on Steam Deck or read-only-root distros, use the `tar.gz` build. If the AppImage won't launch, try `./Cate.AppImage --no-sandbox`.
 
-## Build from Source
+## Build from source
 
-> The steps below are for **contributors** — use the prebuilt release above for daily use.
+For contributors. Use the release above otherwise.
 
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) 20 or 22 LTS (see `.nvmrc`). Node 23+ is not supported; `node-pty` has no prebuilds and native compilation will fail.
+**Prerequisites:**
+- [Node.js](https://nodejs.org/) 20 or 22 LTS (see `.nvmrc`). Node 23+ fails: `node-pty` has no prebuilds and native compilation breaks.
 - npm >= 9
-- Python 3 and a C++ compiler (for `node-pty` native module)
-  - macOS: Xcode Command Line Tools (`xcode-select --install`)
+- Python 3 and a C++ compiler for `node-pty`:
+  - macOS: `xcode-select --install`
   - Debian/Ubuntu: `sudo apt install build-essential python3`
   - Fedora/RHEL: `sudo dnf install @development-tools gcc-c++ make python3`
   - Arch: `sudo pacman -S base-devel python`
-  - Windows: [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (select the "Desktop development with C++" workload)
-
-### Setup
+  - Windows: [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the "Desktop development with C++" workload
 
 ```bash
 git clone https://github.com/0-AI-UG/cate.git
 cd cate
 npm install
-```
 
-### Development
-
-```bash
-npm run dev
-```
-
-This starts the Electron app with hot reload via electron-vite.
-
-### Quality Checks
-
-```bash
+npm run dev          # dev server with hot reload
 npm run typecheck
-npm test            # unit tests (vitest)
-npm run test:e2e    # Playwright integration tests
+npm test             # unit tests (vitest)
+npm run test:e2e     # Playwright integration tests
+npm run build        # production build
+npm run package      # package for distribution (:mac, :win, :linux)
 ```
 
-For the Electron smoke test harness:
-
-```bash
-npm run test:smoke:electron
-```
-
-### Production Build
-
-```bash
-npm run build
-```
-
-### Package for Distribution
-
-```bash
-npm run package
-# or target one platform:
-npm run package:mac
-npm run package:win
-npm run package:linux
-```
-
-Packaged binaries will be in the `release/` directory.
-
-## Security & Packaging
-
-Cate uses a context-isolated preload bridge for all IPC communication. Filesystem access is scoped to registered workspace roots, browser panels use hardened webview settings with disabled node integration, and the updater falls back to opening the GitHub release page when a verified installer path is unavailable. Workspace-scoped `allowedRoots` validation prevents terminals from spawning outside approved directories.
+Packaged binaries land in `release/`.
 
 ## Architecture
 
 ```text
 src/
-├── agent/              # Embedded Pi coding-agent integration
-│   ├── main/           # Agent process manager, auth, marketplace, session files
-│   ├── renderer/       # Agent panel UI, chat thread, providers, model prefs
-│   └── extensions/     # Bundled Cate plan-mode Pi extension
-├── main/               # Electron main process
-│   ├── ipc/            # IPC handlers (filesystem, git, terminal, menu, drag)
-│   ├── analytics       # Update/app event analytics helpers
-│   ├── appContext      # Shared main-process app state
-│   ├── featureFlags    # Runtime feature flags
-│   ├── shellEnv        # Login-shell environment capture
-│   ├── shellResolver   # Shell path resolution with fallback chain
-│   ├── workspaceManager# Workspace lifecycle and session persistence
-│   ├── workspaceRoots  # Allowed-roots registration and validation
-│   ├── windowRegistry  # Window management (main, dock, detached)
-│   ├── webSecurity     # Webview hardening and CSP
-│   ├── auto-updater    # Update checks and release fetch
-│   ├── sentry          # Sentry integration
-│   ├── store           # electron-store persistence
-│   ├── jsonFileStore   # JSON-backed file persistence helpers
-│   ├── menu            # Application menu
-│   └── sessionTrust    # Session restore validation
-├── preload/            # Context-isolated bridge exposed to the renderer
-├── renderer/           # React 18 application
-│   ├── assets/         # Renderer images and asset declarations
-│   ├── canvas/         # Infinite canvas rendering, drag, resize, placement
-│   ├── docking/        # Tabs, splits, detached dock windows, drag/drop
-│   ├── drag/           # Cross-window drag-and-drop runtime and state
-│   ├── panels/         # Terminal, Editor, Browser, Document, Git, Explorer,
-│   │                   # Projects, Canvas panel registry/components
-│   ├── sidebar/        # Workspace, File Explorer, Source Control,
-│   │                   # Parallel Work, Project List, fileClipboard
-│   ├── dialogs/        # Saved layouts and post-update feedback dialogs
-│   ├── settings/       # Settings window sections and shortcut recorder
-│   ├── ui/             # CommandPalette, GlobalSearch, NodeSwitcher,
-│   │                   # WelcomePage, ShortcutHintOverlay
-│   ├── shells/         # Main, panel, and dock window shells
-│   ├── stores/         # Zustand stores (canvas, app, dock, settings,
-│   │                   # shortcut, status, ui, update, url prompt)
-│   ├── hooks/          # Custom React hooks (shortcuts, canvas interaction)
-│   ├── lib/            # Utilities (coordinates, routing, terminal registry)
-│   ├── workers/        # Monaco/editor workers
-│   └── styles/         # Tailwind/global styles
-└── shared/             # IPC channel definitions and shared TypeScript types
+├── agent/      # Embedded Pi coding-agent: process manager, auth, marketplace, panel UI
+├── main/       # Electron main process: IPC, workspaces, windows, updater, security
+├── preload/    # Context-isolated IPC bridge
+├── renderer/   # React 18 app: canvas, docking, panels, sidebar, stores, hooks
+└── shared/     # IPC channels and shared types
 ```
 
-### Tech Stack
+Cate runs all IPC through a context-isolated preload bridge. Filesystem access is scoped to registered workspace roots, browser panels disable node integration, and terminals can't spawn outside approved directories.
 
-- **Electron 41** — desktop shell (Chromium + Node.js)
-- **React 18** — UI framework with functional components and hooks
-- **Zustand 5** — lightweight state management (no Redux/Context)
-- **Monaco Editor 0.52** — code editing (VS Code's editor component)
-- **xterm.js 5.5 + node-pty 1.0** — terminal emulator with WebGL renderer
-- **@earendil-works/pi packages** — embedded coding-agent runtime, provider auth, and extension marketplace
-- **pdf.js + mammoth** — native PDF and DOCX document rendering
-- **react-markdown + remark-gfm** — Markdown preview with GitHub Flavored Markdown
-- **simple-git 3.27** — git operations
-- **chokidar 4.0** — filesystem watching
-- **@phosphor-icons/react** — app iconography
-- **Tailwind CSS 3.4** — styling
-- **electron-vite 5.0** — bundling with HMR
-- **electron-builder 26** — packaging and distribution
-- **electron-updater 6.8** — update checks
-- **Sentry Electron 5** — crash reporting and diagnostics
-- **Playwright** — end-to-end integration tests
-- **Vitest** — unit test runner
+**Stack:** Electron 41, React 18, Zustand 5, Monaco 0.52, xterm.js 5.5 + node-pty 1.0, Tailwind 3.4, electron-vite, electron-builder, electron-updater, Sentry. PDFs and DOCX via pdf.js and mammoth, git via simple-git, file watching via chokidar. The agent runtime is `@earendil-works/pi`.
 
-## Roadmap
+## Contributing
 
-Cate is under active development. For a detailed history of what changed in each release and a sense of where things are headed, see the [CHANGELOG](CHANGELOG.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Release-by-release history lives in the [CHANGELOG](CHANGELOG.md).
 
-## Star History
+## Star history
 
 <a href="https://www.star-history.com/#0-AI-UG/cate&Date">
   <picture>
@@ -259,10 +124,6 @@ Cate is under active development. For a detailed history of what changed in each
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
   </picture>
 </a>
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,256 +15,117 @@
 > **注意：** 本翻译由机器自动生成，可能存在不准确之处。
 
 <p align="center">
-  一个拥有无限画布的空间桌面 IDE，集成代码编辑、终端、浏览器、文档、AI 代理和 Git。
-</p>
-
-<p align="center">
-  <strong>当前源码版本：</strong> v1.1.0
+  一块无限画布，容纳你的代码、终端、浏览器、文档和 AI 智能体。
 </p>
 
 <p align="center">
   <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT 许可证" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT License" /></a>
   <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
-  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="下载量" /></a>
+  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Downloads" /></a>
 </p>
 
 ---
 
 <p align="center">
-  <img src="assets/demo.gif" alt="Cate 演示" width="900" />
+  <img src="assets/demo.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate 是一款 Electron 桌面应用程序，用于在自由空间中组织开发工具。将浮动的画布面板与固定的标签页和分栏混合使用，将面板分离到独立窗口中，并在多个会话之间保持多个工作区同步。
+Cate 是一款基于无限画布的桌面 IDE。不再堆叠窗口和标签页，而是把编辑器、终端、浏览器、文档和 AI 智能体铺展在自由空间里，按你对项目的思路来摆放。面板可以浮在画布上、停靠成标签和分屏，或拆分到各自的系统窗口。重新打开文件夹时，Cate 会还原一切。
 
 ## 快速开始
 
-打开任意文件夹即可创建工作区——Cate 会在您每次回来时恢复画布布局、面板位置和已打开的终端。右键点击画布添加面板，按 `Cmd+K` 打开命令面板，或将面板拖到 Dock 栏创建标签页和分栏。
+打开一个文件夹。Cate 会把它变成一个工作区，每次回来都会还原你的布局、面板位置和终端。右键点击画布添加面板，按 `Cmd+K` 打开命令面板，把面板拖到停靠区即可创建标签和分屏。无需任何配置文件。
 
-无需配置文件，无需项目设置——只需将 Cate 指向一个目录即可开始工作。
+## 为什么用画布？
 
-## 为什么选择 Cate？
+在你只有几个窗口时，Alt-Tab 够用了。可一旦开着十几个终端、六个文件、文档在另一个窗口、笔记又散落在好几个桌面上，找到正确的窗口本身就成了瓶颈。
 
-Alt-Tab 切换在窗口少时很好用——但当你有 12 个终端、6 个打开的文件、另一个窗口中的文档，以及散落在各个桌面上的笔记时，切换窗口本身就成了真正的瓶颈。
+Cate 给每个项目一块画布，记住你把东西放在哪里。它不是窗口管理器。Hyprland、Niri、GlazeWM 这类平铺式 WM 负责排布你运行的所有系统窗口；Cate 排布的是单个项目的工具，更接近 Figma 而非 WM。
 
-Cate 用**每个项目一个持久化画布**替代了那堆窗口。终端、编辑器、浏览器和笔记保持在你放置的位置，按照你的思维方式分组，第二天回来时它们仍然在那里。
+## 包含什么
 
-> Cate **不是窗口管理器的替代品**。平铺/滚动式窗口管理器（Hyprland、Niri、GlazeWM、KDE）在你主要想要排列操作系统窗口时非常好用。Cate 是围绕单个项目工具的空间画布——更接近 Figma 的无限画布，而非窗口管理器。
+**画布与布局。** 缩放、平移无限画布，把面板停靠成四个区域的标签和分屏，把面板拆分到独立窗口，并保存命名布局。同时开着多个项目，重启后逐一还原。
 
-## 功能特性
+**编辑器与终端。** Monaco 编辑器面板，支持语法高亮、多光标、查找/替换、差异对比和 Markdown 预览。基于 `node-pty` 的原生 xterm.js 终端，植根于工作区并自动检测 shell。文档面板可渲染 PDF、DOCX 和图片。
 
-### 🎨 画布与布局
+**Git。** 一棵感知 git 的文件树，带实时监听与搜索；外加版本控制侧边栏，处理暂存、分支、worktree、历史和行内差异。项目级全文搜索。
 
-- **无限画布** ——缩放、平移，在自由空间中随意排列面板。双指拖动或右键拖动平移；`Cmd+滚轮` 或画布控件缩放。
-- **Dock 系统** ——将浮动面板拖到 Dock 栏创建标签页和分栏。每个 Dock 区域（中央、左侧、右侧、底部）可容纳多个带有类型着色图标的标签页。
-- **分离窗口** ——将面板或完整的 Dock 布局拉到独立的操作系统窗口中。
-- **保存的布局** ——从应用内弹窗（`Cmd+K → "保存的布局…"`）命名、保存、加载和删除画布排列（节点和区域）。
-- **多工作区会话** ——同时打开多个项目，重启后恢复。通过侧边栏在工作区之间切换。
+**AI 智能体。** 运行内置的编码智能体（Pi），支持聊天线程和按线程记忆模型。通过 OAuth 或 API key 接入 Anthropic、OpenAI Codex、GitHub Copilot、Gemini、OpenRouter、Groq、Mistral、DeepSeek 等。可从市场安装扩展。
 
-### 💻 代码、文档与终端
-
-- **Monaco 编辑器面板** ——完整的 VS Code 级编辑体验，支持语法高亮、多光标、查找/替换、差异对比以及 Markdown 预览/源码模式（GFM 渲染）。草稿编辑器在会话之间保留未保存的内容。
-- **持久化编辑器缓冲区** ——基于文件的模型在面板之间复用，草稿编辑器内容随会话持久化。
-- **文档面板** ——画布上的原生 PDF、DOCX 文件和图片查看器，支持基于魔数字节的文件类型检测。
-- **原生终端** ——xterm.js 配合 WebGL 渲染，由 `node-pty` PTY 支持，根植于活动工作区。自动检测 Shell，当配置的 Shell 不可用时优雅降级。
-- **浏览器面板** ——嵌入式 webview 面板，用于预览文档、开发服务器或任意 URL。上下文隔离，安全设置加固。
-
-### 🔧 Git 与源码控制
-
-- **Git 感知的文件浏览器** ——文件树支持实时文件系统监视、已跟踪/未跟踪文件暗显、搜索，以及文件和文件夹的复制/粘贴（带防冲突重命名）。
-- **源码控制侧边栏** ——暂存/取消暂存、分支管理、工作树、提交历史和内联差异视图。Git 监视器自动轮询并展示变更。
-- **项目级搜索** ——在工作区文件中进行全文搜索，结果即时呈现。
-
-### 🤖 AI 代理
-
-- **Pi Agent 面板** ——运行由 `@earendil-works/pi-agent-core` 驱动的应用内编码代理，支持聊天线程、按聊天恢复模型和工作区感知的面板放置。
-- **提供商认证与模型** ——连接 OAuth 提供商如 Anthropic、OpenAI Codex 和 GitHub Copilot，或 API 密钥提供商如 OpenAI、Google Gemini、OpenRouter、Groq、Mistral、DeepSeek 等。
-- **市场与规划模式** ——从市场安装 Pi 扩展，使用 Cate 内置的规划模式助手进行代理引导的实施规划。
-
-### 🔍 搜索与导航
-
-- **画布级搜索**（`Cmd+Shift+F`）——Spotlight 风格的覆盖层，可同时搜索工作区文件、实时终端滚动缓冲区和已打开面板的标题/路径。结果按最近聚焦排序，带有类型着色的图标。
-- **面板切换器**（`Ctrl+Space`）——紧凑的键盘覆盖层，用于在打开的画布面板之间跳转并将选定节点居中。
-- **命令面板**（`Cmd+K`）——快速访问命令、已打开面板和工作区文件。所有覆盖层统一采用 Spotlight 风格的外观。
-
-### 🖥️ 桌面细节
-
-- **自动保存与会话恢复** ——所有面板状态、位置和打开的文件自动持久化。
-- **可选的 macOS 原生窗口标签页** ——在系统标签栏中分组 Cate 窗口。
-- **自动更新检查** ——检查 GitHub 发布版本，有新版本可用时通知。
-- **崩溃恢复能力** ——Sentry 诊断、会话恢复验证、PTY 中的 Shell 降级横幅以及受保护的更新/重启流程，帮助防止嘈杂或循环的崩溃状态。
+**导航。** 跨画布搜索文件、终端回滚和面板标题（`Cmd+Shift+F`）。面板切换器（`Ctrl+Space`）。命令面板（`Cmd+K`）。
 
 ## 安装
 
-如果您只想使用 Cate，请下载预构建版本——不要从源码编译。本仓库当前目标版本为 **v1.1.0**。
+下载预构建版本。日常使用请勿从源码构建。
 
 | 平台 | 格式 | 链接 |
-|------|------|------|
-| macOS | DMG, ZIP (`arm64`, `x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
-| Windows | NSIS 安装程序, ZIP (`x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
-| Linux | AppImage, DEB, `tar.gz` (`x64`) | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+|----------|---------|------|
+| macOS | DMG、ZIP（`arm64`、`x64`） | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+| Windows | NSIS 安装器、ZIP（`x64`） | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
+| Linux | AppImage、DEB、`tar.gz`（`x64`） | [最新版本](https://github.com/0-AI-UG/cate/releases/latest) |
 
-> **macOS 注意：** 发布版本已公证并配置为强化运行时。未签名的本地或测试版本可能需要：
-> ```bash
-> xattr -cr /Applications/Cate.app
-> ```
+> **macOS：** 发布版本已公证。未签名的本地构建可能需要 `xattr -cr /Applications/Cate.app`。
 
-> **Linux 注意：** 在 Steam Deck 或其他只读根分区的发行版上，建议使用 `tar.gz` 便携版本。如果 AppImage 无法启动，请尝试 `--no-sandbox` 作为备选方案（例如 `./Cate.AppImage --no-sandbox`）。
+> **Linux：** 在 Steam Deck 或根目录只读的发行版上，请用 `tar.gz` 版本。若 AppImage 无法启动，试试 `./Cate.AppImage --no-sandbox`。
 
-## 从源码编译
+## 从源码构建
 
-> 以下步骤面向**贡献者**——日常使用请下载上述预构建版本。
+面向贡献者。其他情况请用上面的发布版本。
 
-### 前置要求
-
-- [Node.js](https://nodejs.org/) 20 或 22 LTS（见 `.nvmrc`）。不支持 Node 23+；`node-pty` 没有预编译包，原生编译会失败。
+**前置条件：**
+- [Node.js](https://nodejs.org/) 20 或 22 LTS（见 `.nvmrc`）。Node 23+ 会失败：`node-pty` 没有预构建产物，原生编译会出错。
 - npm >= 9
-- Python 3 和 C++ 编译器（用于 `node-pty` 原生模块）
-  - macOS：Xcode 命令行工具（`xcode-select --install`）
+- 用于 `node-pty` 的 Python 3 和 C++ 编译器：
+  - macOS：`xcode-select --install`
   - Debian/Ubuntu：`sudo apt install build-essential python3`
   - Fedora/RHEL：`sudo dnf install @development-tools gcc-c++ make python3`
   - Arch：`sudo pacman -S base-devel python`
-  - Windows：[Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)（选择"使用 C++ 的桌面开发"工作负载）
-
-### 设置
+  - Windows：[Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)，勾选 "Desktop development with C++" 工作负载
 
 ```bash
 git clone https://github.com/0-AI-UG/cate.git
 cd cate
 npm install
-```
 
-### 开发
-
-```bash
-npm run dev
-```
-
-这将通过 electron-vite 启动带有热重载的 Electron 应用。
-
-### 质量检查
-
-```bash
+npm run dev          # 带热重载的开发服务器
 npm run typecheck
-npm test            # 单元测试 (vitest)
-npm run test:e2e    # Playwright 集成测试
+npm test             # 单元测试（vitest）
+npm run test:e2e     # Playwright 集成测试
+npm run build        # 生产构建
+npm run package      # 打包分发（:mac、:win、:linux）
 ```
 
-Electron 冒烟测试工具：
-
-```bash
-npm run test:smoke:electron
-```
-
-### 生产构建
-
-```bash
-npm run build
-```
-
-### 打包分发
-
-```bash
-npm run package
-# 或指定目标平台：
-npm run package:mac
-npm run package:win
-npm run package:linux
-```
-
-打包后的二进制文件位于 `release/` 目录。
-
-## 安全与打包
-
-Cate 使用上下文隔离的预加载桥接进行所有 IPC 通信。文件系统访问范围限定在已注册的工作区根目录内，浏览器面板使用禁用 Node 集成的强化 webview 设置，更新器在验证的安装程序路径不可用时会回退到打开 GitHub 发布页面。工作区范围的 `allowedRoots` 验证防止终端在批准的目录之外启动。
+打包后的二进制文件位于 `release/`。
 
 ## 架构
 
 ```text
 src/
-├── agent/              # 嵌入式 Pi 编码代理集成
-│   ├── main/           # 代理进程管理器、认证、市场、会话文件
-│   ├── renderer/       # 代理面板 UI、聊天线程、提供商、模型偏好
-│   └── extensions/     # Cate 内置的规划模式 Pi 扩展
-├── main/               # Electron 主进程
-│   ├── ipc/            # IPC 处理器（文件系统、git、终端、菜单、拖拽）
-│   ├── analytics       # 更新/应用事件分析助手
-│   ├── appContext      # 共享主进程应用状态
-│   ├── featureFlags    # 运行时功能标志
-│   ├── shellEnv        # 登录 Shell 环境捕获
-│   ├── shellResolver   # Shell 路径解析与降级链
-│   ├── workspaceManager# 工作区生命周期和会话持久化
-│   ├── workspaceRoots  # 允许的根目录注册和验证
-│   ├── windowRegistry  # 窗口管理（主窗口、Dock、分离窗口）
-│   ├── webSecurity     # Webview 加固和 CSP
-│   ├── auto-updater    # 更新检查和发布获取
-│   ├── sentry          # Sentry 集成
-│   ├── store           # electron-store 持久化
-│   ├── jsonFileStore   # JSON 文件持久化助手
-│   ├── menu            # 应用菜单
-│   └── sessionTrust    # 会话恢复验证
-├── preload/            # 暴露给渲染器的上下文隔离桥接
-├── renderer/           # React 18 应用
-│   ├── assets/         # 渲染器图片和资源声明
-│   ├── canvas/         # 无限画布渲染、拖拽、调整大小、放置
-│   ├── docking/        # 标签页、分栏、分离的 Dock 窗口、拖放
-│   ├── drag/           # 跨窗口拖放运行时和状态
-│   ├── panels/         # 终端、编辑器、浏览器、文档、Git、浏览器、
-│   │                   # 项目、画布面板注册/组件
-│   ├── sidebar/        # 工作区、文件浏览器、源码控制、
-│   │                   # 并行工作、项目列表、文件剪贴板
-│   ├── dialogs/        # 保存的布局和更新后反馈对话框
-│   ├── settings/       # 设置窗口部分和快捷键录制器
-│   ├── ui/             # 命令面板、全局搜索、节点切换器、
-│   │                   # 欢迎页面、快捷键提示覆盖层
-│   ├── shells/         # 主窗口、面板和 Dock 窗口外壳
-│   ├── stores/         # Zustand 状态仓库（画布、应用、Dock、设置、
-│   │                   # 快捷键、状态、UI、更新、URL 提示）
-│   ├── hooks/          # 自定义 React Hooks（快捷键、画布交互）
-│   ├── lib/            # 工具函数（坐标、路由、终端注册表）
-│   ├── workers/        # Monaco/编辑器 Workers
-│   └── styles/         # Tailwind/全局样式
-└── shared/             # IPC 通道定义和共享 TypeScript 类型
+├── agent/      # 内置 Pi 编码智能体：进程管理、鉴权、市场、面板 UI
+├── main/       # Electron 主进程：IPC、工作区、窗口、更新器、安全
+├── preload/    # 上下文隔离的 IPC 桥
+├── renderer/   # React 18 应用：画布、停靠、面板、侧边栏、store、hooks
+└── shared/     # IPC 通道与共享类型
 ```
 
-### 技术栈
+Cate 的所有 IPC 都经过上下文隔离的 preload 桥。文件系统访问限定在已注册的工作区根目录，浏览器面板禁用 Node 集成，终端无法在批准目录之外启动。
 
-- **Electron 41** ——桌面外壳（Chromium + Node.js）
-- **React 18** ——UI 框架，函数组件和 Hooks
-- **Zustand 5** ——轻量级状态管理（无 Redux/Context）
-- **Monaco Editor 0.52** ——代码编辑（VS Code 编辑器组件）
-- **xterm.js 5.5 + node-pty 1.0** ——终端模拟器，WebGL 渲染
-- **@earendil-works/pi 系列包** ——嵌入式编码代理运行时、提供商认证和扩展市场
-- **pdf.js + mammoth** ——原生 PDF 和 DOCX 文档渲染
-- **react-markdown + remark-gfm** ——Markdown 预览，GitHub 风格 Markdown
-- **simple-git 3.27** ——Git 操作
-- **chokidar 4.0** ——文件系统监视
-- **@phosphor-icons/react** ——应用图标
-- **Tailwind CSS 3.4** ——样式
-- **electron-vite 5.0** ——打包与 HMR
-- **electron-builder 26** ——打包和分发
-- **electron-updater 6.8** ——更新检查
-- **Sentry Electron 5** ——崩溃报告和诊断
-- **Playwright** ——端到端集成测试
-- **Vitest** ——单元测试运行器
+**技术栈：** Electron 41、React 18、Zustand 5、Monaco 0.52、xterm.js 5.5 + node-pty 1.0、Tailwind 3.4、electron-vite、electron-builder、electron-updater、Sentry。PDF 和 DOCX 用 pdf.js 与 mammoth，git 用 simple-git，文件监听用 chokidar。智能体运行时为 `@earendil-works/pi`。
 
-## 路线图
+## 贡献
 
-Cate 正在积极开发中。有关每个版本的详细变更历史以及未来方向，请查看 [CHANGELOG](CHANGELOG.md)。
+见 [CONTRIBUTING.md](CONTRIBUTING.md)。逐版本的历史记录在 [CHANGELOG](CHANGELOG.md)。
 
-## Star 趋势
+## Star 历史
 
 <a href="https://www.star-history.com/#0-AI-UG/cate&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date&theme=dark" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
-    <img alt="Star 趋势图" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=0-AI-UG/cate&type=Date" />
   </picture>
 </a>
-
-## 贡献
-
-请参阅 [CONTRIBUTING.md](CONTRIBUTING.md) 了解贡献指南。
 
 ## 许可证
 


### PR DESCRIPTION
Cuts the README down by about half. Dropped the version banner and Roadmap section, folded the feature bullets into short prose, and trimmed the architecture tree and tech stack.

Regenerated the FR, DE, and zh-CN translations to match.