### PR TITLE
feat(agent): track agent messages sent for analytics

### DIFF
--- a/src/agent/main/ipcAgent.ts
+++ b/src/agent/main/ipcAgent.ts
@@ -63,6 +63,7 @@ import { deleteSession, listSessions, loadSessionTranscript } from './sessionFil
 import { agentDirFor } from './agentDir'
 import { readCustomOpenAI, saveCustomOpenAI } from './customModels'
 import log from '../../main/logger'
+import { sendEvent } from '../../main/analytics'
 import type {
   AgentCreateOptions,
   AgentExtensionUIResponse,
@@ -73,6 +74,16 @@ import type {
 } from '../../shared/types'
 import type { AuthManager } from './authManager'
 import type { AgentManager } from './agentManager'
+
+// Anonymous telemetry for user-sent agent messages. We record only the kind of
+// message, its length, and whether it carried images — never the message text.
+function trackMessageSent(kind: 'prompt' | 'steer' | 'follow_up', text: string, images?: unknown[]): void {
+  void sendEvent('agent_message_sent', {
+    kind,
+    chars: typeof text === 'string' ? text.length : 0,
+    has_images: Array.isArray(images) && images.length > 0,
+  })
+}
 
 export function registerAgentHandlers(_authManager: AuthManager, agentManager: AgentManager): void {
   ipcMain.handle(AGENT_CREATE, async (event, options: AgentCreateOptions) => {
@@ -89,6 +100,7 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
   ipcMain.handle(
     AGENT_PROMPT,
     async (_event, panelId: string, text: string, images?: AgentImageAttachment[]) => {
+      trackMessageSent('prompt', text, images)
       await agentManager.prompt(panelId, text, images)
     },
   )
@@ -96,6 +108,7 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
   ipcMain.handle(
     AGENT_STEER,
     async (_event, panelId: string, text: string, images?: AgentImageAttachment[]) => {
+      trackMessageSent('steer', text, images)
       await agentManager.steer(panelId, text, images)
     },
   )
@@ -103,6 +116,7 @@ export function registerAgentHandlers(_authManager: AuthManager, agentManager: A
   ipcMain.handle(
     AGENT_FOLLOW_UP,
     async (_event, panelId: string, text: string, images?: AgentImageAttachment[]) => {
+      trackMessageSent('follow_up', text, images)
       await agentManager.followUp(panelId, text, images)
     },
   )

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -11,6 +11,8 @@
 //   - update_manual_open_clicked : user clicked through to GitHub release page
 //   - feedback_submitted       : 1-5 rating + optional free-text comment, post-update
 //   - feedback_dismissed       : user skipped/closed the post-update feedback dialog
+//   - agent_message_sent       : user sent a message to an agent — kind (prompt/
+//                                steer/follow_up), char count, has_images. No text.
 //
 // What we deliberately do NOT send: file paths, project names, workspace
 // contents, hostname, IP-derived identifiers, user account info.


### PR DESCRIPTION
## Summary
Emits an anonymous `agent_message_sent` telemetry event whenever a user sends a message to an agent, so message volume shows up on the cero-analytics dashboard (the dashboard side — KPI card + chart + `/api/stats/app-messages` — is already merged).

## Changes
- **`src/agent/main/ipcAgent.ts`**: a `trackMessageSent()` helper wired into the main-process `AGENT_PROMPT`, `AGENT_STEER`, and `AGENT_FOLLOW_UP` handlers. Capturing in main (not the renderer) means every user message counts regardless of which UI sent it (sidebar, dock, detached window, or the `cate` skill). Reuses the existing `sendEvent` pipeline, so it respects `usageAnalyticsEnabled` and the offline buffer.
- **`src/main/analytics.ts`**: documents the new event in the header comment.

## Privacy
The event carries only the message `kind` (prompt/steer/follow_up), character count, and a `has_images` flag — **never the message text** — matching analytics.ts's documented stance.