### PR TITLE
feat(canvas): add Text element

### DIFF
--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -509,6 +509,100 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
   if (!node) return null
 
+  // ---------------------------------------------------------------------------
+  // Bare text node — text elements live directly on the canvas with no window
+  // chrome (no tab bar, border, or background). The whole block is the drag
+  // handle when unfocused; when focused it becomes editable. Resize handles
+  // show only while active. Everything else (move, resize, focus, z-order,
+  // persistence) reuses the normal canvas-node machinery.
+  // ---------------------------------------------------------------------------
+  if (primaryPanelType === 'text') {
+    const textPanelId = primaryPanel?.id ?? node.panelId
+    const active = isFocused || isSelected
+    return (
+      <>
+        <div
+          ref={nodeRef}
+          data-node-id={nodeId}
+          data-node-active={isFocused ? 'true' : 'false'}
+          style={{
+            ...containerStyle,
+            background: 'transparent',
+            backgroundColor: 'transparent',
+            border: 'none',
+            boxShadow: 'none',
+            borderRadius: 0,
+            overflow: 'visible',
+            outline: active ? '1.5px solid var(--focus-blue)' : 'none',
+            outlineOffset: 2,
+            userSelect: 'auto',
+          }}
+          onClick={handleClick}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          {/* Text content (editable once the node is focused). */}
+          <div style={{ width: '100%', height: '100%' }}>
+            {renderPanel(textPanelId)}
+          </div>
+          {/* Drag layer — on top while unfocused so a press moves the block and
+              a click focuses it. Disabled once focused so the text is editable. */}
+          <div
+            onMouseDown={(e) => {
+              if (isFocused || e.button !== 0) return
+              if (handToolPanShouldWin(e)) return
+              e.stopPropagation()
+              handleDragStart(e)
+            }}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 2,
+              cursor: isFocused ? 'text' : 'grab',
+              pointerEvents: isFocused ? 'none' : 'auto',
+            }}
+          />
+
+          {/* Close / delete — appears while the block is active or hovered. */}
+          {(active || isHovered) && (
+            <button
+              type="button"
+              title="Delete text"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleClose()
+              }}
+              className="absolute flex items-center justify-center w-5 h-5 rounded-full border border-subtle bg-surface-0 text-secondary hover:text-primary hover:bg-hover-strong shadow-[0_4px_12px_-4px_var(--shadow-node)]"
+              style={{ top: -8, right: -8, zIndex: 3 }}
+            >
+              <X size={11} weight="bold" />
+            </button>
+          )}
+        </div>
+
+        {/* Resize handles — only while active, to keep the block clean. */}
+        {!isWholeNodeDragSource && (active || isHovered) && (
+          <div
+            aria-hidden
+            data-resize-frame-for={nodeId}
+            style={{
+              position: 'absolute',
+              left: node.origin.x,
+              top: node.origin.y,
+              width: node.size.width,
+              height: node.size.height,
+              zIndex: 1000 + node.zOrder,
+              pointerEvents: 'none',
+            }}
+          >
+            <NodeResizeOverlay onResizeStart={handleResizeStartGuarded} />
+          </div>
+        )}
+      </>
+    )
+  }
+
   return (
     <>
     {glowStyle && <div aria-hidden data-glow-for={nodeId} style={glowStyle} />}

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -8,6 +8,7 @@ import {
   Terminal,
   Globe,
   FileText,
+  TextT,
   Minus,
   Plus,
   Square,
@@ -47,6 +48,7 @@ interface CanvasToolbarProps {
   onNewBrowser: () => void
   onNewEditor: () => void
   onNewAgent: () => void
+  onNewText: () => void
   onNewCanvas: () => void
   onNewRegion: () => void
   onAutoLayout: () => void
@@ -127,6 +129,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   onNewBrowser,
   onNewEditor,
   onNewAgent,
+  onNewText,
   onNewCanvas,
   onNewRegion,
   onAutoLayout,
@@ -231,6 +234,11 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
             data-theme="dark-warm"
             className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 min-w-[200px] rounded-lg border border-subtle bg-surface-4/95 backdrop-blur-xl backdrop-saturate-150 shadow-[0_10px_30px_-10px_var(--shadow-node)] p-1"
           >
+            <MenuItem
+              onClick={pick(onNewText)}
+              icon={<TextT size={16} />}
+              label="New Text"
+            />
             <MenuItem
               onClick={pick(onNewRegion)}
               icon={<Square size={16} />}

--- a/src/renderer/lib/session.ts
+++ b/src/renderer/lib/session.ts
@@ -128,6 +128,11 @@ function buildWorkspaceFile(
     url: n.url ?? undefined,
     regionId: n.regionId,
     documentType: n.documentType,
+    text: n.text,
+    textColor: n.textColor,
+    textBgColor: n.textBgColor,
+    textFontSize: n.textFontSize,
+    textFontFamily: n.textFontFamily,
   }))
 
   const regions: ProjectCanvasRegion[] = snapshot.regions
@@ -240,6 +245,11 @@ export async function saveSession(): Promise<void> {
           ? panel?.unsavedContent
           : undefined,
         documentType: panel?.documentType,
+        text: panel?.type === 'text' ? panel?.text : undefined,
+        textColor: panel?.type === 'text' ? panel?.textColor : undefined,
+        textBgColor: panel?.type === 'text' ? panel?.textBgColor : undefined,
+        textFontSize: panel?.type === 'text' ? panel?.textFontSize : undefined,
+        textFontFamily: panel?.type === 'text' ? panel?.textFontFamily : undefined,
       }
     })
 
