### PR TITLE
fix(canvas): route keyboard shortcuts to the active canvas store

### DIFF
--- a/src/renderer/hooks/useShortcuts.activeCanvas.test.tsx
+++ b/src/renderer/hooks/useShortcuts.activeCanvas.test.tsx
@@ -1,0 +1,137 @@
+// =============================================================================
+// useShortcuts — active-canvas routing regression test.
+//
+// Pins the fix for the bug where keyboard canvas actions (navigate/pan/zoom)
+// were dispatched to the App-level *singleton* canvas store captured from
+// context on mount, instead of the canvas the user is actually looking at.
+//
+// CanvasPanel gives each canvas its own per-panel store and marks itself the
+// active canvas via setActiveCanvasPanelId. Only the first canvas aliases the
+// legacy singleton; any later canvas gets a fresh store. useShortcuts must
+// resolve the *active* store at dispatch time — otherwise Cmd/Shift+Arrow fire
+// but nothing moves on screen (the symptom from the field report).
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Heavy renderer modules whose import-time side effects explode under jsdom,
+// pulled in transitively via the canvas/app stores. Mirrors the other hook tests.
+vi.mock('../lib/terminalRegistry', () => ({
+  terminalRegistry: { release: vi.fn(), setPendingTransfer: vi.fn() },
+}))
+vi.mock('../lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+import * as React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import type { StoreApi } from 'zustand'
+import { useShortcuts } from './useShortcuts'
+import { CanvasStoreProvider } from '../stores/CanvasStoreContext'
+import {
+  getOrCreateCanvasStoreForPanel,
+  releaseCanvasStoreForPanel,
+  type CanvasStore,
+} from '../stores/canvasStore'
+import {
+  registerCanvasOps,
+  unregisterCanvasOps,
+  setActiveCanvasPanelId,
+} from '../stores/appStore'
+import { createCanvasOps } from '../lib/canvasBridge'
+
+// Tell React this is an act() environment (silences the act warning + flushes effects).
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const PRIMARY = 'panel-primary'
+const ACTIVE = 'panel-active'
+
+let primary: StoreApi<CanvasStore>
+let active: StoreApi<CanvasStore>
+let container: HTMLDivElement
+let root: Root
+
+function Harness({ store }: { store: StoreApi<CanvasStore> }) {
+  // Mirror App: useShortcuts runs under the singleton context provider.
+  return (
+    <CanvasStoreProvider store={store}>
+      <Inner />
+    </CanvasStoreProvider>
+  )
+}
+function Inner() {
+  useShortcuts()
+  return null
+}
+
+function dispatchKey(init: Partial<KeyboardEventInit> & { key: string }) {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...init }))
+  })
+}
+
+beforeEach(() => {
+  // electronAPI is consumed in useShortcuts' effect (menu subscriptions).
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    onMenuTriggerAction: () => () => {},
+    onMenuLoadLayout: () => () => {},
+  }
+
+  // First panel inherits the legacy singleton; the second gets a fresh store.
+  primary = getOrCreateCanvasStoreForPanel(PRIMARY) as unknown as StoreApi<CanvasStore>
+  active = getOrCreateCanvasStoreForPanel(ACTIVE) as unknown as StoreApi<CanvasStore>
+  registerCanvasOps(PRIMARY, createCanvasOps(primary))
+  registerCanvasOps(ACTIVE, createCanvasOps(active))
+  // The user is looking at the second canvas.
+  setActiveCanvasPanelId(ACTIVE)
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  // Provider store is the singleton/primary — exactly what App passes.
+  act(() => { root.render(<Harness store={primary} />) })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  container.remove()
+  unregisterCanvasOps(PRIMARY)
+  unregisterCanvasOps(ACTIVE)
+  releaseCanvasStoreForPanel(PRIMARY)
+  releaseCanvasStoreForPanel(ACTIVE)
+})
+
+describe('useShortcuts active-canvas routing', () => {
+  it('Cmd+Arrow navigation targets the active canvas, not the captured singleton', () => {
+    // Two nodes on the ACTIVE canvas, left and right.
+    const left = active.getState().addNode('left-panel', 'editor', { x: 0, y: 0 })
+    const right = active.getState().addNode('right-panel', 'editor', { x: 2000, y: 0 })
+    expect(left && right).toBeTruthy()
+    // Cursor starts on the left node.
+    act(() => { active.getState().selectNodes([left]) })
+
+    dispatchKey({ key: 'ArrowRight', metaKey: true })
+
+    // Selection moved to the right node on the ACTIVE store...
+    expect([...active.getState().selectedNodeIds]).toEqual([right])
+    // ...and the captured singleton/primary was never touched.
+    expect(primary.getState().selectedNodeIds.size).toBe(0)
+  })
+
+  it('Shift+Arrow pan moves the active canvas viewport, not the singleton', () => {
+    const before = active.getState().viewportOffset
+    const primaryBefore = primary.getState().viewportOffset
+
+    dispatchKey({ key: 'ArrowUp', shiftKey: true })
+
+    // animateViewportTo sets offsetAnimTarget and drives RAF; under jsdom the
+    // target is committed via the easing loop, but the store's pan intent is
+    // observable immediately as suppressAutoFocus + a changed target. Assert the
+    // active store reacted and the primary did not.
+    expect(active.getState().suppressAutoFocus).toBe(true)
+    expect(primary.getState().suppressAutoFocus).toBe(false)
+    expect(primaryBefore).toBe(primary.getState().viewportOffset)
+    void before
+  })
+})

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -6,7 +6,7 @@
 import { useEffect } from 'react'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
