### PR TITLE
feat(titlebar): always use themed title bar on macOS, drop native-tabs setting

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,7 +19,7 @@ import { registerHandlers as registerFilesystemHandlers, stopWatchersForWindow }
 import { registerHandlers as registerGitHandlers } from './ipc/git'
 import { registerHandlers as registerShellHandlers, unregisterTerminalsForWindow } from './ipc/shell'
 import { registerHandlers as registerGitMonitorHandlers, stopMonitorsForWindow } from './ipc/git-monitor'
-import { registerHandlers as registerStoreHandlers, loadSettingsSyncFromDisk, getSettingSync, readBootSnapshot, writeBootSnapshot } from './store'
+import { registerHandlers as registerStoreHandlers, loadSettingsSyncFromDisk, readBootSnapshot, writeBootSnapshot } from './store'
 import { registerProjectStateHandlers, saveProjectStateSync, runLegacyMigrationIfNeeded } from './projectWorkspaceStore'
 import { registerHandlers as registerMenuHandlers } from './ipc/menu'
 import { registerHandlers as registerNotificationHandlers } from './ipc/notifications'
@@ -131,19 +131,14 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   const snapGeom = bootSnap?.geometry
   const snapBg = bootSnap?.backgroundColor
 
-  // Apply the active theme's native appearance before the window exists so the
-  // macOS native title bar (native-tabs mode) paints with the right dark/light
-  // material on the first frame. themeSource is app-wide, so we only need it
-  // once from the main window's snapshot; the renderer keeps it in sync after.
+  // Apply the active theme's native appearance before the window exists so
+  // native chrome (menus, scrollbars, the window backdrop) paints with the
+  // right dark/light material on the first frame. themeSource is app-wide, so
+  // we only need it once from the main window's snapshot; the renderer keeps it
+  // in sync after.
   if (windowType === 'main' && bootSnap?.appearance) {
     try { nativeTheme.themeSource = bootSnap.appearance } catch { /* noop */ }
   }