@@ -427,6 +437,11 @@ export function projectFilesToSnapshot(
       url: pn.url,
       regionId: pn.regionId,
       documentType: pn.documentType,
+      text: pn.text,
+      textColor: pn.textColor,
+      textBgColor: pn.textBgColor,
+      textFontSize: pn.textFontSize,
+      textFontFamily: pn.textFontFamily,
       ptyId: ephemeral?.ptyId,
       workingDirectory: ephemeral?.workingDirectory,
       unsavedContent: ephemeral?.unsavedContent,
@@ -675,6 +690,30 @@ export async function restoreSession(snapshot: SessionSnapshot, canvasStoreApi?:
       case 'document': {
         const panelId = appStore.createDocument(wsId, nodeSnap.filePath ?? undefined, nodeSnap.documentType, position)
         if (nodeSnap.title) appStore.updatePanelTitle(wsId, panelId, nodeSnap.title)
+        const canvasState = getCanvasState()
+        if (canvasState) {
+          const newNodeId = canvasState.nodeForPanel(panelId)
+          if (newNodeId) {
+            canvasState.moveNode(newNodeId, position)
+            canvasState.resizeNode(newNodeId, size)
+            if (nodeSnap.regionId) {
+              const mappedRegionId = regionIdMap.get(nodeSnap.regionId)
+              if (mappedRegionId) canvasState.setNodeRegion(newNodeId, mappedRegionId)
+            }
+          }
+        }
+        break
+      }
+      case 'text': {
+        const panelId = appStore.createText(wsId, position)
+        if (nodeSnap.title) appStore.updatePanelTitle(wsId, panelId, nodeSnap.title)
+        appStore.updateTextPanel(wsId, panelId, {
+          text: nodeSnap.text ?? '',
+          textColor: nodeSnap.textColor,
+          textBgColor: nodeSnap.textBgColor,
+          textFontSize: nodeSnap.textFontSize,
+          textFontFamily: nodeSnap.textFontFamily,
+        })
         const canvasState = getCanvasState()
         if (canvasState) {
           const newNodeId = canvasState.nodeForPanel(panelId)

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -254,6 +254,11 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
     if (wsId) useAppStore.getState().createAgent(wsId)
   }, [workspaceId])
 
+  const onNewText = useCallback(async () => {
+    const wsId = await ensureWorkspaceFolder(workspaceId)
+    if (wsId) useAppStore.getState().createText(wsId)
+  }, [workspaceId])
+
   const onZoomIn = useCallback(() => {
     store.getState().animateZoomTo(zoomLevel + 0.1)
   }, [zoomLevel, store])
@@ -328,6 +333,7 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
             onNewBrowser={onNewBrowser}
             onNewEditor={onNewEditor}
             onNewAgent={onNewAgent}
+            onNewText={onNewText}
             onNewCanvas={onNewCanvas}
             onNewRegion={onNewRegion}
             onAutoLayout={onAutoLayout}

--- a/src/renderer/panels/TextPanel.tsx
+++ b/src/renderer/panels/TextPanel.tsx
@@ -1,0 +1,218 @@
+// =============================================================================
+// TextPanel — a free-form text element that lives directly on the canvas with
+// no window chrome (the bare rendering lives in CanvasNode). The whole element
+// shares one text color, fill color, font size and font family. A compact
+// floating toolbar appears above the block while it's active. Content +
+// styling persist on the PanelState; position/size persist on the canvas node.
+// =============================================================================
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Minus, Plus, TextAa, PaintBucket } from '@phosphor-icons/react'
+import type { PanelProps } from './types'
+import { useAppStore } from '../stores/appStore'
+import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
+
+// Curated font stacks. Values are full CSS font-family stacks so they degrade
+// gracefully on machines that lack the preferred face.
+const FONT_FAMILIES: { label: string; value: string }[] = [
+  { label: 'System', value: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' },
+  { label: 'Serif', value: 'Georgia, "Times New Roman", Times, serif' },
+  { label: 'Mono', value: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace' },
+  { label: 'Rounded', value: '"SF Pro Rounded", "Hiragino Maru Gothic ProN", "Nunito", system-ui, sans-serif' },
+]
+
+const FONT_SIZE_MIN = 8
+const FONT_SIZE_MAX = 200
+const DEFAULT_FONT_SIZE = 24
+const DEFAULT_FONT_FAMILY = FONT_FAMILIES[0].value
+// Shown in the color pickers before the user has chosen a value. The rendered
+// text falls back to the theme's primary color; the fill falls back to none.
+const DEFAULT_TEXT_PICKER = '#E6E6E6'
+const DEFAULT_FILL_PICKER = '#FFD60A'
+// Tiny checkerboard so a transparent fill swatch reads as "none".
+const CHECKER =
+  'repeating-conic-gradient(#888 0% 25%, #ccc 0% 50%) 50% / 8px 8px'
+
+const clampFontSize = (n: number): number =>
+  Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, Math.round(n)))
+
+// Compact color swatch with a hidden native color input layered on top.
+function Swatch({
+  icon,
+  title,
+  value,
+  display,
+  onChange,
+}: {
+  icon: React.ReactNode
+  title: string
+  value: string
+  display: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <label
+      className="relative flex items-center gap-1 cursor-pointer text-secondary hover:text-primary"
+      title={title}
+    >
+      {icon}
+      <span
+        className="w-4 h-4 rounded border border-subtle shrink-0"
+        style={{ background: display }}
+      />
+      <input
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+      />
+    </label>
+  )
+}
+
+export default function TextPanel({ panelId, workspaceId, nodeId }: PanelProps) {
+  const panel = useAppStore((s) => {
+    const ws =
+      s.workspaces.find((w) => w.id === workspaceId) ??
+      s.workspaces.find((w) => w.id === s.selectedWorkspaceId)
+    return ws?.panels[panelId]
+  })
+  const updateTextPanel = useAppStore((s) => s.updateTextPanel)
+  // Whether this element's canvas node is currently active (focused/selected).
+  // Drives toolbar visibility and auto-focus. Falls back to false in contexts
+  // without a canvas store (text only ever lives on the canvas).
+  const isNodeActive = useCanvasStoreContext((s) =>
+    nodeId ? s.focusedNodeId === nodeId || s.selectedNodeIds.has(nodeId) : false,
+  )
+
+  const text = panel?.text ?? ''
+  const color = panel?.textColor
+  const bg = panel?.textBgColor
+  const fontSize = panel?.textFontSize ?? DEFAULT_FONT_SIZE
+  const fontFamily = panel?.textFontFamily ?? DEFAULT_FONT_FAMILY
+
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  const [hovered, setHovered] = useState(false)
+  const [focused, setFocused] = useState(false)
+
+  // Make a freshly created or just-selected text block immediately editable.
+  useEffect(() => {
+    if (isNodeActive && taRef.current && document.activeElement !== taRef.current) {
+      taRef.current.focus()
+    }
+  }, [isNodeActive])
+
+  const patch = useCallback(
+    (p: Parameters<typeof updateTextPanel>[2]) => updateTextPanel(workspaceId, panelId, p),
+    [updateTextPanel, workspaceId, panelId],
+  )
+
+  const setFontSize = useCallback(
+    (next: number) => patch({ textFontSize: clampFontSize(next) }),
+    [patch],
+  )
+
+  const showToolbar = isNodeActive || focused || hovered
+  const colorStyle = color ?? 'var(--text-primary)'
+
+  return (
+    <div
+      className="relative w-full h-full"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Floating formatting toolbar — sits just above the block while active. */}
+      {showToolbar && (
+        <div
+          className="absolute left-0 -top-10 flex items-center gap-2 px-2 py-1 rounded-lg border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)] text-secondary"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Swatch
+            icon={<TextAa size={14} />}
+            title="Text color"
+            value={color ?? DEFAULT_TEXT_PICKER}
+            display={color ?? DEFAULT_TEXT_PICKER}
+            onChange={(v) => patch({ textColor: v })}
+          />
+          <Swatch
+            icon={<PaintBucket size={14} />}
+            title="Fill color"
+            value={bg ?? DEFAULT_FILL_PICKER}
+            display={bg ?? CHECKER}
+            onChange={(v) => patch({ textBgColor: v })}
+          />
+
+          <div className="w-px h-4 bg-surface-5" />
+
+          {/* Font size */}
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => setFontSize(fontSize - 2)}
+              title="Decrease font size"
+              className="w-5 h-5 flex items-center justify-center rounded hover:bg-hover-strong hover:text-primary"
+            >
+              <Minus size={12} />
+            </button>
+            <input
+              type="number"
+              min={FONT_SIZE_MIN}
+              max={FONT_SIZE_MAX}
+              value={fontSize}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10)
+                if (!Number.isNaN(n)) setFontSize(n)
+              }}
+              title="Font size (px)"
+              className="w-10 h-5 text-center text-[11px] tabular-nums rounded bg-surface-2 text-primary border border-subtle outline-none focus:border-focus"
+            />
+            <button
+              type="button"
+              onClick={() => setFontSize(fontSize + 2)}
+              title="Increase font size"
+              className="w-5 h-5 flex items-center justify-center rounded hover:bg-hover-strong hover:text-primary"
+            >
+              <Plus size={12} />
+            </button>
+          </div>
+
+          <div className="w-px h-4 bg-surface-5" />
+
+          {/* Font family */}
+          <select
+            value={fontFamily}
+            onChange={(e) => patch({ textFontFamily: e.target.value })}
+            title="Font family"
+            className="h-5 max-w-[7rem] text-[11px] rounded bg-surface-2 text-primary border border-subtle outline-none focus:border-focus px-1 cursor-pointer"
+          >
+            {FONT_FAMILIES.map((f) => (
+              <option key={f.label} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Editable text + fill */}
+      <textarea
+        ref={taRef}
+        value={text}
+        onChange={(e) => patch({ text: e.target.value })}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Type something…"
+        spellCheck={false}
+        className="w-full h-full resize-none outline-none px-2 py-1.5 leading-snug placeholder:text-muted"
+        style={{
+          color: colorStyle,
+          fontSize: `${fontSize}px`,
+          fontFamily,
+          background: bg ?? 'transparent',
+          borderRadius: 6,
+        }}
+      />
+    </div>
+  )
+}

