### PR TITLE
fix(cmdk): remove hover flicker and soften selection highlight

### DIFF
--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -678,7 +678,7 @@ const Row: React.FC<{
 }> = ({ selected, onClick, onMouseEnter, children }) => (
   <div
     className={`flex items-center gap-2.5 mx-1.5 px-2.5 py-1.5 cursor-pointer rounded-md ${
-      selected ? 'bg-[rgb(var(--agent-rgb))]/22' : 'hover:bg-hover'
+      selected ? 'bg-[rgb(var(--agent-rgb))]/12' : ''
     }`}
     onClick={onClick}
     onMouseEnter={onMouseEnter}


### PR DESCRIPTION
## What

Fixes two issues in the Cmd+K command palette rows:

1. **Hover flicker** — Hovering a row produced a brief gray flash before snapping to the agent-colored highlight.
2. **Highlight too extreme** — The selected background was too strong.

## Why it flickered

The `Row` component applied `hover:bg-hover` to unselected rows. On `mouseenter`:

1. The browser instantly painted the CSS `:hover` background (`bg-hover`, gray).
2. One frame later, React's `onMouseEnter → setSelectedIndex` re-rendered the row into its selected style (`bg-[rgb(var(--agent-rgb))]/22`), dropping `hover:bg-hover`.

That sequence is the flash: gray hover → agent-colored selection. Since hovering a row already selects it, the `hover:bg-hover` class was redundant and the sole cause of the flicker.

## Change

- Drop `hover:bg-hover` — selection follows the mouse, so a single clean highlight is shown.
- Lower selected opacity `/22 → /12` to soften the highlight.

Single-hunk change to `src/renderer/ui/CommandPalette.tsx`.