### PR TITLE
feat(explorer): keyboard navigation for the file tree (#268)

### DIFF
--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -8,6 +8,7 @@ import log from '../lib/logger'
 import { ArrowClockwise, FilePlus, FolderPlus, MagnifyingGlass, X, Folder, File } from '@phosphor-icons/react'
 import type { FileTreeNode as FileTreeNodeType, FileSearchResult } from '../../shared/types'
 import { FileTreeNode } from './FileTreeNode'
+import { isNavKey, resolveTreeNavAction } from './treeKeyboardNav'
 import { buildGitTreeDecorations, folderColorClass, lookupNodeDecoration, toPosixPath, type GitTree } from './gitStatusDecoration'
 import { getClipboard, hasClipboard } from './fileClipboard'
 import { useAppStore } from '../stores/appStore'
@@ -57,16 +58,31 @@ interface FileExplorerProps {
   rootPath: string
 }
 
+// One entry per on-screen row, top to bottom (root nodes + children of expanded
+// folders). Backbone for keyboard navigation and shift-click range ordering.
+interface FlatRow {
+  path: string
+  depth: number
+  isDirectory: boolean
+  parentPath: string | null
+  node: FileTreeNodeType
+}
+
 export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const [nodes, setNodes] = useState<FileTreeNodeType[]>([])
   const [isLoading, setIsLoading] = useState(false)
-  // Bumped on every successful tree read. Nested folders cache their own
-  // children in local state (keyed by stable path, so they survive a root
-  // re-render); this signal tells each cached/expanded folder to re-read from
-  // disk so a reload — or a move/create/delete — actually reflects on-disk state
-  // instead of showing stale children (e.g. a moved file lingering in its old
-  // folder, which reads as a copy).
-  const [refreshSignal, setRefreshSignal] = useState(0)
+  // Expansion state is owned by the explorer (not each FileTreeNode) so this
+  // component knows the tree's full visible structure — needed for keyboard
+  // navigation (issue #268) and as the ordering source for shift-click ranges.
+  //  - expandedPaths: directory paths the user has expanded.
+  //  - childrenCache: each loaded directory's children (one fsReadDir level),
+  //    keyed by stable path so it survives root re-renders. Re-read on reload by
+  //    refreshExpandedChildren so a move/create/delete reflects on-disk state
+  //    instead of showing stale children (e.g. a moved file lingering as a copy).
+  //  - loadingPaths: directories currently being read (drives the "…" spinner).
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
+  const [childrenCache, setChildrenCache] = useState<Map<string, FileTreeNodeType[]>>(new Map())
+  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set())
   const [gitTree, setGitTree] = useState<GitTree | undefined>(undefined)
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
   const [rootCreating, setRootCreating] = useState<'file' | 'folder' | null>(null)
@@ -86,6 +102,11 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   const rootPathRef = useRef(rootPath)
   const createSeqRef = useRef(0)
   const loadRetryTimerRef = useRef<number | null>(null)
+  // Mirror of expandedPaths so the stable loadTree/refresh callbacks can read the
+  // current set without taking it as a dependency (which would re-create the
+  // fs-watch effect on every expand/collapse).
+  const expandedPathsRef = useRef(expandedPaths)
+  useEffect(() => { expandedPathsRef.current = expandedPaths }, [expandedPaths])
 
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
 
@@ -97,24 +118,113 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
     setTimeout(() => searchInputRef.current?.focus(), 0)
   }, [])
 