-import { useAppStore } from '../stores/appStore'
+import { useAppStore, getActiveCanvasOps } from '../stores/appStore'
 import { useUIStore } from '../stores/uiStore'
 import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
@@ -54,7 +54,15 @@ export function useShortcuts(): void {
 
   useEffect(() => {
     const shortcutStore = useShortcutStore.getState
-    const canvasStore = canvasStoreApi.getState
+    // Resolve the *active* canvas store at call time rather than binding to the
+    // context store captured on mount. The visible canvas is a per-panel store
+    // (CanvasPanel registers it and marks itself active via setActiveCanvasPanelId);
+    // the App-level context only aliases the legacy singleton, which is usually
+    // NOT the canvas the user is looking at once more than one canvas exists.
+    // Routing every canvas action through the active store keeps keyboard
+    // navigation/pan/zoom acting on the canvas actually on screen. Falls back to
+    // the context store for single-canvas / detached windows.
+    const canvasStore = () => (getActiveCanvasOps()?.storeApi ?? canvasStoreApi).getState()
     const appStore = useAppStore.getState
 
     /**

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -99,7 +99,7 @@ export function setActiveCanvasPanelId(canvasPanelId: string) {
 }
 
 /** Returns the CanvasOperations for the currently active canvas, falling back to the primary */
-function getActiveCanvasOps(): CanvasOperations | null {
+export function getActiveCanvasOps(): CanvasOperations | null {
   if (activeCanvasPanelId) {
     const ops = canvasOpsRegistry.get(activeCanvasPanelId)
     if (ops) return ops


### PR DESCRIPTION
## Problem

Canvas keyboard shortcuts (Cmd+Arrow navigate, Shift+Arrow pan, and also zoom, focus, undo/redo, select-all, group, delete) fired but did nothing on screen — the keystroke matched and `preventDefault` ran, yet the visible canvas never moved.

## Root cause

`useShortcuts` captured `useCanvasStoreApi()` once on mount, which resolves to the **App-level singleton** canvas store. But each workspace's canvas has its **own** per-panel store (`getOrCreateCanvasStoreForPanel`); only the *first* canvas to register aliases the legacy singleton. So on any secondary canvas — a second or switched-to workspace, a restored session, or a nested canvas — the active store diverges from the singleton, and every canvas shortcut mutated an **off-screen** store.

This is why it appeared to work in single-workspace dev sessions (active canvas == singleton) but broke in real multi-canvas usage. The Cmd/Shift+Arrow feature was simply the first thing to exercise canvas shortcuts on a non-primary canvas; the pre-existing zoom/focus/undo shortcuts had the same latent bug under the same condition.

## Fix

Resolve the active canvas store **at dispatch time** via `getActiveCanvasOps()` (already tracked through `setActiveCanvasPanelId` on workspace switch and canvas pointer-down), falling back to the context store for single-canvas / detached windows:

```ts
const canvasStore = () => (getActiveCanvasOps()?.storeApi ?? canvasStoreApi).getState()
```

Since every action already called `canvasStore()`, this one-line change re-points all of them at the canvas actually on screen.

## Changes

- `useShortcuts.ts` — resolve the active canvas store per call instead of binding to the captured context store.
- `appStore.ts` — export the previously module-private `getActiveCanvasOps()`.
- `useShortcuts.activeCanvas.test.tsx` — regression test: with the provider set to the singleton but a different canvas marked active, Cmd+Arrow navigates the active store (not the singleton) and Shift+Arrow pans the active store. Both assertions fail on the old code.

## Testing

- New regression test fails without the fix, passes with it.
- Full hooks/stores/drag suites green (207 passed, 3 skipped).