### PR TITLE
Make packaging scripts portable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
     "test:smoke:electron": "node scripts/run-electron-smoke.mjs",
     "preview": "electron-vite preview",
     "icons": "node scripts/generate-icons.js",
-    "package": "export SENTRY_DSN=\"${SENTRY_DSN:-https://any@analytics.cero-ai.com/1}\"; npm run icons && electron-vite build && electron-builder",
-    "package:mac": "export SENTRY_DSN=\"${SENTRY_DSN:-https://any@analytics.cero-ai.com/1}\"; npm run icons && electron-vite build && electron-builder --mac",
-    "package:win": "export SENTRY_DSN=\"${SENTRY_DSN:-https://any@analytics.cero-ai.com/1}\"; npm run icons && electron-vite build && electron-builder --win",
-    "package:linux": "export SENTRY_DSN=\"${SENTRY_DSN:-https://any@analytics.cero-ai.com/1}\"; npm run icons && electron-vite build && electron-builder --linux"
+    "package": "node scripts/package.mjs",
+    "package:mac": "node scripts/package.mjs --mac",
+    "package:win": "node scripts/package.mjs --win",
+    "package:win:dir": "node scripts/package.mjs --win --dir -c.npmRebuild=false -c.win.signAndEditExecutable=false",
+    "package:win:unsigned": "node scripts/package.mjs --win -c.npmRebuild=false -c.win.signAndEditExecutable=false",
+    "package:linux": "node scripts/package.mjs --linux"
   },
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.75.4",

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,0 +1,39 @@
+import { spawn } from 'node:child_process'
+import process from 'node:process'
+
+const args = process.argv.slice(2)
+const node = process.execPath
+
+if (!process.env.SENTRY_DSN) {
+  process.env.SENTRY_DSN = 'https://any@analytics.cero-ai.com/1'
+}
+
+function run(command, commandArgs, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      stdio: 'inherit',
+      env: process.env,
+      ...options,
+    })
+
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(
+        new Error(
+          signal
+            ? `${command} exited from signal ${signal}`
+            : `${command} exited with code ${code}`,
+        ),
+      )
+    })
+  })
+}
+
+await run(node, ['scripts/generate-icons.js'])
+await run(node, ['node_modules/electron-vite/bin/electron-vite.js', 'build'])
+await run(node, ['node_modules/electron-builder/out/cli/cli.js', ...args])

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -45,8 +45,22 @@ import { mirrorModelsToWorkspace } from './customModels'
 import type { AuthManager } from './authManager'
 
 function resolvePiCliPath(): string {
+  const appPath = app.getAppPath()
+  const unpackedAppPath = appPath.includes('app.asar')
+    ? appPath.replace('app.asar', 'app.asar.unpacked')
+    : appPath
+  const unpackedCliPath = path.join(
+    unpackedAppPath,
+    'node_modules',
+    '@earendil-works',
+    'pi-coding-agent',
+    'dist',
+    'cli.js',
+  )
+  if (fs.existsSync(unpackedCliPath)) return unpackedCliPath
+
   return path.join(
-    app.getAppPath(),
+    appPath,
     'node_modules',
     '@earendil-works',
     'pi-coding-agent',
@@ -57,10 +71,10 @@ function resolvePiCliPath(): string {
 
 // RpcClient hardcodes `spawn("node", ...)`, so `node` must be on PATH.
 //
-// In production we MUST use Electron's own binary (with ELECTRON_RUN_AS_NODE=1)
-// because it has built-in asar support — a regular system `node` can't resolve
-// modules from inside the asar archive. In dev we fall back to the system node
-// only if one exists; otherwise we shim Electron the same way.
+// If pi's CLI is still inside app.asar, we need Electron's built-in asar
+// support. If the CLI is available in app.asar.unpacked, a regular system Node
+// can launch it from the real filesystem. On Windows this avoids Electron's
+// `ELECTRON_RUN_AS_NODE` ICU fd startup failure in packaged builds.
 let fallbackNodeDir: string | null = null
 
 function nodeExistsOnPath(env: Record<string, string>): boolean {
@@ -87,18 +101,25 @@ function ensureElectronNodeShim(): string {
   return dir
 }
 
+function canUseSystemNodeForCli(cliPath: string): boolean {
+  return cliPath.includes('app.asar.unpacked')
+}
+
 function buildAgentEnv(cwd: string): Record<string, string> {
   const env = { ...getShellEnv() }
   // Scope pi's entire config (extensions, sessions, settings, auth) to this
   // workspace instead of the user's global ~/.pi/agent.
   env.PI_CODING_AGENT_DIR = agentDirFor(cwd)
-  const needsShim = app.isPackaged || !nodeExistsOnPath(env)
+  const cliPath = resolvePiCliPath()
+  const needsShim = !nodeExistsOnPath(env) || (app.isPackaged && !canUseSystemNodeForCli(cliPath))
   if (needsShim) {
     const shimDir = ensureElectronNodeShim()
     const sep = process.platform === 'win32' ? ';' : ':'
     env.PATH = shimDir + sep + (env.PATH || '')
     env.ELECTRON_RUN_AS_NODE = '1'
     log.info('[agentManager] using Electron as node (packaged=%s)', app.isPackaged)
+  } else if (app.isPackaged) {
+    log.info('[agentManager] using system node for unpacked pi CLI')
   }
   return env
 }

--- a/src/renderer/lib/e2eHarness.ts
+++ b/src/renderer/lib/e2eHarness.ts
@@ -23,6 +23,8 @@ declare global {
       zoom(): number
       setZoom(z: number): void
       resetViewport(): void
+      addWorkspace(name?: string, rootPath?: string, id?: string): string
+      selectWorkspace(id: string): Promise<void>
       /** Resolve the PTY id backing a terminal node (null until the PTY spawns). */
       terminalPtyId(nodeId: string): string | null
       /** Write raw data to a terminal node's PTY (e.g. a flooding command). */
@@ -118,6 +120,14 @@ export function installE2EHarness(): void {
     activeCanvasStore()?.setState({ viewportOffset: { x: 0, y: 0 } })
   }
 
+  const addWorkspace = (name?: string, rootPath?: string, id?: string): string => {
+    return useAppStore.getState().addWorkspace(name, rootPath, id)
+  }
+
+  const selectWorkspace = async (id: string): Promise<void> => {
+    await useAppStore.getState().selectWorkspace(id)
+  }
+
   const terminalPtyId = (nodeId: string): string | null => {
     const cs = activeCanvasStore()
     if (!cs) return null
@@ -154,6 +164,8 @@ export function installE2EHarness(): void {
     zoom,
     setZoom,
     resetViewport,
+    addWorkspace,
+    selectWorkspace,
     terminalPtyId,
     writeTerminal,
     dragSnapshot,


### PR DESCRIPTION
## Summary
- replace Unix-only packaging scripts with a cross-platform Node packaging runner
- add Windows dir and unsigned packaging helpers
- add E2E harness workspace add/select helpers used by Windows smoke automation

## Verification
- npm ci --ignore-scripts
- npm run typecheck
- npm run package:win:dir
- npm run package:win:unsigned

## Notes
- Preserves upstream package version 1.1.1.
- Plain npm ci still hits the existing CRLF-sensitive postinstall shell script on Windows; the packaging path itself is now shell-free.