-  // Build flat list of visible paths for shift-click range selection
-  const visiblePaths = useMemo(() => {
-    const paths: string[] = []
-    // We just collect top-level node paths; child visibility is managed by
-    // each FileTreeNode's local expansion state, so we flatten all nodes here.
-    // For shift-select we only need top-level; deeper nodes will be gathered
-    // by the recursive component passing the same visiblePaths down.
-    const collect = (nodeList: FileTreeNodeType[]) => {
-      for (const n of nodeList) {
-        paths.push(n.path)
-        // Children are loaded lazily by FileTreeNode, so we can't reliably
-        // enumerate them here. The shift-select will work on sibling level.
-        if (n.children.length > 0) collect(n.children)
+  // Flat, top-to-bottom list of every visible row: root nodes plus the children
+  // of each expanded folder. Drives keyboard navigation and shift-click ranges.
+  const flatRows = useMemo<FlatRow[]>(() => {
+    const out: FlatRow[] = []
+    const walk = (list: FileTreeNodeType[], depth: number, parentPath: string | null) => {
+      for (const n of list) {
+        out.push({ path: n.path, depth, isDirectory: n.isDirectory, parentPath, node: n })
+        if (n.isDirectory && expandedPaths.has(n.path)) {
+          const kids = childrenCache.get(n.path)
+          if (kids) walk(kids, depth + 1, n.path)
+        }
       }
     }
-    collect(nodes)
-    return paths
-  }, [nodes])
+    walk(nodes, 0, null)
+    return out
+  }, [nodes, expandedPaths, childrenCache])
+
+  const flatIndexByPath = useMemo(
+    () => new Map(flatRows.map((r, i) => [r.path, i] as const)),
+    [flatRows],
+  )
+
+  // ---------------------------------------------------------------------------
+  // Expansion controls (lifted out of FileTreeNode)
+  // ---------------------------------------------------------------------------
+
+  // Lazily read a directory's children into the cache (one fsReadDir level).
+  const ensureChildrenLoaded = useCallback(async (path: string) => {
+    if (!window.electronAPI || childrenCache.has(path)) return
+    setLoadingPaths((s) => new Set(s).add(path))
+    try {
+      const entries = await window.electronAPI.fsReadDir(path)
+      setChildrenCache((prev) => new Map(prev).set(path, entries))
+    } catch {
+      // Cache an empty array so an unreadable folder doesn't retry-loop.
+      setChildrenCache((prev) => new Map(prev).set(path, []))
+    } finally {
+      setLoadingPaths((s) => {
+        const n = new Set(s)
+        n.delete(path)
+        return n
+      })
+    }
+  }, [childrenCache])
+
+  const expand = useCallback(async (path: string) => {
+    setExpandedPaths((s) => (s.has(path) ? s : new Set(s).add(path)))
+    await ensureChildrenLoaded(path)
+  }, [ensureChildrenLoaded])
+
+  const collapse = useCallback((path: string) => {
+    setExpandedPaths((s) => {
+      if (!s.has(path)) return s
+      const n = new Set(s)
+      n.delete(path)
+      return n
+    })
+  }, [])
+
+  const toggleExpand = useCallback((path: string) => {
+    if (expandedPaths.has(path)) collapse(path)
+    else void expand(path)
+  }, [expandedPaths, expand, collapse])
+
+  // Re-read the children of every currently-expanded folder from disk and prune
+  // any expanded paths that no longer exist. Called after a (re)load so reloads,
+  // fs-watch events, and create/move/delete reflect on-disk state. Expansion
+  // itself is preserved across reloads (only vanished paths are dropped). Reads
+  // expandedPaths via a ref so this callback stays stable for loadTree.
+  const refreshExpandedChildren = useCallback(async () => {
+    if (!window.electronAPI) return
+    const paths = [...expandedPathsRef.current]
+    if (paths.length === 0) {
+      // Nothing expanded → drop stale cache so a later expand reads fresh.
+      setChildrenCache((prev) => (prev.size === 0 ? prev : new Map()))
+      return
+    }
+    const results = await Promise.all(
+      paths.map(async (p) => {
+        try {
+          return [p, await window.electronAPI!.fsReadDir(p)] as const
+        } catch {
+          return [p, null] as const // null = path gone / unreadable
+        }
+      }),
+    )
+    // Rebuild the cache from the expanded set only; collapsed folders re-read on
+    // next expand. Orphaned entries (parent pruned) are simply not walked.
+    setChildrenCache(() => {
+      const next = new Map<string, FileTreeNodeType[]>()
+      for (const [p, kids] of results) {
+        if (kids) next.set(p, kids)
+      }
+      return next
+    })
+    setExpandedPaths((prev) => {
+      let changed = false
+      const next = new Set(prev)
+      for (const [p, kids] of results) {
+        if (kids === null && next.has(p)) {
+          next.delete(p)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [])
 
   // ---------------------------------------------------------------------------
   // Load tree
@@ -149,9 +259,9 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       }
 
       setNodes(entries)
-      // Invalidate cached children in every expanded/loaded nested folder so the
-      // refreshed root read propagates the whole way down the tree.
-      setRefreshSignal((n) => n + 1)
+      // Re-read every expanded folder so the refreshed root read propagates the
+      // whole way down the tree (and prune folders that vanished on disk).
+      void refreshExpandedChildren()
       setIsLoading(false)
     } catch (err) {
       // The read was rejected (e.g. the root path isn't registered as an allowed
@@ -169,7 +279,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       setGitTree(undefined)
       setIsLoading(false)
     }
-  }, [])
+  }, [refreshExpandedChildren])
 
   // ---------------------------------------------------------------------------
   // Watch for filesystem changes
@@ -276,14 +386,10 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
 
   const handleSelect = useCallback(
     (path: string, meta: { shift?: boolean; cmd?: boolean }) => {
-      // Shift-range needs the paths in their actual on-screen order. visiblePaths
-      // only has top-level entries (nested children live in each FileTreeNode's
-      // local state), so read the rendered rows from the DOM instead — that
-      // reflects exactly what's visible, including expanded sub-folders.
-      const domOrder = meta.shift && treeContainerRef.current
-        ? Array.from(treeContainerRef.current.querySelectorAll<HTMLElement>('[data-filepath]'))
-            .map((el) => el.dataset.filepath!)
-        : visiblePaths
+      // Shift-range needs the paths in their actual on-screen order. flatRows is
+      // exactly that — every visible row, top to bottom, including the children
+      // of expanded folders.
+      const order = flatRows.map((r) => r.path)
       setSelectedPaths((prev) => {
         if (meta.cmd) {
           // Toggle individual selection
@@ -298,13 +404,13 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
         }
         if (meta.shift && lastSelectedPath.current) {
           // Range selection across the visible rows (anchor → clicked).
-          const startIdx = domOrder.indexOf(lastSelectedPath.current)
-          const endIdx = domOrder.indexOf(path)
+          const startIdx = order.indexOf(lastSelectedPath.current)
+          const endIdx = order.indexOf(path)
           if (startIdx !== -1 && endIdx !== -1) {
             const [lo, hi] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx]
             const next = new Set(prev)
             for (let i = lo; i <= hi; i++) {
-              next.add(domOrder[i])
+              next.add(order[i])
             }
             // Keep the anchor where it was so a second shift-click re-ranges
             // from the same origin (matches Finder/VS Code behavior).
@@ -321,8 +427,19 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       // the list from jumping when a row deep in the tree is clicked.
       treeContainerRef.current?.focus({ preventScroll: true })
     },
-    [visiblePaths],
+    [flatRows],
   )
+
+  // Move the keyboard cursor to a single row: select it and scroll it into view.
+  const moveCursorTo = useCallback((path: string) => {
+    setSelectedPaths(new Set([path]))
+    lastSelectedPath.current = path
+    requestAnimationFrame(() => {
+      treeContainerRef.current
+        ?.querySelector<HTMLElement>(`[data-filepath="${CSS.escape(path)}"]`)
+        ?.scrollIntoView({ block: 'nearest' })
+    })
+  }, [])
 
   const handleFileOpen = useCallback(
     (filePaths: string[], mode?: 'dock' | 'canvas') => {
@@ -366,31 +483,55 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
   }, [handleReload])
 
   const handleTreeKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Inline rename/create inputs handle their own keys.
+    if (e.target instanceof HTMLInputElement) return
+
     if ((e.key === 'Delete' || e.key === 'Backspace') && selectedPaths.size > 0) {
       e.preventDefault()
       void deletePaths([...selectedPaths])
+      return
     }
-  }, [selectedPaths, deletePaths])
+
+    // VS Code-style tree navigation (issue #268). Only plain (unmodified) arrow/
+    // Enter keys act here — Cmd+Arrow (canvas navigate) and Shift+Arrow (canvas
+    // pan) are claimed by the global capture-phase handler before they reach us,
+    // and bailing on any modifier keeps the explorer from ever stealing them.
+    if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+    if (!isNavKey(e.key)) return
+
+    const activePath = selectedPaths.size === 1 ? [...selectedPaths][0] : null
+    const action = resolveTreeNavAction(e.key, flatRows, activePath, (p) => expandedPaths.has(p))
+    if (!action) {
+      // Still swallow the key (e.g. Right on a file) so the scroll container
+      // doesn't scroll instead.
+      if (flatRows.length > 0) e.preventDefault()
+      return
+    }
+    e.preventDefault()
+    switch (action.type) {
+      case 'move': moveCursorTo(action.path); break
+      case 'expand': void expand(action.path); break
+      case 'collapse': collapse(action.path); break
+      case 'toggle': toggleExpand(action.path); break
+      case 'open': handleFileOpen([action.path], 'dock'); break
+    }
+  }, [
+    selectedPaths, deletePaths, flatRows,
+    expandedPaths, expand, collapse, toggleExpand, handleFileOpen, moveCursorTo,
+  ])
 
   // Resolve the target directory for new file/folder creation based on selection
   const getSelectedDir = useCallback((): string | null => {
     if (selectedPaths.size !== 1) return null
     const selectedPath = [...selectedPaths][0]
-    // Find if the selected path is a directory by searching the tree
-    const findNode = (nodeList: FileTreeNodeType[]): FileTreeNodeType | null => {
-      for (const n of nodeList) {
-        if (n.path === selectedPath) return n
-        if (n.children.length > 0) {
-          const found = findNode(n.children)
-          if (found) return found
-        }
-      }
-      return null
+    const row = flatRows[flatIndexByPath.get(selectedPath) ?? -1]
+    if (row) {
+      return row.isDirectory ? row.path : row.path.substring(0, row.path.lastIndexOf('/'))
     }
-    const node = findNode(nodes)
-    if (!node) return null
-    return node.isDirectory ? node.path : node.path.substring(0, node.path.lastIndexOf('/'))
-  }, [selectedPaths, nodes])
+    // Selected row isn't currently visible — fall back to its parent dir.
+    const slash = selectedPath.lastIndexOf('/')
+    return slash > 0 ? selectedPath.substring(0, slash) : rootPath
+  }, [selectedPaths, flatRows, flatIndexByPath, rootPath])
 
   const startRootCreate = useCallback((type: 'file' | 'folder') => {
     const targetDir = getSelectedDir()
@@ -686,13 +827,15 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
               depth={0}
               git={gitTree}
               selectedPaths={selectedPaths}
+              expandedPaths={expandedPaths}
+              childrenCache={childrenCache}
+              loadingPaths={loadingPaths}
               onSelect={handleSelect}
               onFileOpen={handleFileOpen}
+              onToggleExpand={toggleExpand}
+              onExpand={expand}
               onDeletePaths={deletePaths}
               onTreeChanged={handleReload}
-              refreshSignal={refreshSignal}
-              visiblePaths={visiblePaths}
-              searchQuery=""
               rootPath={rootPath}
               createRequest={createRequest}
               onCreateRequestHandled={() => setCreateRequest(null)}

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -17,7 +17,6 @@ import {
   PaintBrush,
   Image as ImageIcon,
 } from '@phosphor-icons/react'
-import log from '../lib/logger'
 import { isExternalFileDrag, importDroppedEntries } from '../lib/importExternalEntries'
 import type { FileTreeNode as FileTreeNodeType } from '../../shared/types'
 import { folderColorClass, lookupNodeDecoration, type GitTree } from './gitStatusDecoration'
@@ -105,18 +104,21 @@ interface FileTreeNodeProps {
   /** Git decorations for the whole tree (undefined outside a git repo). */
   git?: GitTree
   selectedPaths: Set<string>
+  /** Explorer-owned expansion state (see FileExplorer). */
+  expandedPaths: Set<string>
+  /** Explorer-owned cache of each loaded directory's children, keyed by path. */
+  childrenCache: Map<string, FileTreeNodeType[]>
+  /** Directories currently being read (drives the "…" spinner). */
+  loadingPaths: Set<string>
   onSelect: (path: string, meta: { shift?: boolean; cmd?: boolean }) => void
   onFileOpen: (paths: string[], mode?: 'dock' | 'canvas') => void
+  /** Toggle a directory's expansion (lazy-loads children on expand). */
+  onToggleExpand: (path: string) => void
+  /** Force-expand a directory (used before showing an inline create input / paste). */
+  onExpand: (path: string) => Promise<void> | void
   /** Delete the given paths (confirms + reloads + clears selection in the explorer). */
   onDeletePaths?: (paths: string[]) => void
   onTreeChanged?: () => void
-  /** Bumped by the explorer on every tree read; signals cached/expanded folders
-   *  to re-read their children from disk so reloads reflect on-disk state. */
-  refreshSignal?: number
-  /** Flat ordered list of visible file paths for shift-click range selection */
-  visiblePaths: string[]
-  /** Lowercased search query; when non-empty, filters files and force-expands directories */
-  searchQuery?: string
   /** Workspace root path — used to compute relative paths for "Copy Relative Path". */
   rootPath: string
   /** External request to create a file/folder in a specific directory */
@@ -130,21 +132,23 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   depth,
   git,
   selectedPaths,
+  expandedPaths,
+  childrenCache,
+  loadingPaths,
   onSelect,
   onFileOpen,
+  onToggleExpand,
+  onExpand,
   onDeletePaths,
   onTreeChanged,
-  refreshSignal,
-  visiblePaths,
-  searchQuery,
   rootPath,
   createRequest,
   onCreateRequestHandled,
 }) => {
-  const isSearching = !!searchQuery
-  const [isExpanded, setIsExpanded] = useState(node.isExpanded)
-  const [children, setChildren] = useState<FileTreeNodeType[]>(node.children)
-  const [isLoading, setIsLoading] = useState(false)
+  // Expansion/children state is owned by the explorer; derive this node's slice.
+  const isExpanded = expandedPaths.has(node.path)
+  const children = childrenCache.get(node.path) ?? []
+  const isLoading = loadingPaths.has(node.path)
   const [isRenaming, setIsRenaming] = useState(false)
   const [isCreating, setIsCreating] = useState<'file' | 'folder' | null>(null)
   const [renameValue, setRenameValue] = useState(node.name)
@@ -165,46 +169,11 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       : ''
 
   const isSelected = selectedPaths.has(node.path)
-  const effectiveExpanded = isExpanded || isSearching
-  const iconDef = getFileIcon(node.fileExtension, node.isDirectory, effectiveExpanded)
-
-  // Auto-load directory children when search becomes active
-  useEffect(() => {
-    if (isSearching && node.isDirectory && children.length === 0 && window.electronAPI) {
-      window.electronAPI.fsReadDir(node.path).then(setChildren).catch(() => {})
-    }
-  }, [isSearching, node.isDirectory, node.path, children.length])
-
-  // While searching, hide files whose name doesn't match
-  const isHiddenBySearch = isSearching && !node.isDirectory && !node.name.toLowerCase().includes(searchQuery!)
+  const iconDef = getFileIcon(node.fileExtension, node.isDirectory, isExpanded)
 
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
-
-  const reloadChildren = useCallback(async () => {
-    if (!window.electronAPI || !node.isDirectory) return
-    try {
-      const entries = await window.electronAPI.fsReadDir(node.path)
-      setChildren(entries)
-    } catch {
-      /* ignore */
-    }
-  }, [node.path, node.isDirectory])
-
-  // Re-read children from disk when the explorer bumps refreshSignal (manual
-  // reload, fs-watch event, or a move/create/delete). Only folders we've already
-  // cached — expanded, or previously loaded then collapsed — need invalidating;
-  // never-opened folders read fresh on first expand. Acting only on an actual
-  // signal change (not on mount) avoids a redundant read right after loading.
-  const prevRefreshRef = useRef(refreshSignal)
-  useEffect(() => {
-    if (prevRefreshRef.current === refreshSignal) return
-    prevRefreshRef.current = refreshSignal
-    if (node.isDirectory && (isExpanded || children.length > 0)) {
-      reloadChildren()
-    }
-  }, [refreshSignal, node.isDirectory, isExpanded, children.length, reloadChildren])
 
   const parentDir = node.isDirectory ? node.path : node.path.substring(0, node.path.lastIndexOf('/'))
 
@@ -212,32 +181,15 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   // Handlers
   // ---------------------------------------------------------------------------
 
-  const handleClick = useCallback(async (e: React.MouseEvent) => {
+  const handleClick = useCallback((e: React.MouseEvent) => {
     const meta = { shift: e.shiftKey, cmd: e.metaKey || e.ctrlKey }
-    if (node.isDirectory) {
-      // Directories: toggle expand on click, but also select
-      onSelect(node.path, meta)
-      if (!meta.shift && !meta.cmd) {
-        const willExpand = !isExpanded
-        setIsExpanded(willExpand)
-
-        if (willExpand && children.length === 0 && window.electronAPI) {
-          setIsLoading(true)
-          try {
-            const entries = await window.electronAPI.fsReadDir(node.path)
-            setChildren(entries)
-          } catch {
-            setChildren([])
-          } finally {
-            setIsLoading(false)
-          }
-        }
-      }
-    } else {
-      // Files: single click only selects. Double-click opens (see handleDoubleClick).
-      onSelect(node.path, meta)
+    onSelect(node.path, meta)
+    // Directories: a plain click also toggles expand (the explorer lazy-loads
+    // children). Modifier-clicks only adjust the selection.
+    if (node.isDirectory && !meta.shift && !meta.cmd) {
+      onToggleExpand(node.path)
     }
-  }, [node, isExpanded, children.length, onSelect])
+  }, [node.path, node.isDirectory, onSelect, onToggleExpand])
 
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     if (node.isDirectory) return
@@ -348,15 +300,12 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   // --- Create new file/folder ---
   const startCreate = useCallback((type: 'file' | 'folder') => {
     if (node.isDirectory) {
-      setIsExpanded(true)
-      if (children.length === 0) {
-        window.electronAPI?.fsReadDir(node.path).then(setChildren).catch((err) => log.warn('[file-tree] Read dir failed:', err))
-      }
+      void onExpand(node.path)
     }
     setCreateValue('')
     setIsCreating(type)
     setTimeout(() => createInputRef.current?.focus(), 0)
-  }, [node.isDirectory, node.path, children.length])
+  }, [node.isDirectory, node.path, onExpand])
 
   // Handle external create requests (from header buttons targeting a selected folder)
   const lastHandledSeqRef = useRef(0)
@@ -386,14 +335,12 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       } else {
         await window.electronAPI.fsWriteFile(newPath, '')
       }
