### PR TITLE
fix(settings): give the settings dialog a fixed height

### DIFF
--- a/src/renderer/settings/SettingsWindow.tsx
+++ b/src/renderer/settings/SettingsWindow.tsx
@@ -125,7 +125,7 @@ export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowPr
       onClick={onClose}
     >
       <div
-        className="w-[min(900px,92vw)] max-h-[80vh] bg-surface-1 rounded-xl border border-subtle shadow-[0_24px_64px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/40 flex flex-col overflow-hidden"
+        className="w-[min(900px,92vw)] h-[80vh] bg-surface-1 rounded-xl border border-subtle shadow-[0_24px_64px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/40 flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Problem

In the settings dialog, searching changed the dialog's height. The container used `max-h-[80vh]` — a ceiling, not a fixed height — so the dialog sized itself to its content and shrank as the search filtered rows out. The frame jumped on every keystroke.

## Fix

Change `max-h-[80vh]` → `h-[80vh]` on the dialog container. The shell now holds a constant height; the inner content column (`flex-1 overflow-y-auto`) still scrolls as before, so filtering only changes what scrolls inside a stable-sized box.