### PR TITLE
fix(release): --force-local for tar on Windows

### DIFF
--- a/scripts/build-companion-tarball.mjs
+++ b/scripts/build-companion-tarball.mjs
@@ -60,6 +60,10 @@ const RIPGREP_TRIPLES = {
 }
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const dist = path.join(repoRoot, 'dist-companion')
+// GNU tar (the Windows runner's tar) reads the `D:` in an absolute archive path
+// as an rsh host spec ("Cannot connect to D:"). --force-local disables that. Only
+// on win32: macOS/Linux use bsdtar, which rejects the flag and has no drive colon.
+const FORCE_LOCAL = process.platform === 'win32' ? ['--force-local'] : []
 
 const args = process.argv.slice(2)
 const useDocker = args.includes('--docker')
@@ -110,7 +114,7 @@ if (missing.length) throw new Error(`[companion] incomplete stage for ${targetAr
 // --no-xattrs: don't archive extended attributes (macOS keeps re-stamping a
 // com.apple.provenance xattr that otherwise makes GNU tar warn on extraction
 // on the Ubuntu server). Supported by both bsdtar and GNU tar.
-execFileSync('tar', ['--no-xattrs', '-czf', outTar, '-C', stageDir, '.'], { stdio: 'inherit' })
+execFileSync('tar', [...FORCE_LOCAL, '--no-xattrs', '-czf', outTar, '-C', stageDir, '.'], { stdio: 'inherit' })
 console.log(`[companion] wrote ${path.relative(repoRoot, outTar)}`)
 
 // --------------------------------------------------------------------------
@@ -369,7 +373,7 @@ function stagePi(outRoot) {
   if (!existsSync(tar)) throw new Error(`pi tarball not found at ${tar}`)
   rmSync(outRoot, { recursive: true, force: true })
   mkdirSync(outRoot, { recursive: true })
-  execFileSync('tar', ['-xzf', tar, '-C', outRoot], { stdio: 'ignore' })
+  execFileSync('tar', [...FORCE_LOCAL, '-xzf', tar, '-C', outRoot], { stdio: 'ignore' })
   if (!existsSync(path.join(outRoot, 'dist', 'cli.js'))) throw new Error('staged pi missing dist/cli.js')
   console.log(`[companion] staged pi ${piVersion}`)
 }

--- a/scripts/build-pi-tarball.mjs
+++ b/scripts/build-pi-tarball.mjs
@@ -25,6 +25,10 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const dist = path.join(repoRoot, 'dist-companion')
+// GNU tar (the Windows runner's tar) reads the `D:` in an absolute archive path
+// as an rsh host spec ("Cannot connect to D:"). --force-local disables that. Only
+// on win32: macOS/Linux use bsdtar, which rejects the flag and has no drive colon.
+const FORCE_LOCAL = process.platform === 'win32' ? ['--force-local'] : []
 const piSrc = path.join(repoRoot, 'node_modules', '@earendil-works', 'pi-coding-agent')
 
 if (!existsSync(piSrc)) {
@@ -90,7 +94,7 @@ const stagedSize = dirSizeMb(stage)
 const outTar = path.join(dist, `cate-pi-${piVersion}.tgz`)
 rmSync(outTar, { force: true })
 // --no-xattrs: macOS provenance xattrs would make GNU tar warn on extraction.
-execFileSync('tar', ['--no-xattrs', '-czf', outTar, '-C', stage, '.'], { stdio: 'inherit' })
+execFileSync('tar', [...FORCE_LOCAL, '--no-xattrs', '-czf', outTar, '-C', stage, '.'], { stdio: 'inherit' })
 console.log(`[pi] wrote ${path.relative(repoRoot, outTar)} (staged ${stagedSize} MB)`)
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #279. With the EXDEV fix in, the Windows jobs got further but now fail packaging the tarballs:

```
tar (child): Cannot connect to D: resolve failed
tar: D\:\a\cate\cate\dist-companion\cate-pi-0.75.5.tgz: Cannot write: Broken pipe
```

GNU tar (what resolves to `tar` on the runner) treats the `D:` in an absolute archive path as an rsh `host:path` spec. Add `--force-local` on win32 for the two packaging tars + the pi-tarball extraction. macOS/Linux use bsdtar (no remote parsing, rejects the flag), so it's gated on `process.platform`. Verified the darwin build still runs end to end locally.