### PR TITLE
fix(workspace): stop the reload loop when two Cates share a project

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -48,6 +48,7 @@ import { startPerfMonitor, getLatestSnapshot } from './perf/perfMonitor'
 import { PERF_GET } from '../shared/ipc-channels'
 import { installWebContentsSecurity } from './webSecurity'
 import { installThemeSkill } from './installThemeSkill'
+import { releaseAllProjectLocks } from './projectLock'
 import {
   startCrossWindowDrag,
   updateCrossWindowCursor,
@@ -1419,6 +1420,9 @@ app.on('will-quit', () => {
   // we write something if it didn't.
   log.info('will-quit: sync project state save fallback')
   saveProjectStateSync()
+  // Drop per-project locks so a co-running instance can take over immediately
+  // (a crash skips this; the next instance reclaims the stale lock by pid).
+  releaseAllProjectLocks()
   // Kill all PTYs now — AFTER session save so the renderer had access to live
   // PTY data (CWD, scrollback) during the flush triggered in before-quit.
   // Must happen while the JS environment is still alive. If we let them die

--- a/src/main/projectLock.test.ts
+++ b/src/main/projectLock.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  acquireProjectLock,
+  releaseProjectLock,
+  releaseAllProjectLocks,
+  holdsProjectLock,
+} from './projectLock'
+
+describe('projectLock', () => {
+  let root: string
+  const lockFile = () => path.join(root, '.cate', 'workspace.lock')
+  const writeOwner = (pid: number) => {
+    fs.mkdirSync(path.dirname(lockFile()), { recursive: true })
+    fs.writeFileSync(lockFile(), JSON.stringify({ pid }))
+  }
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-lock-'))
+  })
+  afterEach(() => {
+    releaseAllProjectLocks()
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('acquires a free lock and records our pid', () => {
+    expect(acquireProjectLock(root)).toBe(true)
+    expect(holdsProjectLock(root)).toBe(true)
+    expect(JSON.parse(fs.readFileSync(lockFile(), 'utf-8')).pid).toBe(process.pid)
+  })
+
+  it('reclaims a lock left by a dead pid', () => {
+    writeOwner(999999) // overwhelmingly unlikely to be alive
+    expect(acquireProjectLock(root)).toBe(true)
+  })
+
+  it('refuses a lock held by a live pid', () => {
+    // The parent process is alive for the test and isn't our own pid.
+    writeOwner(process.ppid)
+    expect(acquireProjectLock(root)).toBe(false)
+    expect(holdsProjectLock(root)).toBe(false)
+  })
+
+  it('release deletes our lock file', () => {
+    acquireProjectLock(root)
+    releaseProjectLock(root)
+    expect(fs.existsSync(lockFile())).toBe(false)
+  })
+
+  it('release leaves a lock owned by someone else', () => {
+    acquireProjectLock(root)
+    writeOwner(process.ppid)
+    releaseProjectLock(root)
+    expect(fs.existsSync(lockFile())).toBe(true)
+  })
+})

--- a/src/main/projectLock.ts
+++ b/src/main/projectLock.ts
@@ -1,0 +1,78 @@
+import fs from 'fs'
+import path from 'path'
+import log from './logger'
+
+// ---------------------------------------------------------------------------
+// Per-project lock for .cate/workspace.json
+//
+// The single-instance lock (index.ts) is keyed on Electron's userData dir, but
+// a dev build and an installed build deliberately use *different* userData dirs
+// (the `app.isPackaged` split), so they each win their own single-instance lock
+// and can run side by side. When both open the *same project*, both autosave
+// .cate/workspace.json (~30s) and each reads the other's write as an external
+// edit — the spurious "Reload workspace?" loop.
+//
+// So we drop a .cate/workspace.lock holding the owning pid when a project opens
+// here. A second Cate that finds a *live* owner won't autosave that project.
+// The pid lets us recover from a crash: a leftover lock whose pid is gone is
+// reclaimed instead of bricking the project read-only. Advisory only — if the
+// file can't be written we fail open and behave as the owner.
+// ---------------------------------------------------------------------------
+
+const heldRoots = new Set<string>()
+
+function lockPath(rootPath: string): string {
+  return path.join(rootPath, '.cate', 'workspace.lock')
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0) // signal 0 = existence check, sends nothing
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM' // exists, not ours to signal
+  }
+}
+
+function ownerPid(file: string): number | null {
+  try {
+    const pid = JSON.parse(fs.readFileSync(file, 'utf-8'))?.pid
+    return typeof pid === 'number' ? pid : null
+  } catch {
+    return null // missing or corrupt
+  }
+}
+
+/** Take this project's lock. Returns false only if a live instance holds it. */
+export function acquireProjectLock(rootPath: string): boolean {
+  const file = lockPath(rootPath)
+  const pid = ownerPid(file)
+  if (pid !== null && pid !== process.pid && isProcessAlive(pid)) return false
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify({ pid: process.pid }))
+  } catch (err) {
+    log.warn('projectLock: could not write lock for %s, proceeding unlocked: %O', rootPath, err)
+  }
+  heldRoots.add(rootPath)
+  return true
+}
+
+export function holdsProjectLock(rootPath: string): boolean {
+  return heldRoots.has(rootPath)
+}
+
+/** Release one project's lock, but only if the file on disk is still ours. */
+export function releaseProjectLock(rootPath: string): void {
+  if (!heldRoots.delete(rootPath)) return
+  const file = lockPath(rootPath)
+  if (ownerPid(file) === process.pid) {
+    try { fs.unlinkSync(file) } catch { /* best effort */ }
+  }
+}
+
+/** Release every lock this process holds. Called on quit. */
+export function releaseAllProjectLocks(): void {
+  for (const root of [...heldRoots]) releaseProjectLock(root)
+}

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -10,6 +10,7 @@ import {
   WORKSPACE_EXTERNAL_EDIT,
   WORKSPACE_EXTERNAL_EDIT_DISMISS,
 } from '../shared/ipc-channels'
