### PR TITLE
feat(settings): editable settings.json with live reload + worktree dev fix

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -31,6 +31,12 @@ export async function launchApp(opts: { perf?: boolean } = {}): Promise<LaunchRe
   const mainWindow = await electronApp.firstWindow()
   await mainWindow.waitForLoadState('domcontentloaded')
   await mainWindow.waitForFunction(() => window.__cateE2E?.ready === true, { timeout: 15_000 })
+  // The harness `ready` flag is set by its own effect the moment e2eHarness
+  // installs — independent of App's async init(), which restores/creates the
+  // workspace and mounts the Canvas. Wait for the Canvas to actually be in the
+  // DOM so specs don't race a not-yet-mounted canvas (activeCanvasPanelId would
+  // otherwise transiently return null right after launch).
+  await mainWindow.waitForSelector('[data-canvas-panel-id]', { timeout: 15_000 })
   return { electronApp, mainWindow }
 }
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,14 @@
     "package:win:unsigned": "node scripts/package.mjs --win -c.npmRebuild=false -c.win.signAndEditExecutable=false",
     "package:linux": "node scripts/package.mjs --linux"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "electron",
+      "node-pty",
+      "sharp",
+      "esbuild"
+    ]
+  },
   "dependencies": {
     "@earendil-works/pi-agent-core": "^0.75.4",
     "@earendil-works/pi-ai": "^0.75.5",

--- a/scripts/patch-electron-name.sh
+++ b/scripts/patch-electron-name.sh
@@ -4,6 +4,18 @@
 # extraction, causing posix_spawnp to fail at runtime.
 chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true
 
+# Ensure Electron's binary is present before we try to launch it. pnpm (used for
+# git worktrees) blocks dependency build scripts by default, so a fresh worktree
+# install leaves the `electron` package without its downloaded binary — no dist/
+# or path.txt — and `electron-vite dev` then fails with "Error: Electron
+# uninstall". Materialize it directly via Electron's own installer (the download
+# is cached globally, so this is ~1s after the first machine-wide install). This
+# is a no-op on npm installs, where the binary is already in place.
+if [ ! -e "node_modules/electron/dist" ] && [ -f "node_modules/electron/install.js" ]; then
+  echo "[patch-electron-name] Electron binary missing — installing…"
+  node node_modules/electron/install.js
+fi
+
 PLIST="node_modules/electron/dist/Electron.app/Contents/Info.plist"
 if [ -f "$PLIST" ]; then
   /usr/libexec/PlistBuddy -c "Set CFBundleDisplayName Cate" "$PLIST" 2>/dev/null

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import { registerHandlers as registerGitHandlers } from './ipc/git'
 import { registerHandlers as registerShellHandlers, unregisterTerminalsForWindow, getRunningTerminals } from './ipc/shell'
 import { registerHandlers as registerGitMonitorHandlers, stopMonitorsForWindow } from './ipc/git-monitor'
 import { registerHandlers as registerStoreHandlers, loadSettingsSyncFromDisk, readBootSnapshot, writeBootSnapshot, getSettingSync, setSettingsFromMain } from './store'
+import { flushPendingWritesSync as flushSettingsPendingWritesSync } from './settingsFile'
 import { registerProjectStateHandlers, saveProjectStateSync, runLegacyMigrationIfNeeded } from './projectWorkspaceStore'
 import { registerHandlers as registerMenuHandlers } from './ipc/menu'
 import { registerHandlers as registerNotificationHandlers } from './ipc/notifications'
@@ -1756,6 +1757,9 @@ app.on('will-quit', () => {
   // we write something if it didn't.
   log.info('will-quit: sync project state save fallback')
   saveProjectStateSync()
+  // Flush any pending debounced settings.json write so a just-changed setting
+  // survives the quit (the async writer wouldn't fire before process exit).
+  flushSettingsPendingWritesSync()
   // Drop per-project locks so a co-running instance can take over immediately
   // (a crash skips this; the next instance reclaims the stale lock by pid).
   releaseAllProjectLocks()

--- a/src/main/settingsFile.test.ts
+++ b/src/main/settingsFile.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import path from 'path'
+import { tmpdir } from 'os'
+
+// settingsFile reads app.getPath('userData'). Point it at a per-test temp dir
+// (mutated in beforeEach) so each case starts from a clean userData folder.
+const dirRef = { current: tmpdir() }
+vi.mock('electron', () => ({
+  app: { getPath: () => dirRef.current },
+}))
+vi.mock('./logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+// chokidar isn't exercised here; stub it so importing the module is cheap.
+vi.mock('chokidar', () => ({ watch: () => ({ on: vi.fn(), close: vi.fn() }) }))
+
+import { DEFAULT_SETTINGS } from '../shared/types'
+
+let counter = 0
+
+// Re-import a fresh copy of the module so its cached state (loaded/current)
+// resets between tests.
+async function freshModule() {
+  vi.resetModules()
+  return import('./settingsFile')
+}
+
+function settingsPath() {
+  return path.join(dirRef.current, 'settings.json')
+}
+
+beforeEach(() => {
+  dirRef.current = path.join(tmpdir(), `cate-settings-test-${process.pid}-${counter++}`)
+  fs.mkdirSync(dirRef.current, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(dirRef.current, { recursive: true, force: true })
+})
+
+describe('settingsFile', () => {
+  it('seeds settings.json with defaults on first run', async () => {
+    const m = await freshModule()
+    m.loadSettingsSync()
+    expect(fs.existsSync(settingsPath())).toBe(true)
+    const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+    expect(onDisk.defaultPanelWidth).toBe(DEFAULT_SETTINGS.defaultPanelWidth)
+    expect(m.getSetting('defaultPanelWidth')).toBe(DEFAULT_SETTINGS.defaultPanelWidth)
+  })
+
+  it('migrates valid settings out of the legacy config.json, ignoring junk', async () => {
+    // Legacy electron-store file with one real setting, one wrong-typed setting,
+    // and a non-settings key that must not leak into settings.json.
+    fs.writeFileSync(
+      path.join(dirRef.current, 'config.json'),
+      JSON.stringify({ editorFontSize: 18, zoomSpeed: 'fast', recentProjects: ['/x'] }),
+    )
+    const m = await freshModule()
+    m.loadSettingsSync()
+    expect(m.getSetting('editorFontSize')).toBe(18)
+    // Wrong-typed value rejected → default retained.
+    expect(m.getSetting('zoomSpeed')).toBe(DEFAULT_SETTINGS.zoomSpeed)
+    const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+    expect(onDisk.editorFontSize).toBe(18)
+    expect('recentProjects' in onDisk).toBe(false)
+  })
+
+  it('loads an existing settings.json over defaults', async () => {
+    fs.writeFileSync(settingsPath(), JSON.stringify({ terminalScrollback: 9000 }))
+    const m = await freshModule()
+    m.loadSettingsSync()
+    expect(m.getSetting('terminalScrollback')).toBe(9000)
+    expect(m.getSetting('showMinimap')).toBe(DEFAULT_SETTINGS.showMinimap)
+  })
+
+  it('validates setSetting and persists on sync flush', async () => {
+    const m = await freshModule()
+    m.loadSettingsSync()
+
+    expect(m.setSetting('warnBeforeQuit', true)).toBe(true)
+    // Wrong type is rejected and leaves the value unchanged.
+    expect(m.setSetting('warnBeforeQuit', 'nope' as never)).toBe(false)
+    expect(m.getSetting('warnBeforeQuit')).toBe(true)
+
+    m.flushPendingWritesSync()
+    const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+    expect(onDisk.warnBeforeQuit).toBe(true)
+  })
+
+  it('resets a key back to its default', async () => {
+    const m = await freshModule()
+    m.loadSettingsSync()
+    m.setSetting('editorFontSize', 22)
+    expect(m.getSetting('editorFontSize')).toBe(22)
+    m.resetSetting('editorFontSize')
+    expect(m.getSetting('editorFontSize')).toBe(DEFAULT_SETTINGS.editorFontSize)
+  })
+
+  it('ensureSettingsFile creates the file when missing', async () => {
+    const m = await freshModule()
+    m.loadSettingsSync()
+    fs.rmSync(settingsPath(), { force: true })
+    const p = await m.ensureSettingsFile()
+    expect(p).toBe(settingsPath())
+    await expect(fsp.access(p)).resolves.toBeUndefined()
+  })
+
+  it('isSettingsKey distinguishes known keys', async () => {
+    const m = await freshModule()
+    expect(m.isSettingsKey('editorFontSize')).toBe(true)
+    expect(m.isSettingsKey('recentProjects')).toBe(false)
+  })
+})

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -1,0 +1,327 @@
+// =============================================================================
+// settingsFile — owns the user-editable settings.json file.
+//
+// VS Code model: a dedicated `<userData>/settings.json` is the source of truth
+// for AppSettings. It holds ONLY user settings (the other electron-store keys —
+// recentProjects, layouts, remoteProjects, sidebarSession — stay in config.json).
+//
+//   - Loaded synchronously at startup so the main process can read settings
+//     before any window is constructed.
+//   - On first run it is seeded from the legacy electron-store config.json so
+//     existing users keep their settings.
+//   - Writes are debounced + atomic (tmp + rename), pretty-printed so the file
+//     stays comfortably hand-editable.
+//   - A chokidar watcher detects EXTERNAL edits (the user editing the file in an
+//     editor) and reports the changed keys. Our own programmatic writes are
+//     suppressed by content comparison so we never react to our own changes.
+// =============================================================================
+
+import { app } from 'electron'
+import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
+import { watch, type FSWatcher } from 'chokidar'
+import log from './logger'
+import { DEFAULT_SETTINGS } from '../shared/types'
+import type { AppSettings } from '../shared/types'
+
+const SETTINGS_FILENAME = 'settings.json'
+
+// ---------------------------------------------------------------------------
+// Settings schema: expected key → expected typeof value (or 'array'). The
+// single authority for which keys are valid settings and what shape they take;
+// shared with the on-disk merge so a malformed hand-edit can't poison state.
+// ---------------------------------------------------------------------------
+const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
+  defaultShellPath: 'string',
+  warnBeforeQuit: 'boolean',
+  activeThemeId: 'string',
+  systemLightThemeId: 'string',
+  systemDarkThemeId: 'string',
+  customThemes: 'array',
+  editorFontSize: 'number',
+  showMinimap: 'boolean',
+  defaultPanelWidth: 'number',
+  defaultPanelHeight: 'number',
+  zoomSpeed: 'number',
+  autoFocusLargestVisibleNode: 'boolean',
+  canvasGridStyle: 'string',
+  snapToGrid: 'boolean',
+  placementPicker: 'boolean',
+  terminalFontFamily: 'string',
+  terminalFontSize: 'number',
+  terminalScrollback: 'number',
+  terminalScrollSpeed: 'number',
+  terminalContrast: 'number',
+  terminalCursorBlink: 'boolean',
+  terminalOptionIsMeta: 'boolean',
+  autoSuspendIdleTerminals: 'boolean',
+  browserHomepage: 'string',
+  browserSearchEngine: 'string',
+  terminalLinkOpenTarget: 'string',
+  sidebarTintOpacity: 'number',
+  showFileExplorerOnLaunch: 'boolean',
+  fileExclusions: 'array',
+  notificationsEnabled: 'boolean',
+  notifyOnlyWhenUnfocused: 'boolean',
+  crashReportingEnabled: 'boolean',
+  usageAnalyticsEnabled: 'boolean',
+  telemetryConsentDecided: 'boolean',
+  onboardingCompleted: 'boolean',
+}
+
+const SETTINGS_KEYS = Object.keys(SETTINGS_SCHEMA) as Array<keyof AppSettings>
+
+/** Merge only known, type-correct keys from a parsed object into `target`. */
+function mergeValidatedSettings(target: Partial<AppSettings>, source: Record<string, unknown>): void {
+  for (const key of SETTINGS_KEYS) {
+    if (!(key in source)) continue
+    const val = source[key]
+    const expected = SETTINGS_SCHEMA[key]
+    if (expected === 'array') {
+      if (!Array.isArray(val)) { log.warn('Settings schema mismatch: %s expected array, got %s', key, typeof val); continue }
+    } else if (typeof val !== expected) {
+      log.warn('Settings schema mismatch: %s expected %s, got %s', key, expected, typeof val); continue
+    }
+    ;(target as Record<string, unknown>)[key as string] = val
+  }
+}
+
+export function isSettingsKey(key: string): key is keyof AppSettings {
+  return Object.prototype.hasOwnProperty.call(SETTINGS_SCHEMA, key)
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+// Authoritative in-memory settings: DEFAULT_SETTINGS overlaid with whatever the
+// file holds. Always complete (every key present), so reads never miss a key.
+let current: AppSettings = { ...DEFAULT_SETTINGS }
+let loaded = false
+
+// The exact string we last wrote to disk. The watcher compares the file's
+// content against this to ignore the change event our own write produces.
+let lastWrittenContent = ''
+
+let watcher: FSWatcher | null = null
+let writeTimer: ReturnType<typeof setTimeout> | null = null
+const WRITE_DEBOUNCE_MS = 150
+
+export function getSettingsFilePath(): string {
+  return path.join(app.getPath('userData'), SETTINGS_FILENAME)
+}
+
+function legacyConfigPath(): string {
+  return path.join(app.getPath('userData'), 'config.json')
+}
+
+/** Serialize the current settings as the canonical, hand-editable JSON text. */
+function serialize(settings: AppSettings): string {
+  return JSON.stringify(settings, null, 2) + '\n'
+}
+
+// ---------------------------------------------------------------------------
+// Load (synchronous — runs at startup before any window is created)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load settings synchronously from settings.json. On first run (file absent)
+ * the legacy electron-store config.json is migrated in and settings.json is
+ * written so it exists for the watcher and for hand-editing. Idempotent.
+ */
+export function loadSettingsSync(): void {
+  if (loaded) return
+  const filePath = getSettingsFilePath()
+  try {
+    if (fsSync.existsSync(filePath)) {
+      const raw = fsSync.readFileSync(filePath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        mergeValidatedSettings(current, parsed as Record<string, unknown>)
+      }
+      lastWrittenContent = raw
+      loaded = true
+      return
+    }
+  } catch (err) {
+    log.warn('[settingsFile] Sync load failed, falling back to migration/defaults: %O', err)
+  }
+
+  // First run (or unreadable file): migrate settings out of the legacy
+  // electron-store config.json, then seed settings.json from the result.
+  try {
+    const cfg = legacyConfigPath()
+    if (fsSync.existsSync(cfg)) {
+      const parsed = JSON.parse(fsSync.readFileSync(cfg, 'utf-8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        mergeValidatedSettings(current, parsed as Record<string, unknown>)
+        log.info('[settingsFile] Migrated settings from legacy config.json')
+      }
+    }
+  } catch (err) {
+    log.warn('[settingsFile] Legacy config migration failed: %O', err)
+  }
+
+  loaded = true
+  writeSync()
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export function getSetting<K extends keyof AppSettings>(key: K): AppSettings[K] {
+  return (current[key] ?? DEFAULT_SETTINGS[key]) as AppSettings[K]
+}
+
+export function getAllSettings(): AppSettings {
+  return { ...current }
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+/** Write settings.json synchronously (used during first-run seeding). */
+function writeSync(): void {
+  const content = serialize(current)
+  try {
+    const p = getSettingsFilePath()
+    fsSync.mkdirSync(path.dirname(p), { recursive: true })
+    fsSync.writeFileSync(p, content, 'utf-8')
+    lastWrittenContent = content
+  } catch (err) {
+    log.warn('[settingsFile] Sync write failed: %O', err)
+  }
+}
+
+async function flushWrite(): Promise<void> {
+  writeTimer = null
+  const content = serialize(current)
+  // Record before the write so a watcher event racing the rename still matches.
+  lastWrittenContent = content
+  try {
+    const p = getSettingsFilePath()
+    await fs.mkdir(path.dirname(p), { recursive: true })
+    const tmp = p + '.tmp'
+    await fs.writeFile(tmp, content, 'utf-8')
+    await fs.rename(tmp, p)
+  } catch (err) {
+    log.warn('[settingsFile] Write failed: %O', err)
+  }
+}
+
+function scheduleWrite(): void {
+  if (writeTimer) return
+  writeTimer = setTimeout(() => { void flushWrite() }, WRITE_DEBOUNCE_MS)
+}
+
+/** Update one setting, validating its type. No-op (returns false) on a type
+ *  mismatch or unknown key. Persists via a debounced atomic write. */
+export function setSetting<K extends keyof AppSettings>(key: K, value: AppSettings[K]): boolean {
+  if (!isSettingsKey(key)) return false
+  const expected = SETTINGS_SCHEMA[key]
+  if (expected === 'array' ? !Array.isArray(value) : typeof value !== expected) {
+    log.warn('[settingsFile] Rejected set for %s: expected %s', String(key), expected)
+    return false
+  }
+  current[key] = value
+  scheduleWrite()
+  return true
+}
+
+/** Reset one key to its default and persist. */
+export function resetSetting(key: keyof AppSettings): void {
+  // Indexing with a union key widens the assignment target to `never`; the
+  // value is the matching default, so a structured cast is safe.
+  ;(current as unknown as Record<string, unknown>)[key] = DEFAULT_SETTINGS[key]
+  scheduleWrite()
+}
+
+/** Reset every setting to defaults and persist. */
+export function resetAllSettings(): void {
+  current = { ...DEFAULT_SETTINGS }
+  scheduleWrite()
+}
+
+/** Ensure settings.json exists on disk (writing current settings if not), and
+ *  return its absolute path. Used before opening the file in an editor. */
+export async function ensureSettingsFile(): Promise<string> {
+  const p = getSettingsFilePath()
+  try {
+    await fs.access(p)
+  } catch {
+    await flushWrite()
+  }
+  return p
+}
+
+// ---------------------------------------------------------------------------
+// External-edit watching
+// ---------------------------------------------------------------------------
+
+/**
+ * Start watching settings.json for EXTERNAL edits. When the user edits the file
+ * (e.g. in a Cate editor panel) and saves, `onExternal` fires with the new
+ * settings and the list of keys that changed. Our own programmatic writes are
+ * filtered out by comparing the on-disk content with what we last wrote.
+ */
+export function startWatching(
+  onExternal: (next: AppSettings, changedKeys: Array<keyof AppSettings>) => void,
+): void {
+  if (watcher) return
+  const filePath = getSettingsFilePath()
+  watcher = watch(filePath, { ignoreInitial: true })
+
+  const handle = async (): Promise<void> => {
+    let raw: string
+    try {
+      raw = await fs.readFile(filePath, 'utf-8')
+    } catch {
+      return // transient (mid-rename) — the trailing event will settle it
+    }
+    if (raw === lastWrittenContent) return // our own write — ignore the echo
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      log.warn('[settingsFile] External edit is not valid JSON — keeping current settings')
+      return
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return
+
+    // Build a fresh, fully-defaulted settings object from the file and diff it
+    // against the live state so we report exactly which keys the user changed.
+    const next: AppSettings = { ...DEFAULT_SETTINGS }
+    mergeValidatedSettings(next, parsed as Record<string, unknown>)
+    const changed = SETTINGS_KEYS.filter(
+      (k) => JSON.stringify(next[k]) !== JSON.stringify(current[k]),
+    )
+    lastWrittenContent = raw
+    if (changed.length === 0) return
+
+    current = next
+    onExternal(getAllSettings(), changed)
+  }
+
+  watcher.on('change', () => { void handle() })
+  watcher.on('add', () => { void handle() })
+  watcher.on('error', (err) => log.warn('[settingsFile] Watcher error: %O', err))
+}
+
+export function stopWatching(): void {
+  if (writeTimer) { clearTimeout(writeTimer); writeTimer = null; void flushWrite() }
+  if (watcher) { void watcher.close(); watcher = null }
+}
+
+/** Synchronously flush a pending debounced write. Called on app quit so a
+ *  setting changed in the last 150 ms isn't lost when the process exits before
+ *  the async writer fires. */
+export function flushPendingWritesSync(): void {
+  if (!writeTimer) return
+  clearTimeout(writeTimer)
+  writeTimer = null
+  writeSync()
+}

--- a/src/main/store.test.ts
+++ b/src/main/store.test.ts
@@ -1,9 +1,12 @@
 // =============================================================================
 // store.ts corruption resilience — a corrupt config.json must NOT break the
-// settings IPC surface for the whole session. We verify store.ts's own logic:
-//   1. getStore() (via SETTINGS_GET) resolves to defaults instead of rejecting
-//      when config.json is invalid JSON (it passes clearInvalidConfig: true).
-//   2. the corrupt file is preserved as a `config.json.corrupt-*` backup.
+// store IPC surface for the whole session. We verify store.ts's own logic:
+//   1. AppSettings now live in settings.json (see ./settingsFile), so a corrupt
+//      config.json can't affect SETTINGS_GET at all — it still returns defaults.
+//   2. getStore() (reached via a config.json-backed IPC like LAYOUT_LIST)
+//      resolves to defaults instead of rejecting when config.json is invalid
+//      JSON (it passes clearInvalidConfig: true), and preserves the corrupt file
+//      as a `config.json.corrupt-*` backup.
 //
 // electron-store is replaced with a faithful fake that reproduces its
 // clearInvalidConfig contract (reset-to-defaults on a JSON SyntaxError) — the
@@ -34,6 +37,9 @@ vi.mock('./windowRegistry', () => ({ broadcastToAll: vi.fn() }))
 vi.mock('./logger', () => ({
   default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }))
+// settingsFile starts a chokidar watcher in registerHandlers(); stub it so the
+// test doesn't create a real filesystem watcher on the temp userData dir.
+vi.mock('chokidar', () => ({ watch: () => ({ on: vi.fn(), close: vi.fn() }) }))
 
 // Faithful electron-store fake: honors clearInvalidConfig like the real one.
 vi.mock('electron-store', () => {
@@ -60,13 +66,16 @@ vi.mock('electron-store', () => {
 })
 
 const { registerHandlers } = await import('./store')
-const { SETTINGS_GET } = await import('../shared/ipc-channels')
+const { SETTINGS_GET, LAYOUT_LIST } = await import('../shared/ipc-channels')
 const { DEFAULT_SETTINGS } = await import('../shared/types')
 
-beforeAll(() => {
+beforeAll(async () => {
   // Corrupt config.json must exist before the first getStore() call.
   fs.writeFileSync(cfgPath, '{ this is : not valid json,,, ')
   registerHandlers()
+  // Trigger getStore() through a config.json-backed IPC so the corrupt config is
+  // detected, backed up, and reset to defaults.
+  await handlers.get(LAYOUT_LIST)?.({})
 })
 
 afterAll(() => {
@@ -74,11 +83,15 @@ afterAll(() => {
 })
 
 describe('store corruption resilience', () => {
-  test('SETTINGS_GET resolves to defaults instead of rejecting on a corrupt config', async () => {
+  test('a corrupt config.json keeps the store IPC surface working', async () => {
+    // Settings live in settings.json now → unaffected by a corrupt config.json.
     const getHandler = handlers.get(SETTINGS_GET)
     expect(getHandler).toBeTypeOf('function')
-    const value = await getHandler!({}, 'warnBeforeQuit')
-    expect(value).toBe(DEFAULT_SETTINGS.warnBeforeQuit)
+    expect(await getHandler!({}, 'warnBeforeQuit')).toBe(DEFAULT_SETTINGS.warnBeforeQuit)
+    // A config.json-backed IPC resolves to defaults instead of rejecting.
+    const layoutHandler = handlers.get(LAYOUT_LIST)
+    expect(layoutHandler).toBeTypeOf('function')
+    expect(await layoutHandler!({})).toEqual([])
   })
 
   test('the corrupt config is preserved as a .corrupt-* backup', () => {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -14,6 +14,8 @@ import {
   SETTINGS_GET_ALL,
   SETTINGS_RESET,
   SETTINGS_CHANGED,
+  SETTINGS_OPEN_IN_EDITOR,
+  SETTINGS_RELOADED,
   BOOT_SNAPSHOT_WRITE,
   RECENT_PROJECTS_GET,
   RECENT_PROJECTS_ADD,
@@ -30,6 +32,18 @@ import {
 import { DEFAULT_SETTINGS } from '../shared/types'
 import type { AppSettings, SidebarSession, RemoteProjectEntry } from '../shared/types'
 import { broadcastToAll } from './windowRegistry'
+import {
+  loadSettingsSync,
+  getSetting as getSettingFromFile,
+  getAllSettings,
+  setSetting as setSettingInFile,
+  resetSetting as resetSettingInFile,
+  resetAllSettings,
+  ensureSettingsFile,
+  startWatching as startSettingsWatch,
+} from './settingsFile'
+import { grantFileAccess } from './ipc/pathValidation'
+import { recordPersistentGrant } from './grantedPathStore'
 
 /** Push saved-layout names to the native Layouts menu. Imported lazily so the
  *  static module graph (and anything that pulls in ./store, e.g. terminal IPC)
@@ -39,64 +53,43 @@ async function pushLayoutNamesToMenu(names: string[]): Promise<void> {
   setLayoutNames(names)
 }
 
-// ---------------------------------------------------------------------------
-// Settings schema: expected key → expected typeof value (or 'array')
-// ---------------------------------------------------------------------------
-const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
-  defaultShellPath: 'string',
-  warnBeforeQuit: 'boolean',
-  activeThemeId: 'string',
-  systemLightThemeId: 'string',
-  systemDarkThemeId: 'string',
-  customThemes: 'array',
-  editorFontSize: 'number',
-  showMinimap: 'boolean',
-  defaultPanelWidth: 'number',
-  defaultPanelHeight: 'number',
-  zoomSpeed: 'number',
-  autoFocusLargestVisibleNode: 'boolean',
-  canvasGridStyle: 'string',
-  snapToGrid: 'boolean',
-  placementPicker: 'boolean',
-  terminalFontFamily: 'string',
-  terminalFontSize: 'number',
-  terminalScrollback: 'number',
-  terminalScrollSpeed: 'number',
-  terminalContrast: 'number',
-  terminalCursorBlink: 'boolean',
-  terminalOptionIsMeta: 'boolean',
-  autoSuspendIdleTerminals: 'boolean',
-  browserHomepage: 'string',
-  browserSearchEngine: 'string',
-  terminalLinkOpenTarget: 'string',
-  sidebarTintOpacity: 'number',
-  showFileExplorerOnLaunch: 'boolean',
-  fileExclusions: 'array',
-  notificationsEnabled: 'boolean',
-  notifyOnlyWhenUnfocused: 'boolean',
-  crashReportingEnabled: 'boolean',
-  usageAnalyticsEnabled: 'boolean',
-  telemetryConsentDecided: 'boolean',
-  onboardingCompleted: 'boolean',
-}
-
 // Settings that open windows react to live (via onSettingsChanged). The
 // SETTINGS_CHANGED broadcast is scoped to these so routine edits — font size,
 // zoom speed, etc. — don't wake every window/explorer on each change.
 const LIVE_REACTIVE_SETTINGS = new Set<keyof AppSettings>(['fileExclusions'])
 
-/** Safely merge only known, type-correct keys from a parsed object into the settings cache. */
-function mergeValidatedSettings(target: Partial<AppSettings>, source: Record<string, unknown>): void {
-  for (const key of Object.keys(SETTINGS_SCHEMA) as Array<keyof AppSettings>) {
-    if (!(key in source)) continue
-    const val = source[key]
-    const expected = SETTINGS_SCHEMA[key]
-    if (expected === 'array') {
-      if (!Array.isArray(val)) { log.warn('Settings schema mismatch: %s expected array, got %s', key, typeof val); continue }
-    } else {
-      if (typeof val !== expected) { log.warn('Settings schema mismatch: %s expected %s, got %s', key, expected, typeof val); continue }
+/**
+ * Apply the main-process side effects of a single settings change. Shared by
+ * the renderer-driven SETTINGS_SET path and the external-file-edit watcher so a
+ * value changed by hand-editing settings.json behaves exactly like one changed
+ * through the UI (live file-exclusion refresh, Sentry toggle, live broadcast).
+ */
+async function applySettingSideEffect(key: keyof AppSettings, value: unknown): Promise<void> {
+  // Notify all windows so live-reactive settings (e.g. file exclusions) can
+  // update without a relaunch. Scoped to keys that actually have live listeners
+  // so routine setting changes don't churn every window.
+  if (LIVE_REACTIVE_SETTINGS.has(key)) {
+    broadcastToAll(SETTINGS_CHANGED, key, value)
+  }
+  // Rebuild active fs watchers so their ignore globs match the new exclusions
+  // (dynamic import avoids a static store<->filesystem cycle).
+  if (key === 'fileExclusions') {
+    try {
+      const { refreshWatcherIgnores } = await import('./ipc/filesystem')
+      refreshWatcherIgnores()
+    } catch (err) {
+      log.warn('Watcher ignore refresh failed: %O', err)
     }
-    ;(target as Record<string, unknown>)[key as string] = val
+  }
+  // Live-toggle Sentry when the crash-reporting setting flips, so the change
+  // takes effect without a relaunch.
+  if (key === 'crashReportingEnabled') {
+    try {
+      const { setCrashReportingEnabled } = await import('./sentry')
+      setCrashReportingEnabled(value !== false)
+    } catch (err) {
+      log.warn('Sentry live-toggle failed: %O', err)
+    }
   }
 }
 
@@ -127,11 +120,14 @@ function backupConfigIfCorrupt(): void {
 async function getStore(): Promise<any> {
   if (storeInstance) return storeInstance
   const { default: Store } = await import('electron-store')
+  // electron-store still backs the non-settings keys (recentProjects,
+  // sidebarSession, remoteProjects, layouts). AppSettings now live in their own
+  // settings.json (see ./settingsFile), so they are no longer read/written here.
   // Preserve a corrupt config before clearInvalidConfig wipes it.
   backupConfigIfCorrupt()
   // clearInvalidConfig: a corrupt config.json resets to defaults instead of
-  // throwing on construction — which would otherwise reject every settings
-  // IPC call (settings, recent projects, layouts) for the whole session.
+  // throwing on construction — which would otherwise reject every store IPC
+  // call (recent projects, layouts, sessions) for the whole session.
   // projectName is set explicitly so the store never depends on Electron
   // app-name detection (electron-store still keys the file off the userData
   // cwd, so this doesn't change the config path — it only removes a failure
@@ -142,7 +138,7 @@ async function getStore(): Promise<any> {
   } catch (err) {
     // clearInvalidConfig only covers JSON SyntaxErrors. For anything else
     // (e.g. an unreadable/locked file), move the bad file aside and retry so
-    // settings keep working rather than failing for the entire session.
+    // the store keeps working rather than failing for the entire session.
     log.error('electron-store construction failed; quarantining config and retrying: %O', err)
     try {
       const cfgPath = path.join(app.getPath('userData'), 'config.json')
@@ -152,53 +148,36 @@ async function getStore(): Promise<any> {
     }
     storeInstance = new Store<AppSettings>(opts)
   }
-  // Hydrate sync cache from the freshly loaded store
-  try {
-    Object.assign(settingsCache, storeInstance.store as Partial<AppSettings>)
-  } catch { /* noop */ }
   return storeInstance
 }
 
 // ---------------------------------------------------------------------------
-// Synchronous settings cache
-// Loaded at startup directly from the electron-store JSON file so that the
-// main process can read settings before the async ESM store is initialized
-// (e.g. inside BrowserWindow constructors). Kept in sync on every SETTINGS_SET.
+// Synchronous settings access — settings live in settings.json, loaded
+// synchronously at startup (see ./settingsFile) so the main process can read
+// them before any window is constructed. These thin re-exports keep the
+// historical `./store` import surface for existing callers.
 // ---------------------------------------------------------------------------
-const settingsCache: Partial<AppSettings> = {}
 
-/** Read settings from the on-disk electron-store JSON file (sync). */
+/** Load settings.json synchronously (migrating from the legacy config.json on
+ *  first run). Safe to call once at startup. */
 export function loadSettingsSyncFromDisk(): void {
-  try {
-    const cfgPath = path.join(app.getPath('userData'), 'config.json')
-    if (!fsSync.existsSync(cfgPath)) return
-    const raw = fsSync.readFileSync(cfgPath, 'utf-8')
-    const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      mergeValidatedSettings(settingsCache, parsed as Record<string, unknown>)
-    }
-  } catch (err) {
-    log.warn('Sync settings load failed: %O', err)
-  }
+  loadSettingsSync()
 }
 
 export function getSettingSync<K extends keyof AppSettings>(key: K): AppSettings[K] {
-  return (settingsCache[key] ?? DEFAULT_SETTINGS[key]) as AppSettings[K]
+  return getSettingFromFile(key)
 }
 
-/** Persist a settings patch from the main process — updates the sync cache
- *  immediately and writes through to the on-disk store. Used by main-driven
- *  flows like first-run telemetry consent. */
+/** Persist a settings patch from the main process — updates settings.json
+ *  (the source of truth) and runs each key's side effects. Used by main-driven
+ *  flows like first-run telemetry consent. getSettingSync() reflects the change
+ *  immediately since settingsFile holds the authoritative in-memory copy. */
 export async function setSettingsFromMain(patch: Partial<AppSettings>): Promise<void> {
-  // Update the sync cache first so any immediate getSettingSync() reflects it.
   for (const [k, v] of Object.entries(patch)) {
-    ;(settingsCache as Record<string, unknown>)[k] = v
-  }
-  try {
-    const store = await getStore()
-    for (const [k, v] of Object.entries(patch)) store.set(k, v as never)
-  } catch (err) {
-    log.warn('[settings] setSettingsFromMain write failed: %O', err)
+    const key = k as keyof AppSettings
+    if (setSettingInFile(key, v as never)) {
+      await applySettingSideEffect(key, v)
+    }
   }
 }
 
@@ -273,58 +252,66 @@ export function writeBootSnapshot(partial: Partial<BootSnapshot>): void {
 
 
 export function registerHandlers(): void {
-  // Settings
+  // Settings — backed by settings.json (see ./settingsFile). The file is the
+  // source of truth; these handlers read/write it and fan out side effects.
   ipcMain.handle(SETTINGS_GET, async (_event, key: keyof AppSettings) => {
-    const store = await getStore()
-    return store.get(key)
+    return getSettingFromFile(key)
   })
 
   ipcMain.handle(
     SETTINGS_SET,
     async (_event, key: keyof AppSettings, value: unknown) => {
-      const store = await getStore()
-      store.set(key, value as never)
-      ;(settingsCache as Record<string, unknown>)[key as string] = value
-      // Notify all windows so live-reactive settings (e.g. file exclusions)
-      // can update without a relaunch. Scoped to keys that actually have live
-      // listeners so routine setting changes don't churn every window.
-      if (LIVE_REACTIVE_SETTINGS.has(key)) {
-        broadcastToAll(SETTINGS_CHANGED, key, value)
-      }
-      // Rebuild active fs watchers so their ignore globs match the new
-      // exclusions (dynamic import avoids a static store<->filesystem cycle).
-      if (key === 'fileExclusions') {
-        try {
-          const { refreshWatcherIgnores } = await import('./ipc/filesystem')
-          refreshWatcherIgnores()
-        } catch (err) {
-          log.warn('Watcher ignore refresh failed: %O', err)
-        }
-      }
-      // Live-toggle Sentry when the user flips the crash-reporting setting,
-      // so they don't need to relaunch for the change to take effect.
-      if (key === 'crashReportingEnabled') {
-        try {
-          const { setCrashReportingEnabled } = await import('./sentry')
-          setCrashReportingEnabled(value !== false)
-        } catch (err) {
-          log.warn('Sentry live-toggle failed: %O', err)
-        }
-      }
+      if (!setSettingInFile(key, value as never)) return
+      await applySettingSideEffect(key, value)
     },
   )
 
   ipcMain.handle(SETTINGS_GET_ALL, async () => {
-    const store = await getStore()
-    return store.store
+    return getAllSettings()
   })
 
   ipcMain.handle(SETTINGS_RESET, async (_event, key?: keyof AppSettings) => {
-    const store = await getStore()
     if (key) {
-      store.reset(key)
+      resetSettingInFile(key)
+      await applySettingSideEffect(key, getSettingFromFile(key))
     } else {
-      store.clear()
+      resetAllSettings()
+    }
+  })
+
+  // Grant the calling window read+write access to settings.json and return its
+  // path so the renderer can open it in an editor panel (VS Code's "Open
+  // Settings (JSON)"). The path is computed here in main — never supplied by the
+  // renderer — so this does not widen the renderer's filesystem reach beyond
+  // this one app-owned file. The grant is persisted so a restored editor panel
+  // pointing at settings.json keeps working across launches.
+  ipcMain.handle(SETTINGS_OPEN_IN_EDITOR, async (event) => {
+    const filePath = await ensureSettingsFile()
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) return filePath
+    try {
+      const safePath = await grantFileAccess(win.id, filePath)
+      await recordPersistentGrant(safePath)
+      // Grant every currently-open window too, so a panel dragged to another
+      // window keeps access (mirrors the Save-As grant fan-out).
+      for (const other of BrowserWindow.getAllWindows()) {
+        if (other.id === win.id || other.isDestroyed()) continue
+        try { await grantFileAccess(other.id, safePath) } catch { /* best effort */ }
+      }
+      return safePath
+    } catch (err) {
+      log.warn('[SETTINGS_OPEN_IN_EDITOR] grant failed: %O', err)
+      return filePath
+    }
+  })
+
+  // React to external edits of settings.json (user editing the file directly):
+  // broadcast the full settings so renderers merge live, and run the same
+  // per-key side effects as a UI change.
+  startSettingsWatch((next, changedKeys) => {
+    broadcastToAll(SETTINGS_RELOADED, next)
+    for (const key of changedKeys) {
+      void applySettingSideEffect(key, next[key])
     }
   })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -67,6 +67,8 @@ import {
   SETTINGS_GET_ALL,
   SETTINGS_RESET,
   SETTINGS_CHANGED,
+  SETTINGS_OPEN_IN_EDITOR,
+  SETTINGS_RELOADED,
   SESSION_FLUSH_SAVE,
   SESSION_FLUSH_SAVE_DONE,
   PROJECT_STATE_SAVE,
@@ -661,6 +663,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(SETTINGS_CHANGED, listener)
     return () => {
       ipcRenderer.removeListener(SETTINGS_CHANGED, listener)
+    }
+  },
+
+  settingsOpenInEditor(): Promise<string> {
+    return ipcRenderer.invoke(SETTINGS_OPEN_IN_EDITOR)
+  },
+
+  onSettingsReloaded(callback: (settings: AppSettings) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, settings: AppSettings): void => {
+      callback(settings)
+    }
+    ipcRenderer.on(SETTINGS_RELOADED, listener)
+    return () => {
+      ipcRenderer.removeListener(SETTINGS_RELOADED, listener)
     }
   },
 

--- a/src/renderer/settings/SettingsWindow.tsx
+++ b/src/renderer/settings/SettingsWindow.tsx
@@ -9,8 +9,11 @@
 // collapse, and the sidebar lists only sections that still have matches.
 // =============================================================================
 
-import { X, MagnifyingGlass } from '@phosphor-icons/react'
+import { X, MagnifyingGlass, BracketsCurly } from '@phosphor-icons/react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import log from '../lib/logger'
+import { useAppStore } from '../stores/appStore'
+import { openFileAsPanel } from '../lib/fileRouting'
 import { GeneralSettings } from './GeneralSettings'
 import { AppearanceSettings } from './AppearanceSettings'
 import { CanvasSettings } from './CanvasSettings'
@@ -110,6 +113,27 @@ export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowPr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, visibleSections])
 
+  // Open the underlying settings.json in a Cate editor panel (VS Code's "Open
+  // Settings (JSON)"). Main grants this window access to the file and returns
+  // its path; we then close the dialog and mount an editor on it. Edits saved
+  // there write back to the file, which the watcher reloads into the UI live.
+  const openSettingsJson = async () => {
+    try {
+      const filePath = await window.electronAPI.settingsOpenInEditor()
+      onClose()
+      const workspaceId = useAppStore.getState().selectedWorkspaceId
+      if (workspaceId) {
+        openFileAsPanel(workspaceId, filePath)
+      } else {
+        // No workspace/canvas to host an editor panel — reveal the file so the
+        // user can still open it in their own editor.
+        void window.electronAPI.shellShowInFolder(filePath)
+      }
+    } catch (err) {
+      log.warn('[settings] Failed to open settings.json:', err)
+    }
+  }
+
   if (!isOpen) return null
 
   const jumpTo = (id: string) => {
@@ -131,12 +155,22 @@ export function SettingsWindow({ isOpen, onClose, initialTab }: SettingsWindowPr
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-5 pb-3 flex-shrink-0 border-b border-subtle bg-surface-0/40">
           <h2 className="text-lg font-semibold text-primary">Settings</h2>
-          <button
-            onClick={onClose}
-            className="w-6 h-6 flex items-center justify-center rounded-md hover:bg-hover text-secondary hover:text-primary"
-          >
-            <X size={14} />
-          </button>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={openSettingsJson}
+              title="Open settings.json in an editor — edit and export your settings directly"
+              className="flex items-center gap-1.5 px-2 h-7 rounded-md border border-subtle text-secondary hover:bg-hover hover:text-primary text-xs"
+            >
+              <BracketsCurly size={14} />
+              Open settings.json
+            </button>
+            <button
+              onClick={onClose}
+              className="w-6 h-6 flex items-center justify-center rounded-md hover:bg-hover text-secondary hover:text-primary"
+            >
+              <X size={14} />
+            </button>
+          </div>
         </div>
 
         {/* Body: sidebar + scrollable content */}

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -17,7 +17,25 @@ interface ElectronSettingsAPI {
   settingsSet: (key: string, value: unknown) => Promise<void>
   settingsGetAll: () => Promise<Partial<AppSettings>>
   settingsReset: (key: string) => Promise<void>
+  settingsOpenInEditor?: () => Promise<string>
+  onSettingsReloaded?: (callback: (settings: Partial<AppSettings>) => void) => () => void
 }
+
+// Copy only known AppSettings keys from a source object onto a target patch.
+function pickKnownSettings(source: Partial<AppSettings>): Partial<AppSettings> {
+  const out: Partial<AppSettings> = {}
+  for (const key of Object.keys(DEFAULT_SETTINGS) as (keyof AppSettings)[]) {
+    if (key in source && source[key] !== undefined) {
+      ;(out as Record<string, unknown>)[key] = source[key]
+    }
+  }
+  return out
+}
+
+// Subscribe once (per window) to external settings.json edits so the UI tracks
+// hand-edits to the file live. Guarded so repeat loadSettings() calls (e.g. in
+// detached windows) don't stack listeners.
+let reloadSubscribed = false
 
 function getElectronAPI(): ElectronSettingsAPI | null {
   if (
@@ -120,6 +138,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     } catch {
       // Fall back to defaults on error
       set({ _loaded: true })
+    }
+
+    // Track external edits to settings.json (VS Code-style) so the UI updates
+    // live when the file is hand-edited.
+    if (!reloadSubscribed && api.onSettingsReloaded) {
+      reloadSubscribed = true
+      api.onSettingsReloaded((settings) => {
+        set(pickKnownSettings(settings))
+      })
     }
   },
 

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -333,6 +333,14 @@ export interface ElectronAPI {
   /** Subscribe to setting-change broadcasts from main (key + new value). Returns unsubscribe. */
   onSettingsChanged(callback: (key: keyof AppSettings, value: unknown) => void): () => void
 
+  /** Grant this window access to settings.json and return its absolute path so
+   *  it can be opened in an editor panel. */
+  settingsOpenInEditor(): Promise<string>
+
+  /** Subscribe to full-settings broadcasts emitted when settings.json is edited
+   *  externally. Returns unsubscribe. */
+  onSettingsReloaded(callback: (settings: AppSettings) => void): () => void
+
   // ---------------------------------------------------------------------------
   // Session
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -85,6 +85,12 @@ export const SETTINGS_SET = 'settings:set'
 export const SETTINGS_GET_ALL = 'settings:getAll'
 export const SETTINGS_RESET = 'settings:reset'
 export const SETTINGS_CHANGED = 'settings:changed' // main -> renderer (broadcast)
+// Grant the calling window access to settings.json and return its path so the
+// renderer can open it in an editor panel (VS Code "Open Settings (JSON)").
+export const SETTINGS_OPEN_IN_EDITOR = 'settings:openInEditor'
+// Broadcast when settings.json was edited externally (the user editing the
+// file directly). Carries the full settings object so renderers merge live.
+export const SETTINGS_RELOADED = 'settings:reloaded' // main -> renderer (broadcast)
 
 // Session
 export const SESSION_FLUSH_SAVE = 'session:flushSave' // main -> renderer


### PR DESCRIPTION
## Settings as an editable settings.json (VS Code model)

Backs \`AppSettings\` with a dedicated, human-editable \`<userData>/settings.json\` instead of mixing them into electron-store's \`config.json\`. The file is the source of truth:

- Loaded synchronously at startup; on first run, existing settings are **migrated** out of \`config.json\`.
- Written **atomically + debounced**, pretty-printed so it stays hand-editable.
- **Watched for external edits** (chokidar) — hand-edits apply live across windows, with self-write suppression so our own writes don't echo.
- New **"Open settings.json"** button in the Settings dialog header grants the window access to the app-owned file and opens it in an editor panel; saving there writes back and the watcher reloads the UI live.

Other electron-store keys (recentProjects, layouts, remoteProjects, sidebarSession) stay in \`config.json\`.

### Files
- \`src/main/settingsFile.ts\` (new) — owns the file: load/migrate, validated authoritative copy, debounced atomic writes, watcher. Plus \`settingsFile.test.ts\` (7 tests).
- \`src/main/store.ts\` — settings IPC delegate to settingsFile; shared side-effect helper runs for UI **and** external edits; new \`SETTINGS_OPEN_IN_EDITOR\` handler + \`SETTINGS_RELOADED\` broadcast.
- \`src/main/index.ts\` — sync settings flush on quit.
- preload / \`electron-api.d.ts\` / \`ipc-channels.ts\` — new bridge (\`settingsOpenInEditor\`, \`onSettingsReloaded\`).
- \`settingsStore.ts\` — merges external reloads live.
- \`SettingsWindow.tsx\` — the Open button.

## Worktree dev fix (second commit)

pnpm (used for git worktrees) blocks dependency build scripts by default, so a fresh worktree install left the \`electron\` package without its binary and \`electron-vite dev\` failed with "Electron uninstall". The predev/postinstall patch script now self-heals the binary when missing (no-op on npm), and \`pnpm.onlyBuiltDependencies\` is declared so fresh pnpm installs build it directly.

## Verification
- \`tsc --noEmit\` clean, \`npm run build\` clean.
- Full suite: **754 passing** (3 skipped), including 7 new settingsFile tests.

Note: JSON, not JSONC — typed comments won't survive a UI-driven write (potential follow-up).