### PR TITLE
fix(agent): position chat-input popovers correctly at any zoom

### DIFF
--- a/src/agent/renderer/AgentChatInput.tsx
+++ b/src/agent/renderer/AgentChatInput.tsx
@@ -5,7 +5,7 @@
 // the only local state is transient UI (popover open, drag-over, slash index).
 // =============================================================================
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Stop,
@@ -18,32 +18,13 @@ import {
   ImageAttachButton,
   ImageChips,
   ThinkingLevelPicker,
+  useNodePortalTarget,
 } from './AgentPanelChrome'
 import type {
   AgentImageAttachment,
   AgentSlashCommand,
   AgentThinkingLevel,
 } from '../../shared/types'
-
-// Resolve the canvas-node element this popover lives inside, so portalled
-// content can be positioned relative to it (the node, not the viewport,
-// is the scroll/zoom frame of reference).
-function useNodePortalTarget(ref: React.RefObject<Element | null>) {
-  const getTarget = useCallback(
-    () => ref.current?.closest('[data-node-id]') as HTMLElement | null,
-    [ref],
-  )
-  const toLocal = useCallback(
-    (viewport: { top: number; left: number }) => {
-      const target = getTarget()
-      if (!target) return viewport
-      const tr = target.getBoundingClientRect()
-      return { top: viewport.top - tr.top, left: viewport.left - tr.left }
-    },
-    [getTarget],
-  )
-  return { getTarget, toLocal }
-}
 
 export function ChatInput({
   draft,

--- a/src/agent/renderer/AgentPanelChrome.tsx
+++ b/src/agent/renderer/AgentPanelChrome.tsx
@@ -550,7 +550,10 @@ function ThinkingBars({ count, size = 10 }: { count: number; size?: number }) {
   )
 }
 
-function useNodePortalTarget(ref: React.RefObject<Element | null>) {
+// Resolve the canvas-node element this popover lives inside, so portalled
+// content can be positioned relative to it (the node, not the viewport, is
+// the scroll/zoom frame of reference). Shared by the chat-input popovers too.
+export function useNodePortalTarget(ref: React.RefObject<Element | null>) {
   const getTarget = useCallback(
     () => ref.current?.closest('[data-node-id]') as HTMLElement | null,
     [ref],
@@ -560,7 +563,17 @@ function useNodePortalTarget(ref: React.RefObject<Element | null>) {
       const target = getTarget()
       if (!target) return viewport
       const tr = target.getBoundingClientRect()
-      return { top: viewport.top - tr.top, left: viewport.left - tr.left }
+      // The node lives inside the zoom-scaled canvas world, so a child
+      // positioned with absolute top/left has those values multiplied by the
+      // canvas zoom on screen. getBoundingClientRect is in screen space, so
+      // divide the screen-space delta by the node's effective scale to land
+      // the popover exactly on its anchor at any zoom. (Detached panel/dock
+      // windows aren't scaled, so scale is 1 and this is a no-op there.)
+      const scale = target.offsetWidth > 0 ? tr.width / target.offsetWidth : 1
+      return {
+        top: (viewport.top - tr.top) / scale,
+        left: (viewport.left - tr.left) / scale,
+      }
     },
     [getTarget],
   )


### PR DESCRIPTION
The compact, stats, and thinking-level popovers in the agent chat input rendered offset from their buttons, and the offset grew with canvas zoom.

These popovers are portalled into the canvas node, which sits inside the zoom-scaled canvas world. Their position came straight from `getBoundingClientRect` (screen space), so the absolute top/left got scaled by the zoom a second time, pushing the popover away from its anchor.

Fix divides the screen-space delta by the node's effective scale (`rect.width / offsetWidth`) so the popover lands on its button at any zoom. Detached panel/dock windows aren't scaled, so scale is 1 and they're unaffected. Also dedupes the `useNodePortalTarget` hook that was copied into both files.