### PR TITLE
fix(notifications): make notification clicks reliably focus the window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1159,6 +1159,13 @@ function buildSinglePanelDockState(panelId: string): WindowDockState {
 // Set app name before menu and window creation
 app.setName('Cate')
 
+// Windows: the toast notification system keys off the AppUserModelID, and it
+// must match the install shortcut's ID (electron-builder uses `appId`) for the
+// notification 'click' event to fire reliably. No-op on macOS/Linux.
+if (process.platform === 'win32') {
+  app.setAppUserModelId('com.cate.app')
+}
+
 // In dev mode, use a separate userData directory so dev and production don't collide
 if (!app.isPackaged) {
   app.setPath('userData', path.join(app.getPath('userData'), 'Dev'))

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -7,6 +7,12 @@ import { NOTIFY_OS, NOTIFY_ACTION } from '../../shared/ipc-channels'
 import { sendToWindow, windowFromEvent, focusWindow } from '../windowRegistry'
 import type { NotificationAction } from '../../shared/types'
 
+// Hold a strong reference to every shown notification until it resolves.
+// Without this the Notification is GC'd once the IPC handler returns, and on
+// some platforms (notably macOS) its 'click' event then never fires — the OS
+// banner still shows, but clicking it is dead. Released on click/close/failed.
+const liveNotifications = new Set<Notification>()
+
 export function registerHandlers(): void {
   ipcMain.handle(
     NOTIFY_OS,
@@ -22,6 +28,10 @@ export function registerHandlers(): void {
           title: payload.title,
           body: payload.body,
         })
+        liveNotifications.add(notification)
+        const release = (): void => {
+          liveNotifications.delete(notification)
+        }
 
         notification.on('click', () => {
           // Focus the owning window
@@ -33,7 +43,11 @@ export function registerHandlers(): void {
           if (payload.action) {
             sendToWindow(ownerWindowId, NOTIFY_ACTION, payload.action)
           }
+
+          release()
         })
+        notification.on('close', release)
+        notification.on('failed', release)
 
         notification.show()
       }

--- a/src/main/windowRegistry.ts
+++ b/src/main/windowRegistry.ts
@@ -101,6 +101,19 @@ export function getAllWindows(): BrowserWindow[] {
 export function focusWindow(win: BrowserWindow): void {
   if (win.isMinimized()) win.restore()
   win.focus()
+
+  // macOS lets a backgrounded app raise itself on focus(); Windows and Linux do
+  // not — their foreground-lock / focus-stealing prevention often leaves focus()
+  // only flashing the taskbar. Briefly toggling always-on-top forces the window
+  // to the front, then releases it so it isn't actually pinned. (A notification
+  // click grants the app the foreground rights this relies on.) Preserve an
+  // existing always-on-top state if the window already had one.
+  if (process.platform !== 'darwin') {
+    const alreadyPinned = win.isAlwaysOnTop()
+    win.setAlwaysOnTop(true)
+    win.focus()
+    if (!alreadyPinned) win.setAlwaysOnTop(false)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
OS notification banners showed correctly, but **clicking them often did nothing** — the window wouldn't focus/raise. This fixes the click-to-focus path across all three platforms.

## Changes
- **`src/main/index.ts`** — set `AppUserModelId` on Windows. The toast system keys off the AppUserModelID, and it must match the install shortcut's id (electron-builder `appId`) for the notification `click` event to fire at all. No-op on macOS/Linux.
- **`src/main/ipc/notifications.ts`** — hold a strong reference to each `Notification` until it resolves (`click`/`close`/`failed`). Without this the object is GC'd once the IPC handler returns and its `click` event never fires — the banner still shows, but the click is dead (notably on macOS).
- **`src/main/windowRegistry.ts`** — in `focusWindow`, briefly toggle always-on-top on Windows/Linux so the window actually raises to the front. Their foreground-lock / focus-stealing prevention otherwise leaves `focus()` only flashing the taskbar. Any pre-existing always-on-top state is preserved.

## Test plan
- Trigger an OS notification (e.g. an agent finishing while the app is backgrounded) on each platform; click the banner → the owning Cate window comes to the front and any notification action is delivered.
- macOS: confirm clicks fire after the IPC handler returns (no GC race).
- Windows: confirm the banner appears under the Cate identity and clicking raises the window.
