### PR TITLE
feat(docking): rename a tab by double-clicking its title

### DIFF
--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -262,6 +262,13 @@ export function DockTabBar(props: DockTabBarProps) {
               <span
                 className={`truncate flex-1 min-w-0 ${agentInfoByPanel[panelId]?.state === 'running' ? 'cate-notif-pulse' : ''}`}
                 style={worktreeTitleStyle(worktreeColorByPanel[panelId], agentInfoByPanel[panelId]?.state === 'running')}
+                onDoubleClick={(e) => {
+                  // Double-click the title to inline-rename — same flow as the
+                  // right-click menu's "Rename". Stop propagation so it doesn't
+                  // bubble to the tab's drag/parent handlers.
+                  e.stopPropagation()
+                  beginRename(panelId, getPanelTitle(panelId))
+                }}
               >{getPanelTitle(panelId)}</span>
             )}
             {agentInfoByPanel[panelId]?.state === 'waitingForInput' && (


### PR DESCRIPTION
## Summary

Lets you rename a canvas/dock tab by **double-clicking its title**. Until now, inline rename was only reachable via the tab's right-click context menu -> "Rename". Double-click is the expected gesture for tab renaming in most editors, so this wires it up to the exact same inline-rename flow.

### Why
Renaming a tab required discovering and opening the right-click context menu. Double-click is the conventional, discoverable shortcut for the same action.

### What
- Add an `onDoubleClick` to the tab title `<span>` in `DockTabBar` that calls `beginRename(panelId, getPanelTitle(panelId))` — the same handler the context menu's "Rename" case invokes.
- The handler calls `e.stopPropagation()` so the double-click doesn't bubble to the tab's drag / parent handlers. A single click still activates the tab as before.
- No new prop threading was needed: `beginRename` was already passed from `DockTabStack` -> `DockTabBar`. Commit path is unchanged (`commitRename` -> `renamePanelByUser`, which sets `titleUserOverridden: true`).

### Files
- `src/renderer/docking/DockTabBar.tsx` — added the `onDoubleClick` handler on the tab title span (~lines 265-271).

### Testing
- `npx tsc --noEmit` — clean.
- `npm test` — 42 files passed, 411 passed / 3 skipped (pre-existing skips), exit 0. No regressions.
- No unit test added: `DockTabBar` pulls in the drag subsystem and other store/registry side effects, so an isolated render harness hangs vitest on teardown. Per project guidance, I skipped scaffolding heavy mocks for a 7-line additive handler that reuses the already-tested `beginRename`/`commitRename` path. The change is verified via tsc + the full existing suite.