### PR TITLE
fix(title): show just "Cate" for default workspace name

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -176,7 +176,9 @@ function MainApp() {
   // workspaces apart at a glance.
   useEffect(() => {
     const name = currentWorkspace?.name?.trim()
-    const title = name ? `${name} — Cate` : 'Cate'
+    // Treat the default "Workspace" placeholder as no real name, so the title
+    // is just "Cate" until the user actually renames the workspace.
+    const title = name && name !== 'Workspace' ? `${name} — Cate` : 'Cate'
     const api = (window as unknown as { electronAPI?: { windowSetTitle?: (t: string) => Promise<void> } }).electronAPI
     api?.windowSetTitle?.(title).catch(() => { /* noop */ })
   }, [currentWorkspace?.name])


### PR DESCRIPTION
The window title was built as `${workspaceName} — Cate`, and the default placeholder workspace name is `Workspace`, producing **"Workspace — Cate"**.

This treats the default `Workspace` placeholder as "no real name" (matching how the sidebar distinguishes custom names at `WorkspaceTab.tsx:572`), so the title is just **"Cate"** until the user actually renames the workspace. Renamed workspaces still append their name (e.g. "Cate Dev — Cate") to keep macOS native tabs distinguishable.