### PR TITLE
One .cate/.gitignore for session, agent and worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,8 @@ test-results/
 # Claude Code local settings
 .claude/settings.local.json
 
-# Cate workspace
+# Cate workspace + local session state
 .cate/
 
 # Local logo scratch dir
 _logos/
-
-# Cate local session state
-.cate/

--- a/src/agent/main/agentDir.ts
+++ b/src/agent/main/agentDir.ts
@@ -19,6 +19,7 @@ import path from 'path'
 import { app } from 'electron'
 import { watch, type FSWatcher } from 'chokidar'
 import log from '../../main/logger'
+import { ensureCateGitignore } from '../../main/cateGitignore'
 
 const CATE_DIR = '.cate'
 const PI_AGENT_DIR = 'pi-agent'
@@ -81,9 +82,9 @@ export async function prepareAgentDir(cwd: string): Promise<string> {
   await fsp.mkdir(dir, { recursive: true })
   await ensureSharedAuth()
   await copyAuth(sharedAuthPath(), workspaceAuthPath(cwd))
-  // Sessions, settings, and the auth copy must never be committed.
-  try { await fsp.writeFile(path.join(dir, '.gitignore'), '*\n', { flag: 'wx' }) }
-  catch { /* already exists — leave the user's copy */ }
+  // Sessions, settings, and the auth copy must never be committed — covered by
+  // the single .cate/.gitignore (ignores everything but workspace.json).
+  await ensureCateGitignore(path.join(cwd, CATE_DIR))
   return dir
 }
 

--- a/src/main/cateGitignore.test.ts
+++ b/src/main/cateGitignore.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { ensureCateGitignore } from './cateGitignore'
+
+describe('ensureCateGitignore', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cate-gitignore-'))
+  })
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true })
+  })
+
+  it('creates the dir and writes an ignore-all-but-workspace.json rule', async () => {
+    const cateDir = path.join(root, '.cate')
+    await ensureCateGitignore(cateDir)
+
+    const content = await fsp.readFile(path.join(cateDir, '.gitignore'), 'utf-8')
+    expect(content).toContain('\n*\n')
+    expect(content).toContain('!.gitignore')
+    expect(content).toContain('!workspace.json')
+    // session.json, *.bak, the pi-agent dir and worktrees are all covered by `*`.
+    expect(content).not.toContain('session.json')
+  })
+
+  it('leaves an existing .gitignore untouched', async () => {
+    const cateDir = path.join(root, '.cate')
+    await fsp.mkdir(cateDir, { recursive: true })
+    await fsp.writeFile(path.join(cateDir, '.gitignore'), 'custom\n', 'utf-8')
+
+    await ensureCateGitignore(cateDir)
+
+    const content = await fsp.readFile(path.join(cateDir, '.gitignore'), 'utf-8')
+    expect(content).toBe('custom\n')
+  })
+})

--- a/src/main/cateGitignore.ts
+++ b/src/main/cateGitignore.ts
@@ -1,0 +1,31 @@
+// =============================================================================
+// One .gitignore for the whole .cate/ dir.
+//
+// Only workspace.json is meant to be shared/committed; everything else under
+// .cate/ is machine-local — session.json, the *.tmp/*.bak atomic-write scratch
+// files, the pi-agent dir (sessions + the auth.json copy), and worktrees. A
+// single ignore-all-but-workspace rule covers all of it, so the subsystems that
+// create .cate/ (project state, agent dir, worktrees) all funnel through here
+// instead of dropping their own per-dir .gitignore.
+// =============================================================================
+
+import fsp from 'fs/promises'
+import path from 'path'
+
+const CONTENT = `# Cate project-local state. Only workspace.json is shared; everything else
+# (session state, backups, the pi-agent dir, and worktrees) stays local.
+*
+!.gitignore
+!workspace.json
+`
+
+/** Ensure <cateDir>/.gitignore exists. Best-effort and write-once: an existing
+ *  file (e.g. one the user customised) is left untouched. */
+export async function ensureCateGitignore(cateDir: string): Promise<void> {
+  try {
+    await fsp.mkdir(cateDir, { recursive: true })
+    await fsp.writeFile(path.join(cateDir, '.gitignore'), CONTENT, { flag: 'wx' })
+  } catch {
+    /* already exists, or dir not writable — nothing to do */
+  }
+}

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -11,6 +11,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { validateCwd, addAllowedRoot, removeAllowedRoot } from './pathValidation'
 import { getShellEnv } from '../shellEnv'
