### PR TITLE
fix(loading): paint the startup splash in the themed boot color

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,6 +130,10 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   const bootSnap = windowType === 'main' ? readBootSnapshot() : null
   const snapGeom = bootSnap?.geometry
   const snapBg = bootSnap?.backgroundColor
+  // The exact background color used for both the native window backdrop and the
+  // renderer's first-paint loading splash, so the splash matches the themed
+  // window before the renderer's JS theme injection runs.
+  const bgColor = snapBg ?? '#1f1e1c'
 
   // Apply the active theme's native appearance before the window exists so
   // native chrome (menus, scrollbars, the window backdrop) paints with the
@@ -162,7 +166,7 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
         ? { x: 10, y: 6 }
         : undefined,
     frame: !(isPanel || isDock),
-    backgroundColor: snapBg ?? '#1f1e1c',
+    backgroundColor: bgColor,
     icon: nativeImage.createFromPath(iconPath),
     webPreferences: {
       preload: path.join(__dirname, '../preload/index.js'),
@@ -318,6 +322,9 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   // Build query string from params
   const queryParts: string[] = []
   queryParts.push(`type=${encodeURIComponent(windowType)}`)
+  // Pass the themed boot background so the renderer can paint its loading splash
+  // to match the window backdrop on the first frame (main window only).
+  if (windowType === 'main') queryParts.push(`bg=${encodeURIComponent(bgColor)}`)
   if (params?.panelType) queryParts.push(`panelType=${encodeURIComponent(params.panelType)}`)
   if (params?.panelId) queryParts.push(`panelId=${encodeURIComponent(params.panelId)}`)
   if (params?.workspaceId) queryParts.push(`workspaceId=${encodeURIComponent(params.workspaceId)}`)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -66,6 +66,11 @@ function getWindowParams(): { type: string; panelType?: string; panelId?: string
   }
 }
 
+// Themed background passed by main from the boot snapshot (the same color as the
+// native window backdrop). Lets the loading splash paint in the theme color on
+// the very first frame, before the renderer's JS theme injection runs.
+const BOOT_BG = new URLSearchParams(window.location.search).get('bg') ?? undefined
+
 // -----------------------------------------------------------------------------
 // App — routes to the correct shell based on window type
 // -----------------------------------------------------------------------------
@@ -540,7 +545,10 @@ function MainApp() {
       <PerfHud />
 
       {initializing && (
-        <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-surface-4 select-none pointer-events-none">
+        <div
+          className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-surface-4 select-none pointer-events-none"
+          style={{ backgroundColor: BOOT_BG }}
+        >
           <svg viewBox="0 0 389 204" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-8 text-muted">
             <path d="M274 203.2L307.29 1.79999H388.29L384.51 24.84H329.97L320.5 80.16H342.22H366.34L362.74 103.2H338.62H316.5L304.06 180.16H358.6L355 203.2H314.5H274Z" fill="currentColor"/>
             <path d="M201.264 203.2L230.424 26.5H197.124L201.264 1.3H294.864L290.724 26.5H257.424L228.264 203.2H201.264Z" fill="currentColor"/>


### PR DESCRIPTION
## Problem

On cold launch, the startup loading splash (shown while the renderer initializes, `App.tsx`) appeared in a fixed dark color rather than the active theme — most visible on light/non-default themes. The window's own backdrop was already themed (via the boot snapshot), but this `fixed inset-0` overlay was not.

**Root cause:** the splash used `bg-surface-4`, but `applyTheme()` runs in a `useEffect` *after* first paint, so the splash's first frame resolved `surface-4` from the default-dark `:root` fallback regardless of the saved theme.

## Fix

Reuse the boot-snapshot background color (the exact value already applied to the native window `backgroundColor`) and pass it to the renderer via a `bg=` URL query param on main windows — mirroring the existing `type`/`nativeTabsBoot` param pattern. The splash paints that color inline, so it matches the themed window backdrop on the very first frame with no theme-injection flash. Falls back to `bg-surface-4` when the param is absent.

- `src/main/index.ts` — capture `bgColor` (used for both the window backdrop and the new `bg` param); add `bg` to the main-window query.
- `src/renderer/App.tsx` — read `BOOT_BG` from the URL; apply as the splash's inline `backgroundColor`.

The logo's muted gray reads fine on both dark and light boot backgrounds, so it didn't need separate theming. No new IPC; the color follows the same per-launch lifecycle as the native backdrop.

## Test

`tsc --noEmit` clean. Renderer-only behavior change (plus one main-process query param); Windows/Linux unaffected.