### PR TITLE
fix(canvas): make Hand tool fully inert — grab cursor only, no clicks

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -46,6 +46,45 @@ function injectCanvasInteractingStyle(): void {
       pointer-events: none !important;
       cursor: grab !important;
     }
+    /* Hand tool active: the whole node is inert. Only the grab cursor shows
+       (no resize/"scale", text, or button cursors), and every left-press falls
+       through to the node container -> canvas pan handler. Panel content, chrome
+       buttons, and resize strips stop intercepting events, so nothing is
+       clickable in this mode. */
+    .canvas-tool-hand [data-node-id],
+    .canvas-tool-hand [data-node-id] *,
+    .canvas-tool-hand [data-resize-frame-for],
+    .canvas-tool-hand [data-resize-frame-for] * {
+      cursor: grab !important;
+    }
+    .canvas-tool-hand [data-node-id] [data-panel-content],
+    .canvas-tool-hand [data-grab-button],
+    .canvas-tool-hand [data-resize-overlay] {
+      pointer-events: none !important;
+    }
+    /* Regions get the same treatment: grab cursor only, and the label + resize
+       brackets stop intercepting so a press on a region pans the canvas. The
+       region body itself keeps pointer-events so its bail-to-pan handler runs. */
+    .canvas-tool-hand [data-region-id],
+    .canvas-tool-hand [data-region-id] *,
+    .canvas-tool-hand [data-region-resize-handle] {
+      cursor: grab !important;
+    }
+    .canvas-tool-hand [data-region-id] *,
+    .canvas-tool-hand [data-region-resize-handle] {
+      pointer-events: none !important;
+    }
+    /* During an active hand-pan, show the closed-hand (grabbing) cursor over
+       nodes too, matching the canvas background. */
+    .canvas-interacting.canvas-tool-hand [data-node-id],
+    .canvas-interacting.canvas-tool-hand [data-node-id] *,
+    .canvas-interacting.canvas-tool-hand [data-resize-frame-for],
+    .canvas-interacting.canvas-tool-hand [data-resize-frame-for] *,
+    .canvas-interacting.canvas-tool-hand [data-region-id],
+    .canvas-interacting.canvas-tool-hand [data-region-id] *,
+    .canvas-interacting.canvas-tool-hand [data-region-resize-handle] {
+      cursor: grabbing !important;
+    }
   `
   document.head.appendChild(style)
 }

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -434,6 +434,8 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       if (wasDragged.current) return
+      // Hand tool (or Space-hold): clicks pan/move only — never select.
+      if (effectiveCanvasTool(useUIStore.getState()) === 'hand') return
       if (e.shiftKey) {
         canvasApi.getState().toggleNodeSelection(nodeId)
         return

--- a/src/renderer/canvas/CanvasRegionComponent.tsx
+++ b/src/renderer/canvas/CanvasRegionComponent.tsx
@@ -3,6 +3,7 @@ import type { CanvasRegion } from '../../shared/types'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import { useAppStore, getCanvasOpsById } from '../stores/appStore'
+import { useUIStore, effectiveCanvasTool } from '../stores/uiStore'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
 import { ACCENT_COLORS, ACCENT_COLOR_NAMES, ACCENT_PALETTE, REGION_FILL_ALPHA, REGION_FILL_COLORS } from '../../shared/colors'
 
@@ -65,6 +66,12 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
       return
     }
     if (e.button !== 0) return
+
+    // Hand tool (or Space-hold): a left-press must pan the canvas, never select
+    // or drag the region. Bail without stopping propagation so the event bubbles
+    // to the canvas container's pan handler.
+    if (effectiveCanvasTool(useUIStore.getState()) === 'hand') return
+
     e.stopPropagation()
 
     // Shift-click: toggle selection
@@ -295,6 +302,8 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
 
   // Resize handle mouse down
   const handleResizeStart = useCallback((e: React.MouseEvent, handle: ResizeHandle) => {
+    // Hand tool (or Space-hold): let the press bubble to the canvas pan handler.
+    if (effectiveCanvasTool(useUIStore.getState()) === 'hand') return
     e.preventDefault()
     e.stopPropagation()
 
@@ -399,7 +408,6 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
               textShadow: '0 1px 3px rgba(0, 0, 0, 0.7)',
               background: 'transparent',
               border: 'none',
-              borderBottom: '1px solid var(--text-primary)',
               borderRadius: 0,
               padding: 0,
               outline: 'none',
@@ -450,6 +458,7 @@ const CanvasRegionComponent: React.FC<Props> = ({ region, zoomLevel }) => {
         return (
           <div
             key={handle}
+            data-region-resize-handle={handle}
             style={{
               position: 'absolute',
               left: region.origin.x + (isLeft ? 0 : region.size.width - bracketLen),


### PR DESCRIPTION
## Problem

In Hand mode (`H` key or Space-hold) the canvas should only pan and zoom. But node and region chrome still leaked through:

- Resize strips showed `ns-resize` / `ew-resize` / `nwse-resize` ("scale") cursors on hover, so it looked like nodes could be scaled.
- Chrome buttons (close/maximize/pin), tab bars, and non-embedded panels (Git, FileExplorer, Agent, …) stayed clickable and ran their actions.
- Region labels and resize brackets had the same problem (text/resize cursors + clickable).

The existing `.canvas-tool-hand` CSS only neutralized embedded surfaces (`iframe`/`webview`/Monaco/xterm).

## Fix

Extend the `.canvas-tool-hand` CSS so the **entire node/region is inert** in Hand mode:

- **Only the grab cursor shows** — forced across all node/region chrome and resize strips, overriding the resize/text/button cursors. Becomes `grabbing` during an active pan.
- **Nothing is clickable** — `pointer-events: none` on panel content, chrome buttons, node resize strips, and region labels/brackets. Presses fall through to the node/region container, whose mousedown handlers already bail-to-bubble, so the canvas pan handler takes over.

Relies on the existing JS guards (`handToolPanShouldWin`, region mousedown/resize bails); the CSS just makes coverage complete instead of embedded-surfaces-only. Added a `data-region-resize-handle` attribute so region brackets can be targeted.

## Testing

- `npm run typecheck` — clean
- `npm run test:unit` — 425 passed, 3 skipped
- `npm run build` — succeeds

Manual: with `H` active, the cursor stays a hand everywhere (node edges, title bars, regions) and clicks on buttons/tabs/panels only pan.