### PR TITLE
fix(agent): report custom OpenAI endpoint as connected

### DIFF
--- a/src/agent/main/authManager.ts
+++ b/src/agent/main/authManager.ts
@@ -24,6 +24,7 @@ import {
 } from '@earendil-works/pi-ai'
 import { getOAuthProvider, getOAuthProviders } from '@earendil-works/pi-ai/oauth'
 import { sharedAuthPath } from './agentDir'
+import { readCustomOpenAI } from './customModels'
 import log from '../../main/logger'
 import type {
   AuthProviderDescriptor,
@@ -188,6 +189,18 @@ export class AuthManager {
         connectedAt: connected ? this.connectedAt.get(p.id) : undefined,
       })
     }
+
+    // Custom OpenAI-compatible endpoint (lives in models.json, not auth.json).
+    // Connected once a baseUrl and at least one model are configured — the key
+    // is optional since local servers (Ollama, LM Studio, vLLM) ignore it.
+    const custom = await readCustomOpenAI()
+    const customConnected = !!custom && !!custom.baseUrl && custom.models.length > 0
+    result.push({
+      id: 'custom-openai',
+      connected: customConnected,
+      source: customConnected ? 'config' : undefined,
+      connectedAt: customConnected ? this.connectedAt.get('custom-openai') : undefined,
+    })
 
     return result
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1010,7 +1010,7 @@ export interface AuthProviderStatus {
   /** Last connect time as ISO string, if known. */
   connectedAt?: string
   /** Where the credential lives. */
-  source?: 'oauth' | 'safeStorage' | 'env'
+  source?: 'oauth' | 'safeStorage' | 'env' | 'config'
 }
 
 /** A user-defined OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, a


### PR DESCRIPTION
Configured custom OpenAI endpoint showed "Connect custom-openai to start" with a disabled chat input, even though Settings said "Configured".

`authManager.status()` only looked at auth.json and built-in providers, so the custom-openai config (stored in models.json) never showed as connected. Now it reports connected when a baseUrl and at least one model are set. Key stays optional since local servers ignore it.

Closes #247