### PR TITLE
feat(settings): sidebar nav with search + scroll-spy in the settings dialog

### DIFF
--- a/src/renderer/settings/AppearanceSettings.tsx
+++ b/src/renderer/settings/AppearanceSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Check, Trash, Upload, DownloadSimple, Sparkle } from '@phosphor-icons/react'
 import { useSettingsStore } from '../stores/settingsStore'
-import { SettingRow, Select, NumberInput } from './SettingsComponents'
+import { SettingRow, Select, NumberInput, SearchableBlock } from './SettingsComponents'
 import type { Theme } from '../../shared/types'
 import { validateTheme } from '../../shared/theme'
 import { BASE_DARK, BASE_LIGHT, BUILT_IN_THEMES } from '../../shared/themes'
@@ -91,6 +91,7 @@ export function AppearanceSettings() {
 
   return (
     <div className="flex flex-col gap-1">
+      <SearchableBlock keywords="theme appearance color dark light catalog import export system mode">
       {/* Mode + catalog header */}
       <div className="flex items-center justify-between py-2.5">
         <span className="text-sm text-primary">Theme</span>
@@ -158,6 +159,7 @@ export function AppearanceSettings() {
         </div>
         <h4 className="text-[13px] font-semibold text-primary">Create your own theme</h4>
       </button>
+      </SearchableBlock>
 
       <SettingRow label="Editor font size">
         <NumberInput value={store.editorFontSize} onChange={(v) => store.setSetting('editorFontSize', v)} min={8} max={32} step={1} />

--- a/src/renderer/settings/FileExplorerSettings.tsx
+++ b/src/renderer/settings/FileExplorerSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Plus, X, ArrowCounterClockwise } from '@phosphor-icons/react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { DEFAULT_SETTINGS } from '../../shared/types'
+import { SearchableBlock } from './SettingsComponents'
 
 function sameAsDefault(list: string[]): boolean {
   const defaults = DEFAULT_SETTINGS.fileExclusions
@@ -48,6 +49,7 @@ export function FileExplorerSettings() {
   }
 
   return (
+    <SearchableBlock keywords="file explorer exclusions hidden ignore folders gitignore exclude">
     <div className="flex flex-col gap-1">
       <p className="text-xs text-muted mb-3">
         Folders and files with these exact names are hidden from the file
@@ -114,5 +116,6 @@ export function FileExplorerSettings() {
         </button>
       </div>
     </div>
+    </SearchableBlock>
   )
 }

--- a/src/renderer/settings/SettingsComponents.test.tsx
+++ b/src/renderer/settings/SettingsComponents.test.tsx
@@ -1,0 +1,108 @@
+// =============================================================================
+// Rendering tests for the settings search-filtering primitives.
+//
+// SettingRow and SearchableBlock self-hide based on SettingsSearchContext:
+//   - no active query           → always visible
+//   - query matches label/desc  → visible
+//   - query matches nothing     → hidden (returns null)
+//   - section title matched     → visible regardless of the query
+// Visible rows/blocks carry a `data-srow` marker, which the SettingsWindow
+// match-scan relies on to decide whether a section still has content.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { SettingRow, SearchableBlock } from './SettingsComponents'
+import { SettingsSearchContext, type SettingsSearchState } from './SettingsSearchContext'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+})
+
+function render(search: SettingsSearchState, ui: React.ReactNode): HTMLDivElement {
+  act(() => {
+    root.render(
+      <SettingsSearchContext.Provider value={search}>{ui}</SettingsSearchContext.Provider>,
+    )
+  })
+  return host
+}
+
+const settingRow = (
+  <SettingRow label="Editor font size" description="Monaco editor font size in px">
+    <button>control</button>
+  </SettingRow>
+)
+
+const isVisible = (el: HTMLElement) => el.querySelector('[data-srow]') !== null
+
+describe('SettingRow filtering', () => {
+  it('renders (with a data-srow marker) when there is no active query', () => {
+    const el = render({ query: '', sectionMatched: false }, settingRow)
+    expect(isVisible(el)).toBe(true)
+    expect(el.textContent).toContain('Editor font size')
+  })
+
+  it('renders when the query matches the label', () => {
+    const el = render({ query: 'font', sectionMatched: false }, settingRow)
+    expect(isVisible(el)).toBe(true)
+  })
+
+  it('renders when the query matches the description', () => {
+    const el = render({ query: 'monaco', sectionMatched: false }, settingRow)
+    expect(isVisible(el)).toBe(true)
+  })
+
+  it('hides (renders nothing) when the query matches neither label nor description', () => {
+    const el = render({ query: 'terminal', sectionMatched: false }, settingRow)
+    expect(isVisible(el)).toBe(false)
+    expect(el.textContent).toBe('')
+  })
+
+  it('stays visible when the enclosing section title matched, even on a non-matching query', () => {
+    const el = render({ query: 'terminal', sectionMatched: true }, settingRow)
+    expect(isVisible(el)).toBe(true)
+  })
+})
+
+describe('SearchableBlock filtering', () => {
+  const block = (
+    <SearchableBlock keywords="theme appearance color">
+      <span>theme catalog</span>
+    </SearchableBlock>
+  )
+
+  it('renders its children when there is no active query', () => {
+    const el = render({ query: '', sectionMatched: false }, block)
+    expect(isVisible(el)).toBe(true)
+    expect(el.textContent).toContain('theme catalog')
+  })
+
+  it('renders when the query matches a keyword', () => {
+    const el = render({ query: 'color', sectionMatched: false }, block)
+    expect(isVisible(el)).toBe(true)
+  })
+
+  it('hides when the query matches no keyword and the section title did not match', () => {
+    const el = render({ query: 'font', sectionMatched: false }, block)
+    expect(isVisible(el)).toBe(false)
+    expect(el.textContent).toBe('')
+  })
+
+  it('stays visible when the section title matched', () => {
+    const el = render({ query: 'font', sectionMatched: true }, block)
+    expect(isVisible(el)).toBe(true)
+  })
+})

--- a/src/renderer/settings/SettingsComponents.tsx
+++ b/src/renderer/settings/SettingsComponents.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
+import { useSettingsSearch, matchesQuery } from './SettingsSearchContext'
 
 // -----------------------------------------------------------------------------
 // SettingRow — label + control layout
@@ -18,8 +19,14 @@ interface SettingRowProps {
 }
 
 export function SettingRow({ label, description, hint, children }: SettingRowProps) {
+  const { query, sectionMatched } = useSettingsSearch()
+  // Hide when there's an active query the section title didn't match and
+  // neither the label nor description contains it.
+  if (query !== '' && !sectionMatched && !matchesQuery(label, query) && !matchesQuery(description, query)) {
+    return null
+  }
   return (
-    <div className="flex items-center justify-between py-2.5 border-b border-subtle">
+    <div data-srow className="flex items-center justify-between py-2.5 border-b border-subtle">
       <div className="flex flex-col min-w-0">
         <span className="text-sm text-primary">{label}</span>
         {description && <span className="text-xs text-muted mt-0.5">{description}</span>}
@@ -28,6 +35,26 @@ export function SettingRow({ label, description, hint, children }: SettingRowPro
       <div className="flex-shrink-0 ml-4">{children}</div>
     </div>
   )
+}
+
+// -----------------------------------------------------------------------------
+// SearchableBlock — wraps custom (non-SettingRow) content so it participates
+// in settings search. Hidden when an active query matches neither the section
+// title nor the block's keywords.
+// -----------------------------------------------------------------------------
+
+interface SearchableBlockProps {
+  /** Space-separated terms describing this block, matched against the query. */
+  keywords?: string
+  children: ReactNode
+}
+
+export function SearchableBlock({ keywords, children }: SearchableBlockProps) {
+  const { query, sectionMatched } = useSettingsSearch()
+  if (query !== '' && !sectionMatched && !matchesQuery(keywords, query)) {
+    return null
+  }
+  return <div data-srow>{children}</div>
 }
 
 // -----------------------------------------------------------------------------

--- a/src/renderer/settings/SettingsSearchContext.test.ts
+++ b/src/renderer/settings/SettingsSearchContext.test.ts
@@ -1,0 +1,36 @@
+// =============================================================================
+// Unit tests for matchesQuery — the substring matcher behind settings search.
+// Callers pass an already-lowercased query; the matcher lowercases the text
+// side and treats an empty query as "matches everything".
+// =============================================================================
+
+import { describe, expect, it } from 'vitest'
+import { matchesQuery } from './SettingsSearchContext'
+
+describe('matchesQuery', () => {
+  it('an empty query matches everything', () => {
+    expect(matchesQuery('Editor font size', '')).toBe(true)
+    expect(matchesQuery('', '')).toBe(true)
+    expect(matchesQuery(undefined, '')).toBe(true)
+  })
+
+  it('matches a substring of the text', () => {
+    expect(matchesQuery('Editor font size', 'font')).toBe(true)
+    expect(matchesQuery('Terminal font family', 'family')).toBe(true)
+  })
+
+  it('is case-insensitive on the text side', () => {
+    expect(matchesQuery('Editor FONT Size', 'font')).toBe(true)
+    expect(matchesQuery('SAVE FILE', 'save')).toBe(true)
+  })
+
+  it('returns false when the text does not contain the query', () => {
+    expect(matchesQuery('Save File', 'terminal')).toBe(false)
+    expect(matchesQuery('Zoom to Fit', 'redo')).toBe(false)
+  })
+
+  it('treats missing text as a non-match for a non-empty query', () => {
+    expect(matchesQuery(undefined, 'font')).toBe(false)
+    expect(matchesQuery('', 'font')).toBe(false)
+  })
+})

--- a/src/renderer/settings/SettingsSearchContext.tsx
+++ b/src/renderer/settings/SettingsSearchContext.tsx
@@ -1,0 +1,33 @@
+// =============================================================================
+// SettingsSearchContext — drives live filtering of settings rows/blocks.
+//
+// SettingsWindow provides a lowercased+trimmed `query` per section, plus
+// `sectionMatched` (true when the query matches the section's own title, so the
+// whole section is shown). SettingRow and SearchableBlock consume this to hide
+// themselves when they don't match. Default value makes those components behave
+// normally when rendered outside the provider.
+// =============================================================================
+
+import { createContext, useContext } from 'react'
+
+export interface SettingsSearchState {
+  /** Lowercased, trimmed search query. Empty string = no active search. */
+  query: string
+  /** True when the active query matches the enclosing section's title. */
+  sectionMatched: boolean
+}
+
+export const SettingsSearchContext = createContext<SettingsSearchState>({
+  query: '',
+  sectionMatched: false,
+})
+
+export function useSettingsSearch(): SettingsSearchState {
+  return useContext(SettingsSearchContext)
+}
+
+/** True when `query` is empty or `text` contains it (case-insensitive). */
+export function matchesQuery(text: string | undefined, query: string): boolean {
+  if (query === '') return true
+  return (text ?? '').toLowerCase().includes(query)
+}

--- a/src/renderer/settings/SettingsWindow.tsx
+++ b/src/renderer/settings/SettingsWindow.tsx
@@ -1,9 +1,16 @@
 // =============================================================================
-// SettingsWindow — Single scrollable settings card with all sections.
+// SettingsWindow — wide settings dialog: a left sidebar (search + section nav
+// with scroll-spy) beside one long scrollable content column.
+//
+// The content stays a single scrollable page; the sidebar jumps to a section
+// on click and highlights whichever section is currently scrolled into view.
+// The search box live-filters individual setting rows across every section
+// (via SettingsSearchContext) — non-matching rows hide, empty sections
+// collapse, and the sidebar lists only sections that still have matches.
 // =============================================================================
 
-import { X } from '@phosphor-icons/react'
-import { useEffect, useRef } from 'react'
+import { X, MagnifyingGlass } from '@phosphor-icons/react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { GeneralSettings } from './GeneralSettings'
 import { AppearanceSettings } from './AppearanceSettings'
 import { CanvasSettings } from './CanvasSettings'
@@ -13,6 +20,7 @@ import { SidebarSettings } from './SidebarSettings'
 import { FileExplorerSettings } from './FileExplorerSettings'
 import { ShortcutSettings } from './ShortcutSettings'
 import { NotificationSettings } from './NotificationSettings'
+import { SettingsSearchContext } from './SettingsSearchContext'
 
 const SECTIONS = [
   { title: 'General', component: GeneralSettings },
@@ -26,6 +34,10 @@ const SECTIONS = [
   { title: 'Shortcuts', component: ShortcutSettings },
 ] as const
 
+// DOM id for a section. Slugify spaces (e.g. "File Explorer") so the result is
+// a valid CSS selector for querySelector/scrollIntoView.
+const sectionId = (title: string): string => `settings-section-${title.toLowerCase().replace(/\s+/g, '-')}`
+
 interface SettingsWindowProps {
   isOpen: boolean
   onClose: () => void
@@ -35,16 +47,77 @@ interface SettingsWindowProps {
 
 export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
+  const [rawQuery, setRawQuery] = useState('')
+  const [activeId, setActiveId] = useState<string>(SECTIONS[0].title.toLowerCase())
+  const [visibleSections, setVisibleSections] = useState<Set<string>>(
+    () => new Set(SECTIONS.map((s) => s.title.toLowerCase())),
+  )
+
+  const query = rawQuery.trim().toLowerCase()
+
+  // Reset search + scroll to the requested section whenever the dialog opens.
   useEffect(() => {
-    if (!isOpen || !initialTab) return
-    const id = `settings-section-${initialTab.toLowerCase()}`
-    // Wait one frame so the section is mounted, then scroll into view.
+    if (!isOpen) return
+    setRawQuery('')
+    const target = (initialTab ?? SECTIONS[0].title).toLowerCase()
+    setActiveId(target)
     requestAnimationFrame(() => {
-      scrollRef.current?.querySelector(`#${id}`)?.scrollIntoView({ block: 'start', behavior: 'auto' })
+      scrollRef.current?.querySelector(`#${sectionId(target)}`)?.scrollIntoView({ block: 'start', behavior: 'auto' })
     })
   }, [isOpen, initialTab])
 
+  // Match scan — after each query change, determine which sections still have
+  // visible content. A section shows when there's no query, when its title
+  // matches, or when it contains at least one visible row/block ([data-srow]).
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    const root = scrollRef.current
+    if (!root) return
+    const next = new Set<string>()
+    for (const { title } of SECTIONS) {
+      const id = title.toLowerCase()
+      if (query === '' || title.toLowerCase().includes(query)) {
+        next.add(id)
+        continue
+      }
+      if (root.querySelector(`#${sectionId(title)} [data-srow]`)) next.add(id)
+    }
+    setVisibleSections(next)
+  }, [query, isOpen])
+
+  // Scroll-spy — highlight the section whose top sits at/above the fold.
+  useEffect(() => {
+    if (!isOpen) return
+    const root = scrollRef.current
+    if (!root) return
+    const onScroll = () => {
+      const sections = Array.from(root.querySelectorAll<HTMLElement>('[data-section-id]'))
+      const rootTop = root.getBoundingClientRect().top
+      let current: string | undefined
+      for (const s of sections) {
+        if (s.hidden) continue
+        const top = s.getBoundingClientRect().top - rootTop
+        if (top <= 16) current = s.dataset.sectionId
+        else break
+      }
+      const fallback = sections.find((s) => !s.hidden)?.dataset.sectionId
+      setActiveId((prev) => current ?? fallback ?? prev)
+    }
+    onScroll()
+    root.addEventListener('scroll', onScroll, { passive: true })
+    return () => root.removeEventListener('scroll', onScroll)
+    // Re-attach when visibility changes so hidden sections are skipped.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, visibleSections])
+
   if (!isOpen) return null
+
+  const jumpTo = (id: string) => {
+    scrollRef.current?.querySelector(`#${sectionId(id)}`)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+    setActiveId(id)
+  }
+
+  const navSections = SECTIONS.filter(({ title }) => query === '' || visibleSections.has(title.toLowerCase()))
 
   return (
     <div
@@ -52,7 +125,7 @@ export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowPr
       onClick={onClose}
     >
       <div
-        className="w-[520px] max-h-[80vh] bg-surface-1 rounded-xl border border-subtle shadow-[0_24px_64px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/40 flex flex-col overflow-hidden"
+        className="w-[min(900px,92vw)] max-h-[80vh] bg-surface-1 rounded-xl border border-subtle shadow-[0_24px_64px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/40 flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
@@ -66,17 +139,77 @@ export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowPr
           </button>
         </div>
 
-        {/* Scrollable sections */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4">
-          <div className="flex flex-col gap-6">
-            {SECTIONS.map(({ title, component: Component }) => (
-              <section key={title} id={`settings-section-${title.toLowerCase()}`}>
-                <h3 className="text-xs font-medium text-muted uppercase tracking-wider mb-2">
-                  {title}
-                </h3>
-                <Component />
-              </section>
-            ))}
+        {/* Body: sidebar + scrollable content */}
+        <div className="flex flex-1 min-h-0" data-sidebar-scrollarea>
+          {/* Sidebar */}
+          <div className="w-[208px] flex-shrink-0 flex flex-col bg-surface-0/30">
+            <div className="p-3 flex-shrink-0">
+              <div className="relative">
+                <MagnifyingGlass
+                  size={13}
+                  className="absolute left-2 top-1/2 -translate-y-1/2 text-muted pointer-events-none"
+                />
+                <input
+                  type="text"
+                  value={rawQuery}
+                  onChange={(e) => setRawQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape' && rawQuery) {
+                      e.stopPropagation()
+                      setRawQuery('')
+                    }
+                  }}
+                  placeholder="Search settings…"
+                  className="w-full bg-surface-5 border border-subtle rounded-md pl-7 pr-2 py-1 text-sm text-primary placeholder:text-muted focus:border-focus-blue focus:outline-none"
+                />
+              </div>
+            </div>
+            <nav className="flex-1 overflow-y-auto px-2 pb-3 flex flex-col gap-0.5">
+              {navSections.map(({ title }) => {
+                const id = title.toLowerCase()
+                const active = id === activeId
+                return (
+                  <button
+                    key={title}
+                    onClick={() => jumpTo(id)}
+                    className={`text-left px-2.5 py-1.5 rounded-md text-sm transition-colors ${
+                      active ? 'bg-surface-3 text-primary' : 'text-secondary hover:bg-hover hover:text-primary'
+                    }`}
+                  >
+                    {title}
+                  </button>
+                )
+              })}
+              {navSections.length === 0 && (
+                <span className="px-2.5 py-1.5 text-xs text-muted">No matches</span>
+              )}
+            </nav>
+          </div>
+
+          {/* Scrollable sections */}
+          <div ref={scrollRef} className="flex-1 overflow-y-auto px-6 py-4">
+            <div className="flex flex-col gap-6">
+              {SECTIONS.map(({ title, component: Component }) => {
+                const id = title.toLowerCase()
+                const sectionMatched = query !== '' && title.toLowerCase().includes(query)
+                const hidden = query !== '' && !visibleSections.has(id)
+                return (
+                  <section key={title} id={sectionId(title)} data-section-id={id} hidden={hidden}>
+                    <h3 className="text-sm font-semibold text-primary mb-2">
+                      {title}
+                    </h3>
+                    <SettingsSearchContext.Provider value={{ query, sectionMatched }}>
+                      <Component />
+                    </SettingsSearchContext.Provider>
+                  </section>
+                )
+              })}
+              {query !== '' && visibleSections.size === 0 && (
+                <div className="py-10 text-center text-sm text-muted">
+                  No settings match “{rawQuery.trim()}”.
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/settings/ShortcutSettings.tsx
+++ b/src/renderer/settings/ShortcutSettings.tsx
@@ -3,17 +3,26 @@ import { SHORTCUT_ACTIONS, SHORTCUT_DISPLAY_NAMES, displayString } from '../../s
 import type { ShortcutAction } from '../../shared/types'
 import { ShortcutRecorder } from './ShortcutRecorder'
 import { ArrowCounterClockwise } from '@phosphor-icons/react'
+import { useSettingsSearch, matchesQuery } from './SettingsSearchContext'
 
 export function ShortcutSettings() {
   const shortcuts = useShortcutStore((s) => s.shortcuts)
   const resetShortcut = useShortcutStore((s) => s.resetShortcut)
   const resetAll = useShortcutStore((s) => s.resetAll)
+  const { query, sectionMatched } = useSettingsSearch()
+
+  // Filter rows to those matching the active query (unless the section title
+  // itself matched, in which case show all).
+  const visibleActions = SHORTCUT_ACTIONS.filter(
+    (action) => sectionMatched || matchesQuery(SHORTCUT_DISPLAY_NAMES[action], query),
+  )
 
   return (
     <div className="flex flex-col gap-0">
-      {SHORTCUT_ACTIONS.map((action) => (
+      {visibleActions.map((action) => (
         <div
           key={action}
+          data-srow
           className="flex items-center justify-between py-2 border-b border-subtle"
         >
           <span className="text-sm text-primary">
@@ -35,14 +44,16 @@ export function ShortcutSettings() {
           </div>
         </div>
       ))}
-      <div className="mt-4 flex justify-end">
-        <button
-          onClick={resetAll}
-          className="px-3 py-1.5 text-xs text-secondary hover:text-primary bg-surface-5 hover:bg-hover rounded-md transition-colors"
-        >
-          Reset All to Defaults
-        </button>
-      </div>
+      {visibleActions.length > 0 && (
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={resetAll}
+            className="px-3 py-1.5 text-xs text-secondary hover:text-primary bg-surface-5 hover:bg-hover rounded-md transition-colors"
+          >
+            Reset All to Defaults
+          </button>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What

Reworks the Settings dialog into a wider two-column layout: a left **sidebar** beside the existing single scrollable content column.

- **Wider dialog** — `min(900px, 92vw)` (was 520px).
- **Sidebar nav** — one item per section; **scroll-spy** highlights the section currently in view, and clicking an item **jumps** to it. Content remains one continuous scroll page (no tabs/pages).
- **Search** — a search box in the sidebar live-filters individual setting rows across all sections. Non-matching rows hide, empty sections collapse, and the sidebar lists only sections that still have matches. Typing a section name (e.g. `terminal`) shows that whole section.
- **Polish** — sidebar/content use the same scrollbar style as the app sidebars (`data-sidebar-scrollarea`); no separator border; section titles are normal-case (no all-caps).

## How

Filtering is driven by a small `SettingsSearchContext` (`{ query, sectionMatched }`) so most section components need no changes — `SettingRow` self-hides when it doesn't match. Custom (non-`SettingRow`) blocks in **Appearance** (theme catalog) and **File Explorer** (exclusions) opt in via a new `SearchableBlock`. `ShortcutSettings` filters its rows by display name. The `SettingsWindow` runs a layout-effect scan over `[data-srow]` markers to decide section/sidebar visibility, plus a scroll listener for scroll-spy. The `initialTab` deep-link still works.

## Tests

New tests for the filtering primitives:
- `SettingsSearchContext.test.ts` — `matchesQuery` (empty query, case-insensitive substring, non-match, missing text).
- `SettingsComponents.test.tsx` — `SettingRow` / `SearchableBlock` visibility across query/`sectionMatched` combinations and the `data-srow` marker.

Full suite: 546 passed / 3 skipped. `tsc --noEmit` clean.

## Scope

Renderer-only UI; no settings persistence/IPC changes. Windows/Linux unaffected.