### PR TITLE
fix: prevent canvas wipe on deferred-workspace activation + persistent browser login (#220)

### DIFF
--- a/src/main/projectWorkspaceStore.test.ts
+++ b/src/main/projectWorkspaceStore.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+
+// projectWorkspaceStore imports electron + a few main-only modules at load time.
+// Mock them so the module can be imported under vitest's node environment.
+vi.mock('electron', () => ({
+  app: { getPath: () => tmpdir() },
+  ipcMain: { handle: vi.fn() },
+}))
+vi.mock('./logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('./windowRegistry', () => ({ broadcastToAll: vi.fn() }))
+vi.mock('./cateGitignore', () => ({ ensureCateGitignore: vi.fn(async () => {}) }))
+
+import { saveProjectState, loadProjectState } from './projectWorkspaceStore'
+import type { ProjectWorkspaceFile, ProjectSessionFile, ProjectCanvasNode } from '../shared/types'
+
+function makeNode(panelId: string): ProjectCanvasNode {
+  return {
+    panelId,
+    panelType: 'terminal',
+    title: panelId,
+    origin: { x: 0, y: 0 },
+    size: { width: 100, height: 100 },
+  }
+}
+
+function makeWorkspace(nodes: ProjectCanvasNode[]): ProjectWorkspaceFile {
+  return {
+    version: 1,
+    name: 'WS',
+    color: '',
+    canvas: { nodes, regions: [], zoomLevel: 1, viewportOffset: { x: 0, y: 0 } },
+  }
+}
+
+function makeSession(): ProjectSessionFile {
+  return { version: 1, focusedNodeId: null, nodes: {} }
+}
+
+let root: string
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(tmpdir(), 'cate-pws-'))
+})
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+})
+
+async function readWorkspaceJson(rootPath: string): Promise<ProjectWorkspaceFile> {
+  const raw = await fs.readFile(path.join(rootPath, '.cate', 'workspace.json'), 'utf-8')
+  return JSON.parse(raw) as ProjectWorkspaceFile
+}
+
+describe('saveProjectState — issue #220 empty-overwrite guard', () => {
+  it('persists a non-empty canvas normally', async () => {
+    await saveProjectState(root, makeWorkspace([makeNode('a'), makeNode('b')]), makeSession())
+    const onDisk = await readWorkspaceJson(root)
+    expect(onDisk.canvas.nodes).toHaveLength(2)
+  })
+
+  it('refuses to overwrite a non-empty canvas with an empty one', async () => {
+    await saveProjectState(root, makeWorkspace([makeNode('a'), makeNode('b')]), makeSession())
+    // A racey activation save serializes an empty canvas — must be rejected.
+    await saveProjectState(root, makeWorkspace([]), makeSession())
+    const onDisk = await readWorkspaceJson(root)
+    expect(onDisk.canvas.nodes).toHaveLength(2)
+  })
+
+  it('allows an empty canvas when nothing (or only empty) is on disk', async () => {
+    await saveProjectState(root, makeWorkspace([]), makeSession())
+    const onDisk = await readWorkspaceJson(root)
+    expect(onDisk.canvas.nodes).toHaveLength(0)
+  })
+
+  it('still allows shrinking a non-empty canvas to a smaller non-empty one', async () => {
+    await saveProjectState(root, makeWorkspace([makeNode('a'), makeNode('b')]), makeSession())
+    await saveProjectState(root, makeWorkspace([makeNode('a')]), makeSession())
+    const onDisk = await readWorkspaceJson(root)
+    expect(onDisk.canvas.nodes).toHaveLength(1)
+  })
+})
+
+describe('loadProjectState — issue #220 prefer-richer fallback', () => {
+  it('recovers a richer .bak when the primary file was wiped to empty', async () => {
+    const cateDir = path.join(root, '.cate')
+    await fs.mkdir(cateDir, { recursive: true })
+    const wsPath = path.join(cateDir, 'workspace.json')
+    // Primary file is structurally valid but empty (the data-loss footgun);
+    // .bak still holds the good canvas.
+    await fs.writeFile(wsPath, JSON.stringify(makeWorkspace([])), 'utf-8')
+    await fs.writeFile(wsPath + '.bak', JSON.stringify(makeWorkspace([makeNode('a'), makeNode('b')])), 'utf-8')
+    await fs.writeFile(path.join(cateDir, 'session.json'), JSON.stringify(makeSession()), 'utf-8')
+
+    const loaded = await loadProjectState(root)
+    expect(loaded).not.toBeNull()
+    expect(loaded!.workspace.canvas.nodes).toHaveLength(2)
+  })
+
+  it('uses the primary file when it is the richest', async () => {
+    const cateDir = path.join(root, '.cate')
+    await fs.mkdir(cateDir, { recursive: true })
+    const wsPath = path.join(cateDir, 'workspace.json')
+    await fs.writeFile(wsPath, JSON.stringify(makeWorkspace([makeNode('a'), makeNode('b'), makeNode('c')])), 'utf-8')
+    await fs.writeFile(wsPath + '.bak', JSON.stringify(makeWorkspace([makeNode('a')])), 'utf-8')
+    await fs.writeFile(path.join(cateDir, 'session.json'), JSON.stringify(makeSession()), 'utf-8')
+
+    const loaded = await loadProjectState(root)
+    expect(loaded!.workspace.canvas.nodes).toHaveLength(3)
+  })
+})

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -132,12 +132,57 @@ async function tryReadJson<T>(filePath: string): Promise<T | null> {
   }
 }
 
