### PR TITLE
fix(sidebar): header alignment, multi-select/delete, and scrollbar polish

### DIFF
--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -273,6 +273,9 @@ export function useShortcuts(): void {
       // shortcut below (which deletes the currently focused panel).
       if ((e.key === 'Delete' || e.key === 'Backspace') && !e.metaKey) {
         if (terminalHasFocus) return
+        // The sidebar (workspace list / file explorer) owns Delete/Backspace
+        // when focused, so its own handler can delete the multi-selection.
+        if (isSidebarKeyNavFocused()) return
         const state = canvasStore()
         if (state.selectedNodeIds.size > 0 || state.selectedRegionIds.size > 0) {
           // Don't delete if a text input is focused
@@ -329,6 +332,10 @@ export function useShortcuts(): void {
       // the keystroke would never reach the shell (issue #172).
       if (action === 'deleteNode') {
         if (terminalHasFocus || isTextSurfaceFocused()) return
+        // Cmd+Backspace inside the sidebar deletes the selected workspaces/files
+        // — let it bubble to the sidebar's own keydown handler instead of
+        // closing a canvas panel.
+        if (isSidebarKeyNavFocused()) return
       }
 
       // Keyboard-only passthrough: when a browser panel is focused, let
@@ -369,6 +376,17 @@ export function useShortcuts(): void {
       if (active.getAttribute('contenteditable') === 'true') return true
       if (active.closest('[contenteditable="true"]')) return true
       return false
+    }
+
+    /**
+     * True when focus is inside a sidebar list that handles its own
+     * Delete/Backspace (workspace list, file explorer). Those containers are
+     * tagged with `data-sidebar-keynav`; when one is focused the global canvas
+     * delete shortcuts must stand down so the list can delete its selection.
+     */
+    function isSidebarKeyNavFocused(): boolean {
+      const active = document.activeElement as HTMLElement | null
+      return !!active?.closest('[data-sidebar-keynav]')
     }
 
     document.addEventListener('keydown', handleKeyDown, { capture: true })

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -79,6 +79,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const searchInputRef = useRef<HTMLInputElement>(null)
   const rootCreateInputRef = useRef<HTMLInputElement>(null)
   const lastSelectedPath = useRef<string | null>(null)
+  const treeContainerRef = useRef<HTMLDivElement>(null)
   const cleanupRef = useRef<(() => void) | null>(null)
   const reloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rootPathRef = useRef(rootPath)
@@ -274,6 +275,14 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
 
   const handleSelect = useCallback(
     (path: string, meta: { shift?: boolean; cmd?: boolean }) => {
+      // Shift-range needs the paths in their actual on-screen order. visiblePaths
+      // only has top-level entries (nested children live in each FileTreeNode's
+      // local state), so read the rendered rows from the DOM instead — that
+      // reflects exactly what's visible, including expanded sub-folders.
+      const domOrder = meta.shift && treeContainerRef.current
+        ? Array.from(treeContainerRef.current.querySelectorAll<HTMLElement>('[data-filepath]'))
+            .map((el) => el.dataset.filepath!)
+        : visiblePaths
       setSelectedPaths((prev) => {
         if (meta.cmd) {
           // Toggle individual selection
@@ -287,15 +296,17 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
           return next
         }
         if (meta.shift && lastSelectedPath.current) {
-          // Range selection
-          const startIdx = visiblePaths.indexOf(lastSelectedPath.current)
-          const endIdx = visiblePaths.indexOf(path)
+          // Range selection across the visible rows (anchor → clicked).
+          const startIdx = domOrder.indexOf(lastSelectedPath.current)
+          const endIdx = domOrder.indexOf(path)
           if (startIdx !== -1 && endIdx !== -1) {
             const [lo, hi] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx]
             const next = new Set(prev)
             for (let i = lo; i <= hi; i++) {
-              next.add(visiblePaths[i])
+              next.add(domOrder[i])
             }
+            // Keep the anchor where it was so a second shift-click re-ranges
+            // from the same origin (matches Finder/VS Code behavior).
             return next
           }
         }
@@ -303,6 +314,11 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
         lastSelectedPath.current = path
         return new Set([path])
       })
+      // Move keyboard focus into the tree so Delete/Backspace is handled here.
+      // The rows are draggable <div>s, which don't reliably take focus on click,
+      // so focus the (tabbable) scroll container explicitly. preventScroll keeps
+      // the list from jumping when a row deep in the tree is clicked.
+      treeContainerRef.current?.focus({ preventScroll: true })
     },
     [visiblePaths],
   )
@@ -327,6 +343,33 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const handleReload = useCallback(() => {
     if (rootPath) loadTree(rootPath)
   }, [rootPath, loadTree])
+
+  // Delete one or many paths in a single confirm (used by both the
+  // Cmd+Backspace / Delete keyboard shortcut and the right-click menu, so a
+  // multi-selection is removed all at once rather than one file per action).
+  const deletePaths = useCallback(async (paths: string[]) => {
+    if (!window.electronAPI || paths.length === 0) return
+    const label = paths.length === 1
+      ? `"${paths[0].split('/').pop()}"`
+      : `${paths.length} items`
+    if (!window.confirm(`Delete ${label}? This cannot be undone.`)) return
+    for (const p of paths) {
+      try {
+        await window.electronAPI.fsDelete(p)
+      } catch (err) {
+        console.error('[file-explorer] Failed to delete entry:', err)
+      }
+    }
+    setSelectedPaths(new Set())
+    handleReload()
+  }, [handleReload])
+
+  const handleTreeKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.key === 'Delete' || e.key === 'Backspace') && selectedPaths.size > 0) {
+      e.preventDefault()
+      void deletePaths([...selectedPaths])
+    }
+  }, [selectedPaths, deletePaths])
 
   // Resolve the target directory for new file/folder creation based on selection
   const getSelectedDir = useCallback((): string | null => {
@@ -596,7 +639,15 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
         </div>
       ) : (
         <div
-          className="flex-1 overflow-y-auto py-1"
+          ref={treeContainerRef}
+          className="flex-1 overflow-y-auto py-1 outline-none"
+          // Focusable + tagged so Delete/Backspace (incl. Cmd+Backspace) deletes
+          // the selection here instead of being swallowed by the canvas-level
+          // shortcut handler. Focused explicitly from onSelect (draggable rows
+          // don't reliably focus this container on click).
+          tabIndex={-1}
+          data-sidebar-keynav
+          onKeyDown={handleTreeKeyDown}
           onClick={(e) => {
             // Click on empty area clears selection
             if (e.target === e.currentTarget) setSelectedPaths(new Set())
@@ -636,6 +687,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
               selectedPaths={selectedPaths}
               onSelect={handleSelect}
               onFileOpen={handleFileOpen}
+              onDeletePaths={deletePaths}
               onTreeChanged={handleReload}
               refreshSignal={refreshSignal}
               visiblePaths={visiblePaths}

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -106,6 +106,8 @@ interface FileTreeNodeProps {
   selectedPaths: Set<string>
   onSelect: (path: string, meta: { shift?: boolean; cmd?: boolean }) => void
   onFileOpen: (paths: string[], mode?: 'dock' | 'canvas') => void
+  /** Delete the given paths (confirms + reloads + clears selection in the explorer). */
+  onDeletePaths?: (paths: string[]) => void
   onTreeChanged?: () => void
   /** Bumped by the explorer on every tree read; signals cached/expanded folders
    *  to re-read their children from disk so reloads reflect on-disk state. */
@@ -129,6 +131,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   selectedPaths,
   onSelect,
   onFileOpen,
+  onDeletePaths,
   onTreeChanged,
   refreshSignal,
   visiblePaths,
@@ -287,7 +290,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       { id: 'copy-rel-path', label: 'Copy Relative Path', accelerator: 'Alt+Shift+Cmd+C' },
       { id: 'copy-name', label: 'Copy Name' },
       { type: 'separator' },
-      { id: 'delete', label: 'Delete', accelerator: 'Cmd+Backspace' },
+      { id: 'delete', label: pathsToOpen.length > 1 ? `Delete ${pathsToOpen.length} Items` : 'Delete', accelerator: 'Cmd+Backspace' },
     )
 
     const id = await window.electronAPI.showContextMenu(items)
@@ -303,10 +306,16 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       case 'copy-path': navigator.clipboard.writeText(node.path); break
       case 'copy-rel-path': navigator.clipboard.writeText(relPath); break
       case 'copy-name': navigator.clipboard.writeText(node.name); break
-      case 'delete': handleDelete(); break
+      case 'delete':
+        // Delete the whole multi-selection in one go when this node is part of
+        // it; otherwise just this node. Falls back to the local single-node
+        // delete if no explorer-level handler was provided.
+        if (onDeletePaths) onDeletePaths(pathsToOpen)
+        else handleDelete()
+        break
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [node, rootPath, selectedPaths, onFileOpen])
+  }, [node, rootPath, selectedPaths, onFileOpen, onDeletePaths])
 
   // --- Rename ---
   const startRename = useCallback(() => {
@@ -498,6 +507,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     <div>
       {/* Node row */}
       <div
+        data-filepath={node.path}
         className={`h-7 flex items-center gap-1.5 px-2 text-sm text-primary cursor-pointer rounded-sm ${
           isSelected ? 'bg-surface-6 text-primary' : 'hover:bg-hover'
         } ${isIgnored ? 'opacity-40' : ''} ${isDragOver && node.isDirectory ? 'ring-1 ring-blue-500/60 bg-blue-500/10' : ''}`}
@@ -619,6 +629,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
               selectedPaths={selectedPaths}
               onSelect={onSelect}
               onFileOpen={onFileOpen}
+              onDeletePaths={onDeletePaths}
               onTreeChanged={onTreeChanged}
               refreshSignal={refreshSignal}
               visiblePaths={visiblePaths}

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -27,6 +27,7 @@ export const ProjectList: React.FC = () => {
   }, [workspaces])
 
   const handleWorkspaceClick = useCallback((index: number, wsId: string, e?: React.MouseEvent) => {
+    // Shift-click — select the contiguous range from the anchor to here.
     if (e?.shiftKey && lastClickedIndexRef.current !== null) {
       const start = Math.min(lastClickedIndexRef.current, index)
       const end = Math.max(lastClickedIndexRef.current, index)
@@ -35,6 +36,19 @@ export const ProjectList: React.FC = () => {
         rangeIds.add(workspaces[i].id)
       }
       setMultiSelected(rangeIds)
+      return
+    }
+
+    // Cmd/Ctrl-click — toggle this workspace in/out of the multi-selection
+    // (matches the file explorer's multi-select).
+    if (e?.metaKey || e?.ctrlKey) {
+      setMultiSelected((prev) => {
+        const next = new Set(prev)
+        if (next.has(wsId)) next.delete(wsId)
+        else next.add(wsId)
+        return next
+      })
+      lastClickedIndexRef.current = index
       return
     }
 
@@ -99,6 +113,7 @@ export const ProjectList: React.FC = () => {
       className="flex flex-col h-full"
       ref={containerRef}
       tabIndex={-1}
+      data-sidebar-keynav
       onKeyDown={handleKeyDown}
     >
       <SidebarSectionHeader
@@ -110,8 +125,11 @@ export const ProjectList: React.FC = () => {
         }
       />
 
-      {/* Scrollable workspace list */}
-      <div className="flex-1 overflow-y-auto py-1">
+      {/* Scrollable workspace list. No top padding so the first row sits flush
+          beneath the 36px header — matching the canvas dock tab bar, whose
+          content starts flush below its bar. A top gap makes the header read
+          as taller than the canvas header. */}
+      <div className="flex-1 overflow-y-auto pb-1">
         <div className="flex flex-col">
           {displayWorkspaces.map((ws, index) => {
             const isLast = index === displayWorkspaces.length - 1

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -338,6 +338,12 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
     <div
       className={`flex-1 min-w-0 flex flex-col h-full overflow-hidden transition-opacity duration-200 relative ${
         isExpanded ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      } ${
+        // Left sidebar's vertical scrollbar is on its right edge — exactly where
+        // the 6px resize handle sits. Inset the content by the handle width so
+        // the scrollbar clears it and stays draggable. (The right sidebar's
+        // scrollbar is next to its activity bar, away from its handle.)
+        side === 'left' ? 'pr-1' : ''
       }`}
     >
       <div className="flex-1 min-h-0 overflow-hidden relative">
@@ -364,6 +370,7 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
 
   return (
     <div
+      data-sidebar-scrollarea
       className={`flex-shrink-0 relative flex flex-row h-full select-none overflow-hidden ${
         isResizing ? '' : 'transition-[width] duration-200 ease-in-out'
       }`}
@@ -408,7 +415,7 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
       {/* Resize handle on the inner edge, only when expanded */}
       {isExpanded && (
         <div
-          className={`absolute top-0 ${side === 'left' ? 'right-0' : 'left-0'} w-[6px] h-full cursor-col-resize z-10 ${
+          className={`absolute top-0 ${side === 'left' ? 'right-0' : 'left-0'} w-[4px] h-full cursor-col-resize z-10 ${
             isResizing ? 'bg-blue-500/30' : ''
           }`}
           onMouseDown={handleResizeDown}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -489,6 +489,9 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   }, [workspace.name, workspace.rootPath])
 
   const handleTitleClick = useCallback((e: React.MouseEvent) => {
+    // Modified clicks are multi-select gestures — let them fall through to the
+    // row handler instead of entering rename.
+    if (e.shiftKey || e.metaKey || e.ctrlKey) return
     // First click selects the workspace (parent handler). Once selected, a
     // click on the title enters rename mode — replacing the dedicated pencil.
     if (!isSelected) return

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -119,6 +119,27 @@
   }
 }
 
+/* Sidebar scrollbars: a touch thicker, squared-off, and only visible while the
+   pointer is over the sidebar. The thumb is transparent until then (its track
+   space stays reserved, so revealing it doesn't shift the content). Unlayered
+   so it overrides the @layer base defaults above. */
+[data-sidebar-scrollarea] ::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+[data-sidebar-scrollarea] ::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 0;
+  /* Fade the thumb in/out as the pointer enters/leaves the sidebar. */
+  transition: background-color 280ms ease;
+}
+[data-sidebar-scrollarea]:hover ::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+}
+[data-sidebar-scrollarea]:hover ::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
 /* Electron window drag region */
 .titlebar-drag {
   -webkit-app-region: drag;


### PR DESCRIPTION
## Summary
Polish pass on the left sidebar (workspaces + file explorer).

- **Header alignment** — the Workspaces header read as taller than the canvas tab bar; both are 36px, but the list's top padding pushed the first row down. Removed it so the first row sits flush (matches the canvas content).
- **Multi-delete** — `Cmd/Delete` was being swallowed by the canvas-level shortcut handler (capture phase). Added a `data-sidebar-keynav` guard so it reaches the sidebar. Workspaces delete the multi-selection; the file explorer now deletes the whole selection from **both** the keyboard and the right-click menu ("Delete N Items") in a single confirm.
- **Multi-select** — explorer shift-range now uses the actual rendered row order (DOM) instead of the top-level-only `visiblePaths`, so ranges work across expanded folders. Workspaces gain **Cmd/Ctrl-click** toggle; modified clicks on a workspace title no longer start a rename.
- **Scrollbar / resize handle** — inset the left sidebar's scroll content so the scrollbar clears the resize handle; slimmed the handle to 4px; restyled the sidebar scrollbar (squared, slightly thicker, fades in on hover).

## Testing
- `npm run typecheck` clean
- `npm test` — 532 passed / 3 skipped
- Verified live in the dev app (header alignment + scrollbar). Multi-select/delete verified interactively.