### PR TITLE
fix(release): sync companion/pi versions before building the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,20 @@ jobs:
       - name: Generate icons
         run: npm run icons
 
+      # Regenerate the embedded companion + pi version strings (src/companion/
+      # version.ts, piVersion.ts) from package.json / the installed pi BEFORE
+      # building the app. `npm run build` bakes COMPANION_VERSION/PI_VERSION into
+      # the app, and the daemon resolves its tarball by that version
+      # (cate-companion-<COMPANION_VERSION>-<target>.tgz). A release whose version
+      # bump only touched package.json (e.g. a beta tag) otherwise leaves the
+      # committed version.ts stale, so the app looks for the wrong tarball name —
+      # in dev/e2e that means no ripgrep and 0-result content search (which gates
+      # the macOS release), and in the shipped app a missing companion/pi pull.
+      - name: Sync companion + pi versions to package.json
+        run: |
+          npm run build:companion
+          npm run pi:tarball
+
       - name: Build app
         run: npm run build
         env:


### PR DESCRIPTION
Fixes the macOS content-search e2e failure (16 `search.spec.ts` tests, all 0-result) that gated beta.5.

**Root cause.** The app bakes `COMPANION_VERSION`/`PI_VERSION` (from `src/companion/version.ts`, `piVersion.ts`) at `npm run build` time, and the local daemon resolves its tarball by that version: `devTarball()` looks for `dist-companion/cate-companion-<COMPANION_VERSION>-<target>.tgz`. A beta tag bumps only `package.json`, so the committed `version.ts` stays at `1.1.1` while the tarball build later names the artifact `1.1.1-beta.N`. The app then looks for a tarball that doesn't exist → no ripgrep → 0-result content search (which is the blocking macOS gate). It also means the **shipped** beta would fail to pull the right companion/pi.

**Fix.** Regenerate `version.ts` + `piVersion.ts` from `package.json` / the installed pi **before** `npm run build`, so the embedded versions match the artifacts the release produces.

This is why CI passed but CD didn't: CI ran at a clean `1.1.1` (committed version.ts matched), CD runs at a `-beta.N` tag where only package.json moved. Verified the daemon resolution path in `companionArtifacts.ts`; locally the daemon starts with matched versions (search works) and the prior CD failures were 30s settle timeouts (no daemon), not the local teardown hangs.