### PR TITLE
fix(file-explorer): retry initial load to fix empty tree on new workspace

### DIFF
--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -17,6 +17,14 @@ import { isExternalFileDrag, importDroppedEntries } from '../lib/importExternalE
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
 import type { DockLayoutNode } from '../../shared/types'
 
+// Opening a workspace sets its root path optimistically in the renderer, but
+// main only registers that path as an allowed root once the async workspace
+// sync resolves. A read issued before then is rejected (it throws, rather than
+// returning [] like a genuinely empty directory), so retry a few times to ride
+// out that race instead of leaving the tree stuck empty until a manual reload.
+const FS_READ_RETRIES = 5
+const FS_READ_RETRY_DELAY_MS = 120
+
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
@@ -68,6 +76,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const reloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rootPathRef = useRef(rootPath)
   const createSeqRef = useRef(0)
+  const loadRetryTimerRef = useRef<number | null>(null)
 
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
 
@@ -102,7 +111,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   // Load tree
   // ---------------------------------------------------------------------------
 
-  const loadTree = useCallback(async (dirPath: string) => {
+  const loadTree = useCallback(async (dirPath: string, attempt = 0) => {
     if (!window.electronAPI) return
 
     setIsLoading(true)
@@ -131,11 +140,21 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       }
 
       setNodes(entries)
+      setIsLoading(false)
     } catch (err) {
+      // The read was rejected (e.g. the root path isn't registered as an allowed
+      // root in main yet — see FS_READ_RETRIES note). Retry a few times before
+      // giving up, but bail if the root changed underneath us in the meantime.
+      if (attempt < FS_READ_RETRIES && rootPathRef.current === dirPath) {
+        loadRetryTimerRef.current = window.setTimeout(
+          () => loadTree(dirPath, attempt + 1),
+          FS_READ_RETRY_DELAY_MS,
+        )
+        return
+      }
       log.warn('[file-explorer] Load tree failed:', err)
       setNodes([])
       setGitTree(undefined)
-    } finally {
       setIsLoading(false)
     }
   }, [])
@@ -151,6 +170,12 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
     if (cleanupRef.current) {
       cleanupRef.current()
       cleanupRef.current = null
+    }
+
+    // Cancel any in-flight load retry from a previous root.
+    if (loadRetryTimerRef.current !== null) {
+      window.clearTimeout(loadRetryTimerRef.current)
+      loadRetryTimerRef.current = null
     }
 
     if (!rootPath || !window.electronAPI) return
@@ -196,6 +221,10 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       if (cleanupRef.current) {
         cleanupRef.current()
         cleanupRef.current = null
+      }
+      if (loadRetryTimerRef.current !== null) {
+        window.clearTimeout(loadRetryTimerRef.current)
+        loadRetryTimerRef.current = null
       }
     }
   }, [rootPath, loadTree])


### PR DESCRIPTION
## Problem

Opening a new workspace showed an **empty file explorer** until a manual reload.

## Root cause

A renderer↔main race:

1. `setWorkspaceRootPath` (`appStore.ts`) sets the workspace `rootPath` *optimistically* in the renderer.
2. `FileExplorerPanel` immediately mounts `FileExplorer`, whose effect fires `loadTree` → `fsReadDir`.
3. But main only registers that path as an allowed root via `addAllowedRoot` **after** the async workspace sync resolves (`workspaceManager.ts`).
4. So the first `fsReadDir` is rejected by `validatePathStrict` ("outside allowed directories"). `loadTree`'s catch swallowed the error and set `nodes = []` → empty tree.
5. A manual reload worked because by then the sync had completed and the root was registered.

## Fix

`loadTree` now retries on the throw path. A genuinely empty directory returns `[]` rather than throwing, so retrying only affects the transient rejection case. It retries up to 5 times at 120ms intervals, bails if the root changes underneath it, and cancels the pending timer on root change / unmount to avoid stray state updates.

This rides out the registration race deterministically and covers both `FileExplorer` mount points (dockable panel and sidebar).

## Testing

- `npx tsc --noEmit` passes.
- Manual: open a folder into a fresh workspace — the tree now populates without needing the reload button.