### PR TITLE
fix(release): codesign companion native binaries for macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,23 @@ jobs:
         if: runner.os != 'Linux'
         run: npm rebuild node-pty --build-from-source
 
+      # Import the Developer ID cert into a scoped keychain and export the signing
+      # identity, so the next step can codesign the companion's bundled native
+      # binaries. Without this, notarytool rejects the unsigned node-pty/rg Mach-O
+      # inside companion-host.tgz and the macOS release fails to notarize.
+      - name: Set up macOS signing for companion natives
+        if: matrix.platform == 'mac'
+        env:
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+        run: bash scripts/ci-mac-signing-keychain.sh
+
       # The local workspace runs the companion daemon tarball, shipped inside the
       # installer (electron-builder.yml extraResources → companion-host.tgz). Build
       # this runner's host-target tarball and stage it under the fixed name so the
-      # extraResource exists. Each runner builds only its own host target.
+      # extraResource exists. Each runner builds only its own host target. On macOS
+      # the build script signs the bundled natives via CATE_MAC_SIGN_IDENTITY
+      # (exported above) before packing, so the tarball notarizes inside the app.
       - name: Build + stage host companion tarball
         shell: bash
         run: |
@@ -241,6 +254,16 @@ jobs:
       - name: Compile node-pty from source (mac/win; Linux builds it at install)
         if: runner.os != 'Linux'
         run: npm rebuild node-pty --build-from-source
