### PR TITLE
feat(canvas): keyboard panel navigation and canvas panning

### DIFF
--- a/src/renderer/canvas/useCanvasNodeStyle.ts
+++ b/src/renderer/canvas/useCanvasNodeStyle.ts
@@ -14,6 +14,10 @@ const SHADOW_UNFOCUSED = `0 12px 36px -14px rgba(0,0,0,0.28), 0 4px 10px -5px rg
 const SHADOW_HOVERED = `${SHADOW_UNFOCUSED}, 0 0 18px rgba(255,255,255,0.015)`
 // Active/focused pane: a very faint bright (white) halo — no blue tint.
 const FOCUS_GLOW = `0 0 20px 1px rgba(255,255,255,0.025), 0 0 8px rgba(255,255,255,0.02)`
+// Selected-but-not-activated pane (e.g. jumped to via Cmd+Arrow): a crisp
+// accent outline ring so it's clearly "this is the current node" without the
+// active-pane halo. Distinct from the focus glow above.
+const SELECTION_RING = `0 0 0 2px var(--focus-blue), 0 0 14px -2px var(--focus-blue)`
 
 function boxShadow(hovered: boolean): string {
   if (hovered) return SHADOW_HOVERED
@@ -116,7 +120,8 @@ export function useCanvasNodeStyle(args: StyleArgs) {
       height: node.size.height,
       zIndex: 999,
       borderRadius: CORNER_RADIUS,
-      boxShadow: FOCUS_GLOW,
+      // Focused/active → soft halo; selected-only (keyboard jump) → outline ring.
+      boxShadow: isFocused ? FOCUS_GLOW : SELECTION_RING,
       pointerEvents: 'none',
       transform: isEntering ? 'scale(0.85)' : isExiting ? 'scale(0.9)' : 'scale(1)',
       opacity: isEntering || isExiting ? 0 : 1,

--- a/src/renderer/hooks/useAutoFocusLargestVisible.ts
+++ b/src/renderer/hooks/useAutoFocusLargestVisible.ts
@@ -41,6 +41,10 @@ export function useAutoFocusLargestVisible(canvasApi: StoreApi<CanvasStore>): vo
 
       const state = canvasApi.getState()
       const { nodes, viewportOffset, zoomLevel, containerSize, focusedNodeId } = state
+      // Keyboard canvas movement (Cmd+Arrow jump / Shift+Arrow pan) deliberately
+      // selects without activating — don't fight it by auto-focusing whatever
+      // scrolls into view.
+      if (state.suppressAutoFocus) return
       if (containerSize.width <= 0 || containerSize.height <= 0) return
       if (zoomLevel <= 0) return
 

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -11,10 +11,17 @@ import { useUIStore } from '../stores/uiStore'
 import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
 
-// Single-key (no-modifier) actions that must be suppressed while typing.
-const TOOL_AND_NAV_ACTIONS = new Set<ShortcutAction>([
-  'toolSelect', 'toolHand',
+// Single-key (no-modifier) tool shortcuts (V, H) — suppressed while typing.
+const TOOL_ACTIONS = new Set<ShortcutAction>(['toolSelect', 'toolHand'])
+
+// Cmd+Arrow panel navigation — moves the selection cursor between nodes.
+const NAVIGATE_ACTIONS = new Set<ShortcutAction>([
   'navigateUp', 'navigateDown', 'navigateLeft', 'navigateRight',
+])
+
+// Shift+Arrow canvas panning.
+const PAN_ACTIONS = new Set<ShortcutAction>([
+  'panUp', 'panDown', 'panLeft', 'panRight',
 ])
 
 /**
@@ -154,16 +161,28 @@ export function useShortcuts(): void {
           useUIStore.getState().setActiveTool('hand')
           break
         case 'navigateUp':
-          canvasStore().navigateDirection('up')
+          canvasStore().navigateSelect('up')
           break
         case 'navigateDown':
-          canvasStore().navigateDirection('down')
+          canvasStore().navigateSelect('down')
           break
         case 'navigateLeft':
-          canvasStore().navigateDirection('left')
+          canvasStore().navigateSelect('left')
           break
         case 'navigateRight':
-          canvasStore().navigateDirection('right')
+          canvasStore().navigateSelect('right')
+          break
+        case 'panUp':
+          canvasStore().panViewport('up')
+          break
+        case 'panDown':
+          canvasStore().panViewport('down')
+          break
+        case 'panLeft':
+          canvasStore().panViewport('left')
+          break
+        case 'panRight':
+          canvasStore().panViewport('right')
           break
         case 'autoLayout':
           canvasStore().autoLayout()
@@ -312,12 +331,28 @@ export function useShortcuts(): void {
       // When panel switcher is open, only handle the toggle shortcut
       const ui = useUIStore.getState()
 
-      // Single-key tool/navigation shortcuts (V, H, arrows) must not fire while
-      // typing in a terminal/editor, or steal arrows from the open overlays.
-      if (TOOL_AND_NAV_ACTIONS.has(action)) {
+      // Single-key tool shortcuts (V, H) must not fire while typing in a
+      // terminal/editor.
+      if (TOOL_ACTIONS.has(action)) {
         if (terminalHasFocus || isTextSurfaceFocused()) return
-        const navOnly = action !== 'toolSelect' && action !== 'toolHand'
-        if (navOnly && (ui.showNodeSwitcher || ui.showCommandPalette)) return
+      }
+
+      // Cmd+Arrow navigation / Shift+Arrow panning.
+      if (NAVIGATE_ACTIONS.has(action) || PAN_ACTIONS.has(action)) {
+        // Let an open overlay own the arrow keys.
+        if (ui.showNodeSwitcher || ui.showCommandPalette) return
+        // Defer to a real text editor (Monaco / input / textarea /
+        // contenteditable) so its own Cmd/Shift+Arrow editing keys keep
+        // working. Terminals don't rely on those chords, so canvas navigation
+        // overrides a focused terminal — letting the user jump/pan straight out
+        // of one and keep going.
+        if (!terminalHasFocus && isTextSurfaceFocused()) return
+        // Navigating deliberately doesn't activate the destination, so drop
+        // keyboard focus out of a focused terminal — otherwise its cursor keeps
+        // capturing input and the next arrow never reaches the canvas.
+        if (NAVIGATE_ACTIONS.has(action) && terminalHasFocus) {
+          ;(document.activeElement as HTMLElement | null)?.blur()
+        }
       }
       // Context-aware guard: when a real text editor (Monaco, input, textarea,
       // contenteditable) has focus, let Cmd+Z/Y fall through to it natively.

--- a/src/renderer/stores/canvasStore.test.ts
+++ b/src/renderer/stores/canvasStore.test.ts
@@ -184,6 +184,124 @@ describe('canvasStore.navigateDirection', () => {
 })
 
 // =============================================================================
+// navigateSelect — Cmd+Arrow node jumping that selects without activating.
+// =============================================================================
+
+describe('canvasStore.navigateSelect', () => {
+  function setup() {
+    const store = createCanvasStore()
+    store.getState().setContainerSize({ width: 1000, height: 800 })
+    const c = store.getState().addNode('c', 'editor', { x: -50, y: -40 }, { width: 100, height: 80 })
+    const r = store.getState().addNode('r', 'editor', { x: 450, y: -40 }, { width: 100, height: 80 })
+    const l = store.getState().addNode('l', 'editor', { x: -550, y: -40 }, { width: 100, height: 80 })
+    const u = store.getState().addNode('u', 'editor', { x: -50, y: -540 }, { width: 100, height: 80 })
+    const d = store.getState().addNode('d', 'editor', { x: -50, y: 460 }, { width: 100, height: 80 })
+    return { store, c, r, l, u, d }
+  }
+
+  it('moves the selection to the nearest node in each direction', () => {
+    const { store, c, r, l, u, d } = setup()
+    const nav = (dir: 'up' | 'down' | 'left' | 'right') => {
+      store.getState().selectNodes([c])
+      store.getState().navigateSelect(dir)
+      return [...store.getState().selectedNodeIds]
+    }
+    expect(nav('right')).toEqual([r])
+    expect(nav('left')).toEqual([l])
+    expect(nav('up')).toEqual([u])
+    expect(nav('down')).toEqual([d])
+  })
+
+  it('does NOT activate (focus) the destination, so arrows keep jumping', () => {
+    const { store, c, r } = setup()
+    store.getState().focusNode(c)
+    store.getState().navigateSelect('right')
+    expect(store.getState().focusedNodeId).toBeNull()
+    expect([...store.getState().selectedNodeIds]).toEqual([r])
+  })
+
+  it('uses the focused node as the reference when nothing is selected', () => {
+    const { store, c, r } = setup()
+    store.getState().focusNode(c)
+    store.getState().navigateSelect('right')
+    expect([...store.getState().selectedNodeIds]).toEqual([r])
+  })
+
+  it('chains: jumping again continues from the newly selected node', () => {
+    const { store, c, r } = setup()
+    const rr = store.getState().addNode('rr', 'editor', { x: 950, y: -40 }, { width: 100, height: 80 })
+    store.getState().selectNodes([c])
+    store.getState().navigateSelect('right')
+    expect([...store.getState().selectedNodeIds]).toEqual([r])
+    store.getState().navigateSelect('right')
+    expect([...store.getState().selectedNodeIds]).toEqual([rr])
+  })
+
+  it('is a no-op when no node lies in the requested direction', () => {
+    const { store, r } = setup()
+    store.getState().selectNodes([r]) // rightmost
+    store.getState().navigateSelect('right')
+    expect([...store.getState().selectedNodeIds]).toEqual([r])
+  })
+
+  it('suppresses auto-focus on jump, and resumes it on explicit focus or manual pan', () => {
+    const { store, c, r } = setup()
+    store.getState().selectNodes([c])
+    store.getState().navigateSelect('right')
+    expect(store.getState().suppressAutoFocus).toBe(true)
+
+    // Clicking / explicitly focusing a node resumes auto-focus.
+    store.getState().focusNode(r)
+    expect(store.getState().suppressAutoFocus).toBe(false)
+
+    // A keyboard pan suppresses again; a manual pan resumes.
+    store.getState().panViewport('left')
+    expect(store.getState().suppressAutoFocus).toBe(true)
+    store.getState().setViewportOffset({ x: 10, y: 10 })
+    expect(store.getState().suppressAutoFocus).toBe(false)
+  })
+})
+
+// =============================================================================
+// panViewport — Shift+Arrow canvas panning.
+// =============================================================================
+
+describe('canvasStore.panViewport', () => {
+  it('pans the viewport one step per direction without touching selection/focus', () => {
+    const store = createCanvasStore()
+    store.getState().setViewportOffset({ x: 0, y: 0 })
+
+    store.getState().panViewport('right')
+    expect(store.getState().viewportOffset.x).toBeLessThan(0)
+    store.getState().panViewport('left') // back to start
+    expect(store.getState().viewportOffset.x).toBeCloseTo(0)
+
+    store.getState().setViewportOffset({ x: 0, y: 0 })
+    store.getState().panViewport('down')
+    expect(store.getState().viewportOffset.y).toBeLessThan(0)
+    store.getState().setViewportOffset({ x: 0, y: 0 })
+    store.getState().panViewport('up')
+    expect(store.getState().viewportOffset.y).toBeGreaterThan(0)
+
+    // No selection/focus side effects.
+    expect(store.getState().focusedNodeId).toBeNull()
+    expect(store.getState().selectedNodeIds.size).toBe(0)
+  })
+
+  it('left and right pan by equal and opposite amounts', () => {
+    const store = createCanvasStore()
+    store.getState().setViewportOffset({ x: 0, y: 0 })
+    store.getState().panViewport('left')
+    const left = store.getState().viewportOffset.x
+    store.getState().setViewportOffset({ x: 0, y: 0 })
+    store.getState().panViewport('right')
+    const right = store.getState().viewportOffset.x
+    expect(left).toBeCloseTo(-right)
+    expect(left).toBeGreaterThan(0)
+  })
+})
+
+// =============================================================================
 // zoomToSelection — fit and center the current selection.
 // =============================================================================
 

--- a/src/renderer/stores/canvasStore.ts
+++ b/src/renderer/stores/canvasStore.ts
@@ -60,6 +60,11 @@ export interface CanvasStoreState {
   }
   selectedNodeIds: Set<string>
   selectedRegionIds: Set<string>
+  /** When true, the auto-focus-largest-visible hook stands down. Set while the
+   *  user is moving the canvas by keyboard (Cmd+Arrow jump / Shift+Arrow pan)
+   *  so those movements don't auto-activate whatever scrolls into view; cleared
+   *  by any explicit focus, manual pan, or zoom. */
+  suppressAutoFocus: boolean
   /** Region currently being hovered as a drop target during a node drag. */
   dropTargetRegionId: string | null
   /** Undo history — snapshots of {nodes, regions}. */
@@ -99,6 +104,8 @@ export interface CanvasStoreActions {
   setContainerSize: (size: Size) => void
   zoomAroundCenter: (newZoom: number) => void
   animateZoomTo: (targetZoom: number) => void
+  // Smoothly ease the viewport offset toward a target (Shift/Cmd+Arrow movement)
+  animateViewportTo: (target: Point) => void
 
   // Derived getters
   canvasToView: (point: Point) => Point
@@ -114,6 +121,14 @@ export interface CanvasStoreActions {
 
   // Move focus to the spatially-nearest node in a direction, centering it
   navigateDirection: (dir: 'up' | 'down' | 'left' | 'right') => void
+
+  // Move the selection cursor to the spatially-nearest node in a direction and
+  // centre it — without focusing it, so panel content never grabs the keyboard
+  // and the user can keep jumping (Cmd+Arrow).
+  navigateSelect: (dir: 'up' | 'down' | 'left' | 'right') => void
+
+  // Pan the canvas viewport one step in a direction (Shift+Arrow).
+  panViewport: (dir: 'up' | 'down' | 'left' | 'right') => void
 
   zoomToFit: () => void
   zoomToSelection: () => void
@@ -293,6 +308,48 @@ function rectsOverlap(a: Rect, b: Rect): boolean {
   )
 }
 
+/** View-space pixels the canvas pans per Shift+Arrow keystroke. */
+const PAN_STEP = 120
+
+/**
+ * Find the spatially-nearest node in a direction from a reference centre.
+ * Uses a directional cone: the candidate must lie in the half-plane AND the
+ * move axis must dominate, so we don't jump to a node that's mostly sideways.
+ * Shared by navigateDirection (focus + activate) and navigateSelect (select
+ * without activating).
+ */
+function findNodeInDirection(
+  nodeList: CanvasNodeState[],
+  refX: number,
+  refY: number,
+  dir: 'up' | 'down' | 'left' | 'right',
+  excludeId?: CanvasNodeId,
+): CanvasNodeState | null {
+  let best: CanvasNodeState | null = null
+  let bestScore = Infinity
+  for (const n of nodeList) {
+    if (excludeId && n.id === excludeId) continue
+    const dx = n.origin.x + n.size.width / 2 - refX
+    const dy = n.origin.y + n.size.height / 2 - refY
+    const adx = Math.abs(dx)
+    const ady = Math.abs(dy)
+
+    let inCone: boolean
+    let score: number
+    if (dir === 'left') { inCone = dx < 0 && adx >= ady; score = adx + 2 * ady }
+    else if (dir === 'right') { inCone = dx > 0 && adx >= ady; score = adx + 2 * ady }
+    else if (dir === 'up') { inCone = dy < 0 && ady >= adx; score = ady + 2 * adx }
+    else { inCone = dy > 0 && ady >= adx; score = ady + 2 * adx }
+    if (!inCone) continue
+
+    if (score < bestScore) {
+      bestScore = score
+      best = n
+    }
+  }
+  return best
+}
+
 // -----------------------------------------------------------------------------
 // Store factory — creates independent canvas store instances
 // -----------------------------------------------------------------------------
@@ -306,6 +363,21 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
       cancelAnimationFrame(activeZoomAnimationRafId)
       activeZoomAnimationRafId = 0
     }
+  }
+
+  // Per-instance viewport-pan animation tracking. `offsetAnimTarget` is the
+  // destination the tween is easing toward; tracking it (rather than reading
+  // the mid-flight offset) lets rapid Shift+Arrow / Cmd+Arrow presses stack
+  // smoothly instead of lagging behind the keystrokes.
+  let activeOffsetAnimationRafId = 0
+  let offsetAnimTarget: Point | null = null
+
+  function cancelOffsetAnim() {
+    if (activeOffsetAnimationRafId) {
+      cancelAnimationFrame(activeOffsetAnimationRafId)
+      activeOffsetAnimationRafId = 0
+    }
+    offsetAnimTarget = null
   }
 
   return create<CanvasStore>((set, get) => ({
@@ -322,6 +394,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
   snapGuides: { lines: [] },
   selectedNodeIds: new Set<string>(),
   selectedRegionIds: new Set<string>(),
+  suppressAutoFocus: false,
   dropTargetRegionId: null,
   history: [],
   future: [],
@@ -514,6 +587,8 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
         nextZOrder: state.nextZOrder + 1,
         focusedNodeId: id,
         focusEpoch: state.focusEpoch + 1,
+        // An explicit focus (click, switcher, auto-focus) ends keyboard-nav mode.
+        suppressAutoFocus: false,
       }
     })
   },
@@ -581,12 +656,16 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
   },
 
   setViewportOffset(offset) {
-    set({ viewportOffset: offset })
+    // A manual pan (wheel / drag) interrupts any in-flight keyboard tween and
+    // resumes auto-focus-largest.
+    cancelOffsetAnim()
+    if (get().suppressAutoFocus) set({ viewportOffset: offset, suppressAutoFocus: false })
+    else set({ viewportOffset: offset })
   },
 
   setZoomAndOffset(zoom, offset) {
     const clamped = Math.min(Math.max(zoom, ZOOM_MIN), ZOOM_MAX)
-    set({ zoomLevel: clamped, viewportOffset: offset })
+    set({ zoomLevel: clamped, viewportOffset: offset, suppressAutoFocus: false })
   },
 
   setContainerSize(size) {
@@ -610,6 +689,7 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
     }
     set({
       zoomLevel: clamped,
+      suppressAutoFocus: false,
       viewportOffset: {
         x: centerView.x - centerCanvas.x * clamped,
         y: centerView.y - centerCanvas.y * clamped,
@@ -619,6 +699,8 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
 
   animateZoomTo(targetZoom) {
     cancelZoomAnim()
+    cancelOffsetAnim()
+    if (get().suppressAutoFocus) set({ suppressAutoFocus: false })
 
     const clampedTarget = Math.min(Math.max(targetZoom, ZOOM_MIN), ZOOM_MAX)
 
@@ -658,6 +740,41 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
     }
 
     activeZoomAnimationRafId = requestAnimationFrame(tick)
+  },
+
+  animateViewportTo(target) {
+    // A pan and a zoom-recentre must not both drive viewportOffset at once.
+    cancelZoomAnim()
+    offsetAnimTarget = target
+
+    // No RAF (e.g. the node test environment) — apply instantly.
+    if (typeof requestAnimationFrame !== 'function') {
+      activeOffsetAnimationRafId = 0
+      offsetAnimTarget = null
+      set({ viewportOffset: target })
+      return
+    }
+
+    // A loop is already running — it will glide to the updated target.
+    if (activeOffsetAnimationRafId) return
+
+    const EASE = 0.18
+    const tick = () => {
+      const t = offsetAnimTarget
+      if (!t) { activeOffsetAnimationRafId = 0; return }
+      const { viewportOffset: o } = get()
+      const dx = t.x - o.x
+      const dy = t.y - o.y
+      if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) {
+        set({ viewportOffset: { x: t.x, y: t.y } })
+        activeOffsetAnimationRafId = 0
+        offsetAnimTarget = null
+        return
+      }
+      set({ viewportOffset: { x: o.x + dx * EASE, y: o.y + dy * EASE } })
+      activeOffsetAnimationRafId = requestAnimationFrame(tick)
+    }
+    activeOffsetAnimationRafId = requestAnimationFrame(tick)
   },
 
   // --- Derived getters ---
@@ -787,32 +904,78 @@ export function createCanvasStore(): UseBoundStore<StoreApi<CanvasStore>> {
       refY = center.y
     }
 
-    let best: CanvasNodeState | null = null
-    let bestScore = Infinity
-    for (const n of nodeList) {
-      if (current && n.id === current.id) continue
-      const dx = n.origin.x + n.size.width / 2 - refX
-      const dy = n.origin.y + n.size.height / 2 - refY
-      const adx = Math.abs(dx)
-      const ady = Math.abs(dy)
+    const best = findNodeInDirection(nodeList, refX, refY, dir, current?.id)
+    if (best) get().focusAndCenter(best.id)
+  },
 
-      // Directional cone: the candidate must lie in the half-plane AND the move
-      // axis must dominate, so we don't jump to a node that's mostly sideways.
-      let inCone: boolean
-      let score: number
-      if (dir === 'left') { inCone = dx < 0 && adx >= ady; score = adx + 2 * ady }
-      else if (dir === 'right') { inCone = dx > 0 && adx >= ady; score = adx + 2 * ady }
-      else if (dir === 'up') { inCone = dy < 0 && ady >= adx; score = ady + 2 * adx }
-      else { inCone = dy > 0 && ady >= adx; score = ady + 2 * adx }
-      if (!inCone) continue
+  navigateSelect(dir) {
+    const state = get()
+    const nodeList = Object.values(state.nodes)
+    if (nodeList.length === 0) return
 
-      if (score < bestScore) {
-        bestScore = score
-        best = n
-      }
+    // Reference center: the single selected node, else the focused node, else
+    // the viewport center. Using selection (not focus) as the cursor lets the
+    // user chain jumps without the destination grabbing keyboard focus.
+    let ref: CanvasNodeState | null = null
+    if (state.selectedNodeIds.size === 1) {
+      const id = [...state.selectedNodeIds][0]
+      ref = state.nodes[id] ?? null
+    }
+    if (!ref && state.focusedNodeId) ref = state.nodes[state.focusedNodeId] ?? null
+
+    let refX: number
+    let refY: number
+    if (ref) {
+      refX = ref.origin.x + ref.size.width / 2
+      refY = ref.origin.y + ref.size.height / 2
+    } else {
+      const cs = state.containerSize
+      const center = get().viewToCanvas({ x: cs.width / 2, y: cs.height / 2 })
+      refX = center.x
+      refY = center.y
     }
 
-    if (best) get().focusAndCenter(best.id)
+    const best = findNodeInDirection(nodeList, refX, refY, dir, ref?.id)
+    if (!best) return
+
+    // Select + raise the target and clear focus so no panel content grabs the
+    // keyboard — otherwise the next arrow would be swallowed by the node
+    // instead of moving to the one beyond it. The viewport then glides to
+    // centre the node (see animateViewportTo) instead of snapping.
+    set({
+      nodes: { ...state.nodes, [best.id]: { ...best, zOrder: state.nextZOrder } },
+      nextZOrder: state.nextZOrder + 1,
+      selectedNodeIds: new Set([best.id]),
+      selectedRegionIds: new Set<string>(),
+      focusedNodeId: null,
+      // Don't let auto-focus-largest re-activate a node as we pan to centre.
+      suppressAutoFocus: true,
+    })
+    const cs = state.containerSize
+    const zoom = state.zoomLevel
+    if (cs.width > 0 && cs.height > 0) {
+      get().animateViewportTo({
+        x: cs.width / 2 - (best.origin.x + best.size.width / 2) * zoom,
+        y: cs.height / 2 - (best.origin.y + best.size.height / 2) * zoom,
+      })
+    }
+  },
+
+  panViewport(dir) {
+    // Panning the canvas by keyboard must not auto-activate nodes scrolling
+    // into view.
+    if (!get().suppressAutoFocus) set({ suppressAutoFocus: true })
+    // Accumulate from the in-flight target (if animating) so repeated key
+    // presses stack smoothly rather than chasing the easing tween.
+    const o = offsetAnimTarget ?? get().viewportOffset
+    // Arrow direction = direction the camera moves, so content scrolls the
+    // opposite way (Down reveals what's below → offset.y decreases).
+    const target =
+      dir === 'up' ? { x: o.x, y: o.y + PAN_STEP }
+      : dir === 'down' ? { x: o.x, y: o.y - PAN_STEP }
+      : dir === 'left' ? { x: o.x + PAN_STEP, y: o.y }
+      : { x: o.x - PAN_STEP, y: o.y }
+    get().animateViewportTo(target)
   },
 
   zoomToFit() {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -446,6 +446,10 @@ export type ShortcutAction =
   | 'navigateDown'
   | 'navigateLeft'
   | 'navigateRight'
+  | 'panUp'
+  | 'panDown'
+  | 'panLeft'
+  | 'panRight'
 
 /** Actions the native menu can dispatch into the renderer. Superset of
  *  ShortcutAction — includes a few menu-only items that have no keyboard
@@ -486,6 +490,10 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   'navigateDown',
   'navigateLeft',
   'navigateRight',
+  'panUp',
+  'panDown',
+  'panLeft',
+  'panRight',
 ]
 
 export const SHORTCUT_DISPLAY_NAMES: Record<ShortcutAction, string> = {
@@ -513,10 +521,14 @@ export const SHORTCUT_DISPLAY_NAMES: Record<ShortcutAction, string> = {
   deleteNode: 'Delete Focused Panel',
   toolSelect: 'Select Tool',
   toolHand: 'Hand Tool',
-  navigateUp: 'Navigate Up',
-  navigateDown: 'Navigate Down',
-  navigateLeft: 'Navigate Left',
-  navigateRight: 'Navigate Right',
+  navigateUp: 'Navigate to Panel Above',
+  navigateDown: 'Navigate to Panel Below',
+  navigateLeft: 'Navigate to Panel Left',
+  navigateRight: 'Navigate to Panel Right',
+  panUp: 'Pan Canvas Up',
+  panDown: 'Pan Canvas Down',
+  panLeft: 'Pan Canvas Left',
+  panRight: 'Pan Canvas Right',
 }
 
 export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
@@ -544,10 +556,14 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   deleteNode: storedShortcut('Backspace', { command: true }),
   toolSelect: storedShortcut('v'),
   toolHand: storedShortcut('h'),
-  navigateUp: storedShortcut('↑'),
-  navigateDown: storedShortcut('↓'),
-  navigateLeft: storedShortcut('←'),
-  navigateRight: storedShortcut('→'),
+  navigateUp: storedShortcut('↑', { command: true }),
+  navigateDown: storedShortcut('↓', { command: true }),
+  navigateLeft: storedShortcut('←', { command: true }),
+  navigateRight: storedShortcut('→', { command: true }),
+  panUp: storedShortcut('↑', { shift: true }),
+  panDown: storedShortcut('↓', { shift: true }),
+  panLeft: storedShortcut('←', { shift: true }),
+  panRight: storedShortcut('→', { shift: true }),
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds keyboard navigation across the canvas:

- **Cmd + ↑ ↓ ← →** — jump the selection to the spatially-nearest panel and centre it. Selects **without activating** (no focus grab into the panel's terminal/editor), so jumps chain. A focused terminal is overridden; real text editors (Monaco/inputs) and open overlays keep their own arrow keys.
- **Shift + ↑ ↓ ← →** — pan the canvas in steps.
- Both glide via a single eased viewport tween (matching the zoom animation's feel); repeated/held presses stack smoothly instead of lagging behind the easing.

## Behaviour details
- **Auto-focus suppression:** while keyboard-moving the canvas, the `autoFocusLargestVisibleNode` hook stands down, so panning to a node no longer auto-activates whatever scrolls into view. It resumes on any explicit focus (click), manual pan (wheel/drag), or zoom.
- **Distinct selection visual:** the jumped-to panel (selected but not focused) renders with an accent outline ring, distinct from the active-pane halo.

## Notes
- Plain arrow keys no longer navigate (they previously did jump-and-activate); the existing `navigateDirection` store method is kept for compatibility.
- New bindings appear automatically in Settings → Shortcuts (editable/resettable).

## Testing
- `npm run typecheck` clean
- `npx vitest run` — 553 passed / 3 skipped (+ new tests covering jump selection, chaining, non-activation, pan, and the auto-focus suppression lifecycle)