### PR TITLE
feat(updates): opt-in beta / pre-release update channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # A tag with a semver pre-release suffix (a hyphen, e.g. v1.2.0-beta.1)
+          # is published as a GitHub pre-release. GitHub excludes pre-releases
+          # from the "Latest" badge and the /releases/latest API the website
+          # uses, so stable users and the public download are unaffected — only
+          # users who opted into beta builds in-app (autoUpdater.allowPrerelease)
+          # are offered it. The later "Publish release" step un-drafts without
+          # touching the pre-release flag, so it stays a pre-release.
+          PRERELEASE_FLAG=""
+          case "${{ github.ref_name }}" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
             echo "Release ${{ github.ref_name }} already exists — skipping creation"
           else
-            gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --title "${{ github.ref_name }}" --draft --generate-notes
+            gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --title "${{ github.ref_name }}" --draft --generate-notes $PRERELEASE_FLAG
           fi
 
   release:

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -24,6 +24,8 @@ import {
 } from '../shared/ipc-channels'
 import { getWindowType } from './windowRegistry'
 import { sendEvent } from './analytics'
+import { getSettingSync } from './store'
+import { compareSemver, isPrereleaseVersion } from './semver'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -32,6 +34,10 @@ import { sendEvent } from './analytics'
 const GITHUB_OWNER = '0-AI-UG'
 const GITHUB_REPO = 'cate'
 const API_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`
+// Full release list (newest first), including pre-releases — used by the
+// fallback path when the beta channel is opted into, since /releases/latest
+// excludes pre-releases by design.
+const API_RELEASES_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=30`
 
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = false
@@ -51,10 +57,10 @@ export function isInstallingUpdate(): boolean { return updateInstalling }
 type UpdateStatus =
   | { state: 'idle' }
   | { state: 'checking' }
-  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string }
-  | { state: 'downloading'; version: string; percent?: number }
-  | { state: 'downloaded'; version: string }
-  | { state: 'manual'; version: string; releaseUrl: string }
+  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string; prerelease?: boolean }
+  | { state: 'downloading'; version: string; percent?: number; prerelease?: boolean }
+  | { state: 'downloaded'; version: string; prerelease?: boolean }
+  | { state: 'manual'; version: string; releaseUrl: string; prerelease?: boolean }
   | { state: 'error'; message: string }
 
 let currentStatus: UpdateStatus = { state: 'idle' }
