### PR TITLE
feat(shortcuts): open new file on Cmd+N + VS Code/browser keymap parity

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -3,8 +3,8 @@
 // =============================================================================
 
 import { BrowserWindow, Menu, shell, app } from 'electron'
-import { MENU_OPEN_SETTINGS, MENU_TRIGGER_ACTION } from '../shared/ipc-channels'
-import type { MenuActionId } from '../shared/types'
+import { MENU_OPEN_SETTINGS, MENU_TRIGGER_ACTION, BROWSER_SHORTCUT } from '../shared/ipc-channels'
+import type { MenuActionId, BrowserShortcutAction } from '../shared/types'
 import { checkForUpdatesManually } from './auto-updater'
 import { listPanelWindows, getWindow, getWindowType } from './windowRegistry'
 
@@ -16,6 +16,16 @@ function dispatch(action: MenuActionId): () => void {
   return (): void => {
     const win = BrowserWindow.getFocusedWindow()
     if (win) win.webContents.send(MENU_TRIGGER_ACTION, action)
+  }
+}
+
+/** Dispatch a browser navigation action to the focused window's BrowserPanel.
+ *  These items carry no accelerator: the keys (Cmd+R/[/]/L) are handled
+ *  panel-locally so they never steal Monaco's Cmd+[ / Cmd+] / Cmd+L. */
+function dispatchBrowser(action: BrowserShortcutAction): () => void {
+  return (): void => {
+    const win = BrowserWindow.getFocusedWindow()
+    if (win) win.webContents.send(BROWSER_SHORTCUT, action)
   }
 }
 
@@ -96,6 +106,7 @@ export function buildApplicationMenu(): void {
           },
         },
         { type: 'separator' },
+        { label: 'New File', accelerator: 'CmdOrCtrl+N', click: dispatch('newFile') },
         { label: 'New Editor', accelerator: 'CmdOrCtrl+Shift+E', click: dispatch('newEditor') },
         { label: 'New Terminal', accelerator: 'CmdOrCtrl+T', click: dispatch('newTerminal') },
         { label: 'New Browser', accelerator: 'CmdOrCtrl+Shift+B', click: dispatch('newBrowser') },
@@ -123,7 +134,7 @@ export function buildApplicationMenu(): void {
         { role: 'delete' },
         { role: 'selectAll' },
         { type: 'separator' },
-        { label: 'Find in Files...', accelerator: 'CmdOrCtrl+Shift+H', click: dispatch('commandPalette') },
+        { label: 'Find in Files...', accelerator: 'CmdOrCtrl+Shift+F', click: dispatch('commandPalette') },
       ],
     },
     // View menu
