### PR TITLE
fix(release): portable Windows tar, drop darwin-x64, dedup node-pty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,14 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
-      # The companion tarball stages node-pty's native binary from build/Release,
-      # but a plain `npm install` satisfies node-pty from a shipped prebuild and
-      # never populates build/Release. Compile from source so the tarball build
-      # finds it. (node-pty is N-API: the node-20 binary runs under the tarball's
-      # bundled node-22 runtime.)
-      - name: Compile node-pty from source (companion tarball needs build/Release)
+      # The companion tarball stages node-pty's native binary from build/Release.
+      # On macOS/Windows `npm install` satisfies node-pty from a shipped prebuild
+      # and never populates build/Release, so compile from source here. On Linux
+      # node-pty ships NO prebuild, so `npm install` already built it from source
+      # into build/Release — a rebuild would just duplicate that, so skip it.
+      # (node-pty is N-API: the node-20 binary runs under the bundled node-22.)
+      - name: Compile node-pty from source (mac/win; Linux builds it at install)
+        if: runner.os != 'Linux'
         run: npm rebuild node-pty --build-from-source
 
       # The local workspace runs the companion daemon tarball, shipped inside the
@@ -188,8 +190,6 @@ jobs:
             docker: true
           - os: macos-latest
             target: darwin-arm64
-          - os: macos-13
-            target: darwin-x64
           - os: windows-latest
             target: win32-x64
 
@@ -219,11 +219,13 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      # Native targets stage node-pty from build/Release; a plain install only
-      # leaves a prebuild, so compile from source. (The --docker linux-arm64
-      # cross-build compiles node-pty inside the container, so skip it there.)
-      - name: Compile node-pty from source (native targets)
-        if: ${{ !matrix.docker }}
+      # Stage node-pty from build/Release. macOS/Windows installs use a shipped
+      # prebuild (build/Release empty) so compile from source; Linux ships no
+      # prebuild, so `npm install` already built it from source. The --docker
+      # linux-arm64 cross-build compiles node-pty in the container — all of these
+      # Linux cases are exactly the ones runner.os != 'Linux' skips.
+      - name: Compile node-pty from source (mac/win; Linux builds it at install)
+        if: runner.os != 'Linux'
         run: npm rebuild node-pty --build-from-source
 
       - name: Build companion tarball (${{ matrix.target }})

