### PR TITLE
fix(cmdk): stop file-name floods from starving in-file search

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -180,15 +180,18 @@ async function searchFiles(
   const lowerQuery = query.toLowerCase()
   const allowDotFiles = query.startsWith('.')
   const exclusionSet = currentExclusionSet()
-  const results: FileSearchResult[] = []
-  const seenPaths = new Set<string>()
 
-  const pushResult = (r: FileSearchResult): boolean => {
-    if (seenPaths.has(r.path)) return results.length < maxResults
-    seenPaths.add(r.path)
-    results.push(r)
-    return results.length < maxResults
-  }
+  // Name and content matches accumulate into separate buckets, each with its own
+  // budget. This is what keeps in-file search alive: with a single shared cap, a
+  // query matching many file names fills the whole result limit during the cheap
+  // name pass, the walk short-circuits before recursing into deep directories,
+  // and content search silently returns nothing. Independent budgets let the walk
+  // keep reading file contents even once the name bucket is full.
+  const nameResults: FileSearchResult[] = []
+  const contentResults: FileSearchResult[] = []
+  const seenPaths = new Set<string>()
+  const budgetsFull = () =>
+    nameResults.length >= maxResults && contentResults.length >= maxResults
 
   const walk = async (dir: string): Promise<boolean> => {
     let entries: string[]
@@ -216,9 +219,10 @@ async function searchFiles(
 
       const isDirectory = stat.isDirectory()
       const nameMatches = entry.toLowerCase().includes(lowerQuery)
-      if (nameMatches) {
+      if (nameMatches && nameResults.length < maxResults && !seenPaths.has(full)) {
+        seenPaths.add(full)
         const relativePath = path.relative(rootPath, full).split(path.sep).join('/')
-        if (!pushResult({ name: entry, path: full, relativePath, isDirectory, nameMatch: true })) return false
+        nameResults.push({ name: entry, path: full, relativePath, isDirectory, nameMatch: true })
       }
 
       if (isDirectory) {
@@ -231,7 +235,7 @@ async function searchFiles(
 
     // Content-search files at this level (skip ones already added by name).
     for (const f of files) {
-      if (results.length >= maxResults) return false
+      if (contentResults.length >= maxResults) break
       if (seenPaths.has(f.full)) continue
       if (f.size === 0 || f.size > maxFileBytes) continue
       if (BINARY_EXTENSIONS.has(f.ext)) continue
@@ -261,15 +265,16 @@ async function searchFiles(
       const line = text.slice(lineStart, lineEnd).trim().slice(0, 200)
       const lineNumber = (text.slice(0, lineStart).match(/\n/g)?.length ?? 0) + 1
       const relativePath = path.relative(rootPath, f.full).split(path.sep).join('/')
-      if (!pushResult({
+      seenPaths.add(f.full)
+      contentResults.push({
         name: f.name, path: f.full, relativePath,
         isDirectory: false, nameMatch: false,
         contentPreview: line, contentLine: lineNumber,
-      })) return false
+      })
     }
 
     for (const sub of subdirs) {
-      if (results.length >= maxResults) return false
+      if (budgetsFull()) return false
       const cont = await walk(sub)
       if (!cont) return false
     }
@@ -277,6 +282,14 @@ async function searchFiles(
   }
 
   await walk(rootPath)
+
+  // Merge the buckets into a single capped list. Name matches rank first, but
+  // content matches keep a reserved share of the cap so a flood of name matches
+  // can't crowd them out entirely — the whole point of also searching contents.
+  const reserve = Math.min(contentResults.length, Math.floor(maxResults / 2))
+  const keepName = Math.min(nameResults.length, maxResults - reserve)
+  const keepContent = Math.min(contentResults.length, maxResults - keepName)
+  const results = [...nameResults.slice(0, keepName), ...contentResults.slice(0, keepContent)]
   // Sort: name matches first, then by relative path length (shallower first).
   results.sort((a, b) => {
     if (a.nameMatch !== b.nameMatch) return a.nameMatch ? -1 : 1

--- a/src/main/ipc/searchBudget.test.ts
+++ b/src/main/ipc/searchBudget.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { FileSearchResult } from '../../shared/types'
+
+// Capture ipcMain.handle registrations so we can call the search handler
+// directly, mirroring fileExclusions.test.ts.
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, fn)
+    },
+  },
+}))
+vi.mock('../windowRegistry', () => ({ windowFromEvent: () => undefined, sendToWindow: vi.fn() }))
+vi.mock('../store', () => ({ getSettingSync: (k: string) => (k === 'fileExclusions' ? [] : undefined) }))
+
+const { registerHandlers } = await import('./filesystem')
+const { addAllowedRoot, removeAllowedRoot } = await import('./pathValidation')
+const { FS_SEARCH } = await import('../../shared/ipc-channels')
+
+registerHandlers()
+const searchHandler = handlers.get(FS_SEARCH)!
+const fakeEvent = { sender: {} } as unknown
+const search = (root: string, q: string, max: number) =>
+  searchHandler(fakeEvent, root, q, { maxResults: max }) as Promise<FileSearchResult[]>
+
+describe('search content-vs-name budgets', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'cate-budget-')))
+    addAllowedRoot(root)
+  })
+
+  afterEach(async () => {
+    removeAllowedRoot(root)
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  // The regression: a flood of file-name matches used to fill the shared result
+  // cap before the depth-first walk recursed into deep dirs, so in-file matches
+  // there were never found ("Cmd+K stopped searching inside files").
+  test('a flood of name matches does not starve deep content matches', async () => {
+    const max = 50
+    // More name-only matches than the entire cap, all at the shallow level.
+    for (let i = 0; i < max + 30; i++) {
+      await fs.writeFile(path.join(root, `widget-${i}.txt`), 'nothing relevant', 'utf8')
+    }
+    // A content-only match buried several directories deep.
+    const deep = path.join(root, 'a', 'b', 'c', 'd')
+    await fs.mkdir(deep, { recursive: true })
+    await fs.writeFile(path.join(deep, 'real.txt'), 'the widget lives here', 'utf8')
+
+    const res = await search(root, 'widget', max)
+    const content = res.filter((r) => !r.nameMatch)
+
+    expect(res.length).toBeLessThanOrEqual(max)
+    expect(content.length).toBeGreaterThan(0)
+    expect(content.some((r) => r.relativePath.endsWith('a/b/c/d/real.txt'))).toBe(true)
+    // Name matches still dominate the result (they rank first and keep most slots).
+    expect(res.filter((r) => r.nameMatch).length).toBeGreaterThan(content.length)
+  })
+
+  // No name matches at all → content matches may use the full cap (no regression
+  // for pure in-file search).
+  test('content matches can fill the cap when no names match', async () => {
+    const max = 20
+    for (let i = 0; i < max + 10; i++) {
+      await fs.writeFile(path.join(root, `note-${i}.txt`), 'contains needle text', 'utf8')
+    }
+    const res = await search(root, 'needle', max)
+    expect(res.length).toBe(max)
+    expect(res.every((r) => !r.nameMatch)).toBe(true)
+  })
+
+  test('name matches still rank ahead of content matches', async () => {
+    await fs.writeFile(path.join(root, 'needle.txt'), 'unrelated', 'utf8')
+    await fs.writeFile(path.join(root, 'other.txt'), 'has a needle inside', 'utf8')
+    const res = await search(root, 'needle', 50)
+    expect(res[0].nameMatch).toBe(true)
+    expect(res[0].name).toBe('needle.txt')
+    expect(res.some((r) => !r.nameMatch && r.relativePath === 'other.txt')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

Cmd+K stopped searching **inside** files — it still looked up file *names* but no longer returned in-file content matches. The file-explorer search (consolidated into the same backend) had the same regression.

## Root cause

`searchFiles` in `src/main/ipc/filesystem.ts` accumulated both name matches and content matches into a single list capped at `maxResults` (the palette passes `50`). The walk is depth-first and matches names *before* content at each level. Once a query matched `maxResults` file names — common in any sizeable project for everyday terms like `store`, `panel`, `index` — the shared cap filled during the cheap name pass and the walk short-circuited **before** ever recursing into deep directories. Content there was never searched, so results looked name-only.

Reproduced with a synthetic tree (80 name-only matches at the shallow level + one content-only match buried 4 dirs deep): before the fix, search returned `name=50 content=0` and never found the deep match.

## Fix

Give name and content matches **independent budgets**:

- The walk keeps reading file contents even after the name bucket is full, and only stops once *both* buckets are satisfied.
- When merging into the capped result list, content matches keep a reserved share (up to half the cap) so a flood of name matches can't crowd them out — while name matches still rank first.
- Pure in-file search (no name matches) can still use the full cap, so there's no regression for content-heavy queries.

## Tests

Adds `src/main/ipc/searchBudget.test.ts`:
- a flood of name matches no longer starves a deep content match;
- content matches can fill the whole cap when no names match;
- name matches still rank ahead of content matches.

Full suite (`vitest run`, 54 files / 549 tests) and `tsc --noEmit` pass.