-      if (node.isDirectory) {
-        await reloadChildren()
-      }
+      // onTreeChanged → loadTree → refreshExpandedChildren re-reads this folder.
       onTreeChanged?.()
     } catch (err) {
       console.error('[file-tree] Failed to create entry:', err)
     }
-  }, [isCreating, createValue, node.isDirectory, node.path, parentDir, reloadChildren, onTreeChanged])
+  }, [isCreating, createValue, node.isDirectory, node.path, parentDir, onTreeChanged])
 
   // --- Paste (copy from clipboard) ---
   const handlePaste = useCallback(async () => {
@@ -401,7 +348,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     const sources = getClipboard()
     if (sources.length === 0) return
     const destDir = node.isDirectory ? node.path : parentDir
-    if (node.isDirectory && !isExpanded) setIsExpanded(true)
+    if (node.isDirectory) void onExpand(node.path)
     for (const src of sources) {
       try {
         await window.electronAPI.fsCopy(src, destDir)
@@ -410,8 +357,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       }
     }
     onTreeChanged?.()
-    if (node.isDirectory) await reloadChildren()
-  }, [node.isDirectory, node.path, parentDir, isExpanded, reloadChildren, onTreeChanged])
+  }, [node.isDirectory, node.path, parentDir, onExpand, onTreeChanged])
 
   // --- Delete ---
   const handleDelete = useCallback(async () => {
@@ -502,8 +448,6 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   // Render
   // ---------------------------------------------------------------------------
 
-  if (isHiddenBySearch) return null
-
   return (
     <div>
       {/* Node row */}
@@ -535,7 +479,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
         {node.isDirectory ? (
           <span
             className="flex-shrink-0 text-muted transition-transform duration-150"
-            style={{ transform: effectiveExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+            style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
           >
             <CaretRight size={12} />
           </span>
@@ -615,7 +559,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       )}
 
       {/* Expanded children */}
-      {node.isDirectory && effectiveExpanded && (
+      {node.isDirectory && isExpanded && (
         <div className="relative">
           <div
             className="absolute top-0 bottom-0 w-px bg-surface-5 pointer-events-none"
@@ -628,13 +572,15 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
               depth={depth + 1}
               git={git}
               selectedPaths={selectedPaths}
+              expandedPaths={expandedPaths}
+              childrenCache={childrenCache}
+              loadingPaths={loadingPaths}
               onSelect={onSelect}
               onFileOpen={onFileOpen}
+              onToggleExpand={onToggleExpand}
+              onExpand={onExpand}
               onDeletePaths={onDeletePaths}
               onTreeChanged={onTreeChanged}
-              refreshSignal={refreshSignal}
-              visiblePaths={visiblePaths}
-              searchQuery={searchQuery}
               rootPath={rootPath}
               createRequest={createRequest}
               onCreateRequestHandled={onCreateRequestHandled}

--- a/src/renderer/sidebar/treeKeyboardNav.test.ts
+++ b/src/renderer/sidebar/treeKeyboardNav.test.ts
@@ -1,0 +1,154 @@
+// =============================================================================
+// Unit tests for File Explorer keyboard navigation logic (issue #268).
+// Verifies VS Code-style up/down/left/right/Enter semantics over a flat row
+// list, independent of the DOM, stores, and async children loading.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest'
+import { isNavKey, resolveTreeNavAction, type NavRow } from './treeKeyboardNav'
+
+// A small tree:
+//   src/            (dir, expanded)
+//     a.ts          (file)
+//     util/         (dir, collapsed)
+//   README.md       (file)
+const ROWS: NavRow[] = [
+  { path: '/p/src', depth: 0, isDirectory: true, parentPath: null },
+  { path: '/p/src/a.ts', depth: 1, isDirectory: false, parentPath: '/p/src' },
+  { path: '/p/src/util', depth: 1, isDirectory: true, parentPath: '/p/src' },
+  { path: '/p/README.md', depth: 0, isDirectory: false, parentPath: null },
+]
+
+// src is expanded; util is collapsed.
+const expanded = (p: string) => p === '/p/src'
+
+describe('isNavKey', () => {
+  it('accepts the five navigation keys', () => {
+    for (const k of ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Enter']) {
+      expect(isNavKey(k)).toBe(true)
+    }
+  })
+  it('rejects other keys', () => {
+    for (const k of ['a', 'Tab', 'Escape', 'Delete', ' ']) {
+      expect(isNavKey(k)).toBe(false)
+    }
+  })
+})
+
+describe('resolveTreeNavAction — ArrowDown / ArrowUp', () => {
+  it('moves down to the next visible row', () => {
+    expect(resolveTreeNavAction('ArrowDown', ROWS, '/p/src', expanded)).toEqual({
+      type: 'move', path: '/p/src/a.ts',
+    })
+  })
+
+  it('clamps at the last row', () => {
+    expect(resolveTreeNavAction('ArrowDown', ROWS, '/p/README.md', expanded)).toEqual({
+      type: 'move', path: '/p/README.md',
+    })
+  })
+
+  it('moves up to the previous visible row', () => {
+    expect(resolveTreeNavAction('ArrowUp', ROWS, '/p/src/util', expanded)).toEqual({
+      type: 'move', path: '/p/src/a.ts',
+    })
+  })
+
+  it('clamps at the first row', () => {
+    expect(resolveTreeNavAction('ArrowUp', ROWS, '/p/src', expanded)).toEqual({
+      type: 'move', path: '/p/src',
+    })
+  })
+
+  it('with no selection, ArrowDown seeds the first row', () => {
+    expect(resolveTreeNavAction('ArrowDown', ROWS, null, expanded)).toEqual({
+      type: 'move', path: '/p/src',
+    })
+  })
+
+  it('with no selection, ArrowUp seeds the last row', () => {
+    expect(resolveTreeNavAction('ArrowUp', ROWS, null, expanded)).toEqual({
+      type: 'move', path: '/p/README.md',
+    })
+  })
+
+  it('treats an unknown active path as no selection', () => {
+    expect(resolveTreeNavAction('ArrowDown', ROWS, '/p/gone', expanded)).toEqual({
+      type: 'move', path: '/p/src',
+    })
+  })
+})
+
+describe('resolveTreeNavAction — ArrowRight', () => {
+  it('expands a collapsed folder', () => {
+    expect(resolveTreeNavAction('ArrowRight', ROWS, '/p/src/util', expanded)).toEqual({
+      type: 'expand', path: '/p/src/util',
+    })
+  })
+
+  it('on an expanded folder, steps into the first child', () => {
+    expect(resolveTreeNavAction('ArrowRight', ROWS, '/p/src', expanded)).toEqual({
+      type: 'move', path: '/p/src/a.ts',
+    })
+  })
+
+  it('on a file, does nothing', () => {
+    expect(resolveTreeNavAction('ArrowRight', ROWS, '/p/README.md', expanded)).toBeNull()
+  })
+
+  it('on an expanded but empty folder, does nothing', () => {
+    // src marked expanded but its children are not present below it.
+    const rows: NavRow[] = [{ path: '/p/src', depth: 0, isDirectory: true, parentPath: null }]
+    expect(resolveTreeNavAction('ArrowRight', rows, '/p/src', () => true)).toBeNull()
+  })
+})
+
+describe('resolveTreeNavAction — ArrowLeft', () => {
+  it('collapses an expanded folder', () => {
+    expect(resolveTreeNavAction('ArrowLeft', ROWS, '/p/src', expanded)).toEqual({
+      type: 'collapse', path: '/p/src',
+    })
+  })
+
+  it('on a collapsed folder, moves to the parent', () => {
+    expect(resolveTreeNavAction('ArrowLeft', ROWS, '/p/src/util', expanded)).toEqual({
+      type: 'move', path: '/p/src',
+    })
+  })
+
+  it('on a nested file, moves to the parent', () => {
+    expect(resolveTreeNavAction('ArrowLeft', ROWS, '/p/src/a.ts', expanded)).toEqual({
+      type: 'move', path: '/p/src',
+    })
+  })
+
+  it('on a top-level file, does nothing', () => {
+    expect(resolveTreeNavAction('ArrowLeft', ROWS, '/p/README.md', expanded)).toBeNull()
+  })
+})
+
+describe('resolveTreeNavAction — Enter', () => {
+  it('toggles a directory', () => {
+    expect(resolveTreeNavAction('Enter', ROWS, '/p/src', expanded)).toEqual({
+      type: 'toggle', path: '/p/src',
+    })
+  })
+
+  it('opens a file', () => {
+    expect(resolveTreeNavAction('Enter', ROWS, '/p/src/a.ts', expanded)).toEqual({
+      type: 'open', path: '/p/src/a.ts',
+    })
+  })
+
+  it('with no selection, does nothing', () => {
+    expect(resolveTreeNavAction('Enter', ROWS, null, expanded)).toBeNull()
+  })
+})
+
+describe('resolveTreeNavAction — empty tree', () => {
+  it('returns null for every key', () => {
+    for (const k of ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Enter'] as const) {
+      expect(resolveTreeNavAction(k, [], null, expanded)).toBeNull()
+    }
+  })
+})

--- a/src/renderer/sidebar/treeKeyboardNav.ts
+++ b/src/renderer/sidebar/treeKeyboardNav.ts
@@ -1,0 +1,92 @@
+// =============================================================================
+// treeKeyboardNav — pure decision logic for VS Code-style File Explorer keyboard
+// navigation (issue #268). Kept separate from FileExplorer so it can be unit
+// tested without the DOM, stores, or async children loading.
+//
+// Given the flat list of visible rows, the active (cursor) path, and a predicate
+// telling whether a directory is expanded, resolveTreeNavAction returns the
+// single action the explorer should perform — or null for a no-op.
+// =============================================================================
+
+/** Subset of FileExplorer's FlatRow needed to make navigation decisions. */
+export interface NavRow {
+  path: string
+  depth: number
+  isDirectory: boolean
+  parentPath: string | null
+}
+
+export type NavAction =
+  | { type: 'move'; path: string }
+  | { type: 'expand'; path: string }
+  | { type: 'collapse'; path: string }
+  | { type: 'toggle'; path: string }
+  | { type: 'open'; path: string }
+
+/** Keys this module knows how to handle. */
+export type NavKey = 'ArrowDown' | 'ArrowUp' | 'ArrowRight' | 'ArrowLeft' | 'Enter'
+
+export function isNavKey(key: string): key is NavKey {
+  return (
+    key === 'ArrowDown' ||
+    key === 'ArrowUp' ||
+    key === 'ArrowRight' ||
+    key === 'ArrowLeft' ||
+    key === 'Enter'
+  )
+}
+
+/**
+ * Resolve the navigation action for a key press.
+ *
+ * @param key         the pressed key (plain, no modifiers — caller filters those)
+ * @param rows        visible rows, top to bottom
+ * @param activePath  the single selected/cursor path, or null when 0 or >1 selected
+ * @param isExpanded  predicate: is this directory path currently expanded?
+ */
+export function resolveTreeNavAction(
+  key: NavKey,
+  rows: NavRow[],
+  activePath: string | null,
+  isExpanded: (path: string) => boolean,
+): NavAction | null {
+  if (rows.length === 0) return null
+
+  const idx = activePath != null ? rows.findIndex((r) => r.path === activePath) : -1
+  const active = idx >= 0 ? rows[idx] : null
+
+  switch (key) {
+    case 'ArrowDown': {
+      const next = idx < 0 ? 0 : Math.min(idx + 1, rows.length - 1)
+      return { type: 'move', path: rows[next].path }
+    }
+    case 'ArrowUp': {
+      const next = idx < 0 ? rows.length - 1 : Math.max(idx - 1, 0)
+      return { type: 'move', path: rows[next].path }
+    }
+    case 'ArrowRight': {
+      if (!active) return { type: 'move', path: rows[0].path }
+      if (!active.isDirectory) return null
+      if (!isExpanded(active.path)) return { type: 'expand', path: active.path }
+      // Already expanded → step into the first child (the next row, when it is a
+      // direct child). If children aren't loaded/empty yet, this is a no-op.
+      const child = rows[idx + 1]
+      if (child && child.parentPath === active.path) return { type: 'move', path: child.path }
+      return null
+    }
+    case 'ArrowLeft': {
+      if (!active) return { type: 'move', path: rows[0].path }
+      if (active.isDirectory && isExpanded(active.path)) {
+        return { type: 'collapse', path: active.path }
+      }
+      if (active.parentPath) return { type: 'move', path: active.parentPath }
+      return null
+    }
+    case 'Enter': {
+      if (!active) return null
+      return active.isDirectory
+        ? { type: 'toggle', path: active.path }
+        : { type: 'open', path: active.path }
+    }
+  }
+}


### PR DESCRIPTION
Closes #268.

Adds VS Code-style keyboard navigation to the File Explorer. When focus is in the tree:

- **↑ / ↓** — move to the previous/next visible row (clamped, no wrap)
- **→** — expand a collapsed folder; on an expanded folder, step into the first child; no-op on a file
- **←** — collapse an expanded folder; otherwise jump to the parent folder
- **Enter** — open a file (center dock tab) or toggle a folder
- **Delete/Backspace** — unchanged

## Approach

Per-node expansion state is lifted out of `FileTreeNode` into `FileExplorer` (`expandedPaths` + a children cache), and a derived flat list of visible rows drives both navigation and shift-click range selection. This let me delete the old `querySelectorAll('[data-filepath]')` range hack and replace the `refreshSignal` fan-out with a deterministic `refreshExpandedChildren()` on reload. `FileTreeNode` is now controlled.

The navigation decision logic lives in a pure `treeKeyboardNav` helper with unit tests.

## Canvas shortcuts are untouched

Only plain (unmodified) arrows act in the tree. **Cmd+Arrow** (canvas navigate) and **Shift+Arrow** (canvas pan) are bound on the global capture-phase handler in `useShortcuts.ts`, which `stopPropagation()`s them before they ever reach the explorer; plain arrows are unbound there. The explorer handler additionally bails on any modifier as belt-and-suspenders.

## Testing

- `npm run typecheck` ✓
- `npm run build` ✓
- `npx vitest run` ✓ — 795 passed, 3 skipped (incl. 21 new `treeKeyboardNav` tests)