### PR TITLE
feat(agent): custom OpenAI-compatible endpoint

### DIFF
--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -41,6 +41,7 @@ import { AGENT_EVENT } from '../../shared/ipc-channels'
 import { installSubagentExtension } from './installSubagents'
 import { installPlanModeExtension } from './installPlanMode'
 import { agentDirFor, prepareAgentDir, watchWorkspaceAuth, pushSharedToWorkspace } from './agentDir'
+import { mirrorModelsToWorkspace } from './customModels'
 import type { AuthManager } from './authManager'
 
 function resolvePiCliPath(): string {
@@ -158,6 +159,17 @@ export class AgentManager {
     }
   }
 
+  /** Re-mirror the shared models.json into every open workspace, so the custom
+   *  OpenAI provider edited in cate's UI reaches live pi processes (picked up
+   *  on their next model-list fetch). */
+  syncCustomModelsToOpenSessions(): void {
+    for (const session of this.sessions.values()) {
+      void mirrorModelsToWorkspace(session.cwd).catch((err) => {
+        log.warn('[agentManager] models sync failed for %s: %O', session.panelId, err)
+      })
+    }
+  }
+
   private withLock<T>(panelId: string, fn: () => Promise<T>): Promise<T> {
     const prev = this.locks.get(panelId) ?? Promise.resolve()
     const next = prev.then(fn, fn)
@@ -176,6 +188,7 @@ export class AgentManager {
       // and drop pi's official subagent + plan-mode extensions in so they are
       // auto-discovered the first time pi spins up in this workspace.
       await prepareAgentDir(opts.cwd)
+      await mirrorModelsToWorkspace(opts.cwd)
       await installSubagentExtension(opts.cwd)
       await installPlanModeExtension(opts.cwd)
 

--- a/src/agent/main/customModels.test.ts
+++ b/src/agent/main/customModels.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => testUserData) },
+}))
+
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import {
+  readCustomOpenAI,
+  saveCustomOpenAI,
+  sharedModelsPath,
+  mirrorModelsToWorkspace,
+} from './customModels'
+import { agentDirFor } from './agentDir'
+
+let testUserData: string
+
+beforeEach(() => {
+  testUserData = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-models-'))
+})
+
+afterEach(() => {
+  fs.rmSync(testUserData, { recursive: true, force: true })
+})
+
+describe('customModels', () => {
+  it('returns null when no models.json exists', async () => {
+    expect(await readCustomOpenAI()).toBeNull()
+  })
+
+  it('saves and reads back a custom provider', async () => {
+    await saveCustomOpenAI({
+      baseUrl: 'http://localhost:11434/v1',
+      apiKey: 'secret',
+      models: ['llama3.1:8b', 'qwen2.5-coder:7b'],
+    })
+    const cfg = await readCustomOpenAI()
+    expect(cfg).toEqual({
+      baseUrl: 'http://localhost:11434/v1',
+      apiKey: 'secret',
+      models: ['llama3.1:8b', 'qwen2.5-coder:7b'],
+    })
+  })
+
+  it('writes pi-shaped models.json (openai-completions, models as {id})', async () => {
+    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+    const raw = JSON.parse(await fsp.readFile(sharedModelsPath(), 'utf-8'))
+    expect(raw.providers['custom-openai']).toEqual({
+      baseUrl: 'http://x/v1',
+      api: 'openai-completions',
+      apiKey: 'none', // placeholder when blank, since pi requires a non-empty key
+      models: [{ id: 'm1' }],
+    })
+  })
+
+  it('clears the provider when given null', async () => {
+    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+    await saveCustomOpenAI(null)
+    expect(await readCustomOpenAI()).toBeNull()
+  })
+
+  it('clears the provider when no models are given', async () => {
+    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: [] })
+    expect(await readCustomOpenAI()).toBeNull()
+  })
+
+  it('preserves other providers a user hand-authored in models.json', async () => {
+    await fsp.mkdir(path.dirname(sharedModelsPath()), { recursive: true })
+    await fsp.writeFile(
+      sharedModelsPath(),
+      JSON.stringify({ providers: { mine: { baseUrl: 'http://mine/v1', api: 'openai-completions', apiKey: 'k', models: [{ id: 'foo' }] } } }),
+      'utf-8',
+    )
+    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+    const raw = JSON.parse(await fsp.readFile(sharedModelsPath(), 'utf-8'))
+    expect(raw.providers.mine).toBeDefined()
+    expect(raw.providers['custom-openai']).toBeDefined()
+  })
+
+  it('mirrors the shared file into a workspace dir', async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-ws-'))
+    try {
+      await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+      await mirrorModelsToWorkspace(cwd)
+      const dest = path.join(agentDirFor(cwd), 'models.json')
+      const raw = JSON.parse(await fsp.readFile(dest, 'utf-8'))
+      expect(raw.providers['custom-openai'].baseUrl).toBe('http://x/v1')
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('mirror is a no-op when no shared file exists (never clobbers workspace)', async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-ws-'))
+    try {
+      await mirrorModelsToWorkspace(cwd)
+      const dest = path.join(agentDirFor(cwd), 'models.json')
+      expect(fs.existsSync(dest)).toBe(false)
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/agent/main/customModels.ts
+++ b/src/agent/main/customModels.ts
@@ -1,0 +1,93 @@
+// =============================================================================
+// customModels — a single user-defined OpenAI-compatible provider, persisted to
+// pi's models.json.
+//
+// Like auth.json, the source of truth is one shared file in cate's userData
+// that we mirror into each workspace's .cate/pi-agent dir, because the embedded
+// pi resolves its config from PI_CODING_AGENT_DIR (per-workspace), not the
+// user's global ~/.pi/agent. pi reloads models.json whenever its model list is
+// fetched, so a saved endpoint shows up without restarting a session.
+//
+// We own the `custom-openai` provider key only; any other providers a user
+// hand-authored in models.json are preserved on write.
+// =============================================================================
+
+import fsp from 'fs/promises'
+import path from 'path'
+import { app } from 'electron'
+import log from '../../main/logger'
+import { agentDirFor } from './agentDir'
+import type { CustomOpenAIProvider } from '../../shared/types'
+
+const PROVIDER_ID = 'custom-openai'
+const PI_AGENT_DIR = 'pi-agent'
+
+/** The shared models.json — source of truth, mirrored into each workspace. */
+export function sharedModelsPath(): string {
+  return path.join(app.getPath('userData'), PI_AGENT_DIR, 'models.json')
+}
+
+function workspaceModelsPath(cwd: string): string {
+  return path.join(agentDirFor(cwd), 'models.json')
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function readJson(p: string): Promise<Record<string, any> | null> {
+  try { return JSON.parse(await fsp.readFile(p, 'utf-8')) }
+  catch { return null }
+}
+
+/** Read the configured custom OpenAI provider, or null when none is set. */
+export async function readCustomOpenAI(): Promise<CustomOpenAIProvider | null> {
+  const data = await readJson(sharedModelsPath())
+  const entry = data?.providers?.[PROVIDER_ID]
+  if (!entry) return null
+  return {
+    baseUrl: typeof entry.baseUrl === 'string' ? entry.baseUrl : '',
+    apiKey: typeof entry.apiKey === 'string' ? entry.apiKey : '',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    models: Array.isArray(entry.models)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ? entry.models.map((m: any) => (typeof m?.id === 'string' ? m.id : '')).filter(Boolean)
+      : [],
+  }
+}
+
+/** Write (or clear, when cfg is null/empty) the custom provider, preserving any
+ *  other providers in models.json. */
+export async function saveCustomOpenAI(cfg: CustomOpenAIProvider | null): Promise<void> {
+  const shared = sharedModelsPath()
+  const data = (await readJson(shared)) ?? {}
+  if (!data.providers || typeof data.providers !== 'object') data.providers = {}
+
+  if (!cfg || !cfg.baseUrl.trim() || cfg.models.length === 0) {
+    delete data.providers[PROVIDER_ID]
+  } else {
+    data.providers[PROVIDER_ID] = {
+      baseUrl: cfg.baseUrl.trim(),
+      api: 'openai-completions',
+      // pi requires a non-empty apiKey when models are defined; local servers
+      // (Ollama, LM Studio, vLLM) ignore the value, so default to a placeholder.
+      apiKey: cfg.apiKey.trim() || 'none',
+      models: cfg.models.map((id) => ({ id })),
+    }
+  }
+
+  await fsp.mkdir(path.dirname(shared), { recursive: true, mode: 0o700 })
+  await fsp.writeFile(shared, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+}
+
+/** Copy the shared models.json into a workspace's pi-agent dir. No-op when the
+ *  shared file doesn't exist (so we never clobber a hand-written workspace
+ *  models.json for users who haven't touched this feature). Safe per spawn. */
+export async function mirrorModelsToWorkspace(cwd: string): Promise<void> {
+  const data = await readJson(sharedModelsPath())
+  if (data == null) return
+  const dest = workspaceModelsPath(cwd)
+  try {
+    await fsp.mkdir(path.dirname(dest), { recursive: true })
+    await fsp.writeFile(dest, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+  } catch (err) {
+    log.warn('[customModels] mirror to %s failed: %O', dest, err)
+  }
+}

--- a/src/agent/main/ipcAgent.ts
+++ b/src/agent/main/ipcAgent.ts
@@ -49,6 +49,8 @@ import {
   AGENT_MARKETPLACE_LIST_INSTALLED,
   AGENT_MARKETPLACE_INSTALL,
   AGENT_MARKETPLACE_UNINSTALL,
+  AGENT_CUSTOM_MODELS_GET,
+  AGENT_CUSTOM_MODELS_SAVE,
 } from '../../shared/ipc-channels'
 import {
   fetchMarketplacePage,
@@ -59,6 +61,7 @@ import {
 } from './marketplace'
 import { deleteSession, listSessions, loadSessionTranscript } from './sessionFiles'
 import { agentDirFor } from './agentDir'
+import { readCustomOpenAI, saveCustomOpenAI } from './customModels'
 import log from '../../main/logger'
 import type {
   AgentCreateOptions,
@@ -66,6 +69,7 @@ import type {
   AgentImageAttachment,
   AgentModelRef,
   AgentThinkingLevel,
+  CustomOpenAIProvider,
 } from '../../shared/types'
 import type { AuthManager } from './authManager'
 import type { AgentManager } from './agentManager'
@@ -397,6 +401,24 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
 
   ipcMain.handle(AGENT_MARKETPLACE_UNINSTALL, async (_event, cwd: string, name: string) => {
     return uninstallExtension(cwd, name)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Custom OpenAI-compatible provider (pi models.json)
+  // ---------------------------------------------------------------------------
+
+  ipcMain.handle(AGENT_CUSTOM_MODELS_GET, async () => {
+    try {
+      return await readCustomOpenAI()
+    } catch (err) {
+      log.warn('[ipc.agent] customModelsGet failed: %O', err)
+      return null
+    }
+  })
+
+  ipcMain.handle(AGENT_CUSTOM_MODELS_SAVE, async (_event, cfg: CustomOpenAIProvider | null) => {
+    await saveCustomOpenAI(cfg)
+    agentManager.syncCustomModelsToOpenSessions()
   })
 
   ipcMain.handle(

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -290,12 +290,11 @@ function CustomOpenAIForm({
         onChange={(e) => setModels(e.target.value)}
         autoComplete="off"
         spellCheck={false}
-        placeholder="Model ids, comma-separated (e.g. llama3.1:8b, qwen2.5-coder:7b)"
+        placeholder="Model ids, comma-separated (e.g. llama3.1:8b)"
         className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
       />
       <div className="text-[11px] text-muted leading-relaxed">
-        Any OpenAI-compatible server. Models appear in the picker after the next
-        chat starts.
+        Any OpenAI-compatible server.
       </div>
 
       <div className="flex items-center gap-2">

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -5,8 +5,10 @@
 // its sign-in / API-key form inline beneath it (at most one open at a time).
 // When embedded in Settings the parent owns the surrounding chrome.
 //
-// Only pi's built-in providers are supported. Custom OpenAI-compatible
-// endpoints would belong in pi's models.json — out of scope here.
+// Built-in providers sign in / store an API key. A final "Custom OpenAI
+// endpoint" section lets the user point the agent at any OpenAI-compatible
+// server (Ollama, LM Studio, vLLM, a proxy); it is persisted to pi's
+// models.json via agentCustomModels* IPC.
 // =============================================================================
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -30,6 +32,7 @@ import type {
   AgentModelRef,
   AuthProviderDescriptor,
   AuthProviderStatus,
+  CustomOpenAIProvider,
   OAuthFlowEvent,
 } from '../../shared/types'
 import { loadDefaultModel, saveDefaultModel } from './agentModelPrefs'
@@ -143,8 +146,183 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false, avai
               )
             })}
           </Section>
+          <Section label="Custom">
+            <CustomOpenAIRow
+              expanded={expandedKey === 'custom-openai'}
+              onToggle={() => toggle('custom-openai')}
+            />
+          </Section>
         </div>
       </div>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Custom OpenAI-compatible endpoint — one user-defined provider written to pi's
+// models.json. Connects the agent to Ollama, LM Studio, vLLM, a proxy, etc.
+// -----------------------------------------------------------------------------
+
+function CustomOpenAIRow({
+  expanded,
+  onToggle,
+}: {
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const [cfg, setCfg] = useState<CustomOpenAIProvider | null>(null)
+
+  useEffect(() => {
+    window.electronAPI.agentCustomModelsGet()
+      .then((c) => setCfg(c))
+      .catch((err) => log.warn('[CustomOpenAIRow] load failed', err))
+  }, [])
+
+  const configured = !!cfg && !!cfg.baseUrl && cfg.models.length > 0
+  return (
+    <div className="border-b border-white/5 last:border-0">
+      <button
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-white/[0.04]"
+      >
+        <span className="flex-1 truncate text-[12.5px] text-primary">Custom OpenAI endpoint</span>
+        {configured ? (
+          <span className="inline-flex items-center gap-1 text-[10px] text-agent-light/90">
+            <CheckCircle size={10} weight="fill" /> Configured
+          </span>
+        ) : (
+          <CircleDashed size={11} className="text-muted/60" />
+        )}
+        {expanded
+          ? <CaretDown size={10} className="text-muted/60" />
+          : <CaretRight size={10} className="text-muted/60" />}
+      </button>
+      {expanded && (
+        <div className="p-2.5 border-t border-white/5 bg-black/10">
+          <CustomOpenAIForm cfg={cfg} onSaved={setCfg} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CustomOpenAIForm({
+  cfg,
+  onSaved,
+}: {
+  cfg: CustomOpenAIProvider | null
+  onSaved: (cfg: CustomOpenAIProvider | null) => void
+}) {
+  const [baseUrl, setBaseUrl] = useState(cfg?.baseUrl ?? '')
+  const [apiKey, setApiKey] = useState(cfg?.apiKey ?? '')
+  const [models, setModels] = useState((cfg?.models ?? []).join(', '))
+  const [reveal, setReveal] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  const handleSave = useCallback(async () => {
+    const url = baseUrl.trim()
+    const modelIds = models.split(',').map((m) => m.trim()).filter(Boolean)
+    if (!url) { setError('Base URL is required'); return }
+    if (modelIds.length === 0) { setError('Add at least one model id'); return }
+    setSaving(true); setError(null)
+    const next: CustomOpenAIProvider = { baseUrl: url, apiKey: apiKey.trim(), models: modelIds }
+    try {
+      await window.electronAPI.agentCustomModelsSave(next)
+      onSaved(next)
+      setSavedAt(Date.now())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [baseUrl, apiKey, models, onSaved])
+
+  const handleRemove = useCallback(async () => {
+    setSaving(true); setError(null)
+    try {
+      await window.electronAPI.agentCustomModelsSave(null)
+      onSaved(null)
+      setBaseUrl(''); setApiKey(''); setModels(''); setSavedAt(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [onSaved])
+
+  const configured = !!cfg && !!cfg.baseUrl && cfg.models.length > 0
+  return (
+    <div className="space-y-2">
+      <input
+        type="text"
+        value={baseUrl}
+        onChange={(e) => setBaseUrl(e.target.value)}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder="Base URL (e.g. http://localhost:11434/v1)"
+        className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+      />
+      <div className="relative">
+        <input
+          type={reveal ? 'text' : 'password'}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="API key (optional for local servers)"
+          className="w-full bg-surface-3 border border-white/10 rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+        />
+        <button
+          type="button"
+          onClick={() => setReveal((r) => !r)}
+          className="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded text-muted hover:text-primary"
+          title={reveal ? 'Hide' : 'Show'}
+        >
+          {reveal ? <EyeSlash size={14} /> : <Eye size={14} />}
+        </button>
+      </div>
+      <input
+        type="text"
+        value={models}
+        onChange={(e) => setModels(e.target.value)}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder="Model ids, comma-separated (e.g. llama3.1:8b, qwen2.5-coder:7b)"
+        className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+      />
+      <div className="text-[11px] text-muted leading-relaxed">
+        Any OpenAI-compatible server. Models appear in the picker after the next
+        chat starts.
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          disabled={saving}
+          onClick={handleSave}
+          className="shrink-0 px-3 py-1.5 rounded-md bg-agent hover:bg-agent-light disabled:opacity-40 text-white text-[12px] font-medium"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {configured && (
+          <button
+            disabled={saving}
+            onClick={handleRemove}
+            className="text-[11px] text-muted hover:text-rose-200"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+
+      {error && <div className="text-[11px] text-rose-300">{error}</div>}
+      {savedAt && !error && (
+        <div className="flex items-center gap-1 text-[11px] text-agent-light">
+          <CheckCircle size={12} weight="fill" /> Saved.
+        </div>
+      )}
     </div>
   )
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -184,6 +184,8 @@ import {
   AGENT_MARKETPLACE_LIST_INSTALLED,
   AGENT_MARKETPLACE_INSTALL,
   AGENT_MARKETPLACE_UNINSTALL,
+  AGENT_CUSTOM_MODELS_GET,
+  AGENT_CUSTOM_MODELS_SAVE,
   AUTH_LIST_PROVIDERS,
   AUTH_STATUS,
   AUTH_OAUTH_START,
@@ -1265,6 +1267,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const listener = (_e: Electron.IpcRendererEvent, req: unknown): void => { callback(req) }
     ipcRenderer.on(AGENT_TOOL_REQUEST, listener)
     return () => { ipcRenderer.removeListener(AGENT_TOOL_REQUEST, listener) }
+  },
+
+  agentCustomModelsGet(): Promise<unknown> {
+    return ipcRenderer.invoke(AGENT_CUSTOM_MODELS_GET)
+  },
+
+  agentCustomModelsSave(cfg: unknown): Promise<void> {
+    return ipcRenderer.invoke(AGENT_CUSTOM_MODELS_SAVE, cfg)
   },
 
   // ---------------------------------------------------------------------------

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -2,7 +2,7 @@
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
 
-import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
+import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, CustomOpenAIProvider, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
 
 export interface NativeContextMenuItem {
   id?: string
@@ -685,6 +685,12 @@ export interface ElectronAPI {
 
   /** Get token + cost + context-usage stats for the current session. */
   agentGetSessionStats(panelId: string): Promise<AgentSessionStats>
+
+  /** Read the user-defined custom OpenAI-compatible provider config. */
+  agentCustomModelsGet(): Promise<CustomOpenAIProvider | null>
+
+  /** Save (or clear, with null) the custom OpenAI-compatible provider config. */
+  agentCustomModelsSave(cfg: CustomOpenAIProvider | null): Promise<void>
 
   /** Get pi's RPC session state snapshot. */
   agentGetState(panelId: string): Promise<AgentRpcState>

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -2,7 +2,7 @@
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
 
-import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CustomOpenAIProvider, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
+import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
 
 export interface NativeContextMenuItem {
   id?: string

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -2,7 +2,7 @@
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
 
-import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
+import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CustomOpenAIProvider, CateWindowParams, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult } from './types'
 
 export interface NativeContextMenuItem {
   id?: string

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -270,6 +270,10 @@ export const AGENT_MARKETPLACE_LIST_INSTALLED = 'agent:marketplaceListInstalled'
 export const AGENT_MARKETPLACE_INSTALL = 'agent:marketplaceInstall'       // renderer -> main
 export const AGENT_MARKETPLACE_UNINSTALL = 'agent:marketplaceUninstall'   // renderer -> main
 
+// Custom OpenAI-compatible provider (pi models.json)
+export const AGENT_CUSTOM_MODELS_GET = 'agent:customModelsGet'   // renderer -> main
+export const AGENT_CUSTOM_MODELS_SAVE = 'agent:customModelsSave' // renderer -> main
+
 // Pi auth / providers
 export const AUTH_LIST_PROVIDERS = 'auth:listProviders'
 export const AUTH_STATUS = 'auth:status'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -986,6 +986,17 @@ export interface AuthProviderStatus {
   source?: 'oauth' | 'safeStorage' | 'env'
 }
 
+/** A user-defined OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, a
+ *  proxy, ...). Surfaced as one extra provider in the agent provider list and
+ *  written to pi's models.json. */
+export interface CustomOpenAIProvider {
+  baseUrl: string
+  /** Empty for local servers that ignore auth; pi gets a placeholder. */
+  apiKey: string
+  /** Model ids exposed by the endpoint, e.g. ['llama3.1:8b']. */
+  models: string[]
+}
+
 export interface AgentModelRef {
   provider: string
   model: string


### PR DESCRIPTION
Adds a "Custom OpenAI endpoint" section at the bottom of the agent provider list so you can point the agent at any OpenAI-compatible server (Ollama, LM Studio, vLLM, a proxy).

You set a base URL, an optional API key, and comma-separated model ids. It's saved to pi's `models.json`.

Why the extra plumbing: Cate scopes pi to a per-workspace config dir, so a global `~/.pi/agent/models.json` isn't read inside Cate. So we keep one shared `models.json` in userData and mirror it into each workspace on spawn, same as the existing `auth.json` scheme. Saved models show up in the picker on the next chat.

Closes #195

## Test
- `tsc` + eslint clean, `vitest` 438 pass (8 new for customModels), prod build ok
- Manual: add endpoint, model appears in picker, agent talks to it

## Screens
_todo: drop a screenshot of the new section_