### PR TITLE
fix(parallel-work): make Clean up remove orphaned worktree entries

### DIFF
--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -946,14 +946,24 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
   }, [rootPath, reconcile])
 
   const handlePrune = useCallback(async () => {
-    if (!rootPath) return
+    if (!rootPath || !selectedWorkspaceId) return
     try {
       await window.electronAPI.gitWorktreePrune(rootPath)
+      // `git worktree prune` only cleans entries git still tracks. The orphans
+      // shown here are store metadata for worktrees git no longer lists, so
+      // prune is a no-op for them — drop those stale entries from the store
+      // explicitly, otherwise "Clean up" appears to do nothing.
+      const list = await window.electronAPI.gitWorktreeList(rootPath)
+      const livePaths = new Set(list.map((g) => g.path))
+      const ws = useAppStore.getState().workspaces.find((w) => w.id === selectedWorkspaceId)
+      for (const w of ws?.worktrees ?? []) {
+        if (!w.isPrimary && !livePaths.has(w.path)) removeWorktree(selectedWorkspaceId, w.id)
+      }
       void reconcile()
     } catch (err: any) {
       setError(err?.message || 'Cleanup failed')
     }
-  }, [rootPath, reconcile])
+  }, [rootPath, selectedWorkspaceId, removeWorktree, reconcile])
 
   const makeCallbacks = useCallback(
     (wt: WorktreeMeta): CardCallbacks => ({


### PR DESCRIPTION
## Problem

The **Clean up** button in the Parallel Work panel (shown next to "Couldn't find N branches") did nothing.

The orphans it targets are store metadata for worktrees that git's `worktree list` no longer returns. `git worktree prune` only cleans git's admin files for worktrees git *still tracks*, so it's a no-op for these; and `reconcile()` only ever *adds* git worktrees into the store — it never removes stale entries. Net effect: the button appeared broken, while the per-item **Remove** worked because it calls `removeWorktree`.

## Fix

`handlePrune` now, after pruning, re-fetches the authoritative worktree list and drops any non-primary store entry whose path git no longer lists (the same condition that defines an orphan), then reconciles. Effectively "Remove" applied to every orphan in one click, plus the original prune.

## Testing

- `tsc --noEmit` clean
- Manual: with orphaned entries showing, clicking Clean up should clear the warning row and orphan entries