### PR TITLE
fix(file-explorer): refresh nested folders so reload reflects disk state

### DIFF
--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -59,6 +59,13 @@ interface FileExplorerProps {
 export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const [nodes, setNodes] = useState<FileTreeNodeType[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  // Bumped on every successful tree read. Nested folders cache their own
+  // children in local state (keyed by stable path, so they survive a root
+  // re-render); this signal tells each cached/expanded folder to re-read from
+  // disk so a reload — or a move/create/delete — actually reflects on-disk state
+  // instead of showing stale children (e.g. a moved file lingering in its old
+  // folder, which reads as a copy).
+  const [refreshSignal, setRefreshSignal] = useState(0)
   const [gitTree, setGitTree] = useState<GitTree | undefined>(undefined)
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
   const [rootCreating, setRootCreating] = useState<'file' | 'folder' | null>(null)
@@ -140,6 +147,9 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       }
 
       setNodes(entries)
+      // Invalidate cached children in every expanded/loaded nested folder so the
+      // refreshed root read propagates the whole way down the tree.
+      setRefreshSignal((n) => n + 1)
       setIsLoading(false)
     } catch (err) {
       // The read was rejected (e.g. the root path isn't registered as an allowed
@@ -627,6 +637,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
               onSelect={handleSelect}
               onFileOpen={handleFileOpen}
               onTreeChanged={handleReload}
+              refreshSignal={refreshSignal}
               visiblePaths={visiblePaths}
               searchQuery=""
               rootPath={rootPath}

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -107,6 +107,9 @@ interface FileTreeNodeProps {
   onSelect: (path: string, meta: { shift?: boolean; cmd?: boolean }) => void
   onFileOpen: (paths: string[], mode?: 'dock' | 'canvas') => void
   onTreeChanged?: () => void
+  /** Bumped by the explorer on every tree read; signals cached/expanded folders
+   *  to re-read their children from disk so reloads reflect on-disk state. */
+  refreshSignal?: number
   /** Flat ordered list of visible file paths for shift-click range selection */
   visiblePaths: string[]
   /** Lowercased search query; when non-empty, filters files and force-expands directories */
@@ -127,6 +130,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   onSelect,
   onFileOpen,
   onTreeChanged,
+  refreshSignal,
   visiblePaths,
   searchQuery,
   rootPath,
@@ -183,6 +187,20 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       /* ignore */
     }
   }, [node.path, node.isDirectory])
+
+  // Re-read children from disk when the explorer bumps refreshSignal (manual
+  // reload, fs-watch event, or a move/create/delete). Only folders we've already
+  // cached — expanded, or previously loaded then collapsed — need invalidating;
+  // never-opened folders read fresh on first expand. Acting only on an actual
+  // signal change (not on mount) avoids a redundant read right after loading.
+  const prevRefreshRef = useRef(refreshSignal)
+  useEffect(() => {
+    if (prevRefreshRef.current === refreshSignal) return
+    prevRefreshRef.current = refreshSignal
+    if (node.isDirectory && (isExpanded || children.length > 0)) {
+      reloadChildren()
+    }
+  }, [refreshSignal, node.isDirectory, isExpanded, children.length, reloadChildren])
 
   const parentDir = node.isDirectory ? node.path : node.path.substring(0, node.path.lastIndexOf('/'))
 
@@ -602,6 +620,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
               onSelect={onSelect}
               onFileOpen={onFileOpen}
               onTreeChanged={onTreeChanged}
+              refreshSignal={refreshSignal}
               visiblePaths={visiblePaths}
               searchQuery={searchQuery}
               rootPath={rootPath}


### PR DESCRIPTION
Dragging a file into a folder looked like a copy: the file stayed in its old folder and also showed up in the new one. On disk it actually moved (Finder confirmed), and reload didn't fix it.

Cause: nested folders cache their own children in local state, keyed by stable path, so they survive a root re-render. Reload only re-read the root dir, so stale nested state was never invalidated.

Fix: a `refreshSignal` bumped on every tree read (manual reload, fs-watch, or a move/create/delete) tells each cached/expanded folder to re-read its children from disk. Never-opened folders stay lazy.

Note: the chokidar watcher still uses `depth: 1`, so external changes deep in nested folders won't auto-refresh, but the reload button now works for them.

Typecheck passes; sidebar tests (33) pass.