@@ -104,17 +110,6 @@ function flushSessionBeforeUpdate(): Promise<void> {
 let isManualCheck = false
 let fallbackInProgress = false
 
-/** Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal. */
-function compareSemver(a: string, b: string): number {
-  const pa = a.replace(/^v/, '').split('.').map(Number)
-  const pb = b.replace(/^v/, '').split('.').map(Number)
-  for (let i = 0; i < 3; i++) {
-    const diff = (pa[i] || 0) - (pb[i] || 0)
-    if (diff !== 0) return diff > 0 ? 1 : -1
-  }
-  return 0
-}
-
 // ---------------------------------------------------------------------------
 // Fallback update check via GitHub Releases API
 // ---------------------------------------------------------------------------
@@ -122,6 +117,8 @@ function compareSemver(a: string, b: string): number {
 interface GitHubRelease {
   tag_name: string
   html_url: string
+  prerelease?: boolean
+  draft?: boolean
   assets: { name: string; browser_download_url: string }[]
 }
 
@@ -129,21 +126,44 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
   if (fallbackInProgress) return
   fallbackInProgress = true
 
+  // When the user has opted into beta builds we must consult the full release
+  // list — /releases/latest excludes pre-releases — and pick the newest entry,
+  // pre-release or not, by semver.
+  const includePrereleases = autoUpdater.allowPrerelease === true
+
   try {
-    log.info('[fallback-updater] Checking GitHub releases API…')
+    log.info('[fallback-updater] Checking GitHub releases API… (betas: %s)', includePrereleases)
 
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 15000)
-    const res = await fetch(API_LATEST_URL, {
+    const res = await fetch(includePrereleases ? API_RELEASES_URL : API_LATEST_URL, {
       signal: controller.signal,
       headers: { 'User-Agent': `Cate/${app.getVersion()}`, Accept: 'application/vnd.github.v3+json' },
     })
     clearTimeout(timeout)
 
     if (!res.ok) throw new Error(`GitHub API responded with ${res.status}`)
-    const data = (await res.json()) as GitHubRelease
 
-    const latestVersion = data.tag_name
+    let chosen: GitHubRelease | null
+    if (includePrereleases) {
+      const list = (await res.json()) as GitHubRelease[]
+      // Drop drafts, then pick the highest version (pre-releases included).
+      chosen = list
+        .filter((r) => !r.draft)
+        .reduce<GitHubRelease | null>(
+          (best, r) => (best === null || compareSemver(r.tag_name, best.tag_name) > 0 ? r : best),
+          null,
+        )
+    } else {
+      chosen = (await res.json()) as GitHubRelease
+    }
+
+    if (!chosen) {
+      broadcastStatus({ state: 'idle' })
+      return
+    }
+
+    const latestVersion = chosen.tag_name
     const currentVersion = app.getVersion()
     log.info('[fallback-updater] Latest: %s  Current: v%s', latestVersion, currentVersion)
 
@@ -162,14 +182,15 @@ async function fallbackCheckForUpdate(manual: boolean): Promise<void> {
       return
     }
 
-    latestReleaseUrl = data.html_url
+    latestReleaseUrl = chosen.html_url
     // Try native auto-update download first — the initial check may have
     // errored (e.g. provider mismatch) but downloadUpdate can still succeed.
     broadcastStatus({
       state: 'available',
       version: latestVersion.replace(/^v/, ''),
       canAutoInstall: true,
-      releaseUrl: data.html_url,
+      releaseUrl: chosen.html_url,
+      prerelease: chosen.prerelease === true || isPrereleaseVersion(latestVersion),
     })
   } catch (err: any) {
     log.error('[fallback-updater] Error:', err)
@@ -201,8 +222,9 @@ export function initAutoUpdater(): void {
     log.info('[auto-updater] Renderer requested download')
     const version = currentStatus.state === 'available' ? currentStatus.version : undefined
     const releaseUrl = currentStatus.state === 'available' ? currentStatus.releaseUrl : latestReleaseUrl
+    const prerelease = currentStatus.state === 'available' ? currentStatus.prerelease : undefined
     void sendEvent('update_download_clicked', { version: version ?? null })
-    broadcastStatus({ state: 'downloading', version: version ?? '' })
+    broadcastStatus({ state: 'downloading', version: version ?? '', prerelease })
     autoUpdater.downloadUpdate().catch((err) => {
       log.warn('[auto-updater] downloadUpdate failed, retrying with fresh check:', err)
       // The native updater may not have update info cached (e.g. initial check
@@ -214,7 +236,7 @@ export function initAutoUpdater(): void {
           log.error('[auto-updater] Retry check also failed, falling back to manual:', err2)
           autoUpdater.autoDownload = false
           if (releaseUrl && version) {
-            broadcastStatus({ state: 'manual', version, releaseUrl })
+            broadcastStatus({ state: 'manual', version, releaseUrl, prerelease })
           } else {
             broadcastStatus({ state: 'error', message: err2?.message || 'Download failed' })
           }
@@ -252,7 +274,13 @@ export function initAutoUpdater(): void {
   // Don't check for updates in dev mode
   if (!app.isPackaged) return
 
-  log.info('Auto-updater initialized')
+  // Honor the beta opt-in: when on, the updater also considers GitHub
+  // pre-releases (e.g. v1.2.0-beta.1). Off by default so stable users never see
+  // staged builds. Re-applied live via setBetaUpdatesEnabled when the toggle
+  // flips (see src/main/store.ts → applySettingSideEffect).
+  autoUpdater.allowPrerelease = getSettingSync('betaUpdatesEnabled') === true
+
+  log.info('Auto-updater initialized (betas: %s)', autoUpdater.allowPrerelease)
 
   autoUpdater.on('update-available', (info) => {
     log.info('Update available: v%s', info.version)
@@ -261,6 +289,7 @@ export function initAutoUpdater(): void {
       state: 'available',
       version: String(info.version),
       canAutoInstall: true,
+      prerelease: isPrereleaseVersion(String(info.version)),
     })
   })
 
@@ -285,16 +314,24 @@ export function initAutoUpdater(): void {
     const version = cur.state === 'downloading' || cur.state === 'available' || cur.state === 'downloaded'
       ? cur.version
       : ''
+    const prerelease = cur.state === 'downloading' || cur.state === 'available' || cur.state === 'downloaded'
+      ? cur.prerelease
+      : undefined
     broadcastStatus({
       state: 'downloading',
       version,
       percent: typeof progress?.percent === 'number' ? progress.percent : undefined,
+      prerelease,
     })
   })
 
   autoUpdater.on('update-downloaded', (info) => {
     log.info('Update downloaded, ready to install')
-    broadcastStatus({ state: 'downloaded', version: String(info?.version ?? '') })
+    broadcastStatus({
+      state: 'downloaded',
+      version: String(info?.version ?? ''),
+      prerelease: isPrereleaseVersion(String(info?.version ?? '')),
+    })
   })
 
   autoUpdater.on('checking-for-update', () => {
@@ -337,5 +374,22 @@ export function checkForUpdatesManually(): void {
     log.warn('[auto-updater] Manual check threw, trying fallback:', err)
     isManualCheck = false
     fallbackCheckForUpdate(true)
+  })
+}
+
+/** React to the beta-updates opt-in flipping. Re-points the updater channel
+ *  (allowPrerelease) and re-checks immediately so turning betas on surfaces an
+ *  available staged build without waiting for the 15-minute poll. Called from
+ *  the settings side-effect path (UI toggle AND hand-edited settings.json).
+ *  No-op until the app is packaged, since checks don't run in dev. */
+export function setBetaUpdatesEnabled(enabled: boolean): void {
+  autoUpdater.allowPrerelease = enabled
+  log.info('[auto-updater] Beta updates %s', enabled ? 'enabled' : 'disabled')
+  if (!app.isPackaged) return
+  // A fresh check on the new channel. Don't surface a "no updates" dialog — this
+  // is a background reaction to a settings change, not a manual check.
+  autoUpdater.checkForUpdates().catch((err) => {
+    log.warn('[auto-updater] Re-check after beta toggle threw, trying fallback:', err)
+    fallbackCheckForUpdate(false)
   })
 }

--- a/src/main/semver.test.ts
+++ b/src/main/semver.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { compareSemver, isPrereleaseVersion } from './semver'
+
+describe('compareSemver', () => {
+  it('orders release versions by core', () => {
+    expect(compareSemver('1.2.1', '1.2.0')).toBe(1)
+    expect(compareSemver('1.2.0', '1.2.1')).toBe(-1)
+    expect(compareSemver('2.0.0', '1.9.9')).toBe(1)
+    expect(compareSemver('1.2.0', '1.2.0')).toBe(0)
+  })
+
+  it('tolerates a leading v', () => {
+    expect(compareSemver('v1.3.0', '1.2.0')).toBe(1)
+    expect(compareSemver('v1.2.0', 'v1.2.0')).toBe(0)
+  })
+
+  it('ranks a pre-release below its own release', () => {
+    expect(compareSemver('1.2.0-beta.1', '1.2.0')).toBe(-1)
+    expect(compareSemver('1.2.0', '1.2.0-beta.1')).toBe(1)
+  })
+
+  it('lets a stable release outrank an earlier beta (roll-forward)', () => {
+    // A tester on 1.2.0-beta.3 should be offered stable 1.2.0.
+    expect(compareSemver('1.2.0', '1.2.0-beta.3')).toBe(1)
+  })
+
+  it('orders pre-releases of the same core numerically', () => {
+    expect(compareSemver('1.2.0-beta.2', '1.2.0-beta.1')).toBe(1)
+    expect(compareSemver('1.2.0-beta.10', '1.2.0-beta.2')).toBe(1)
+    expect(compareSemver('1.2.0-beta.1', '1.2.0-beta.1')).toBe(0)
+  })
+
+  it('full beta channel ordering sorts as expected', () => {
+    const versions = ['1.2.0', '1.2.0-beta.1', '1.2.1', '1.2.0-beta.10', '1.2.0-beta.2']
+    const sorted = [...versions].sort(compareSemver)
+    expect(sorted).toEqual(['1.2.0-beta.1', '1.2.0-beta.2', '1.2.0-beta.10', '1.2.0', '1.2.1'])
+  })
+})
+
+describe('isPrereleaseVersion', () => {
+  it('detects a pre-release suffix', () => {
+    expect(isPrereleaseVersion('1.2.0-beta.1')).toBe(true)
+    expect(isPrereleaseVersion('1.2.0-rc.1')).toBe(true)
+    expect(isPrereleaseVersion('1.2.0')).toBe(false)
+  })
+})

--- a/src/main/semver.ts
+++ b/src/main/semver.ts
@@ -1,0 +1,48 @@
+// =============================================================================
+// Minimal semver comparison — pure, dependency-free so it stays unit-testable
+// in isolation (the auto-updater that consumes it pulls in electron + native
+// modules). Handles only what the updater needs: x.y.z cores plus an optional
+// pre-release suffix used for the beta channel (e.g. 1.2.0-beta.1).
+// =============================================================================
+
+/** A semver string with a pre-release suffix (e.g. 1.2.0-beta.1) identifies a
+ *  beta / staged build. The presence of a `-` is the reliable signal. */
+export function isPrereleaseVersion(version: string): boolean {
+  return version.includes('-')
+}
+
+/** Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal.
+ *  Handles pre-release suffixes per semver: a pre-release ranks BELOW its
+ *  release (1.2.0-beta.1 < 1.2.0), and two pre-releases of the same version are
+ *  ordered by their dot-separated identifiers (numeric parts compared
+ *  numerically). This matters for the beta channel so a tester on 1.2.0-beta.3
+ *  rolls forward to stable 1.2.0 and to later betas, but not backwards. */
+export function compareSemver(a: string, b: string): number {
+  const [coreA, preA] = a.replace(/^v/, '').split('-', 2)
+  const [coreB, preB] = b.replace(/^v/, '').split('-', 2)
+  const na = coreA.split('.').map(Number)
+  const nb = coreB.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    const diff = (na[i] || 0) - (nb[i] || 0)
+    if (diff !== 0) return diff > 0 ? 1 : -1
+  }
+  // Same core version: no suffix outranks a pre-release suffix.
+  if (!preA && !preB) return 0
+  if (!preA) return 1
+  if (!preB) return -1
+  // Both pre-releases: compare identifiers left to right.
+  const ida = preA.split('.')
+  const idb = preB.split('.')
+  for (let i = 0; i < Math.max(ida.length, idb.length); i++) {
+    const xa = ida[i]
+    const xb = idb[i]
+    if (xa === undefined) return -1
+    if (xb === undefined) return 1
+    const numA = Number(xa)
+    const numB = Number(xb)
+    const bothNumeric = !Number.isNaN(numA) && !Number.isNaN(numB)
+    const cmp = bothNumeric ? numA - numB : xa === xb ? 0 : xa > xb ? 1 : -1
+    if (cmp !== 0) return cmp > 0 ? 1 : -1
+  }
+  return 0
+}

--- a/src/main/settingsFile.test.ts
+++ b/src/main/settingsFile.test.ts
@@ -112,4 +112,18 @@ describe('settingsFile', () => {
     expect(m.isSettingsKey('editorFontSize')).toBe(true)
     expect(m.isSettingsKey('recentProjects')).toBe(false)
   })
+
+  it('round-trips the beta-updates opt-in (defaults off)', async () => {
+    const m = await freshModule()
+    m.loadSettingsSync()
+    expect(m.isSettingsKey('betaUpdatesEnabled')).toBe(true)
+    expect(m.getSetting('betaUpdatesEnabled')).toBe(DEFAULT_SETTINGS.betaUpdatesEnabled)
+    expect(DEFAULT_SETTINGS.betaUpdatesEnabled).toBe(false)
+
+    expect(m.setSetting('betaUpdatesEnabled', true)).toBe(true)
+    expect(m.getSetting('betaUpdatesEnabled')).toBe(true)
+    m.flushPendingWritesSync()
+    const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
+    expect(onDisk.betaUpdatesEnabled).toBe(true)
+  })
 })

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -68,6 +68,7 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   usageAnalyticsEnabled: 'boolean',
   telemetryConsentDecided: 'boolean',
   onboardingCompleted: 'boolean',
+  betaUpdatesEnabled: 'boolean',
 }
 
 const SETTINGS_KEYS = Object.keys(SETTINGS_SCHEMA) as Array<keyof AppSettings>

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -91,6 +91,18 @@ async function applySettingSideEffect(key: keyof AppSettings, value: unknown): P
       log.warn('Sentry live-toggle failed: %O', err)
     }
   }
+  // Re-point the auto-updater channel when the beta opt-in flips, and re-check
+  // immediately. Dynamic import keeps ./auto-updater (and electron-updater) out
+  // of ./store's static graph — auto-updater imports ./store, so a static import
+  // here would form a cycle.
+  if (key === 'betaUpdatesEnabled') {
+    try {
+      const { setBetaUpdatesEnabled } = await import('./auto-updater')
+      setBetaUpdatesEnabled(value !== false)
+    } catch (err) {
+      log.warn('Beta-updates live-toggle failed: %O', err)
+    }
+  }
 }
 
 // Lazy-loaded store instance (ESM dynamic import)