+import { ensureCateGitignore } from '../cateGitignore'
 import {
   GIT_IS_REPO,
   GIT_INIT,
@@ -104,18 +105,14 @@ async function ghAvailable(cwd: string): Promise<boolean> {
   }
 }
 
-/** Create a worktree's containing dir and drop a self-ignoring `*` .gitignore
- *  so the checkouts under .cate/worktrees never show as untracked in the parent
- *  repo. Best-effort; the .gitignore is written only when absent. */
+/** Create a worktree's containing dir (.cate/worktrees) and make sure the single
+ *  .cate/.gitignore exists so the checkouts never show as untracked in the
+ *  parent repo. The worktrees dir sits at <root>/.cate/worktrees, so its parent
+ *  is the .cate dir. Best-effort. */
 async function ensureContainingDir(targetPath: string): Promise<void> {
   const containingDir = path.dirname(targetPath)
   await fs.mkdir(containingDir, { recursive: true })
-  const ignorePath = path.join(containingDir, '.gitignore')
-  try {
-    await fs.access(ignorePath)
-  } catch {
-    await fs.writeFile(ignorePath, '*\n').catch(() => {})
-  }
+  await ensureCateGitignore(path.dirname(containingDir))
 }
 
 /** Build a github.com compare URL from the repo's `origin` remote so a PR can

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -13,6 +13,7 @@ import {
 import type { ProjectWorkspaceFile, ProjectSessionFile, MultiWorkspaceSession, SessionSnapshot, DockLayoutNode, WindowDockState } from '../shared/types'
 import { toRelativePath } from '../shared/pathUtils'
 import { broadcastToAll } from './windowRegistry'
+import { ensureCateGitignore } from './cateGitignore'
 
 const CATE_DIR = '.cate'
 const WORKSPACE_FILE = 'workspace.json'
@@ -157,6 +158,7 @@ export async function saveProjectState(
 ): Promise<void> {
   const wsJson = JSON.stringify(workspace, null, 2)
   const sessJson = JSON.stringify(session, null, 2)
+  await ensureCateGitignore(cateDir(rootPath))
   await Promise.all([
     atomicWrite(workspacePath(rootPath), wsJson),
     atomicWrite(sessionPath(rootPath), sessJson),
@@ -388,6 +390,7 @@ export function registerProjectStateHandlers(): void {
       const sessJson = JSON.stringify(session, null, 2)
       lastSavedProjectStates.set(rootPath, { workspace: wsJson, session: sessJson })
       await enqueueSave(rootPath, async () => {
+        await ensureCateGitignore(cateDir(rootPath))
         // session.json is machine-local and never hand-edited, so always write it.
         const writes: Promise<void>[] = [atomicWrite(sessionPath(rootPath), sessJson)]
         if (await workspaceEditedExternallyAsync(rootPath)) {


### PR DESCRIPTION
Cate was dropping three separate `.gitignore` files inside `.cate/` (one per subsystem), and `session.json` plus the `*.bak`/`*.tmp` scratch files weren't ignored at all.

Now there's a single `.cate/.gitignore` that ignores everything except `workspace.json` (the only shareable file). The project-state, agent-dir and worktree code all funnel through one `ensureCateGitignore` helper, written best-effort and write-once so a user's customized copy is never clobbered.

Also de-duped the redundant `.cate/` entry in this repo's own `.gitignore`.