### PR TITLE
docs: clarify contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,42 @@
 # Contributing to Cate
 
-Thanks for your interest in contributing! Here's how to get started.
+Thanks for your interest in contributing! This guide explains how we work so that your time is well spent and nobody is surprised by the outcome.
+
+Please read the [Contribution Workflow](#contribution-workflow) before writing code. The short version: **talk to us before you build anything non-trivial.** It saves everyone the frustration of a finished PR getting turned down.
+
+## Contribution Workflow
+
+Cate is an opinionated product with a specific direction. To keep that direction coherent, we ask that you follow these steps.
+
+### 1. Open an issue first
+
+For anything beyond a trivial fix, **start with an issue**, not a pull request. Describe:
+
+- The problem you want to solve, or the feature you want to add
+- Why it belongs in Cate (the use case, not just the mechanism)
+- Roughly how you imagine it working
+
+This lets us agree on the *what* and the *shape* before you spend hours on the *how*.
+
+You can skip the issue for trivial changes: typos, broken links, obvious one-line bug fixes, doc tweaks. When in doubt, open an issue anyway. It is faster than a rejected PR.
+
+### 2. Say if you want to build it yourself
+
+In the issue, tell us if you'd like to implement it. If you do:
+
+- A maintainer will respond with a "go ahead", a "let's adjust the approach first", or a "this isn't a direction we want to take".
+- Once a maintainer gives you the go ahead and assigns the issue to you, **it's yours**. You own the implementation and can open a PR when it's ready.
+- If you don't want to build it, that's completely fine. File the issue anyway so it's on the radar.
+
+Please wait for the go ahead before starting on larger work. An assigned issue is your signal that a PR will be seriously reviewed and is wanted.
+
+### 3. Open the pull request
+
+Once the issue is approved and assigned to you, build it and open a PR. Link the PR back to the issue (`Closes #123`).
+
+### Why we work this way
+
+We would rather say "not yet" in a one paragraph issue than decline a polished PR you spent a weekend on. The issue-first flow is there to protect your effort, not to gate-keep it. A rejected idea at the issue stage costs you a few minutes; a rejected PR costs you real work. If something still gets declined after discussion, it's about fit and direction, never about the quality of your work.
 
 ## Development Setup
 
@@ -21,8 +57,10 @@ Thanks for your interest in contributing! Here's how to get started.
    git checkout -b my-feature
    ```
 2. Make your changes
-3. Test that the app builds and runs:
+3. Run the checks before you push:
    ```bash
+   npm run typecheck
+   npm run test:unit
    npm run build
    ```
 4. Commit with a clear message following [Conventional Commits](https://www.conventionalcommits.org/):
@@ -33,10 +71,20 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ## Pull Requests
 
-- Keep PRs focused — one feature or fix per PR
-- Describe what changed and why in the PR description
-- Include screenshots for UI changes
-- Make sure `npm run build` passes
+- **One feature or fix per PR.** Keep it focused and reviewable. If a change is large, split it or check in with us about how to stage it.
+- **Link the issue** the PR resolves (`Closes #123`).
+- **Describe what changed and why.** The "why" matters more than the "what".
+- **Include screenshots or a short clip for any UI change.**
+- **Make sure `npm run typecheck`, `npm run test:unit`, and `npm run build` all pass.**
+- **Add or update tests** when you change behavior.
+- **Don't bundle unrelated changes.** No drive-by reformatting, dependency bumps, or refactors mixed into a feature PR.
+- Expect review feedback. A few rounds of back and forth is normal and is not a sign anything is wrong.
+
+### What happens after you open a PR
+
+- A maintainer will review it. We try to be timely, but this is a small team, so please be patient.
+- We may ask for changes, suggest a different approach, or, occasionally, decide it isn't the right fit even after an approved issue (for example if the implementation reveals a problem we didn't foresee). If that happens we will explain why.
+- Once it's approved and green, a maintainer will merge it. We generally squash merge.
 
 ## Project Structure
 
@@ -48,15 +96,23 @@ See the [Architecture section](README.md#architecture) in the README and [`CLAUD
 - Functional React with hooks
 - Zustand for state (no Redux/Context)
 - Tailwind CSS for styling
-- No unnecessary abstractions — keep it simple
+- Match the style of the surrounding code
+- No unnecessary abstractions, keep it simple
 
 ## Reporting Bugs
 
 Open an [issue](https://github.com/0-AI-UG/cate/issues) with:
+
 - Steps to reproduce
 - Expected vs actual behavior
 - OS and version
 - Screenshots if applicable
+
+A bug report does not need the propose-first flow above. Just file it.
+
+## Questions
+
+If you're unsure whether something fits, or how to approach it, open an issue and ask before writing code. Asking early is always welcome.
 
 ## License
 


### PR DESCRIPTION
Rewrites `CONTRIBUTING.md` to make the workflow explicit so contributors don't sink time into a PR that gets declined.

## What changed

- New **Contribution Workflow** section up top: open an issue first for non-trivial changes, say if you want to build it yourself, and only start once a maintainer gives the go-ahead and assigns the issue to you. Trivial fixes can skip straight to a PR.
- A **Why we work this way** note that reframes rejection around fit and direction, not quality.
- **What happens after you open a PR** so review, possible decline, and merge expectations are clear up front.
- Stronger PR rules: link the issue, one change per PR, no drive-by refactors/reformatting/dep bumps, add tests, expect review rounds.
- Updated local checks to include `typecheck` and `test:unit`, not just `build`.
- Added a **Questions** section encouraging asking before coding.
- Removed em dashes throughout.