@@ -131,9 +142,15 @@ export function buildApplicationMenu(): void {
       label: 'View',
       submenu: [
         { label: 'Command Palette...', accelerator: 'CmdOrCtrl+K', click: dispatch('commandPalette') },
+        // VS Code-style aliases for the same unified palette (fuzzy file search +
+        // commands). Hidden so they don't clutter the menu but still bind the key.
+        { label: 'Go to File...', accelerator: 'CmdOrCtrl+P', click: dispatch('commandPalette'), visible: false, acceleratorWorksWhenHidden: true },
+        { label: 'Show All Commands', accelerator: 'CmdOrCtrl+Shift+P', click: dispatch('commandPalette'), visible: false, acceleratorWorksWhenHidden: true },
         { type: 'separator' },
-        { label: 'Toggle Sidebar', accelerator: 'CmdOrCtrl+\\', click: dispatch('toggleSidebar') },
-        { label: 'Toggle File Explorer', accelerator: 'CmdOrCtrl+Shift+F', click: dispatch('toggleFileExplorer') },
+        { label: 'Toggle Sidebar', accelerator: 'CmdOrCtrl+B', click: dispatch('toggleSidebar') },
+        // Secondary sidebar binding (legacy / VS Code split-editor key) kept as an alias.
+        { label: 'Toggle Sidebar', accelerator: 'CmdOrCtrl+\\', click: dispatch('toggleSidebar'), visible: false, acceleratorWorksWhenHidden: true },
+        { label: 'Toggle File Explorer', accelerator: 'CmdOrCtrl+Shift+X', click: dispatch('toggleFileExplorer') },
         { label: 'Toggle Minimap', accelerator: 'CmdOrCtrl+Shift+M', click: dispatch('toggleMinimap') },
         { type: 'separator' },
         { label: 'Zoom In', accelerator: 'CmdOrCtrl+=', click: dispatch('zoomIn') },
@@ -159,13 +176,26 @@ export function buildApplicationMenu(): void {
         { label: 'Previous Panel', accelerator: 'Ctrl+Shift+Tab', click: dispatch('focusPrevious') },
       ],
     },
+    // Browser menu — acts on the focused browser panel. No accelerators: the
+    // keys are handled panel-locally so they don't collide with Monaco.
+    {
+      label: 'Browser',
+      submenu: [
+        { label: 'Reload (⌘R)', click: dispatchBrowser('reload') },
+        { label: 'Force Reload (⌘⇧R)', click: dispatchBrowser('reloadHard') },
+        { type: 'separator' },
+        { label: 'Back (⌘[)', click: dispatchBrowser('back') },
+        { label: 'Forward (⌘])', click: dispatchBrowser('forward') },
+        { type: 'separator' },
+        { label: 'Focus Address Bar (⌘L)', click: dispatchBrowser('focusUrl') },
+      ],
+    },
     // Window menu
     {
       label: 'Window',
       submenu: [
         {
           label: 'New Window',
-          accelerator: 'CmdOrCtrl+N',
           click: (): void => {
             if (!newMainWindowFn) return
             newMainWindowFn()

--- a/src/main/webSecurity.ts
+++ b/src/main/webSecurity.ts
@@ -1,6 +1,29 @@
 import { app, session, shell, type Session, type WebContents } from 'electron'
 import log from './logger'
 import { disableWebviewHardening } from './featureFlags'
+import { BROWSER_SHORTCUT } from '../shared/ipc-channels'
+import type { BrowserShortcutAction } from '../shared/types'
+
+/** Map a webview guest key event to a browser navigation action. Returns null
+ *  for keys we don't own, so the guest page handles them normally. Uses
+ *  `input.code` (layout-independent) rather than `input.key`. */
+function browserActionForInput(input: Electron.Input): BrowserShortcutAction | null {
+  if (input.type !== 'keyDown') return null
+  const mod = process.platform === 'darwin' ? input.meta : input.control
+  if (!mod) return null
+  switch (input.code) {
+    case 'KeyR':
+      return input.shift ? 'reloadHard' : 'reload'
+    case 'KeyL':
+      return input.shift ? null : 'focusUrl'
+    case 'BracketLeft':
+      return input.shift ? null : 'back'
+    case 'BracketRight':
+      return input.shift ? null : 'forward'
+    default:
+      return null
+  }
+}
 
 // Hosts whose OAuth/sign-in flows are forced into the user's real browser via
 // shell.openExternal (see installWebContentsSecurity below) rather than running
@@ -102,6 +125,21 @@ export function installWebContentsSecurity(): void {
           shell.openExternal(url)
         }
         return { action: 'deny' }
+      })
+
+      // Capture browser navigation keys (Cmd+R/[/]/L) even when the guest page
+      // has keyboard focus, and forward them to the embedding renderer so the
+      // focused BrowserPanel can act. Scoped to webview guests, so Monaco's
+      // Cmd+[ / Cmd+] / Cmd+L are never affected.
+      contents.on('before-input-event', (event, input) => {
+        const action = browserActionForInput(input)
+        if (!action) return
+        event.preventDefault()
+        try {
+          contents.hostWebContents?.send(BROWSER_SHORTCUT, action)
+        } catch {
+          /* host gone — ignore */
+        }
       })
     } else {
       contents.setWindowOpenHandler(() => ({ action: 'deny' }))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -77,6 +77,7 @@ import {
   APP_OPEN_PATH,
   MENU_OPEN_SETTINGS,
   MENU_TRIGGER_ACTION,
+  BROWSER_SHORTCUT,
   MENU_SHOW_CONTEXT,
   DIALOG_OPEN_FOLDER,
   DIALOG_SAVE_FILE,
@@ -1039,6 +1040,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const listener = (_e: unknown, action: string): void => { callback(action) }
     ipcRenderer.on(MENU_TRIGGER_ACTION, listener)
     return () => { ipcRenderer.removeListener(MENU_TRIGGER_ACTION, listener) }
+  },
+
+  onBrowserShortcut(callback: (action: string) => void): () => void {
+    const listener = (_e: unknown, action: string): void => { callback(action) }
+    ipcRenderer.on(BROWSER_SHORTCUT, listener)
+    return () => { ipcRenderer.removeListener(BROWSER_SHORTCUT, listener) }
   },
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -83,7 +83,8 @@ export function useShortcuts(): void {
           if (wsId) appStore().createBrowser(wsId)
           break
         }
-        case 'newEditor': {
+        case 'newEditor':
+        case 'newFile': {
           const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
           if (wsId) appStore().createEditor(wsId)
           break

--- a/src/renderer/panels/BrowserPanel.tsx
+++ b/src/renderer/panels/BrowserPanel.tsx
@@ -11,6 +11,7 @@ import { useAppStore } from '../stores/appStore'
 import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { SEARCH_ENGINE_URLS } from '../../shared/types'
 import type { BrowserPanelProps } from './types'
+import type { BrowserShortcutAction } from '../../shared/types'
 import { portalRegistry } from '../lib/portalRegistry'
 import { isUrl, normalizeUrl } from './browserUrl'
 
@@ -34,6 +35,7 @@ interface WebviewElement extends HTMLElement {
   goBack(): void
   goForward(): void
   reload(): void
+  reloadIgnoringCache(): void
   canGoBack(): boolean
   canGoForward(): boolean
   getURL(): string
@@ -68,6 +70,10 @@ export default function BrowserPanel({
   const [webviewSrc] = useState(() => initialUrl)
 
   const webviewRef = useRef<WebviewElement | null>(null)
+  const urlInputRef = useRef<HTMLInputElement | null>(null)
+  // Mirror isFocused into a ref so the long-lived browser-shortcut subscription
+  // reads the current value without re-subscribing on every focus change.
+  const isFocusedRef = useRef(isFocused)
   const [currentUrl, setCurrentUrl] = useState(initialUrl)
   const [inputUrl, setInputUrl] = useState(initialUrl)
   const [canGoBack, setCanGoBack] = useState(false)
@@ -172,10 +178,67 @@ export default function BrowserPanel({
   }, [inputUrl, navigateTo])
 
   // -------------------------------------------------------------------------
+  // Browser navigation shortcuts (Cmd+R/[/]/L)
+  // -------------------------------------------------------------------------
+
+  const runBrowserAction = useCallback((action: BrowserShortcutAction) => {
+    const webview = webviewRef.current
+    switch (action) {
+      case 'reload':
+        webview?.reload()
+        break
+      case 'reloadHard':
+        webview?.reloadIgnoringCache()
+        break
+      case 'back':
+        webview?.goBack()
+        break
+      case 'forward':
+        webview?.goForward()
+        break
+      case 'focusUrl': {
+        const input = urlInputRef.current
+        if (input) {
+          input.focus()
+          input.select()
+        }
+        break
+      }
+    }
+  }, [])
+
+  // Map a key event that lands on the panel chrome (e.g. the URL bar) to a
+  // browser action. The webview-guest case is handled in the main process via
+  // before-input-event (see webSecurity.ts), which forwards through
+  // onBrowserShortcut below. Using e.code keeps this layout-independent.
+  const handleChromeKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!(e.metaKey || e.ctrlKey)) return
+    let action: BrowserShortcutAction | null = null
+    switch (e.code) {
+      case 'KeyR':
+        action = e.shiftKey ? 'reloadHard' : 'reload'
+        break
+      case 'KeyL':
+        if (!e.shiftKey) action = 'focusUrl'
+        break
+      case 'BracketLeft':
+        if (!e.shiftKey) action = 'back'
+        break
+      case 'BracketRight':
+        if (!e.shiftKey) action = 'forward'
+        break
+    }
+    if (!action) return
+    e.preventDefault()
+    runBrowserAction(action)
+  }, [runBrowserAction])
+
+  // -------------------------------------------------------------------------
   // Focus the webview when this panel becomes the focused node
   // -------------------------------------------------------------------------
 
   useEffect(() => {
+    isFocusedRef.current = isFocused
     if (!isFocused) return
     const webview = webviewRef.current
     if (!webview) return
@@ -183,6 +246,16 @@ export default function BrowserPanel({
       webview.focus()
     })
   }, [isFocused])
+
+  // Browser nav keys forwarded from the main process (fired while the webview
+  // guest had keyboard focus) or from the Browser menu. Only the focused panel
+  // reacts, so the key affects the browser the user is actually looking at.
+  useEffect(() => {
+    return window.electronAPI.onBrowserShortcut((action) => {
+      if (!isFocusedRef.current) return
+      runBrowserAction(action as BrowserShortcutAction)
+    })
+  }, [runBrowserAction])
 
   // -------------------------------------------------------------------------
   // Webview event listeners
@@ -298,7 +371,7 @@ export default function BrowserPanel({
   // -------------------------------------------------------------------------
 
   return (
-    <div className="flex flex-col w-full h-full">
+    <div className="flex flex-col w-full h-full" onKeyDown={handleChromeKeyDown}>
       {/* URL bar */}
       <div className="h-10 flex items-center gap-2 px-2 bg-surface-4 border-b border-subtle shrink-0">
         {/* Navigation pill */}
@@ -334,6 +407,7 @@ export default function BrowserPanel({
         <div className="flex-1 flex items-center h-7 rounded-full border border-subtle bg-surface-5 px-3 gap-2 focus-within:border-strong transition-colors">
           <MagnifyingGlass size={13} className="text-muted shrink-0" />
           <input
+            ref={urlInputRef}
             type="text"
             value={inputUrl}
             onChange={(e) => setInputUrl(e.target.value)}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -610,6 +610,10 @@ export interface ElectronAPI {
   /** Subscribe to native menu action dispatches (File, Edit, etc.). */
   onMenuTriggerAction(callback: (action: import('./types').MenuActionId) => void): () => void
 
+  /** Subscribe to browser navigation shortcuts forwarded from a focused webview
+   *  guest (Cmd+R/[/]/L) or the Browser menu. */
+  onBrowserShortcut(callback: (action: import('./types').BrowserShortcutAction) => void): () => void
+
   /** Show a native context menu. Returns the clicked item id, or null if dismissed. */
   showContextMenu(items: NativeContextMenuItem[]): Promise<string | null>
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -142,6 +142,11 @@ export const MENU_OPEN_SETTINGS = 'menu:openSettings'
  *  renderer runs the matching handler (via useShortcuts). */
 export const MENU_TRIGGER_ACTION = 'menu:triggerAction'
 
+/** Browser navigation shortcut (main -> renderer). Sent when a webview guest
+ *  swallows a browser key (Cmd+R/[/]/L) via before-input-event, or from the
+ *  Browser menu. The focused BrowserPanel acts on it. */
+export const BROWSER_SHORTCUT = 'browser:shortcut'
+
 // Native context menu (renderer -> main)
 export const MENU_SHOW_CONTEXT = 'menu:showContext'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -421,6 +421,7 @@ export type ShortcutAction =
   | 'newTerminal'
   | 'newBrowser'
   | 'newEditor'
+  | 'newFile'
   | 'closePanel'
   | 'toggleSidebar'
   | 'toggleFileExplorer'
@@ -451,10 +452,16 @@ export type ShortcutAction =
  *  binding. */
 export type MenuActionId = ShortcutAction | 'openFolder' | 'reloadWorkspace'
 
+/** Browser-panel navigation actions. These are panel-scoped (handled by the
+ *  focused BrowserPanel) rather than global shortcuts, so they don't collide
+ *  with Monaco keys like Cmd+[ / Cmd+] / Cmd+L. */
+export type BrowserShortcutAction = 'reload' | 'reloadHard' | 'back' | 'forward' | 'focusUrl'
+
 export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   'newTerminal',
   'newBrowser',
   'newEditor',
+  'newFile',
   'closePanel',
   'toggleSidebar',
   'toggleFileExplorer',
@@ -485,6 +492,7 @@ export const SHORTCUT_DISPLAY_NAMES: Record<ShortcutAction, string> = {
   newTerminal: 'New Terminal',
   newBrowser: 'New Browser',
   newEditor: 'New Editor',
+  newFile: 'New File',
   closePanel: 'Close Panel',
   toggleSidebar: 'Toggle Sidebar',
   toggleFileExplorer: 'Toggle File Explorer',
@@ -515,8 +523,9 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   newTerminal: storedShortcut('t', { command: true }),
   newBrowser: storedShortcut('b', { command: true, shift: true }),
   newEditor: storedShortcut('e', { command: true, shift: true }),
+  newFile: storedShortcut('n', { command: true }),
   closePanel: storedShortcut('w', { command: true }),
-  toggleSidebar: storedShortcut('\\', { command: true }),
+  toggleSidebar: storedShortcut('b', { command: true }),
   toggleFileExplorer: storedShortcut('x', { command: true, shift: true }),
   toggleMinimap: storedShortcut('m', { command: true, shift: true }),
   nodeSwitcher: storedShortcut(' ', { control: true }),


### PR DESCRIPTION
## Summary
Fixes `Cmd+N` (it opened a whole new app window instead of creating a file on the canvas) and brings the keymap closer to VS Code / browser conventions.

### Cmd+N fix
`Cmd+N` was a native Electron menu accelerator on **Window → New Window**, which swallows the key before the renderer ever sees it. It now creates an **untitled editor on the canvas** via a dedicated `newFile` action. New Window keeps `Cmd+Shift+N` in the File menu.

### VS Code parity (menu accelerators reusing existing actions)
- `Cmd+P` / `Cmd+Shift+P` → command palette (it already does fuzzy file search → "Go to File")
- `Cmd+B` → toggle sidebar (now the primary binding; `Cmd+\` kept as a hidden alias)
- **Find in Files** moved `Cmd+Shift+H` → `Cmd+Shift+F`; file-explorer toggle menu accelerator aligned to `Cmd+Shift+X` to match its stored default (fixes a pre-existing menu/default mismatch)

### Browser shortcuts (panel-scoped)
`Cmd+R`, `Cmd+Shift+R`, `Cmd+[`, `Cmd+]`, `Cmd+L` are handled in `BrowserPanel` plus a main-process `before-input-event` interceptor on webview guests (works even when the page has keyboard focus), with a new **Browser** menu for discoverability. They are deliberately **panel-scoped, not global**, so they never override Monaco's `Cmd+[` / `Cmd+]` / `Cmd+L`.

## Settings
- **New File** (`⌘N`) appears in Settings → Shortcuts automatically and is rebindable.
- Toggle Sidebar now shows `⌘B` there (the VS Code key).
- Browser nav keys are intentionally fixed/panel-local (like the terminal's `⌘F` search) and not in the rebind list.

## Test plan
- `npm run typecheck` ✅
- `npm test` — 546 passed / 3 skipped ✅
- Manual: `Cmd+N` spawns an untitled editor (no new window); `Cmd+Shift+N` still opens a new window; `Cmd+P`/`Cmd+Shift+P`/`Cmd+K` open the palette; `Cmd+B` toggles the sidebar; in Monaco `Cmd+[`/`Cmd+]`/`Cmd+/` are untouched; in a focused browser panel `Cmd+R`/`Cmd+Shift+R`/`Cmd+[`/`Cmd+]`/`Cmd+L` work both when the page and the URL bar have focus.