-
-  // Snapshot native-tabs state at window creation. The renderer reads this via
-  // the URL query so that the React TitlebarStrip matches the actual
-  // titleBarStyle — toggling the setting at runtime only takes effect on the
-  // next launch.
-  const nativeTabsActive = process.platform === 'darwin' && windowType === 'main' && getSettingSync('nativeTabs')
 
   const win = new BrowserWindow({
     width: snapGeom?.width ?? (isDock ? 700 : isPanel ? 700 : 1200),
@@ -154,25 +149,19 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
     minWidth: isDock ? 400 : isPanel ? undefined : 800,
     minHeight: isDock ? 300 : isPanel ? undefined : 600,
     title: isDock ? 'Cate' : isPanel ? 'Cate Panel' : 'Cate',
-    // macOS native window tabs require a standard title bar — `hiddenInset`
-    // suppresses the tab bar entirely. When native tabs are enabled for main
-    // windows we fall back to the default title bar so the tab strip (app
-    // name tab + "+" button) can render.
-    titleBarStyle: isPanel ? 'hidden' : nativeTabsActive ? 'default' : 'hiddenInset',
+    // Main + dock windows hide the native title bar and draw a themed strip in
+    // its place (the macOS native bar can't be tinted to a theme color — only
+    // dark/light — so we always use `hiddenInset` and render TitlebarStrip).
+    titleBarStyle: isPanel ? 'hidden' : 'hiddenInset',
     // Align traffic lights with our 28px themed TitlebarStrip on macOS. Apple's
     // standard NSWindow title bar is ~28pt with lights at y≈7; matching that
     // here makes the themed bar visually identical to a native title bar.
     trafficLightPosition: isDock
       ? { x: 12, y: 11 }
-      : (process.platform === 'darwin' && windowType === 'main' && !nativeTabsActive)
+      : (process.platform === 'darwin' && windowType === 'main')
         ? { x: 10, y: 6 }
         : undefined,
     frame: !(isPanel || isDock),
-    // macOS native window tabs — only on main windows. Setting tabbingIdentifier
-    // makes new windows in this group join as native tabs in the title bar
-    // (subject to System Settings → Desktop & Dock → "Prefer tabs"). Panel and
-    // dock windows are excluded so they stay free-floating.
-    ...(nativeTabsActive ? { tabbingIdentifier: 'cate-main' } : {}),
     backgroundColor: snapBg ?? '#1f1e1c',
     icon: nativeImage.createFromPath(iconPath),
     webPreferences: {
@@ -329,7 +318,6 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   // Build query string from params
   const queryParts: string[] = []
   queryParts.push(`type=${encodeURIComponent(windowType)}`)
-  if (nativeTabsActive) queryParts.push('nativeTabsBoot=1')
   if (params?.panelType) queryParts.push(`panelType=${encodeURIComponent(params.panelType)}`)
   if (params?.panelId) queryParts.push(`panelId=${encodeURIComponent(params.panelId)}`)
   if (params?.workspaceId) queryParts.push(`workspaceId=${encodeURIComponent(params.workspaceId)}`)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -35,7 +35,6 @@ import { broadcastToAll } from './windowRegistry'
 const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   defaultShellPath: 'string',
   warnBeforeQuit: 'boolean',
-  nativeTabs: 'boolean',
   activeThemeId: 'string',
   systemLightThemeId: 'string',
   systemDarkThemeId: 'string',
@@ -141,10 +140,10 @@ export interface BootSnapshot {
   theme?: string
   backgroundColor?: string
   // Desired native window appearance for the active theme. Drives
-  // nativeTheme.themeSource so the macOS native title bar (native-tabs mode)
-  // matches the theme's dark/light instead of the OS. 'system' tracks the OS.
+  // nativeTheme.themeSource so native chrome (menus, scrollbars, the window
+  // backdrop) matches the theme's dark/light instead of the OS. 'system' tracks
+  // the OS.
   appearance?: 'dark' | 'light' | 'system'
-  nativeTabs?: boolean
   lastWorkspaceId?: string
 }
 

--- a/src/renderer/settings/GeneralSettings.tsx
+++ b/src/renderer/settings/GeneralSettings.tsx
@@ -1,12 +1,8 @@
-import { InfoIcon, WarningIcon } from '@phosphor-icons/react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { SettingRow, Toggle, TextInput } from './SettingsComponents'
 
-const NATIVE_TABS_BOOT = new URLSearchParams(window.location.search).get('nativeTabsBoot') === '1'
-
 export function GeneralSettings() {
   const store = useSettingsStore()
-  const nativeTabsPending = store.nativeTabs !== NATIVE_TABS_BOOT
 
   return (
     <div className="flex flex-col gap-1">
@@ -16,30 +12,6 @@ export function GeneralSettings() {
       <SettingRow label="Warn before quit" description="Show confirmation dialog on Cmd+Q">
         <Toggle checked={store.warnBeforeQuit} onChange={(v) => store.setSetting('warnBeforeQuit', v)} />
       </SettingRow>
-      {navigator.userAgent.includes('Mac') && (
-        <SettingRow
-          label="Native macOS window tabs"
-          description="Group main windows as native tabs in the title bar."
-          hint={(NATIVE_TABS_BOOT || nativeTabsPending) ? (
-            <>
-              {NATIVE_TABS_BOOT && (
-                <p className="flex items-center gap-1 text-xs text-muted">
-                  <InfoIcon size={12} />
-                  Title bar matches your theme's dark/light, but macOS can't tint it the exact theme color while tabs are enabled.
-                </p>
-              )}
-              {nativeTabsPending && (
-                <p className="flex items-center gap-1 text-xs text-amber-500 mt-1">
-                  <WarningIcon size={12} />
-                  Restart required for this change to take effect.
-                </p>
-              )}
-            </>
-          ) : undefined}
-        >
-          <Toggle checked={store.nativeTabs} onChange={(v) => store.setSetting('nativeTabs', v)} />
-        </SettingRow>
-      )}
       <SettingRow
         label="Send crash reports"
         description="Anonymously report unhandled errors to help us fix bugs."

--- a/src/renderer/shells/TitlebarStrip.tsx
+++ b/src/renderer/shells/TitlebarStrip.tsx
@@ -1,12 +1,9 @@
 // =============================================================================
-// TitlebarStrip — themed drag region rendered at the top of the main window
-// when macOS native tabs are disabled (titleBarStyle: 'hiddenInset'). Reserves
-// space for the traffic lights and gives the window a drag region matched to
-// the app theme.
-//
-// Reads the boot-time nativeTabs value from the URL (set by main on window
-// create) instead of the live setting, so the strip always matches the actual
-// window chrome. Toggling the setting at runtime has no effect until restart.
+// TitlebarStrip — themed drag region rendered at the top of the main window on
+// macOS (titleBarStyle: 'hiddenInset'). Reserves space for the traffic lights
+// and gives the window a drag region matched to the app theme. macOS always
+// uses the hidden-inset title bar — the native bar can't be tinted to a theme
+// color, only dark/light.
 //
 // In native macOS fullscreen the traffic lights are hidden by the OS, so the
 // strip would otherwise show as a 28px dead zone at the top — subscribe to
@@ -16,7 +13,6 @@
 import { useEffect, useState } from 'react'
 
 const IS_MAC = navigator.userAgent.includes('Mac')
-const NATIVE_TABS_BOOT = new URLSearchParams(window.location.search).get('nativeTabsBoot') === '1'
 
 export default function TitlebarStrip() {
   const [isFullscreen, setIsFullscreen] = useState<boolean>(
@@ -24,11 +20,11 @@ export default function TitlebarStrip() {
   )
 
   useEffect(() => {
-    if (!IS_MAC || NATIVE_TABS_BOOT) return
+    if (!IS_MAC) return
     return window.electronAPI.onFullscreenChange?.((value) => setIsFullscreen(value))
   }, [])
 
-  if (!IS_MAC || NATIVE_TABS_BOOT || isFullscreen) return null
+  if (!IS_MAC || isFullscreen) return null
 
   return (
     <div

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -801,9 +801,6 @@ export interface AppSettings {
   // General
   defaultShellPath: string
   warnBeforeQuit: boolean
-  /** macOS only: enable native window tabs (tabbingIdentifier on main windows).
-   *  Takes effect on next launch. */
-  nativeTabs: boolean
 
   // Appearance
   /** Active unified theme: 'system' (auto light/dark) or a theme id. */
@@ -897,7 +894,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // where it commonly isn't installed.
   defaultShellPath: '',
   warnBeforeQuit: false,
-  nativeTabs: false,
 
   // Appearance
   activeThemeId: 'system',


### PR DESCRIPTION
## Problem

The packaged macOS app showed a **native dark/light title bar** instead of the theme color, while `npm run dev` correctly showed the themed strip. Root cause: the packaged app had the **"Native macOS window tabs"** setting enabled, which forces `titleBarStyle: 'default'` (the native bar). macOS native title bars can only follow the system dark/light material — they cannot be tinted to an arbitrary theme color (only `nativeTheme.themeSource` dark/light is available; `titleBarOverlay` color is Windows/Linux only). Dev had the setting off, so it used the themed `hiddenInset` strip.

## Change

Remove the `nativeTabs` setting and the native `'default'` title-bar path entirely. Every macOS main/dock window now always uses `titleBarStyle: 'hiddenInset'` + the themed `TitlebarStrip`, so the header is always the theme color — no setting required. Windows/Linux are unchanged.

- `src/main/index.ts` — always `hiddenInset` for non-panel windows; drop `nativeTabsActive`, `tabbingIdentifier`, and the `nativeTabsBoot` query param; simplify `trafficLightPosition`
- `src/shared/types.ts` — remove `nativeTabs` from `AppSettings` + `DEFAULT_SETTINGS`
- `src/main/store.ts` — remove `nativeTabs` from the settings schema and `BootSnapshot`
- `src/renderer/settings/GeneralSettings.tsx` — remove the "Native macOS window tabs" toggle
- `src/renderer/shells/TitlebarStrip.tsx` — render whenever on macOS & not fullscreen

## Migration

None needed. The settings loader (`mergeValidatedSettings`) only reads known schema keys, so any leftover persisted `nativeTabs: true` is silently ignored.

## Test

`tsc --noEmit` passes. After install, the packaged app shows the themed title-bar strip with no toggle present.