--- a/scripts/build-companion-tarball.mjs
+++ b/scripts/build-companion-tarball.mjs
@@ -61,6 +61,13 @@ const RIPGREP_TRIPLES = {
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const dist = path.join(repoRoot, 'dist-companion')
 
+// tar invocations must avoid Windows drive letters and backslashes: a `D:`-prefixed
+// path reads as a remote `host:path` spec on BOTH the Windows runner's System32
+// bsdtar (default-shell steps) and Git's msys2 GNU tar (shell: bash steps), and
+// msys2 tar also can't chdir into a backslashed path. So we run tar with `cwd` set
+// and pass the archive as a basename + the -C dir as a forward-slash relative path.
+const fwd = (from, to) => path.relative(from, to).split(path.sep).join('/') || '.'
+
 const args = process.argv.slice(2)
 const useDocker = args.includes('--docker')
 const targetArg = valueOf('--target') ?? `${plat(process.platform)}-${process.arch}`
@@ -109,12 +116,9 @@ if (missing.length) throw new Error(`[companion] incomplete stage for ${targetAr
 
 // --no-xattrs: don't archive extended attributes (macOS keeps re-stamping a
 // com.apple.provenance xattr that otherwise makes GNU tar warn on extraction
-// on the Ubuntu server). Supported by both bsdtar and GNU tar.
-// Run tar from the archive's own dir and name it by basename: tar reads a
-// `D:`-prefixed absolute path as a remote `host:path` spec ("Cannot connect to
-// D:") — true of the Windows runner's bsdtar AND GNU tar, and bsdtar has no
-// --force-local. A colon-free relative name never trips the remote heuristic.
-execFileSync('tar', ['--no-xattrs', '-czf', path.basename(outTar), '-C', stageDir, '.'], { stdio: 'inherit', cwd: path.dirname(outTar) })
+// on the Ubuntu server). Supported by both bsdtar and GNU tar. Basename + relative
+// -C (cwd = dist) keep Windows drive letters out of tar's path args — see `fwd`.
+execFileSync('tar', ['--no-xattrs', '-czf', path.basename(outTar), '-C', fwd(dist, stageDir), '.'], { stdio: 'inherit', cwd: dist })
 console.log(`[companion] wrote ${path.relative(repoRoot, outTar)}`)
 
 // --------------------------------------------------------------------------
@@ -373,9 +377,9 @@ function stagePi(outRoot) {
   if (!existsSync(tar)) throw new Error(`pi tarball not found at ${tar}`)
   rmSync(outRoot, { recursive: true, force: true })
   mkdirSync(outRoot, { recursive: true })
-  // Basename + cwd, not the absolute path — see the packaging tar above (a `D:`
-  // archive path reads as a remote host on the Windows runner's bsdtar).
-  execFileSync('tar', ['-xzf', path.basename(tar), '-C', outRoot], { stdio: 'ignore', cwd: path.dirname(tar) })
+  // Basename archive + relative -C (cwd = the tarball's dir) — see `fwd`. The msys2
+  // GNU tar in the release job's bash step can't chdir into a backslashed `D:\` -C.
+  execFileSync('tar', ['-xzf', path.basename(tar), '-C', fwd(path.dirname(tar), outRoot)], { stdio: 'ignore', cwd: path.dirname(tar) })
   if (!existsSync(path.join(outRoot, 'dist', 'cli.js'))) throw new Error('staged pi missing dist/cli.js')
   console.log(`[companion] staged pi ${piVersion}`)
 }
@@ -394,9 +398,8 @@ function unzipInto(zipPath, destDir) {
   } catch {
     // unzip absent (e.g. Windows runner) — fall through to bsdtar.
   }
-  // Basename + cwd (the bsdtar fallback would otherwise read `C:\…zip` as a
-  // remote host on Windows — see the packaging tar's note).
-  execFileSync('tar', ['-xf', path.basename(zipPath), '-C', destDir], { stdio: 'ignore', cwd: path.dirname(zipPath) })
+  // Basename archive + relative -C (cwd = the zip's dir) — see `fwd`.
+  execFileSync('tar', ['-xf', path.basename(zipPath), '-C', fwd(path.dirname(zipPath), destDir)], { stdio: 'ignore', cwd: path.dirname(zipPath) })
 }
 function valueOf(flag) {
   const i = args.indexOf(flag)

--- a/scripts/build-pi-tarball.mjs
+++ b/scripts/build-pi-tarball.mjs
@@ -26,6 +26,10 @@ import { fileURLToPath } from 'node:url'
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const dist = path.join(repoRoot, 'dist-companion')
 const piSrc = path.join(repoRoot, 'node_modules', '@earendil-works', 'pi-coding-agent')
+// Forward-slash relative path for tar's -C: keeps Windows drive letters/backslashes
+// out of tar args (both bsdtar and msys2 GNU tar choke on `D:\…`). See the companion
+// build script's `fwd` note.
+const fwd = (from, to) => path.relative(from, to).split(path.sep).join('/') || '.'
 
 if (!existsSync(piSrc)) {
   console.error('[pi] @earendil-works/pi-coding-agent not found — run `npm install` first')
@@ -90,10 +94,9 @@ const stagedSize = dirSizeMb(stage)
 const outTar = path.join(dist, `cate-pi-${piVersion}.tgz`)
 rmSync(outTar, { force: true })
 // --no-xattrs: macOS provenance xattrs would make GNU tar warn on extraction.
-// Run from the archive's dir with a colon-free basename: tar reads a `D:`-prefixed
-// absolute path as a remote `host:path` ("Cannot connect to D:") on the Windows
-// runner's bsdtar (which also has no --force-local), and GNU tar does the same.
-execFileSync('tar', ['--no-xattrs', '-czf', path.basename(outTar), '-C', stage, '.'], { stdio: 'inherit', cwd: path.dirname(outTar) })
+// Basename archive + relative -C (cwd = dist) keep Windows drive letters out of
+// tar's path args (both bsdtar and msys2 GNU tar read `D:\…` as a remote host).
+execFileSync('tar', ['--no-xattrs', '-czf', path.basename(outTar), '-C', fwd(dist, stage), '.'], { stdio: 'inherit', cwd: dist })
 console.log(`[pi] wrote ${path.relative(repoRoot, outTar)} (staged ${stagedSize} MB)`)
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #281. Three things, all surfaced by the v1.1.1-beta.* runs.

**Windows tar.** The companion job (default pwsh shell) uses System32 **bsdtar**; the release job's `shell: bash` step uses Git's **msys2 GNU tar**. Both read a `D:`-prefixed absolute archive path as a remote `host:path` ("Cannot connect to D:"), and msys2 tar also can't `chdir` into a backslashed `-C`. Fix: run `tar` with `cwd` set and pass the archive as a basename + `-C` as a forward-slash relative path. No drive letter or backslash reaches tar, on any shell/platform.

**darwin-x64.** Dropped from the companion matrix — `macos-13` (Intel) runners aren't getting picked up and Apple Silicon is the mac target.

**node-pty double build.** The explicit `npm rebuild --build-from-source` is only needed on macOS/Windows (install uses a shipped prebuild, leaving `build/Release` empty). Linux ships no prebuild so install already builds from source — so the rebuild is guarded with `runner.os != 'Linux'`. Deliberately **not** a global `npm_config_build_from_source`: sharp 0.33 honors it and would compile libvips from source.

Verified the darwin build end to end locally (bsdtar, same family as the runner).