--- a/src/renderer/canvas/UpdateButton.tsx
+++ b/src/renderer/canvas/UpdateButton.tsx
@@ -37,7 +37,12 @@ export const UpdateButton: React.FC = () => {
         ? 'Restart'
         : 'Update'
 
-  const title =
+  // Beta / staged build — surfaced only to users who opted into the beta channel
+  // in Settings → Updates. Stable users never receive a pre-release, so this
+  // chip only ever shows for opted-in testers.
+  const isBeta = status.prerelease === true
+
+  const baseTitle =
     status.state === 'downloading'
       ? 'Downloading update…'
       : status.state === 'downloaded'
@@ -45,6 +50,7 @@ export const UpdateButton: React.FC = () => {
         : status.state === 'manual'
           ? 'Open release page to download manually'
           : 'Click to download the update'
+  const title = isBeta ? `Beta build ${status.version || ''} — ${baseTitle}`.trim() : baseTitle
 
   const onClick = () => {
     if (status.state === 'available') {
@@ -61,24 +67,36 @@ export const UpdateButton: React.FC = () => {
   const showFill = isDownloading || status.state === 'downloaded'
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isDownloading}
-      title={title}
-      style={{ WebkitTapHighlightColor: 'transparent' }}
-      className="group relative overflow-hidden flex items-center justify-center gap-1 h-[28px] w-[76px] rounded-full bg-[var(--focus-blue,#3b82f6)] text-white text-[11px] font-medium shadow-[0_0_24px_-2px_rgba(59,130,246,0.7),0_8px_24px_-6px_rgba(59,130,246,0.55)] hover:brightness-110 active:scale-[0.97] disabled:active:scale-100 focus:outline-none transition-all"
-    >
-      {/* Progress fill — lighter blue overlay that grows left-to-right while downloading. */}
-      {showFill && (
+    <span className="flex items-center gap-1.5">
+      {/* Beta tag — marks a staged / pre-release build so an opted-in tester can
+          tell it apart from a stable update at a glance. */}
+      {isBeta && (
         <span
-          aria-hidden
-          className="absolute inset-y-0 left-0 bg-white/25 transition-[width] duration-200 ease-out pointer-events-none"
-          style={{ width: `${percent}%` }}
-        />
+          title={title}
+          className="select-none rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-500 ring-1 ring-amber-500/30"
+        >
+          Beta
+        </span>
       )}
-      <ArrowCircleUp size={12} weight="fill" className="relative z-[1]" />
-      <span className="relative z-[1] whitespace-nowrap">{label}</span>
-    </button>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isDownloading}
+        title={title}
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+        className="group relative overflow-hidden flex items-center justify-center gap-1 h-[28px] w-[76px] rounded-full bg-[var(--focus-blue,#3b82f6)] text-white text-[11px] font-medium shadow-[0_0_24px_-2px_rgba(59,130,246,0.7),0_8px_24px_-6px_rgba(59,130,246,0.55)] hover:brightness-110 active:scale-[0.97] disabled:active:scale-100 focus:outline-none transition-all"
+      >
+        {/* Progress fill — lighter blue overlay that grows left-to-right while downloading. */}
+        {showFill && (
+          <span
+            aria-hidden
+            className="absolute inset-y-0 left-0 bg-white/25 transition-[width] duration-200 ease-out pointer-events-none"
+            style={{ width: `${percent}%` }}
+          />
+        )}
+        <ArrowCircleUp size={12} weight="fill" className="relative z-[1]" />
+        <span className="relative z-[1] whitespace-nowrap">{label}</span>
+      </button>
+    </span>
   )
 }

--- a/src/renderer/settings/SettingsWindow.tsx
+++ b/src/renderer/settings/SettingsWindow.tsx
@@ -23,6 +23,7 @@ import { SidebarSettings } from './SidebarSettings'
 import { FileExplorerSettings } from './FileExplorerSettings'
 import { ShortcutSettings } from './ShortcutSettings'
 import { NotificationSettings } from './NotificationSettings'
+import { UpdatesSettings } from './UpdatesSettings'
 import { SettingsSearchContext } from './SettingsSearchContext'
 
 const SECTIONS = [
@@ -34,6 +35,7 @@ const SECTIONS = [
   { title: 'Sidebar', component: SidebarSettings },
   { title: 'File Explorer', component: FileExplorerSettings },
   { title: 'Notifications', component: NotificationSettings },
+  { title: 'Updates', component: UpdatesSettings },
   { title: 'Shortcuts', component: ShortcutSettings },
 ] as const
 

--- a/src/renderer/settings/UpdatesSettings.tsx
+++ b/src/renderer/settings/UpdatesSettings.tsx
@@ -1,0 +1,20 @@
+import { useSettingsStore } from '../stores/settingsStore'
+import { SettingRow, Toggle } from './SettingsComponents'
+
+export function UpdatesSettings() {
+  const store = useSettingsStore()
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SettingRow
+        label="Receive beta builds"
+        description="Get early access to staged, pre-release versions. Betas may be less stable. They never affect the public download, and turning this off won't downgrade a beta you've already installed — you'll move to stable once it catches up."
+      >
+        <Toggle
+          checked={store.betaUpdatesEnabled}
+          onChange={(v) => store.setSetting('betaUpdatesEnabled', v)}
+        />
+      </SettingRow>
+    </div>
+  )
+}

--- a/src/renderer/stores/updateStore.ts
+++ b/src/renderer/stores/updateStore.ts
@@ -9,10 +9,10 @@ import { create } from 'zustand'
 export type UpdateStatus =
   | { state: 'idle' }
   | { state: 'checking' }
-  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string }
-  | { state: 'downloading'; version: string; percent?: number }
-  | { state: 'downloaded'; version: string }
-  | { state: 'manual'; version: string; releaseUrl: string }
+  | { state: 'available'; version: string; canAutoInstall: boolean; releaseUrl?: string; prerelease?: boolean }
+  | { state: 'downloading'; version: string; percent?: number; prerelease?: boolean }
+  | { state: 'downloaded'; version: string; prerelease?: boolean }
+  | { state: 'manual'; version: string; releaseUrl: string; prerelease?: boolean }
   | { state: 'error'; message: string }
 
 interface UpdateStore {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1060,6 +1060,13 @@ export interface AppSettings {
   /** Whether the user has finished (or skipped) the first-run guided tour.
    *  Set false to replay it. */
   onboardingCompleted: boolean
+
+  // Updates
+  /** Opt in to beta (pre-release / staged) builds. When on, the in-app
+   *  auto-updater also considers GitHub pre-releases (e.g. v1.2.0-beta.1) — see
+   *  src/main/auto-updater.ts (autoUpdater.allowPrerelease). Off by default, so
+   *  stable users and the public website download are never offered betas. */
+  betaUpdatesEnabled: boolean
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -1121,6 +1128,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
   // Onboarding
   onboardingCompleted: false,
+
+  // Updates
+  betaUpdatesEnabled: false,
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an **opt-in beta / pre-release update channel** so staged builds can ship to testers via GitHub pre-releases **without affecting stable users or the public website download**.

A tag with a semver pre-release suffix (e.g. `v1.2.0-beta.1`) is published as a GitHub *pre-release*, which GitHub automatically excludes from the "Latest" badge and the `/releases/latest` API. The in-app updater only considers pre-releases when a user opts in; everyone else stays on stable.

> **Scope note:** this branch also carries the pre-existing `settings.json` refactor (`568bb62`) plus a dev self-heal fix and an e2e wait fix. The beta-channel work builds directly on the `settings.json` settings backing (`settingsFile.ts`), so it can't land independently of it.

## Beta channel (new)

- **Setting** `betaUpdatesEnabled` (default `false`) — added to `AppSettings`/`DEFAULT_SETTINGS` and the `settingsFile` schema, so it round-trips through the editable `settings.json`.
- **Updater** (`auto-updater.ts`) — drives `autoUpdater.allowPrerelease` from the setting; new `setBetaUpdatesEnabled()` re-points the channel and re-checks immediately on toggle; broadcasts carry a `prerelease` flag; the GitHub-API fallback path now queries the full `/releases` list and includes pre-releases when opted in.
- **Semver** — extracted to a pure, dependency-free `semver.ts` and extended to order pre-releases correctly (`1.2.0-beta.1 < 1.2.0`), so testers roll forward to stable but never downgrade.
- **Live toggle** (`store.ts`) — `applySettingSideEffect` re-points the updater on both the UI toggle and external `settings.json` edits.
- **UI** — new **Settings → Updates** section with a "Receive beta builds" toggle; `UpdateButton` shows an amber **Beta** chip + beta-aware tooltip for pre-releases.
- **CI** (`release.yml`) — tags containing a hyphen are published with `--prerelease`.

## Releasing a beta

1. Set `package.json` `version` to e.g. `1.2.0-beta.1`.
2. `git tag v1.2.0-beta.1 && git push origin v1.2.0-beta.1`.
3. CI publishes a GitHub **pre-release**. Only users with **Settings → Updates → Receive beta builds** on are offered it. Companion/pi tarballs are keyed off `v<version>`, so they resolve against the matching pre-release automatically.

## Behaviour notes

- Turning the toggle **off** while on a beta keeps that build until stable catches up (no auto-downgrade) — standard, and stated in the toggle description.

## Test plan

- `npm run typecheck`, `npm run lint`, and `vitest` (incl. new `semver.test.ts` ordering/roll-forward tests and a `betaUpdatesEnabled` round-trip) pass locally.
- Manual (dev): toggle persists to `settings.json` and reacts to hand-edits live.
- Manual (packaged): opt-out → no beta offered; opt-in → `UpdateButton` shows a Beta update that downloads/installs.