+
+      # Sign the bundled darwin natives so a mac host that pulls this per-target
+      # tarball from the release runs Developer ID-signed binaries (no Gatekeeper
+      # quarantine block), mirroring the host tarball staged in the app.
+      - name: Set up macOS signing for companion natives
+        if: startsWith(matrix.target, 'darwin-')
+        env:
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+        run: bash scripts/ci-mac-signing-keychain.sh
 
       - name: Build companion tarball (${{ matrix.target }})
         run: node scripts/build-companion-tarball.mjs --target ${{ matrix.target }} ${{ matrix.docker && '--docker' || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist-companion/
 # Build artifacts
 build/
 !build/entitlements.mac.plist
+!build/entitlements.companion.plist
 # src/companion/build/ is hand-authored source (the companion esbuild config used
 # by `build:companion` and the tarball build), NOT a build-output dir — re-include
 # it so a clean checkout / CI can build the companion daemon + its ripgrep.

--- a/build/entitlements.companion.plist
+++ b/build/entitlements.companion.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the companion's bundled native binaries (node, rg, node-pty's
+  pty.node + spawn-helper), signed before they are packed into the companion
+  tarball. Apple's notarytool recurses into companion-host.tgz and requires every
+  Mach-O to carry a Developer ID + hardened-runtime signature. The bundled `node`
+  additionally needs these so it still runs once hardened: allow-jit /
+  unsigned-executable-memory for V8, and disable-library-validation so it can load
+  pty.node (signed by us, a different team than the Node.js binary's original).
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/build-companion-tarball.mjs
+++ b/scripts/build-companion-tarball.mjs
@@ -100,6 +100,7 @@ await stageNodePty(stageDir)
 await stageNodeRuntime(targetPlatform, targetArch, path.join(stageDir, 'runtime', 'bin', `node${exe}`))
 await stageRipgrep(targetArg, path.join(stageDir, 'runtime', 'bin', `rg${exe}`))
 stagePi(path.join(stageDir, 'pi'))
+signMacNatives(stageDir)
 
 // Fail loudly if anything the daemon's install-probe requires is missing, rather
 // than shipping a tarball that extracts but never satisfies isInstalled (every
@@ -382,6 +383,43 @@ function stagePi(outRoot) {
   execFileSync('tar', ['-xzf', path.basename(tar), '-C', fwd(path.dirname(tar), outRoot)], { stdio: 'ignore', cwd: path.dirname(tar) })
   if (!existsSync(path.join(outRoot, 'dist', 'cli.js'))) throw new Error('staged pi missing dist/cli.js')
   console.log(`[companion] staged pi ${piVersion}`)
+}
+
+/**
+ * Codesign the bundled darwin Mach-O binaries with a Developer ID + hardened
+ * runtime BEFORE they are tarred. Apple's notarytool recurses into the bundled
+ * companion-host.tgz and rejects unsigned binaries, so node, rg and node-pty's
+ * pty.node/spawn-helper must be signed like the app. node also gets the
+ * companion entitlements (JIT + disable-library-validation) so it still runs and
+ * can load pty.node once hardened. No-op unless we're building a darwin tarball
+ * on a darwin host with CATE_MAC_SIGN_IDENTITY set (see ci-mac-signing-keychain.sh);
+ * when absent the binaries stay unsigned and notarization fails loudly.
+ */
+function signMacNatives(stageDir) {
+  const identity = process.env.CATE_MAC_SIGN_IDENTITY
+  if (process.platform !== 'darwin' || targetPlatform !== 'darwin' || !identity) return
+  const entitlements = path.join(repoRoot, 'build', 'entitlements.companion.plist')
+  const keychain = process.env.CATE_MAC_SIGN_KEYCHAIN
+  const pbDir = path.join('node_modules', 'node-pty', 'prebuilds', targetArg)
+  const binaries = [
+    path.join('runtime', 'bin', 'node'),
+    path.join('runtime', 'bin', 'rg'),
+    path.join(pbDir, 'pty.node'),
+    path.join(pbDir, 'spawn-helper'),
+  ]
+  const keychainArg = keychain ? ['--keychain', keychain] : []
+  for (const rel of binaries) {
+    const file = path.join(stageDir, rel)
+    if (!existsSync(file)) continue
+    execFileSync(
+      'codesign',
+      ['--force', '--timestamp', '--options', 'runtime', '--entitlements', entitlements, ...keychainArg, '--sign', identity, file],
+      { stdio: 'inherit' },
+    )
+    // Verify the seal now so a bad signature fails here, not later in notarytool.
+    execFileSync('codesign', ['--verify', '--strict', file], { stdio: 'inherit' })
+  }
+  console.log(`[companion] signed darwin natives for ${targetArg} (Developer ID ${identity})`)
 }
 
 function plat(p) {

--- a/scripts/ci-mac-signing-keychain.sh
+++ b/scripts/ci-mac-signing-keychain.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Import the Developer ID Application cert (CSC_LINK / CSC_KEY_PASSWORD) into a
+# dedicated temporary keychain and export its identity hash + keychain path for
+# later steps (CATE_MAC_SIGN_IDENTITY, CATE_MAC_SIGN_KEYCHAIN via $GITHUB_ENV),
+# so build-companion-tarball.mjs can codesign the bundled native binaries (node,
+# rg, node-pty's pty.node + spawn-helper) BEFORE packing them.
+#
+# Why: Apple's notarytool recurses into companion-host.tgz and rejects unsigned
+# Mach-O ("not signed with a valid Developer ID certificate"), so the daemon
+# binaries must carry a Developer ID + hardened-runtime signature like the app.
+#
+# The keychain is deliberately NOT added to the user search list; the build
+# script passes `--keychain "$CATE_MAC_SIGN_KEYCHAIN"` to codesign instead, so
+# this never collides with the separate keychain electron-builder sets up to
+# sign the app itself during packaging.
+#
+# No-op (exit 0, no identity exported) when MAC_CERTS is absent — the build then
+# stays unsigned and notarization fails loudly, same as before.
+# =============================================================================
+set -euo pipefail
+
+if [ -z "${CSC_LINK:-}" ]; then
+  echo "No MAC_CERTS secret set — skipping companion-native signing setup."
+  echo "(Notarization will reject the unsigned bundled binaries.)"
+  exit 0
+fi
+
+TMP="${RUNNER_TEMP:-/tmp}"
+KEYCHAIN="$TMP/cate-companion-signing.keychain-db"
+CERT="$TMP/cate-companion-cert.p12"
+KPASS="$(uuidgen)"
+
+# Fresh keychain, unlocked, with a long auto-lock timeout so it is still usable
+# from the later build step in the same runner session.
+security create-keychain -p "$KPASS" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KPASS" "$KEYCHAIN"
+
+printf '%s' "$CSC_LINK" | base64 --decode > "$CERT"
+security import "$CERT" -k "$KEYCHAIN" -P "${CSC_KEY_PASSWORD:-}" -T /usr/bin/codesign
+rm -f "$CERT"
+# Let codesign use the imported key without an interactive prompt.
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KPASS" "$KEYCHAIN" >/dev/null
+
+IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+  | awk '/Developer ID Application/ {print $2; exit}')"
+if [ -z "$IDENTITY" ]; then
+  echo "No 'Developer ID Application' identity in the provided cert:" >&2
+  security find-identity -v -p codesigning "$KEYCHAIN" >&2 || true
+  exit 1
+fi
+
+{
+  echo "CATE_MAC_SIGN_IDENTITY=$IDENTITY"
+  echo "CATE_MAC_SIGN_KEYCHAIN=$KEYCHAIN"
+} >> "$GITHUB_ENV"
+echo "Companion natives will be signed with Developer ID identity $IDENTITY"


### PR DESCRIPTION
Fixes the macOS notarization failure that blocked beta.6 (the run after the e2e fix finally reached packaging).

**Cause.** `notarytool` recurses into the bundled `companion-host.tgz` and rejects its unsigned Mach-O binaries:
```
Cate.app/Contents/Resources/companion-host.tgz/.../node-pty/prebuilds/darwin-arm64/pty.node
                                              .../node-pty/prebuilds/darwin-arm64/spawn-helper
                                              .../runtime/bin/rg
→ not signed with a valid Developer ID certificate / no hardened runtime / no secure timestamp
```
New since `76216da` (ship the host tarball in the packaged app), which landed after v1.1.1 — so the first mac release to reach packaging was always going to hit it.

**Fix.** Sign the bundled darwin binaries (`node`, `rg`, `pty.node`, `spawn-helper`) with the Developer ID cert + hardened runtime + secure timestamp **before** packing the tarball:
- `scripts/ci-mac-signing-keychain.sh` imports `MAC_CERTS` into a scoped keychain and exports the identity.
- `build-companion-tarball.mjs` signs the natives when building a darwin tarball with that identity set (no-op otherwise). `node` gets companion entitlements (`allow-jit`, `disable-library-validation`) so it still runs hardened and can load `pty.node`.
- Wired into the release job's host tarball **and** the companion job's per-target darwin tarball (so mac hosts pulling it also get signed binaries).

The keychain is used via `codesign --keychain` (not the search list), so it doesn't clash with the separate keychain electron-builder uses to sign the app. Verified locally: plist lints, the build no-ops without a cert, and the `codesign --options runtime --entitlements` invocation signs + verifies.