+import { holdsProjectLock, acquireProjectLock } from './projectLock'
 import type { ProjectWorkspaceFile, ProjectSessionFile, MultiWorkspaceSession, SessionSnapshot, DockLayoutNode, WindowDockState } from '../shared/types'
 import { toRelativePath } from '../shared/pathUtils'
 import { broadcastToAll } from './windowRegistry'
@@ -389,6 +390,14 @@ export function registerProjectStateHandlers(): void {
       const wsJson = JSON.stringify(workspace, null, 2)
       const sessJson = JSON.stringify(session, null, 2)
       lastSavedProjectStates.set(rootPath, { workspace: wsJson, session: sessJson })
+      // If another live Cate instance owns this project, don't autosave over
+      // it — that's the two-writers loop. Re-acquire each time so we resume
+      // saving once the owner exits; only skip while it's genuinely held.
+      if (!holdsProjectLock(rootPath) && !acquireProjectLock(rootPath)) {
+        log.debug('Skipping save for %s — another Cate instance owns it', cateDir(rootPath))
+        lastSavedProjectStates.delete(rootPath) // keep the quit-time sync fallback out too
+        return
+      }
       await enqueueSave(rootPath, async () => {
         await ensureCateGitignore(cateDir(rootPath))
         // session.json is machine-local and never hand-edited, so always write it.

--- a/src/main/workspaceManager.ts
+++ b/src/main/workspaceManager.ts
@@ -5,7 +5,7 @@
 // Canvas/panel state lives in each renderer window — only metadata is shared.
 // =============================================================================
 
-import { ipcMain } from 'electron'
+import { ipcMain, dialog } from 'electron'
 import { randomUUID } from 'crypto'
 import log from './logger'
 import {
@@ -50,6 +50,20 @@ function rootInUse(rootPath: string, exceptId?: string): boolean {
     if (w.rootPath === rootPath) return true
   }
   return false
+}
+
+/** Claim the lock for a root; if a live instance already owns it, warn that
+ *  layout changes here won't be saved (autosave is suppressed for it). */
+function claimProjectLock(rootPath: string, name?: string): void {
+  if (!rootPath) return
+  if (acquireProjectLock(rootPath)) return
+  void dialog.showMessageBox({
+    type: 'warning',
+    message: 'Another Cate instance has this project open',
+    detail: `Changes you make to the workspace${name ? ` "${name}"` : ''} won't be saved while another Cate instance has it open. Close the other instance to resume saving.`,
+    buttons: ['OK'],
+    noLink: true,
+  })
 }
 
 /** Drop the project lock once no remaining workspace here uses that root. */
@@ -98,7 +112,7 @@ async function createWorkspace(name?: string, rootPath?: string, id?: string): P
   log.info('Workspace created: %s (%s)', info.id, info.rootPath || 'no root')
   if (info.rootPath) {
     addAllowedRoot(info.rootPath)
-    acquireProjectLock(info.rootPath)
+    claimProjectLock(info.rootPath, info.name)
   }
   return { ok: true, workspace: info }
 }
@@ -158,7 +172,7 @@ async function updateWorkspace(id: string, changes: Partial<Omit<WorkspaceInfo, 
     // Release the lock on the old root (if no sibling workspace still uses it)
     // and claim the new one.
     if (existing.rootPath) dropProjectLock(existing.rootPath, id)
-    if (updated.rootPath) acquireProjectLock(updated.rootPath)
+    if (updated.rootPath) claimProjectLock(updated.rootPath, updated.name)
   }
   return { ok: true, workspace: updated }
 }

--- a/src/main/workspaceManager.ts
+++ b/src/main/workspaceManager.ts
@@ -18,6 +18,7 @@ import type { WorkspaceInfo, WorkspaceMutationResult } from '../shared/types'
 import { broadcastToAll, windowFromEvent } from './windowRegistry'
 import { addAllowedRoot, removeAllowedRoot } from './ipc/pathValidation'
 import { resolveTrustedWorkspaceRoot } from './workspaceRoots'
+import { acquireProjectLock, releaseProjectLock } from './projectLock'
 
 // In-memory workspace list — authoritative source of truth
 const workspaces: Map<string, WorkspaceInfo> = new Map()
@@ -35,6 +36,26 @@ function isValidWorkspaceId(id: string): boolean {
 
 function generateId(): string {
   return randomUUID()
+}
+
+// -----------------------------------------------------------------------------
+// Per-project lock — claim ownership of a project's .cate/workspace.json when
+// it's opened here, so a second Cate (dev vs installed) won't autosave over us.
+// -----------------------------------------------------------------------------
+
+/** True if any workspace other than `exceptId` is rooted at `rootPath`. */
+function rootInUse(rootPath: string, exceptId?: string): boolean {
+  for (const [id, w] of workspaces) {
+    if (id === exceptId) continue
+    if (w.rootPath === rootPath) return true
+  }
+  return false
+}
+
+/** Drop the project lock once no remaining workspace here uses that root. */
+function dropProjectLock(rootPath: string, exceptId?: string): void {
+  if (!rootPath || rootInUse(rootPath, exceptId)) return
+  releaseProjectLock(rootPath)
 }
 
 // -----------------------------------------------------------------------------
@@ -77,6 +98,7 @@ async function createWorkspace(name?: string, rootPath?: string, id?: string): P
   log.info('Workspace created: %s (%s)', info.id, info.rootPath || 'no root')
   if (info.rootPath) {
     addAllowedRoot(info.rootPath)
+    acquireProjectLock(info.rootPath)
   }
   return { ok: true, workspace: info }
 }
@@ -122,7 +144,8 @@ async function updateWorkspace(id: string, changes: Partial<Omit<WorkspaceInfo, 
     }
   }
 