+// Count of canvas nodes in a workspace file, or -1 when the value isn't a
+// readable workspace. Used by the data-loss guards (issue #220) to compare the
+// richness of two candidate files / an incoming write vs. what's on disk.
+function workspaceNodeCount(data: unknown): number {
+  if (!isValidWorkspace(data)) return -1
+  const nodes = (data as ProjectWorkspaceFile).canvas?.nodes
+  return Array.isArray(nodes) ? nodes.length : -1
+}
+
+// True when writing `incomingNodeCount` nodes over the workspace.json at
+// `rootPath` would replace a non-empty saved canvas with an empty one — the
+// issue #220 data-loss footgun. The sync read keeps the quit-time fallback
+// (saveProjectStateSync) honest without an await.
+function wouldEmptyOverwriteWorkspaceSync(rootPath: string, incomingNodeCount: number): boolean {
+  if (incomingNodeCount > 0) return false
+  try {
+    const existing = JSON.parse(fsSync.readFileSync(workspacePath(rootPath), 'utf-8'))
+    return workspaceNodeCount(existing) > 0
+  } catch {
+    return false
+  }
+}
+
 async function tryReadWithFallback<T>(filePath: string): Promise<T | null> {
   const result = await tryReadJson<T>(filePath)
   if (result) return result
   const tmp = await tryReadJson<T>(filePath + '.tmp')
   if (tmp) return tmp
   return tryReadJson<T>(filePath + '.bak')
+}
+
+// Workspace-aware read (issue #220): the plain primary file can be a valid but
+// *empty* canvas left behind by a wipe. When that happens, prefer the richer of
+// primary / .tmp / .bak so a previously-wiped workspace still recovers its
+// panels on the next load instead of perpetuating the empty state.
+async function readWorkspaceWithFallback(filePath: string): Promise<ProjectWorkspaceFile | null> {
+  const candidates = await Promise.all([
+    tryReadJson<ProjectWorkspaceFile>(filePath),
+    tryReadJson<ProjectWorkspaceFile>(filePath + '.tmp'),
+    tryReadJson<ProjectWorkspaceFile>(filePath + '.bak'),
+  ])
+  let best: ProjectWorkspaceFile | null = null
+  let bestCount = -1
+  for (const candidate of candidates) {
+    const count = workspaceNodeCount(candidate)
+    if (count > bestCount) {
+      best = candidate
+      bestCount = count
+    }
+  }
+  return best
 }
 
 function isValidWorkspace(data: unknown): data is ProjectWorkspaceFile {
@@ -157,6 +202,26 @@ export async function saveProjectState(
   workspace: ProjectWorkspaceFile,
   session: ProjectSessionFile,
 ): Promise<void> {
+  // Data-loss backstop (issue #220): never overwrite a non-empty saved canvas
+  // with an empty one. A renderer-side race while activating a deferred
+  // (non-selected) workspace can momentarily serialize an empty canvas; without
+  // this guard that empty snapshot clobbers the good workspace.json/session.json
+  // and the loss is permanent — the empty file is still structurally "valid", so
+  // the .bak fallback is never consulted on the next load. This mirrors the
+  // renderer's own shouldPreserveExistingCanvas guard (clearing every panel
+  // already doesn't persist as empty for the selected workspace), extended to
+  // the disk boundary so it also covers deferred/non-selected workspaces.
+  if (workspace.canvas.nodes.length === 0) {
+    const existingCount = workspaceNodeCount(await tryReadJson(workspacePath(rootPath)))
+    if (existingCount > 0) {
+      log.warn(
+        'Refusing to overwrite %d-node canvas with an empty one for %s (issue #220 guard)',
+        existingCount,
+        cateDir(rootPath),
+      )
+      return
+    }
+  }
   const wsJson = JSON.stringify(workspace, null, 2)
   const sessJson = JSON.stringify(session, null, 2)
   await ensureCateGitignore(cateDir(rootPath))
@@ -171,7 +236,7 @@ export async function loadProjectState(rootPath: string): Promise<{
   workspace: ProjectWorkspaceFile
   session: ProjectSessionFile | null
 } | null> {
-  const ws = await tryReadWithFallback<ProjectWorkspaceFile>(workspacePath(rootPath))
+  const ws = await readWorkspaceWithFallback(workspacePath(rootPath))
   if (!ws || !isValidWorkspace(ws)) return null
   // Track the on-disk content so a later autosave can tell our own writes apart
   // from an external edit. Hash the raw file (not a re-serialization) so the
@@ -196,6 +261,10 @@ export function saveProjectStateSync(): void {
       atomicWriteSync(sessionPath(rootPath), session)
       if (workspaceEditedExternallySync(rootPath)) {
         log.info('Skipping workspace.json sync overwrite for %s — edited externally', cateDir(rootPath))
+      } else if (wouldEmptyOverwriteWorkspaceSync(rootPath, workspaceNodeCount(JSON.parse(workspace)))) {
+        // issue #220 guard: don't let the quit-time fallback flush an empty
+        // canvas over a good one (mirrors the async saveProjectState guard).
+        log.warn('Refusing empty workspace.json sync overwrite for %s (issue #220 guard)', cateDir(rootPath))
       } else {
         atomicWriteSync(workspacePath(rootPath), workspace)
         rememberWorkspaceContent(rootPath, workspace)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -17,6 +17,7 @@ import {
   BOOT_SNAPSHOT_WRITE,
   RECENT_PROJECTS_GET,
   RECENT_PROJECTS_ADD,
+  RECENT_PROJECTS_REMOVE,
   SIDEBAR_SESSION_GET,
   SIDEBAR_SESSION_SET,
   LAYOUT_SAVE,
@@ -296,6 +297,16 @@ export function registerHandlers(): void {
     const filtered = existing.filter((p) => p !== projectPath)
     const updated = [projectPath, ...filtered].slice(0, 10)
     store.set('recentProjects', updated)
+  })
+
+  // Drop a project from the recent list (issue #220): closing a workspace should
+  // forget the project so it doesn't reappear on next launch and re-enter the
+  // deferred-restore path. Without this the only way to forget a project was to
+  // hand-edit config.json.
+  ipcMain.handle(RECENT_PROJECTS_REMOVE, async (_event, projectPath: string) => {
+    const store = await getStore()
+    const existing: string[] = store.get('recentProjects', []) as string[]
+    store.set('recentProjects', existing.filter((p) => p !== projectPath))
   })
 
   // Sidebar session (workspace order + active workspace, keyed by root path)

--- a/src/main/webSecurity.ts
+++ b/src/main/webSecurity.ts
@@ -2,6 +2,17 @@ import { app, session, shell, type Session, type WebContents } from 'electron'
 import log from './logger'
 import { disableWebviewHardening } from './featureFlags'
 
+// Hosts whose OAuth/sign-in flows are forced into the user's real browser via
+// shell.openExternal (see installWebContentsSecurity below) rather than running
+// inside the webview — Electron's webview is flagged by these providers as an
+// "insecure browser" and blocks the flow.
+//
+// Note (issue #220): this is by design and independent of the browser panel's
+// persistent session. Even though all browser panels now share a stable
+// persistent partition so cookies/logins survive restarts (see BROWSER_PARTITION
+// in BrowserPanel.tsx), "Sign in with Google/Microsoft/Apple/GitHub" still
+// completes in the system browser, not in-app. In-webview OAuth for these
+// providers is intentionally not supported.
 const OAUTH_HOSTS = new Set([
   'accounts.google.com',
   'login.microsoftonline.com',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -88,6 +88,7 @@ import {
   DIALOG_TERMINAL_LINK_OPEN,
   RECENT_PROJECTS_GET,
   RECENT_PROJECTS_ADD,
+  RECENT_PROJECTS_REMOVE,
   SIDEBAR_SESSION_GET,
   SIDEBAR_SESSION_SET,
   LAYOUT_SAVE,
@@ -735,6 +736,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   recentProjectsAdd(projectPath: string): Promise<void> {
     return ipcRenderer.invoke(RECENT_PROJECTS_ADD, projectPath)
+  },
+  recentProjectsRemove(projectPath: string): Promise<void> {
+    return ipcRenderer.invoke(RECENT_PROJECTS_REMOVE, projectPath)
   },
 
   sidebarSessionGet(): Promise<SidebarSession | null> {

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -20,6 +20,15 @@ import { isUrl, normalizeUrl } from './browserUrl'
 
 // Electron already declares webview in its types - we use 'as any' on the ref instead
 
+// Single shared persistent session for all browser panels (issue #220 bug 2).
+// Previously the partition was keyed to the runtime panelId
+// (`persist:browser-${panelId}`), but panelId is regenerated as a fresh UUID on
+// every session restore, so each restart pointed at a brand-new empty cookie
+// jar and logins were lost (with an orphaned partition leaking on disk per
+// restart). A single stable partition keeps cookies/logins across restarts and
+// panel re-creation. Trade-off: all browser panels share one cookie store.
+const BROWSER_PARTITION = 'persist:browser-shared'
+
 interface WebviewElement extends HTMLElement {
   loadURL(url: string): void
   goBack(): void
@@ -366,7 +375,7 @@ export default function BrowserPanel({
           ref={webviewRef as any}
           src={webviewSrc}
           className={`w-full h-full ${loadError ? 'hidden' : ''}`}
-          partition={`persist:browser-${panelId}`}
+          partition={BROWSER_PARTITION}
         />
 
         {/* Screenshot thumbnail */}

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -423,7 +423,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       }
       case 'remove-workspace':
         if (window.confirm(`Remove "${folderName}" from your workspaces?`)) {
-          removeWorkspace(selectedWorkspaceId)
+          removeWorkspace(selectedWorkspaceId, true)
         }
         break
       case 'find-in-folder': openSearch(); break

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -49,7 +49,7 @@ export const ProjectList: React.FC = () => {
     setMultiSelected(new Set())
     lastClickedIndexRef.current = null
     for (const id of idsToRemove) {
-      useAppStore.getState().removeWorkspace(id)
+      useAppStore.getState().removeWorkspace(id, true)
     }
   }, [multiSelected])
 
@@ -160,7 +160,7 @@ export const ProjectList: React.FC = () => {
                   isSelected={ws.id === selectedWorkspaceId}
                   isMultiSelected={multiSelected.has(ws.id)}
                   onClick={(e) => handleWorkspaceClick(index, ws.id, e)}
-                  onClose={() => removeWorkspace(ws.id)}
+                  onClose={() => removeWorkspace(ws.id, true)}
                   onBulkContextMenu={(e) => handleBulkContextMenu(e, ws.id)}
                 />
               </div>

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -405,7 +405,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       }
       case 'duplicate': app.duplicateWorkspace(workspace.id); break
       case 'close-panels': app.closeAllPanels(workspace.id); break
-      case 'remove': app.removeWorkspace(workspace.id); break
+      case 'remove': app.removeWorkspace(workspace.id, true); break
     }
   }, [workspace.id, workspace.name, workspace.rootPath, workspace.color, workspace.panels, isSelected, onBulkContextMenu])
 

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -292,7 +292,7 @@ interface AppStoreActions {
   // Workspace management
   addWorkspace: (name?: string, rootPath?: string, id?: string) => string
   selectWorkspace: (id: string) => Promise<void>
-  removeWorkspace: (id: string) => void
+  removeWorkspace: (id: string, forgetRecent?: boolean) => void
 
   // Panel creation — each adds a PanelState to the workspace AND places it
   createTerminal: (workspaceId: string, initialInput?: string, position?: Point, placement?: PanelPlacement, cwd?: string) => string
@@ -562,9 +562,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
 
       // Check for deferred restore (lazy workspace loading)
+      let didDeferredRestore = false
       try {
         if (deferredSnapshots.has(id)) {
           await restoreDeferredWorkspace(id, canvasOps?.storeApi)
+          didDeferredRestore = true
         }
       } catch (error) {
         log.error('Failed to restore deferred workspace:', error)
@@ -585,18 +587,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const finalCanvasPanelId = getWorkspaceCanvasPanelId(id)
       if (finalCanvasPanelId && finalCanvasPanelId !== canvasPanelId) {
         setActiveCanvasPanelId(finalCanvasPanelId)
-        const wsFinal = get().workspaces.find((w) => w.id === id)
-        if (wsFinal) {
-          try {
-            getWorkspaceCanvasStore(id)?.getState().loadWorkspaceCanvas(
-              wsFinal.canvasNodes,
-              wsFinal.viewportOffset,
-              wsFinal.zoomLevel,
-              wsFinal.focusedNodeId,
-              wsFinal.regions,
-            )
-          } catch (error) {
-            log.error('Failed to load canvas for workspace:', error)
+        if (didDeferredRestore) {
+          // A deferred restore just populated the canvas *store* directly (via
+          // createTerminal/createBrowser/... → canvas addNode), but the
+          // workspace's own canvasNodes are still empty — they're only filled by
+          // syncCanvasToWorkspace. Reloading the empty canvasNodes here (the
+          // else branch) would wipe the freshly restored canvas, leaving panels
+          // in the sidebar tree but a blank canvas, and the next autosave would
+          // then persist that empty state (issue #220). Instead, capture the
+          // restored store back into the workspace so appStore and disk stay in
+          // sync with what was just restored.
+          get().syncCanvasToWorkspace(id)
+        } else {
+          const wsFinal = get().workspaces.find((w) => w.id === id)
+          if (wsFinal) {
+            try {
+              getWorkspaceCanvasStore(id)?.getState().loadWorkspaceCanvas(
+                wsFinal.canvasNodes,
+                wsFinal.viewportOffset,
+                wsFinal.zoomLevel,
+                wsFinal.focusedNodeId,
+                wsFinal.regions,
+              )
+            } catch (error) {
+              log.error('Failed to load canvas for workspace:', error)
+            }
           }
         }
       }
@@ -669,7 +684,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
   },
 
-  removeWorkspace(id) {
+  removeWorkspace(id, forgetRecent = false) {
+    // When the user explicitly closes a workspace, also forget its project so it
+    // doesn't reappear on next launch (issue #220). Opt-in: the default keeps
+    // recents intact for non-user removals (session-restore teardown, dropping
+    // an uninitialized stray workspace). Capture the rootPath before we mutate.
+    if (forgetRecent) {
+      const closing = get().workspaces.find((w) => w.id === id)
+      if (closing?.rootPath) {
+        window.electronAPI.recentProjectsRemove(closing.rootPath).catch((err) =>
+          log.warn('[workspace] Failed to remove from recent projects:', err),
+        )
+      }
+    }
     // Clean up deferred snapshot if workspace was never switched to
     deferredSnapshots.delete(id)
     // Dispose terminals before removing workspace state

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -420,6 +420,9 @@ export interface ElectronAPI {
   /** Add a project path to the recent projects list. */
   recentProjectsAdd(projectPath: string): Promise<void>
 
+  /** Remove a project path from the recent projects list (issue #220 — forget on close). */
+  recentProjectsRemove(projectPath: string): Promise<void>
+
   /** Get the persisted sidebar arrangement (workspace order + active workspace). */
   sidebarSessionGet(): Promise<SidebarSession | null>
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -164,6 +164,7 @@ export const PANEL_WINDOW_SYNC_META = 'panel:windowSyncMeta'
 // Recent Projects
 export const RECENT_PROJECTS_GET = 'recent-projects:get'
 export const RECENT_PROJECTS_ADD = 'recent-projects:add'
+export const RECENT_PROJECTS_REMOVE = 'recent-projects:remove'
 
 // Sidebar session (persisted workspace order + active workspace, by root path)
 export const SIDEBAR_SESSION_GET = 'sidebar-session:get'


### PR DESCRIPTION
Fixes #220 — two independent, silent state-loss bugs (both confirmed against current `main`).

## Bug 1 — deferred (non-selected) workspace canvas wiped to empty on activation

`restoreSession` populates the canvas **store** directly, but the workspace's own `canvasNodes` stay empty until `syncCanvasToWorkspace` runs. The post-restore "re-resolve" in `selectWorkspace` then reloaded those empty `canvasNodes` *over* the freshly restored store — blanking the canvas (panels still show in the sidebar tree) — and the next autosave persisted the empty state to disk.

- `appStore.selectWorkspace`: after a deferred restore, capture the restored store back into the workspace via `syncCanvasToWorkspace(id)` instead of reloading empty nodes over it.
- **Main-process backstop** (`projectWorkspaceStore`): `saveProjectState` refuses to overwrite a non-empty on-disk canvas with an empty one (covers both the async save path and the quit-time sync fallback). On load, prefer the richest of `workspace.json` / `.tmp` / `.bak`, so a previously-wiped file still recovers its panels instead of perpetuating the empty state. This guard is race-independent — it holds regardless of renderer timing.

## Bug 2 — browser login lost on every restart

The webview partition was keyed to the runtime `panelId`, which is regenerated as a fresh UUID on every session restore — so each restart pointed at a brand-new empty cookie jar and leaked an orphaned partition on disk. Use one shared persistent partition (`persist:browser-shared`) for all browser panels, so logins survive restarts and panel re-creation. Trade-off: all browser panels share one cookie store.

## Papercuts (from the issue)

- Add `recent-projects:remove` IPC, wired to the explicit "Close Workspace" actions (opt-in `removeWorkspace(id, forgetRecent)` — session-restore teardown deliberately does **not** forget recents), so a closed project no longer reappears next launch and re-enters the deferred-restore path.
- Document that OAuth URLs are intentionally opened in the system browser (independent of the new persistent browser session).

## Tests / checks

- New unit tests for the main-process empty-overwrite refusal and prefer-richer load.
- `npm test`: 532 passed | 3 skipped. `tsc --noEmit`: clean. `electron-vite build`: clean.

## Not yet runtime-verified

The exact in-renderer activation race wasn't reproducible enough to confirm by static reading alone; the main-process backstop guarantees no empty-overwrite regardless, and the `selectWorkspace` change addresses the most likely trigger. Recommend a manual pass before merge: with ≥2 recent projects, open a non-first project, add panels, quit, relaunch, wait ~30s, then activate it → canvas should keep its panels; and log into a site in a browser panel, restart → still logged in.