### PR TITLE
fix(release): add signing keychain to search list

### DIFF
--- a/scripts/build-companion-tarball.mjs
+++ b/scripts/build-companion-tarball.mjs
@@ -399,7 +399,6 @@ function signMacNatives(stageDir) {
   const identity = process.env.CATE_MAC_SIGN_IDENTITY
   if (process.platform !== 'darwin' || targetPlatform !== 'darwin' || !identity) return
   const entitlements = path.join(repoRoot, 'build', 'entitlements.companion.plist')
-  const keychain = process.env.CATE_MAC_SIGN_KEYCHAIN
   const pbDir = path.join('node_modules', 'node-pty', 'prebuilds', targetArg)
   const binaries = [
     path.join('runtime', 'bin', 'node'),
@@ -407,13 +406,14 @@ function signMacNatives(stageDir) {
     path.join(pbDir, 'pty.node'),
     path.join(pbDir, 'spawn-helper'),
   ]
-  const keychainArg = keychain ? ['--keychain', keychain] : []
+  // The identity is found via the keychain search list (ci-mac-signing-keychain.sh
+  // adds the signing keychain to it); codesign --keychain alone is unreliable.
   for (const rel of binaries) {
     const file = path.join(stageDir, rel)
     if (!existsSync(file)) continue
     execFileSync(
       'codesign',
-      ['--force', '--timestamp', '--options', 'runtime', '--entitlements', entitlements, ...keychainArg, '--sign', identity, file],
+      ['--force', '--timestamp', '--options', 'runtime', '--entitlements', entitlements, '--sign', identity, file],
       { stdio: 'inherit' },
     )
     // Verify the seal now so a bad signature fails here, not later in notarytool.

--- a/scripts/ci-mac-signing-keychain.sh
+++ b/scripts/ci-mac-signing-keychain.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 # =============================================================================
 # Import the Developer ID Application cert (CSC_LINK / CSC_KEY_PASSWORD) into a
-# dedicated temporary keychain and export its identity hash + keychain path for
-# later steps (CATE_MAC_SIGN_IDENTITY, CATE_MAC_SIGN_KEYCHAIN via $GITHUB_ENV),
-# so build-companion-tarball.mjs can codesign the bundled native binaries (node,
-# rg, node-pty's pty.node + spawn-helper) BEFORE packing them.
+# dedicated temporary keychain, add it to the user search list, and export the
+# identity hash (CATE_MAC_SIGN_IDENTITY via $GITHUB_ENV) so build-companion-
+# tarball.mjs can codesign the bundled native binaries (node, rg, node-pty's
+# pty.node + spawn-helper) BEFORE packing them.
 #
 # Why: Apple's notarytool recurses into companion-host.tgz and rejects unsigned
 # Mach-O ("not signed with a valid Developer ID certificate"), so the daemon
 # binaries must carry a Developer ID + hardened-runtime signature like the app.
 #
-# The keychain is deliberately NOT added to the user search list; the build
-# script passes `--keychain "$CATE_MAC_SIGN_KEYCHAIN"` to codesign instead, so
-# this never collides with the separate keychain electron-builder sets up to
-# sign the app itself during packaging.
+# The keychain is added to the search list so codesign can locate the identity
+# (codesign --keychain alone is unreliable). electron-builder later signs the app
+# with its OWN --keychain, so this extra keychain doesn't make that ambiguous.
 #
 # No-op (exit 0, no identity exported) when MAC_CERTS is absent — the build then
 # stays unsigned and notarization fails loudly, same as before.
@@ -43,6 +42,14 @@ rm -f "$CERT"
 # Let codesign use the imported key without an interactive prompt.
 security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KPASS" "$KEYCHAIN" >/dev/null
 
+# Add this keychain to the user search list (in front, keeping the existing
+# login keychain) so codesign can locate the identity. `codesign --keychain
+# <path>` alone is unreliable for a keychain not in the search list ("The
+# specified item could not be found in the keychain"), so the build script signs
+# via the search list. electron-builder later signs the app with its OWN
+# `--keychain`, so this extra keychain doesn't make its lookup ambiguous.
+security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
+
 IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
   | awk '/Developer ID Application/ {print $2; exit}')"
 if [ -z "$IDENTITY" ]; then
@@ -51,8 +58,5 @@ if [ -z "$IDENTITY" ]; then
   exit 1
 fi
 
-{
-  echo "CATE_MAC_SIGN_IDENTITY=$IDENTITY"
-  echo "CATE_MAC_SIGN_KEYCHAIN=$KEYCHAIN"
-} >> "$GITHUB_ENV"
+echo "CATE_MAC_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
 echo "Companion natives will be signed with Developer ID identity $IDENTITY"


### PR DESCRIPTION
Follow-up to #284. beta.7 reached the companion signing step but `codesign` failed:

```
error: The specified item could not be found in the keychain.
codesign --force --timestamp --options runtime --entitlements … --keychain …/cate-companion-signing.keychain-db --sign C9A0729D… …/runtime/bin/node
```

The identity imported fine (`find-identity` resolved the hash), but `codesign --keychain <path>` alone doesn't reliably locate an identity in a keychain that isn't on the search list. Add the temporary keychain to the user search list (keeping the login keychain) and sign via it; drop `--keychain`. electron-builder still signs the app with its own `--keychain`, so this stays unambiguous.