-  if (existing.rootPath && existing.rootPath !== nextRootPath) {
+  const rootChanged = existing.rootPath !== nextRootPath
+  if (existing.rootPath && rootChanged) {
     removeAllowedRoot(existing.rootPath)
   }
 
@@ -130,6 +153,12 @@ async function updateWorkspace(id: string, changes: Partial<Omit<WorkspaceInfo, 
   workspaces.set(id, updated)
   if (updated.rootPath) {
     addAllowedRoot(updated.rootPath)
+  }
+  if (rootChanged) {
+    // Release the lock on the old root (if no sibling workspace still uses it)
+    // and claim the new one.
+    if (existing.rootPath) dropProjectLock(existing.rootPath, id)
+    if (updated.rootPath) acquireProjectLock(updated.rootPath)
   }
   return { ok: true, workspace: updated }
 }
@@ -140,10 +169,12 @@ function removeWorkspace(id: string): boolean {
     return false
   }
   const existing = workspaces.get(id)
+  const removed = workspaces.delete(id)
   if (existing?.rootPath) {
     removeAllowedRoot(existing.rootPath)
+    // Delete first so rootInUse() doesn't count the workspace we just removed.
+    dropProjectLock(existing.rootPath, id)
   }
-  const removed = workspaces.delete(id)
   if (removed) log.info('Workspace removed: %s', id)
   return removed
 }


### PR DESCRIPTION
## What

Per-project lock so two Cate processes with the same project open don't fight over `.cate/workspace.json`.

## Why

Both processes autosave `workspace.json` every ~30s. Each then reads the other's write, sees it differ from the hash it last wrote, and flags an external edit, so the "Reload workspace?" prompt fires on a loop. The single-instance lock can't catch this case: a dev build and an installed build use different userData dirs and win separate single-instance locks, so both run.

## How

- On open, write the owning pid to `.cate/workspace.lock`.
- Skip the autosave when a live owner already holds the lock, so the two never overwrite each other.
- The pid drives a liveness check (`process.kill(pid, 0)`), so a lock left by a crash is reclaimed instead of leaving the project stuck read-only.
- Re-acquire on each save, so the second instance resumes saving once the owner quits.
- Released on workspace close (ref-counted across windows) and on quit.

## Notes

This is the loop fix on its own. #224 (single-instance lock) is a separate window-focus feature, not needed for this.

## Tests

`npm run typecheck`, `npm test` (477 + 5 new lock tests), `npm run build` all pass.