--- a/src/renderer/panels/registry.ts
+++ b/src/renderer/panels/registry.ts
@@ -19,6 +19,7 @@ import {
   FileText,
   SquaresFour,
   FileDoc,
+  TextT,
   type Icon as PhosphorIcon,
 } from '@phosphor-icons/react'
 import { CateLogo } from '../ui/CateLogo'
@@ -40,6 +41,7 @@ const BrowserPanel = React.lazy(() => import('./BrowserPanel'))
 const CanvasPanel = React.lazy(() => import('./CanvasPanel'))
 const AgentPanel = React.lazy(() => import('../../agent/renderer/AgentPanel'))
 const DocumentPanel = React.lazy(() => import('./DocumentPanel'))
+const TextPanel = React.lazy(() => import('./TextPanel'))
 
 // -----------------------------------------------------------------------------
 // Renderer definition
@@ -119,6 +121,13 @@ export const PANEL_REGISTRY: Record<PanelType, RendererPanelDefinition> = {
     Component: DocumentPanel,
     create: ({ workspaceId, canvasPoint, placement, filePath, documentType }) =>
       useAppStore.getState().createDocument(workspaceId, filePath, documentType, canvasPoint, placement) || null,
+  },
+  text: {
+    ...PANEL_DEFINITIONS.text,
+    icon: TextT,
+    Component: TextPanel,
+    create: ({ workspaceId, canvasPoint, placement }) =>
+      useAppStore.getState().createText(workspaceId, canvasPoint, placement) || null,
   },
 }
 

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -302,6 +302,7 @@ interface AppStoreActions {
   createCanvas: (workspaceId: string, position?: Point, placement?: PanelPlacement) => string
   createAgent: (workspaceId: string, position?: Point, placement?: PanelPlacement) => string
   createDocument: (workspaceId: string, filePath?: string, documentType?: 'pdf' | 'docx' | 'image', position?: Point, placement?: PanelPlacement) => string
+  createText: (workspaceId: string, position?: Point, placement?: PanelPlacement) => string
 
   // Ensure the center dock zone contains a canvas panel for the given workspace.
   // Covers session-restore and new-workspace paths where the center layout may
@@ -322,6 +323,8 @@ interface AppStoreActions {
   setPanelDirty: (workspaceId: string, panelId: string, dirty: boolean) => void
   setPanelMarkdownPreview: (workspaceId: string, panelId: string, preview: boolean) => void
   setPanelUnsavedContent: (workspaceId: string, panelId: string, content: string | undefined) => void
+  /** Text panels only: patch the note body and/or styling. */
+  updateTextPanel: (workspaceId: string, panelId: string, patch: Partial<Pick<PanelState, 'text' | 'textColor' | 'textBgColor' | 'textFontSize' | 'textFontFamily'>>) => void
   addPanel: (workspaceId: string, panel: PanelState) => void
 
   // Helpers
@@ -854,6 +857,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
     return addAndPlacePanel(set, get, workspaceId, panel, placement, position)
   },
 
+  createText(workspaceId, position?, placement?) {
+    const panel: PanelState = {
+      id: generateId(),
+      type: 'text',
+      title: 'Text',
+      isDirty: false,
+      text: '',
+      textFontSize: 24,
+    }
+    return addAndPlacePanel(set, get, workspaceId, panel, placement, position)
+  },
+
   // --- Panel management ---
 
   closePanel(workspaceId, panelId) {
@@ -950,6 +965,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   setPanelUnsavedContent(workspaceId, panelId, content) {
     setPanelField(set, workspaceId, panelId, (panel) => ({ ...panel, unsavedContent: content }))
+  },
+
+  updateTextPanel(workspaceId, panelId, patch) {
+    setPanelField(set, workspaceId, panelId, (panel) => ({ ...panel, ...patch }))
   },
 
   addPanel(workspaceId, panel) {

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -10,6 +10,7 @@ import {
   Terminal,
   Globe,
   FileText,
+  TextT,
   SquaresFour,
   Sidebar,
   FolderOpen,
@@ -57,6 +58,7 @@ const RectangleIcon = () => <Square size={ICON_SIZE} />
 const SaveIcon = () => <FloppyDisk size={ICON_SIZE} />
 const ReloadIcon = () => <ArrowsClockwise size={ICON_SIZE} />
 const AgentIcon = () => <CateLogo size={ICON_SIZE} />
+const TextIcon = () => <TextT size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
 // Search result types (merged from GlobalSearch)
@@ -91,6 +93,7 @@ export const CommandPalette: React.FC = () => {
   const createEditor = useAppStore((s) => s.createEditor)
   const createCanvas = useAppStore((s) => s.createCanvas)
   const createAgent = useAppStore((s) => s.createAgent)
+  const createText = useAppStore((s) => s.createText)
   const toggleSidebar = useUIStore((s) => s.toggleSidebar)
   const setActiveRightSidebarView = useUIStore((s) => s.setActiveRightSidebarView)
   const canvasApi = useCanvasStoreApi()
@@ -146,6 +149,13 @@ export const CommandPalette: React.FC = () => {
         shortcutText: '',
         icon: <AgentIcon />,
         action: () => createAgent(selectedWorkspaceId, undefined, dockCenter),
+      },
+      {
+        id: 'newText',
+        title: 'New Text',
+        shortcutText: '',
+        icon: <TextIcon />,
+        action: () => createText(selectedWorkspaceId),
       },
       {
         id: 'newCanvas',
@@ -227,6 +237,7 @@ export const CommandPalette: React.FC = () => {
       createEditor,
       createCanvas,
       createAgent,
+      createText,
       toggleSidebar,
       setActiveRightSidebarView,
       setShowNodeSwitcher,

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -129,6 +129,18 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(191,90,242)', '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/>'),
     canLiveOnCanvas: false,
   },
+  text: {
+    type: 'text',
+    label: 'Text',
+    brandColor: '#FF6482',
+    switcherColor: '#FF375F',
+    mutedColor: '#a0506a',
+    tintClass: 'text-rose-400',
+    defaultSize: { width: 320, height: 160 },
+    minimumSize: { width: 220, height: 80 },
+    ghostSvg: ghost('rgb(255,100,130)', '<polyline points="4 7 4 5 20 5 20 7"/><line x1="12" y1="5" x2="12" y2="19"/><line x1="9" y1="19" x2="15" y2="19"/>'),
+    canLiveOnCanvas: true,
+  },
 }
 
 /** Ordered list of every known panel type. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,7 +29,7 @@ export interface Rect {
 // Panel types
 // -----------------------------------------------------------------------------
 
-export type PanelType = 'terminal' | 'browser' | 'editor' | 'canvas' | 'agent' | 'document'
+export type PanelType = 'terminal' | 'browser' | 'editor' | 'canvas' | 'agent' | 'document' | 'text'
 
 // -----------------------------------------------------------------------------
 // Canvas node
@@ -121,6 +121,17 @@ export interface PanelState {
    *  tab so that subsequent OSC-0/1/2 title escapes from the running agent
    *  no longer overwrite the chosen name. */
   titleUserOverridden?: boolean
+  /** Text panels only: the note's plain-text body. */
+  text?: string
+  /** Text panels only: CSS color applied to the whole note (hex, e.g. #FF9F0A).
+   *  Unset falls back to the theme's primary text color. */
+  textColor?: string
+  /** Text panels only: fill color behind the note (hex). Unset = transparent. */
+  textBgColor?: string
+  /** Text panels only: font size in px applied to the whole note. */
+  textFontSize?: number
+  /** Text panels only: CSS font-family stack applied to the whole note. */
+  textFontFamily?: string
 }
 
 // -----------------------------------------------------------------------------
@@ -614,6 +625,12 @@ export interface NodeSnapshot {
   unsavedContent?: string
   /** Document panels only: sub-type discriminator for the viewer. */
   documentType?: 'pdf' | 'docx' | 'image'
+  /** Text panels only: note body + styling, restored on load. */
+  text?: string
+  textColor?: string
+  textBgColor?: string
+  textFontSize?: number
+  textFontFamily?: string
 }
 
 export interface SessionSnapshot {
@@ -695,6 +712,12 @@ export interface ProjectCanvasNode {
   regionId?: string
   documentType?: 'pdf' | 'docx' | 'image'
   dockLayout?: DockLayoutNode | null
+  /** Text panels only: note body + styling (committed to workspace.json). */
+  text?: string
+  textColor?: string
+  textBgColor?: string
+  textFontSize?: number
+  textFontFamily?: string
 }
 
 export interface ProjectCanvasRegion {
@@ -973,6 +996,7 @@ export const PANEL_CANVAS_DROP_SIZES: Record<PanelType, Size> = {
   canvas: { width: 640, height: 480 },
   agent: { width: 520, height: 440 },
   document: { width: 640, height: 480 },
+  text: { width: 320, height: 160 },
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a lightweight **Text** element that lives directly on the canvas (Figma/Miro-style), for quick labels and notes alongside terminals, editors, and browsers.

- Editable text with per-element **text color**, **fill color**, **font size**, and **font family**, edited from a compact floating toolbar that appears above the element while it's active.
- Renders chrome-free (no tab bar / border / window background) so it reads as plain text on the canvas — distinct from the windowed panels.
- A small **×** button (top-right, on hover/active) deletes the element.

<img width="1056" height="720" alt="cate-feat-textfield" src="https://github.com/user-attachments/assets/f6c2563f-6dc4-41ff-9630-f168e092087a" />

## Implementation

- New `text` `PanelType` wired through the existing two-touch panel registration: `PANEL_DEFINITIONS` (`src/shared/panels.ts`) + the renderer registry (`src/renderer/panels/registry.ts`), plus a `createText` factory and an `updateTextPanel` action in `appStore`.
- New `TextPanel` component (`src/renderer/panels/TextPanel.tsx`).
- A dedicated bare-rendering branch in `CanvasNode` for `text` nodes that skips the window chrome but reuses the existing move / resize / focus / z-order machinery.
- Creatable from the canvas toolbar "More" menu and the command palette ("New Text").
- Content, styling, and position persist to `.cate/workspace.json` (position via the standard canvas-node origin/size) and restore on load.

## Testing

- `npm run typecheck` — clean
- `npm run test:unit` — 532 passed
- `npm run build` — succeeds

## Notes

Happy to adjust naming, default sizes, the toolbar UX, or split this up if you'd prefer a different shape.
