### PR TITLE
chore: stop tracking .claude directory

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"e4446239-7f49-4ba8-92e6-58af91f10f37","pid":19271,"procStart":"Fri May 29 16:41:22 2026","acquiredAt":1780074041616}

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ build/
 release/
 test-results/
 
-# Claude Code local settings
-.claude/settings.local.json
+# Claude Code
+.claude/
 
 # Cate workspace
 .cate/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` and untracks `scheduled_tasks.lock`, which was the only `.claude` file being shipped to git.