### PR TITLE
Persist all Cate data as JSON; consolidate providers and UI prefs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,6 @@ Managed via npm (`package.json`):
 - **chokidar** — filesystem watching
 - **simple-git** — git operations
 - **@phosphor-icons/react** — icons
-- **electron-store** — persistent settings
 - **electron-updater** — auto-update (GitHub Releases)
 
 ## Architecture
@@ -80,7 +79,16 @@ Zustand stores in `src/renderer/stores/`:
 - **updateStore** — auto-updater status pushed from main
 - **urlPromptStore** — pending URL-open confirmations from terminals
 
-Session persistence saves/restores workspace state as JSON via electron-store.
+Persisted state is stored as hand-editable JSON files under `userData` (no
+electron-store). `settingsFile.ts` owns `settings.json`; `jsonStateFile.ts` is a
+reusable factory for that same pattern (sync load, in-memory authority, debounced
+atomic write, chokidar external-edit watcher, corrupt-file quarantine).
+`workspaceStateStore.ts` uses it for `recent-projects.json`, `sidebar.json`,
+`remote-workspaces.json`, and `layouts.json` (migrated once from the legacy
+`config.json`, which is then deleted). Per-project canvas/session state lives in
+`<project>/.cate/workspace.json` + `session.json`. AI provider credentials are
+global in `userData/pi-agent/auth.json` (+ `models.json`), mirrored into each
+workspace's `.cate/pi-agent/`.
 
 ### Key Patterns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@xterm/xterm": "^5.5.0",
         "chokidar": "^4.0.0",
         "electron-log": "^5.4.3",
-        "electron-store": "^10.0.0",
         "electron-updater": "^6.8.3",
         "mammoth": "^1.12.0",
         "monaco-editor": "^0.52.0",
@@ -7641,45 +7640,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -8009,16 +7969,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/atomically": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
@@ -8883,63 +8833,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/conf": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-14.0.0.tgz",
-      "integrity": "sha512-L6BuueHTRuJHQvQVc6YXYZRtN5vJUtOdCTLn0tRYYV5azfbAFcPghB5zEE40mVrV6w7slMTqUfkDomutIK14fw==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "atomically": "^2.0.3",
-        "debounce-fn": "^6.0.0",
-        "dot-prop": "^9.0.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.7.2",
-        "uint8array-extras": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/conf/node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conf/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9047,21 +8940,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/debounce-fn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -9411,21 +9289,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
-      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -9669,22 +9532,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-store": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-10.1.0.tgz",
-      "integrity": "sha512-oL8bRy7pVCLpwhmXy05Rh/L6O93+k9t6dqSw0+MckIc3OmCTZm6Mp04Q4f/J0rtu84Ky6ywkR8ivtGOmrq+16w==",
-      "license": "MIT",
-      "dependencies": {
-        "conf": "^14.0.0",
-        "type-fest": "^4.41.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -10287,6 +10134,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -10332,22 +10180,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -11660,12 +11492,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -12988,18 +12814,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -14584,6 +14398,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15343,21 +15158,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-      "license": "MIT"
-    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -15945,18 +15745,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typebox": {
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
@@ -15999,18 +15787,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/underscore": {
@@ -17030,12 +16806,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@xterm/xterm": "^5.5.0",
     "chokidar": "^4.0.0",
     "electron-log": "^5.4.3",
-    "electron-store": "^10.0.0",
     "electron-updater": "^6.8.3",
     "mammoth": "^1.12.0",
     "monaco-editor": "^0.52.0",

--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -29,6 +29,7 @@ import { CateLogo } from '../../renderer/ui/CateLogo'
 import log from '../../renderer/lib/logger'
 import type { PanelProps } from '../../renderer/panels/types'
 import { useAppStore } from '../../renderer/stores/appStore'
+import { useUIStore } from '../../renderer/stores/uiStore'
 import { useStatusStore } from '../../renderer/stores/statusStore'
 import { useAgentStore } from './agentStore'
 import { buildFileMentions, type LineRef } from './agentDrop'
@@ -140,7 +141,6 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
     Array<{ provider: string; model: string; label?: string }>
   >([])
   const [view, setView] = useState<'chat' | 'settings'>('chat')
-  const [settingsScopedTo, setSettingsScopedTo] = useState<string | undefined>(undefined)
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
@@ -528,9 +528,16 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
     [openChats],
   )
 
-  const openSettings = useCallback((providerId?: string) => {
-    setSettingsScopedTo(providerId)
+  // The agent panel's own settings (agents / prompts / skills / extensions).
+  const openSettings = useCallback(() => {
     setView('settings')
+  }, [])
+
+  // Provider sign-in now lives in the main Cate Settings (Providers section),
+  // not in the agent panel. Opening it there keeps a single source of truth for
+  // credentials, which are global and shared across all workspaces.
+  const openProviderSettings = useCallback(() => {
+    useUIStore.getState().openSettings('providers')
   }, [])
 
 
@@ -843,7 +850,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
             const open = openChats.find((c) => c.sessionFile === sessionFile)
             if (open) handleCloseChat(open.agentKey)
           }}
-          onOpenSettings={() => openSettings(undefined)}
+          onOpenSettings={() => openSettings()}
           onCollapse={() => setSidebarOpen(false)}
           settingsActive={view === 'settings'}
         />
@@ -882,7 +889,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
                   selected={selectedModel}
                   onPick={handlePickModel}
                   onClose={() => setModelPickerOpen(false)}
-                  onManage={() => { setModelPickerOpen(false); openSettings(undefined) }}
+                  onManage={() => { setModelPickerOpen(false); openProviderSettings() }}
                 />
               )}
             </div>
@@ -900,8 +907,6 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
             commands={commands}
             workspaceId={workspaceId}
             cwd={cwd}
-            scopedProviderId={settingsScopedTo}
-            availableModels={availableModels}
             onBack={() => setView('chat')}
             onRefresh={() => { if (activeAgentKey) void refreshCommands(activeAgentKey) }}
           />
@@ -913,7 +918,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
                   Connect <strong>{selectedModel.provider}</strong> to start.
                 </span>
                 <button
-                  onClick={() => openSettings(selectedModel.provider)}
+                  onClick={() => openProviderSettings()}
                   className="px-2 py-1 rounded-md bg-agent hover:bg-agent-light text-white text-[11px] font-medium shrink-0"
                 >
                   Connect

--- a/src/agent/renderer/AgentSettingsView.tsx
+++ b/src/agent/renderer/AgentSettingsView.tsx
@@ -1,15 +1,15 @@
 // =============================================================================
 // AgentSettingsView — the settings surface that replaces the chat column:
-// providers, the user's agents/prompts/skills files, and the extension
-// marketplace. Reads/writes through electronAPI; opening a file routes to a
-// new editor panel via appStore.
+// the user's agents/prompts/skills files, and the extension marketplace.
+// Reads/writes through electronAPI; opening a file routes to a new editor panel
+// via appStore. Provider sign-in lives in the main Cate Settings (Providers
+// section), not here.
 // =============================================================================
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Plus, FolderOpen, ArrowsClockwise, Trash } from '@phosphor-icons/react'
 import log from '../../renderer/lib/logger'
 import { useAppStore } from '../../renderer/stores/appStore'
-import { ProvidersView } from './ProvidersView'
 import type { AgentSlashCommand } from '../../shared/types'
 
 const TAB_BADGE: Record<'agents' | 'prompts' | 'skills', string> = {
@@ -28,20 +28,16 @@ export function SettingsView({
   commands,
   workspaceId,
   cwd,
-  scopedProviderId,
-  availableModels,
   onBack,
   onRefresh,
 }: {
   commands: AgentSlashCommand[]
   workspaceId: string
   cwd: string
-  scopedProviderId?: string
-  availableModels: Array<{ provider: string; model: string; label?: string }>
   onBack: () => void
   onRefresh: () => void
 }) {
-  const [activeSection, setActiveSection] = useState('providers')
+  const [activeSection, setActiveSection] = useState('agents')
   const scrollRef = useRef<HTMLDivElement>(null)
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({})
 
@@ -57,7 +53,7 @@ export function SettingsView({
     const container = scrollRef.current
     if (!container) return
     const handler = () => {
-      const ids = ['providers', 'agents', 'prompts', 'skills', 'extensions']
+      const ids = ['agents', 'prompts', 'skills', 'extensions']
       let closest = ids[0]
       let closestDist = Infinity
       for (const id of ids) {
@@ -71,8 +67,6 @@ export function SettingsView({
     container.addEventListener('scroll', handler, { passive: true })
     return () => container.removeEventListener('scroll', handler)
   }, [])
-
-  useEffect(() => { if (scopedProviderId) scrollTo('providers') }, [scopedProviderId, scrollTo])
 
   const [agentFiles, setAgentFiles] = useState<Array<{ name: string; description?: string; path: string }>>([])
   const [promptFiles, setPromptFiles] = useState<Array<{ name: string; description?: string; path: string }>>([])
@@ -131,7 +125,7 @@ export function SettingsView({
 
   const [refreshNonce, setRefreshNonce] = useState(0)
 
-  const sections = ['Providers', 'Agents', 'Prompts', 'Skills', 'Extensions'] as const
+  const sections = ['Agents', 'Prompts', 'Skills', 'Extensions'] as const
 
   const renderSkillSection = (
     kind: 'agents' | 'prompts' | 'skills',
@@ -247,11 +241,6 @@ export function SettingsView({
       </div>
 
       <div ref={scrollRef} className="flex-1 overflow-y-auto py-4 pr-4 pl-2 min-h-0 space-y-8">
-        <div ref={(el) => { sectionRefs.current['providers'] = el }}>
-          <div className="text-[13px] font-semibold text-primary mb-3">Providers</div>
-          <ProvidersView embedded scopedProviderId={scopedProviderId} availableModels={availableModels} />
-        </div>
-
         <div ref={(el) => { sectionRefs.current['agents'] = el }}>
           <div className="text-[13px] font-semibold text-primary mb-1">Agents</div>
           {renderSkillSection('agents', agentFiles)}

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -98,61 +98,70 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false, avai
     setExpandedKey((prev) => (prev === key ? null : key))
   }, [])
 
+  const body = (
+    <>
+      <DefaultModelSection models={availableModels ?? []} />
+      <Section label="Sign in">
+        {grouped.oauth.map((p) => {
+          const key = `oauth-${p.id}`
+          return (
+            <ProviderAccordionRow
+              key={key}
+              provider={p}
+              status={statusFor(p.id)}
+              expanded={expandedKey === key}
+              onToggle={() => toggle(key)}
+              onRefresh={refresh}
+            />
+          )
+        })}
+      </Section>
+      <Section label="API key">
+        {grouped.apiKey.map((p) => {
+          const key = `apiKey-${p.id}`
+          return (
+            <ProviderAccordionRow
+              key={key}
+              provider={p}
+              status={statusFor(p.id)}
+              expanded={expandedKey === key}
+              onToggle={() => toggle(key)}
+              onRefresh={refresh}
+            />
+          )
+        })}
+      </Section>
+      <Section label="Custom">
+        <CustomOpenAIRow
+          expanded={expandedKey === 'custom-openai'}
+          onToggle={() => toggle('custom-openai')}
+        />
+      </Section>
+    </>
+  )
+
+  // Embedded in the main Settings window: render as a plain block so it inherits
+  // the section column's width + padding and the page's single scroll — no extra
+  // horizontal inset or nested scroll area like the in-panel (agent) chrome has.
+  if (embedded) {
+    return <div className="space-y-4 text-primary">{body}</div>
+  }
+
   return (
     <div className="flex-1 flex flex-col text-primary min-h-0">
-      {!embedded && (
-        <div className="flex items-center gap-2 px-3 h-9 border-b border-subtle shrink-0">
-          <button
-            onClick={() => onBack?.()}
-            className="p-1 -ml-1 rounded-md text-muted hover:text-primary hover:bg-white/5"
-            title="Back to chat"
-          >
-            <ArrowLeft size={14} />
-          </button>
-          <div className="text-[12px] font-medium text-primary truncate flex-1 min-w-0">Providers</div>
-        </div>
-      )}
+      <div className="flex items-center gap-2 px-3 h-9 border-b border-subtle shrink-0">
+        <button
+          onClick={() => onBack?.()}
+          className="p-1 -ml-1 rounded-md text-muted hover:text-primary hover:bg-white/5"
+          title="Back to chat"
+        >
+          <ArrowLeft size={14} />
+        </button>
+        <div className="text-[12px] font-medium text-primary truncate flex-1 min-w-0">Providers</div>
+      </div>
 
       <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="px-3 py-3 space-y-4">
-          <DefaultModelSection models={availableModels ?? []} />
-          <Section label="Sign in">
-            {grouped.oauth.map((p) => {
-              const key = `oauth-${p.id}`
-              return (
-                <ProviderAccordionRow
-                  key={key}
-                  provider={p}
-                  status={statusFor(p.id)}
-                  expanded={expandedKey === key}
-                  onToggle={() => toggle(key)}
-                  onRefresh={refresh}
-                />
-              )
-            })}
-          </Section>
-          <Section label="API key">
-            {grouped.apiKey.map((p) => {
-              const key = `apiKey-${p.id}`
-              return (
-                <ProviderAccordionRow
-                  key={key}
-                  provider={p}
-                  status={statusFor(p.id)}
-                  expanded={expandedKey === key}
-                  onToggle={() => toggle(key)}
-                  onRefresh={refresh}
-                />
-              )
-            })}
-          </Section>
-          <Section label="Custom">
-            <CustomOpenAIRow
-              expanded={expandedKey === 'custom-openai'}
-              onToggle={() => toggle('custom-openai')}
-            />
-          </Section>
-        </div>
+        <div className="px-3 py-3 space-y-4">{body}</div>
       </div>
     </div>
   )
@@ -333,7 +342,7 @@ function CustomOpenAIForm({
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <div className="px-2 mb-1 text-[10px] uppercase tracking-wider text-muted/70 font-semibold">
+      <div className="mb-1 text-[10px] uppercase tracking-wider text-muted/70 font-semibold">
         {label}
       </div>
       <div className="rounded-lg border border-white/5 bg-white/[0.02] overflow-hidden">
@@ -785,7 +794,7 @@ function DefaultModelSection({ models }: { models: Array<{ provider: string; mod
 
   return (
     <div className="space-y-1.5">
-      <div className="text-[10.5px] uppercase tracking-wider text-muted/70 font-semibold px-0.5">
+      <div className="text-[10.5px] uppercase tracking-wider text-muted/70 font-semibold">
         Default model
       </div>
       <div className="relative">

--- a/src/agent/renderer/agentModelPrefs.ts
+++ b/src/agent/renderer/agentModelPrefs.ts
@@ -1,32 +1,20 @@
 // =============================================================================
-// agentModelPrefs — localStorage-backed model selection prefs for the agent
-// panel. One slot:
-//   - defaultModel: the user-pinned default, applied to every brand-new chat
+// agentModelPrefs — the user-pinned default model applied to every brand-new
+// chat. Persisted in settings.json (key `agentDefaultModel`) via the settings
+// store, so it is hand-editable and exportable alongside the rest of settings.
+// (It lived in renderer localStorage before; see settingsStore for the one-time
+// migration of the legacy `cate.agent.defaultModel.v1` key.)
 // =============================================================================
 
 import type { AgentModelRef } from '../../shared/types'
-
-const DEFAULT_MODEL_KEY = 'cate.agent.defaultModel.v1'
+import { useSettingsStore } from '../../renderer/stores/settingsStore'
 
 export function loadDefaultModel(): AgentModelRef | null {
-  return readModelRef(DEFAULT_MODEL_KEY)
+  const m = useSettingsStore.getState().agentDefaultModel
+  if (m && typeof m.provider === 'string' && typeof m.model === 'string') return m
+  return null
 }
 
 export function saveDefaultModel(model: AgentModelRef | null): void {
-  try {
-    if (model) localStorage.setItem(DEFAULT_MODEL_KEY, JSON.stringify(model))
-    else localStorage.removeItem(DEFAULT_MODEL_KEY)
-  } catch { /* */ }
-}
-
-function readModelRef(key: string): AgentModelRef | null {
-  try {
-    const raw = localStorage.getItem(key)
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed.provider === 'string' && typeof parsed.model === 'string') {
-      return parsed as AgentModelRef
-    }
-  } catch { /* */ }
-  return null
+  useSettingsStore.getState().setSetting('agentDefaultModel', model)
 }

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, vi } from 'vitest'
 
 // analytics.ts pulls in electron at module load (app/ipcMain/net types) and
-// also pulls in ./store (which dynamic-imports electron-store). Stub both so
-// the test runs in plain node — we only exercise pure functions here.
+// also pulls in ./store. Stub both so the test runs in plain node — we only
+// exercise pure functions here.
 vi.mock('electron', () => ({
   app: { getVersion: () => '0.0.0-test', getLocale: () => 'en', isPackaged: false, getPath: () => '/tmp' },
   ipcMain: { on: vi.fn() },

--- a/src/main/canvasBackgroundStore.test.ts
+++ b/src/main/canvasBackgroundStore.test.ts
@@ -1,0 +1,76 @@
+// =============================================================================
+// canvasBackgroundStore — copy-into-userData import + orphan pruning.
+// =============================================================================
+
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-bg-test-'))
+const src = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-bg-src-'))
+
+vi.mock('electron', () => {
+  const electron = { app: { getPath: () => userData } }
+  return { ...electron, default: electron }
+})
+vi.mock('./logger', () => ({
+  default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}))
+
+const { importCanvasBackgroundImage, pruneCanvasBackgrounds } = await import('./canvasBackgroundStore')
+
+const bgDir = path.join(userData, 'canvas-backgrounds')
+const writeSrc = (name: string, bytes: string): string => {
+  const p = path.join(src, name)
+  fs.writeFileSync(p, bytes)
+  return p
+}
+
+beforeEach(() => {
+  try { fs.rmSync(bgDir, { recursive: true, force: true }) } catch { /* noop */ }
+})
+afterAll(() => {
+  for (const d of [userData, src]) { try { fs.rmSync(d, { recursive: true, force: true }) } catch { /* noop */ } }
+})
+
+describe('importCanvasBackgroundImage', () => {
+  test('copies the image into managed app data and returns the managed path', async () => {
+    const source = writeSrc('wall.png', 'PNGDATA')
+    const managed = await importCanvasBackgroundImage(source)
+    expect(path.dirname(managed)).toBe(bgDir)
+    expect(path.extname(managed)).toBe('.png')
+    expect(fs.readFileSync(managed, 'utf-8')).toBe('PNGDATA')
+  })
+
+  test('is idempotent for identical contents (no duplicate copies)', async () => {
+    const source = writeSrc('wall.png', 'SAME')
+    const a = await importCanvasBackgroundImage(source)
+    const b = await importCanvasBackgroundImage(source)
+    expect(a).toBe(b)
+    expect(fs.readdirSync(bgDir)).toHaveLength(1)
+  })
+
+  test('falls back to the original path for an unsupported extension', async () => {
+    const source = writeSrc('notes.txt', 'nope')
+    const managed = await importCanvasBackgroundImage(source)
+    expect(managed).toBe(source)
+    expect(fs.existsSync(bgDir)).toBe(false)
+  })
+})
+
+describe('pruneCanvasBackgrounds', () => {
+  test('deletes every managed copy except the one to keep', async () => {
+    const keep = await importCanvasBackgroundImage(writeSrc('a.png', 'AAA'))
+    await importCanvasBackgroundImage(writeSrc('b.jpg', 'BBB'))
+    expect(fs.readdirSync(bgDir)).toHaveLength(2)
+    pruneCanvasBackgrounds(keep)
+    expect(fs.readdirSync(bgDir)).toEqual([path.basename(keep)])
+  })
+
+  test('clears the directory when nothing should be kept', async () => {
+    await importCanvasBackgroundImage(writeSrc('a.png', 'AAA'))
+    pruneCanvasBackgrounds('')
+    expect(fs.readdirSync(bgDir)).toHaveLength(0)
+  })
+})

--- a/src/main/canvasBackgroundStore.ts
+++ b/src/main/canvasBackgroundStore.ts
@@ -1,0 +1,88 @@
+// =============================================================================
+// canvasBackgroundStore — owns the canvas wallpaper image as managed app data.
+//
+// When the user picks a background image we COPY it into
+// `<userData>/canvas-backgrounds/` and store that managed path in settings,
+// rather than referencing the original file. This makes the wallpaper durable:
+// it survives the source file being moved/renamed/deleted and is self-contained
+// under userData (alongside the rest of Cate's persisted state). The copy is
+// named by a hash of its contents so re-picking the same image is idempotent.
+//
+// `prune` keeps the directory to just the current wallpaper, deleting orphaned
+// copies left by a replace/clear/crash. The renderer still reads bytes via
+// CANVAS_READ_BACKGROUND_IMAGE (which points at the managed path).
+// =============================================================================
+
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import log from './logger'
+
+const DIR_NAME = 'canvas-backgrounds'
+const MAX_BYTES = 40 * 1024 * 1024 // 40 MB — matches the reader's data-URL ceiling.
+const ALLOWED_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.avif'])
+
+function backgroundsDir(): string {
+  return path.join(app.getPath('userData'), DIR_NAME)
+}
+
+/**
+ * Copy `sourcePath` into the managed backgrounds directory and return the
+ * managed absolute path. Validates extension + size (so a bad pick can't bloat
+ * userData). On any failure, falls back to returning the original path so the
+ * feature degrades to a plain reference rather than breaking.
+ */
+export async function importCanvasBackgroundImage(sourcePath: string): Promise<string> {
+  try {
+    const ext = path.extname(sourcePath).toLowerCase()
+    if (!ALLOWED_EXTS.has(ext)) return sourcePath
+    const stat = await fs.promises.stat(sourcePath)
+    if (!stat.isFile() || stat.size > MAX_BYTES) return sourcePath
+
+    const buf = await fs.promises.readFile(sourcePath)
+    const hash = crypto.createHash('sha256').update(buf).digest('hex').slice(0, 16)
+    const dir = backgroundsDir()
+    await fs.promises.mkdir(dir, { recursive: true })
+    const dest = path.join(dir, `${hash}${ext}`)
+
+    // Idempotent: identical contents reuse the same managed file.
+    try {
+      await fs.promises.access(dest)
+      return dest
+    } catch { /* not present — write it below */ }
+
+    const tmp = dest + '.tmp'
+    await fs.promises.writeFile(tmp, buf)
+    await fs.promises.rename(tmp, dest)
+    return dest
+  } catch (err) {
+    log.warn('[canvasBackgroundStore] import of %s failed, keeping original path: %O', sourcePath, err)
+    return sourcePath
+  }
+}
+
+/**
+ * Delete every managed background except `keepPath`. Called whenever the
+ * setting changes so replacing or clearing the wallpaper reclaims the old copy,
+ * and once at startup to clear crash-orphaned files. Best-effort; never throws.
+ */
+export function pruneCanvasBackgrounds(keepPath: string): void {
+  const dir = backgroundsDir()
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dir)
+  } catch {
+    return // directory absent — nothing to prune
+  }
+  const keep = keepPath ? path.resolve(keepPath) : ''
+  for (const name of entries) {
+    const full = path.join(dir, name)
+    if (path.resolve(full) === keep) continue
+    try {
+      fs.unlinkSync(full)
+    } catch (err) {
+      log.warn('[canvasBackgroundStore] prune of %s failed: %O', full, err)
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -24,7 +24,10 @@ import { registerHandlers as registerShellHandlers, unregisterTerminalsForWindow
 import { registerHandlers as registerGitMonitorHandlers, stopMonitorsForWindow } from './ipc/git-monitor'
 import { registerHandlers as registerStoreHandlers, loadSettingsSyncFromDisk, readBootSnapshot, writeBootSnapshot, getSettingSync, setSettingsFromMain } from './store'
 import { flushPendingWritesSync as flushSettingsPendingWritesSync } from './settingsFile'
-import { registerProjectStateHandlers, saveProjectStateSync, runLegacyMigrationIfNeeded } from './projectWorkspaceStore'
+import { flushWorkspaceStateSync } from './workspaceStateStore'
+import { registerUIStateHandlers, flushUIStateSync } from './uiStateStore'
+import { importCanvasBackgroundImage } from './canvasBackgroundStore'
+import { registerProjectStateHandlers, saveProjectStateSync } from './projectWorkspaceStore'
 import { registerHandlers as registerMenuHandlers } from './ipc/menu'
 import { registerHandlers as registerNotificationHandlers } from './ipc/notifications'
 import { registerAgentHandlers } from '../agent/main/ipcAgent'
@@ -585,6 +588,7 @@ function destroyDragGhostWindow(): void {
  */
 function registerCriticalHandlers(): void {
   registerStoreHandlers()
+  registerUIStateHandlers()
   registerProjectStateHandlers()
   registerWorkspaceHandlers()
   registerFilesystemHandlers()
@@ -644,10 +648,12 @@ function registerWindowAndDialogHandlers(): void {
     return result.filePaths[0]
   })
 
-  // Pick an image to use as the canvas wallpaper. Returns the absolute path
-  // (stored in settings); the renderer reads the bytes via
-  // CANVAS_READ_BACKGROUND_IMAGE. No path grant is needed because that reader
-  // runs in main (full fs access) rather than through the sandboxed fs IPC.
+  // Pick an image to use as the canvas wallpaper. The picked file is COPIED into
+  // managed app data (see ./canvasBackgroundStore) and the managed path is
+  // returned for storage in settings — so the wallpaper survives the source
+  // file moving/being deleted and stays self-contained. The renderer reads the
+  // bytes via CANVAS_READ_BACKGROUND_IMAGE; no path grant is needed because that
+  // reader runs in main (full fs access) rather than through the sandboxed fs IPC.
   ipcMain.handle(DIALOG_OPEN_IMAGE, async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender) ?? undefined
     const result = await dialog.showOpenDialog(win!, {
@@ -658,7 +664,7 @@ function registerWindowAndDialogHandlers(): void {
       ],
     })
     if (result.canceled || result.filePaths.length === 0) return null
-    return result.filePaths[0]
+    return importCanvasBackgroundImage(result.filePaths[0])
   })
 
   // Read a canvas-wallpaper image as a data URL. Used both right after the user
@@ -1653,8 +1659,6 @@ app.whenReady().then(async () => {
   // Install the cate-theme authoring skill into ~/.claude/skills (copy-if-missing).
   void installThemeSkill()
 
-  await runLegacyMigrationIfNeeded()
-
   const mainWin = createWindow({ type: 'main' })
   log.info('Main window created (id=%d)', mainWin.id)
 
@@ -1823,6 +1827,11 @@ app.on('will-quit', () => {
   // Flush any pending debounced settings.json write so a just-changed setting
   // survives the quit (the async writer wouldn't fire before process exit).
   flushSettingsPendingWritesSync()
+  // Same for the workspace-state files (recent projects, sidebar, remote
+  // workspaces, layouts) — flush their debounced writes before the process exits.
+  flushWorkspaceStateSync()
+  // And the ui-state.json file (minimap placement).
+  flushUIStateSync()
   // Drop per-project locks so a co-running instance can take over immediately
   // (a crash skips this; the next instance reclaims the stale lock by pid).
   releaseAllProjectLocks()

--- a/src/main/jsonStateFile.test.ts
+++ b/src/main/jsonStateFile.test.ts
@@ -1,0 +1,75 @@
+// =============================================================================
+// jsonStateFile — load/normalize, atomic write, corrupt-file quarantine.
+// =============================================================================
+
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-jsonstate-test-'))
+
+vi.mock('electron', () => {
+  const electron = { app: { getPath: () => userData } }
+  return { ...electron, default: electron }
+})
+vi.mock('chokidar', () => ({ watch: () => ({ on: vi.fn(), close: vi.fn() }) }))
+vi.mock('./logger', () => ({
+  default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}))
+
+const { createJsonStateFile } = await import('./jsonStateFile')
+
+interface Shape { items: string[] }
+const defaults: Shape = { items: [] }
+const normalize = (parsed: unknown, d: Shape): Shape => {
+  const o = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+  return { items: Array.isArray(o.items) ? o.items.filter((x): x is string => typeof x === 'string') : d.items }
+}
+
+function cleanup() {
+  for (const f of fs.readdirSync(userData)) fs.rmSync(path.join(userData, f), { force: true })
+}
+
+beforeEach(cleanup)
+afterAll(() => { try { fs.rmSync(userData, { recursive: true, force: true }) } catch { /* noop */ } })
+
+describe('jsonStateFile', () => {
+  test('absent file loads defaults', () => {
+    const store = createJsonStateFile({ filename: 'a.json', defaults, normalize })
+    expect(store.get()).toEqual({ items: [] })
+  })
+
+  test('set + sync flush writes pretty-printed JSON that reloads', () => {
+    const store = createJsonStateFile({ filename: 'b.json', defaults, normalize })
+    store.set({ items: ['x', 'y'] })
+    store.flushPendingWritesSync()
+    const raw = fs.readFileSync(path.join(userData, 'b.json'), 'utf-8')
+    expect(raw).toBe(JSON.stringify({ items: ['x', 'y'] }, null, 2) + '\n')
+    // A fresh instance reads it back through normalize.
+    const reopened = createJsonStateFile({ filename: 'b.json', defaults, normalize })
+    expect(reopened.get()).toEqual({ items: ['x', 'y'] })
+  })
+
+  test('normalize drops unknown/ill-typed fields', () => {
+    fs.writeFileSync(path.join(userData, 'c.json'), JSON.stringify({ items: ['ok', 3, null], extra: 1 }))
+    const store = createJsonStateFile({ filename: 'c.json', defaults, normalize })
+    expect(store.get()).toEqual({ items: ['ok'] })
+  })
+
+  test('corrupt file is quarantined and falls back to defaults', () => {
+    fs.writeFileSync(path.join(userData, 'd.json'), '{ not valid json,,,')
+    const store = createJsonStateFile({ filename: 'd.json', defaults, normalize })
+    expect(store.get()).toEqual({ items: [] })
+    const backups = fs.readdirSync(userData).filter((f) => f.startsWith('d.json.corrupt-'))
+    expect(backups.length).toBe(1)
+    expect(fs.readFileSync(path.join(userData, backups[0]), 'utf-8')).toContain('not valid json')
+  })
+
+  test('update applies a functional change', () => {
+    const store = createJsonStateFile({ filename: 'e.json', defaults, normalize })
+    store.set({ items: ['a'] })
+    store.update((cur) => ({ items: [...cur.items, 'b'] }))
+    expect(store.get()).toEqual({ items: ['a', 'b'] })
+  })
+})

--- a/src/main/jsonStateFile.ts
+++ b/src/main/jsonStateFile.ts
@@ -1,0 +1,229 @@
+// =============================================================================
+// jsonStateFile — a reusable "JSON file is the source of truth" store, lifted
+// from the pattern proven by ./settingsFile (settings.json).
+//
+// Each instance owns one hand-editable `<userData>/<filename>` and provides:
+//   - Synchronous load at startup (so main can read state before any window).
+//   - An authoritative in-memory copy, always merged over `defaults` so reads
+//     never miss a field.
+//   - Debounced + atomic writes (tmp + rename), pretty-printed so the file
+//     stays comfortably hand-editable.
+//   - A chokidar watcher that detects EXTERNAL edits and reports the new state.
+//     Our own programmatic writes are suppressed by content comparison.
+//   - Corrupt-file quarantine: an unparseable file is copied aside as
+//     `<filename>.corrupt-<ts>` before we fall back to defaults, mirroring the
+//     resilience electron-store gave us via clearInvalidConfig.
+//
+// `normalize` is the single authority for a store's shape: it takes the raw
+// parsed JSON and the defaults and returns a complete, validated value. It must
+// never throw — a malformed hand-edit should degrade to defaults, not crash.
+// =============================================================================
+
+import { app } from 'electron'
+import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
+import { watch, type FSWatcher } from 'chokidar'
+import log from './logger'
+
+export interface JsonStateFileOptions<T> {
+  /** File name under `app.getPath('userData')`. */
+  filename: string
+  /** Complete default value, used when the file is absent/empty/corrupt. */
+  defaults: T
+  /** Validate + normalize raw parsed JSON into a complete T. Never throws. */
+  normalize: (parsed: unknown, defaults: T) => T
+}
+
+export interface JsonStateFile<T> {
+  /** Sync load from disk (idempotent). Returns the current value. */
+  load(): T
+  /** Current in-memory value (always complete). */
+  get(): T
+  /** Replace the whole value and persist via a debounced atomic write. */
+  set(next: T): void
+  /** Functional update over the current value. */
+  update(fn: (current: T) => T): void
+  /** Absolute path of the backing file. */
+  getPath(): string
+  /** Ensure the file exists on disk, returning its path. */
+  ensureFile(): Promise<string>
+  /** Watch for EXTERNAL edits; `onExternal` fires with the new value. */
+  startWatching(onExternal: (next: T) => void): void
+  stopWatching(): void
+  /** Flush a pending debounced write synchronously (call on quit). */
+  flushPendingWritesSync(): void
+}
+
+const WRITE_DEBOUNCE_MS = 150
+
+export function createJsonStateFile<T>(options: JsonStateFileOptions<T>): JsonStateFile<T> {
+  const { filename, defaults, normalize } = options
+
+  // Authoritative in-memory value — defaults until loaded, always complete.
+  let current: T = defaults
+  let loaded = false
+  // The exact string we last wrote; the watcher compares against it to ignore
+  // the change event our own write produces.
+  let lastWrittenContent = ''
+  let watcher: FSWatcher | null = null
+  let writeTimer: ReturnType<typeof setTimeout> | null = null
+
+  function filePath(): string {
+    return path.join(app.getPath('userData'), filename)
+  }
+
+  function serialize(value: T): string {
+    return JSON.stringify(value, null, 2) + '\n'
+  }
+
+  /** Copy an unparseable file aside so a corrupt hand-edit / crash-mid-write is
+   *  preserved for recovery instead of silently overwritten with defaults. */
+  function quarantineCorruptFile(): void {
+    try {
+      const p = filePath()
+      const backup = `${p}.corrupt-${Date.now()}`
+      fsSync.copyFileSync(p, backup)
+      log.error('[jsonStateFile] %s is corrupt; backed up to %s and using defaults', filename, backup)
+    } catch (err) {
+      log.warn('[jsonStateFile] corrupt backup for %s failed: %O', filename, err)
+    }
+  }
+
+  function load(): T {
+    if (loaded) return current
+    const p = filePath()
+    try {
+      if (fsSync.existsSync(p)) {
+        const raw = fsSync.readFileSync(p, 'utf-8')
+        try {
+          const parsed = JSON.parse(raw)
+          current = normalize(parsed, defaults)
+          lastWrittenContent = raw
+        } catch {
+          quarantineCorruptFile()
+          current = defaults
+        }
+      }
+    } catch (err) {
+      log.warn('[jsonStateFile] sync load of %s failed: %O', filename, err)
+      current = defaults
+    }
+    loaded = true
+    return current
+  }
+
+  function writeSync(): void {
+    const content = serialize(current)
+    try {
+      const p = filePath()
+      fsSync.mkdirSync(path.dirname(p), { recursive: true })
+      fsSync.writeFileSync(p, content, 'utf-8')
+      lastWrittenContent = content
+    } catch (err) {
+      log.warn('[jsonStateFile] sync write of %s failed: %O', filename, err)
+    }
+  }
+
+  async function flushWrite(): Promise<void> {
+    writeTimer = null
+    const content = serialize(current)
+    // Record before the write so a watcher event racing the rename still matches.
+    lastWrittenContent = content
+    try {
+      const p = filePath()
+      await fs.mkdir(path.dirname(p), { recursive: true })
+      const tmp = p + '.tmp'
+      await fs.writeFile(tmp, content, 'utf-8')
+      await fs.rename(tmp, p)
+    } catch (err) {
+      log.warn('[jsonStateFile] write of %s failed: %O', filename, err)
+    }
+  }
+
+  function scheduleWrite(): void {
+    if (writeTimer) return
+    writeTimer = setTimeout(() => { void flushWrite() }, WRITE_DEBOUNCE_MS)
+  }
+
+  function set(next: T): void {
+    load()
+    current = next
+    scheduleWrite()
+  }
+
+  function update(fn: (current: T) => T): void {
+    load()
+    current = fn(current)
+    scheduleWrite()
+  }
+
+  async function ensureFile(): Promise<string> {
+    load()
+    const p = filePath()
+    try {
+      await fs.access(p)
+    } catch {
+      await flushWrite()
+    }
+    return p
+  }
+
+  function startWatching(onExternal: (next: T) => void): void {
+    if (watcher) return
+    load()
+    const p = filePath()
+    watcher = watch(p, { ignoreInitial: true })
+
+    const handle = async (): Promise<void> => {
+      let raw: string
+      try {
+        raw = await fs.readFile(p, 'utf-8')
+      } catch {
+        return // transient (mid-rename) — the trailing event settles it
+      }
+      if (raw === lastWrittenContent) return // our own write — ignore the echo
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        log.warn('[jsonStateFile] external edit of %s is not valid JSON — keeping current', filename)
+        return
+      }
+      const next = normalize(parsed, defaults)
+      lastWrittenContent = raw
+      if (JSON.stringify(next) === JSON.stringify(current)) return
+      current = next
+      onExternal(current)
+    }
+
+    watcher.on('change', () => { void handle() })
+    watcher.on('add', () => { void handle() })
+    watcher.on('error', (err) => log.warn('[jsonStateFile] watcher error for %s: %O', filename, err))
+  }
+
+  function stopWatching(): void {
+    if (writeTimer) { clearTimeout(writeTimer); writeTimer = null; void flushWrite() }
+    if (watcher) { void watcher.close(); watcher = null }
+  }
+
+  function flushPendingWritesSync(): void {
+    if (!writeTimer) return
+    clearTimeout(writeTimer)
+    writeTimer = null
+    writeSync()
+  }
+
+  return {
+    load,
+    get: () => { load(); return current },
+    set,
+    update,
+    getPath: filePath,
+    ensureFile,
+    startWatching,
+    stopWatching,
+    flushPendingWritesSync,
+  }
+}

--- a/src/main/projectWorkspaceStore.ts
+++ b/src/main/projectWorkspaceStore.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app } from 'electron'
+import { ipcMain } from 'electron'
 import fs from 'fs/promises'
 import fsSync from 'fs'
 import crypto from 'crypto'
@@ -11,7 +11,7 @@ import {
   WORKSPACE_EXTERNAL_EDIT_DISMISS,
 } from '../shared/ipc-channels'
 import { holdsProjectLock, acquireProjectLock } from './projectLock'
-import type { ProjectWorkspaceFile, ProjectSessionFile, MultiWorkspaceSession, SessionSnapshot, DockLayoutNode, WindowDockState } from '../shared/types'
+import type { ProjectWorkspaceFile, ProjectSessionFile } from '../shared/types'
 import { toRelativePath } from '../shared/pathUtils'
 import { broadcastToAll } from './windowRegistry'
 import { ensureCateGitignore } from './cateGitignore'
@@ -272,168 +272,6 @@ export function saveProjectStateSync(): void {
     } catch (err) {
       log.warn('Sync project state save failed for %s: %O', rootPath, err)
     }
-  }
-}
-
-// MIGRATION: Legacy Sessions/session.json → .cate/ per-project files.
-// Safe to delete runLegacyMigrationIfNeeded, snapshotToWorkspaceFile,
-// snapshotToSessionFile, and the collectPanelIds helpers once all users
-// have launched at least once on a version that includes this migration.
-
-export async function runLegacyMigrationIfNeeded(): Promise<void> {
-  const legacySessionDir = path.join(app.getPath('userData'), 'Sessions')
-  const legacySessionPath = path.join(legacySessionDir, 'session.json')
-
-  let legacyData: MultiWorkspaceSession | null = null
-  try {
-    const raw = await fs.readFile(legacySessionPath, 'utf-8')
-    const parsed = JSON.parse(raw)
-    if (parsed?.version === 2 && Array.isArray(parsed.workspaces)) {
-      legacyData = parsed as MultiWorkspaceSession
-    }
-  } catch {
-    return
-  }
-
-  if (!legacyData) return
-
-  let migrated = 0
-  for (const snapshot of legacyData.workspaces) {
-    if (!snapshot.rootPath) continue
-    const existing = await tryReadJson(workspacePath(snapshot.rootPath))
-    if (existing) continue
-
-    const workspace = snapshotToWorkspaceFile(snapshot)
-    const session = snapshotToSessionFile(snapshot)
-    try {
-      await saveProjectState(snapshot.rootPath, workspace, session)
-      migrated++
-      log.info('[migration] Converted legacy session for %s', snapshot.rootPath)
-    } catch (err) {
-      log.warn('[migration] Failed for %s: %O', snapshot.rootPath, err)
-    }
-  }
-
-  // Rename legacy files so this path is never hit again
-  const suffixes = ['', '.tmp', '.bak']
-  for (const suffix of suffixes) {
-    const src = legacySessionPath + suffix
-    await fs.rename(src, src + '.migrated').catch(() => {})
-  }
-
-  log.info('[migration] Legacy session migration complete (%d workspaces converted)', migrated)
-}
-
-function snapshotToWorkspaceFile(snapshot: SessionSnapshot): ProjectWorkspaceFile {
-  const rootPath = snapshot.rootPath || ''
-  const regions = snapshot.regions
-    ? Object.values(snapshot.regions).map((r) => ({
-        id: r.id,
-        origin: r.origin,
-        size: r.size,
-        label: r.label,
-        color: r.color,
-        zOrder: r.zOrder,
-      }))
-    : []
-
-  const nodes = snapshot.nodes.map((n) => {
-    let regionId = n.regionId
-    // Auto-assign regionId for nodes from pre-region sessions
-    if (!regionId && regions.length > 0) {
-      for (const r of regions) {
-        const overlapX = Math.max(0, Math.min(n.origin.x + n.size.width, r.origin.x + r.size.width) - Math.max(n.origin.x, r.origin.x))
-        const overlapY = Math.max(0, Math.min(n.origin.y + n.size.height, r.origin.y + r.size.height) - Math.max(n.origin.y, r.origin.y))
-        if (n.size.width * n.size.height > 0 && (overlapX * overlapY) / (n.size.width * n.size.height) > 0.5) {
-          regionId = r.id
-          break
-        }
-      }
-    }
-    return {
-      panelId: n.panelId,
-      panelType: n.panelType,
-      title: n.title,
-      origin: n.origin,
-      size: n.size,
-      filePath: n.filePath ? toRelativePath(n.filePath, rootPath) : undefined,
-      url: n.url ?? undefined,
-      proxyUrl: n.proxyUrl ?? undefined,
-      regionId,
-      documentType: n.documentType,
-    }
-  })
-
-  // Derive dockPanels from dockState for sessions saved before dockPanels existed
-  let dockPanels: ProjectWorkspaceFile['dockPanels']
-  if (snapshot.dockPanels) {
-    dockPanels = Object.fromEntries(
-      Object.entries(snapshot.dockPanels).map(([id, p]) => [
-        id,
-        {
-          type: p.type,
-          title: p.title,
-          filePath: p.filePath ? toRelativePath(p.filePath, rootPath) : undefined,
-          url: p.url ?? undefined,
-          proxyUrl: p.proxyUrl ?? undefined,
-        },
-      ]),
-    )
-  } else if (snapshot.dockState) {
-    const panelIds = collectPanelIdsFromZones(snapshot.dockState.zones)
-    const canvasNodeIds = new Set(snapshot.nodes.map((n) => n.panelId))
-    dockPanels = {}
-    for (const id of panelIds) {
-      if (!canvasNodeIds.has(id)) {
-        dockPanels[id] = { type: 'canvas', title: 'Canvas' }
-      }
-    }
-  }
-
-  return {
-    version: 1,
-    name: snapshot.workspaceName,
-    color: '',
-    canvas: { nodes, regions, zoomLevel: snapshot.zoomLevel, viewportOffset: snapshot.viewportOffset },
-    dockState: snapshot.dockState,
-    dockPanels,
-  }
-}
-
-function collectPanelIdsFromZones(zones: WindowDockState): string[] {
-  const ids: string[] = []
-  for (const zone of Object.values(zones)) {
-    if (zone.layout) collectPanelIdsFromNode(zone.layout, ids)
-  }
-  return ids
-}
-
-function collectPanelIdsFromNode(node: DockLayoutNode, ids: string[]): void {
-  if (node.type === 'tabs') {
-    ids.push(...node.panelIds)
-  } else {
-    for (const child of node.children) {
-      collectPanelIdsFromNode(child, ids)
-    }
-  }
-}
-
-function snapshotToSessionFile(snapshot: SessionSnapshot): ProjectSessionFile {
-  const nodes: Record<string, { panelId: string; zOrder: number; creationIndex: number; ptyId?: string; workingDirectory?: string; unsavedContent?: string }> = {}
-  snapshot.nodes.forEach((n, i) => {
-    nodes[n.panelId] = {
-      panelId: n.panelId,
-      zOrder: i,
-      creationIndex: i,
-      ptyId: n.ptyId,
-      workingDirectory: n.workingDirectory ?? undefined,
-      unsavedContent: n.unsavedContent,
-    }
-  })
-  return {
-    version: 1,
-    focusedNodeId: null,
-    nodes,
   }
 }
 

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -2,13 +2,15 @@
 // settingsFile — owns the user-editable settings.json file.
 //
 // VS Code model: a dedicated `<userData>/settings.json` is the source of truth
-// for AppSettings. It holds ONLY user settings (the other electron-store keys —
-// recentProjects, layouts, remoteProjects, sidebarSession — stay in config.json).
+// for AppSettings. It holds ONLY user settings; the workspace/session state that
+// used to share the legacy config.json (recentProjects, layouts, remoteProjects,
+// sidebarSession) now lives in its own files (see ./workspaceStateStore).
 //
 //   - Loaded synchronously at startup so the main process can read settings
 //     before any window is constructed.
-//   - On first run it is seeded from the legacy electron-store config.json so
-//     existing users keep their settings.
+//   - On first run it is seeded from the legacy config.json so existing users
+//     keep their settings. This runs before ./workspaceStateStore migrates and
+//     deletes config.json, so settings are never lost.
 //   - Writes are debounced + atomic (tmp + rename), pretty-printed so the file
 //     stays comfortably hand-editable.
 //   - A chokidar watcher detects EXTERNAL edits (the user editing the file in an
@@ -71,6 +73,11 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   telemetryConsentDecided: 'boolean',
   onboardingCompleted: 'boolean',
   betaUpdatesEnabled: 'boolean',
+  // Agent / layout — structured values. 'object' accepts a plain object or null;
+  // deeper validation (shape of the model ref / sidebar layout) lives in the
+  // renderer consumers, which already tolerate partial/legacy shapes.
+  agentDefaultModel: 'object',
+  sidebarLayout: 'object',
 }
 
 const SETTINGS_KEYS = Object.keys(SETTINGS_SCHEMA) as Array<keyof AppSettings>
@@ -83,6 +90,10 @@ function mergeValidatedSettings(target: Partial<AppSettings>, source: Record<str
     const expected = SETTINGS_SCHEMA[key]
     if (expected === 'array') {
       if (!Array.isArray(val)) { log.warn('Settings schema mismatch: %s expected array, got %s', key, typeof val); continue }
+    } else if (expected === 'object') {
+      // 'object' accepts a plain object or null (a nullable structured value);
+      // arrays are rejected so an array can't masquerade as an object.
+      if (typeof val !== 'object' || Array.isArray(val)) { log.warn('Settings schema mismatch: %s expected object, got %s', key, typeof val); continue }
     } else if (typeof val !== expected) {
       log.warn('Settings schema mismatch: %s expected %s, got %s', key, expected, typeof val); continue
     }
@@ -225,7 +236,11 @@ function scheduleWrite(): void {
 export function setSetting<K extends keyof AppSettings>(key: K, value: AppSettings[K]): boolean {
   if (!isSettingsKey(key)) return false
   const expected = SETTINGS_SCHEMA[key]
-  if (expected === 'array' ? !Array.isArray(value) : typeof value !== expected) {
+  const typeOk =
+    expected === 'array' ? Array.isArray(value)
+    : expected === 'object' ? (typeof value === 'object' && !Array.isArray(value))
+    : typeof value === expected
+  if (!typeOk) {
     log.warn('[settingsFile] Rejected set for %s: expected %s', String(key), expected)
     return false
   }

--- a/src/main/shellEnv.test.ts
+++ b/src/main/shellEnv.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// resolveShell is pulled in by shellEnv; stub it so the module loads without
+// touching the real shell resolver.
+vi.mock('./shellResolver', () => ({
+  resolveShell: () => ({ path: '/bin/zsh', fellBack: false }),
+}))
+vi.mock('./logger', () => ({
+  default: { debug() {}, info() {}, warn() {}, error() {} },
+}))
+
+import { getShellEnv } from './shellEnv'
+
+describe('getShellEnv sanitization', () => {
+  beforeEach(() => {
+    // Before resolution, getShellEnv falls back to process.env — exercise the
+    // scrub on a controlled set of vars.
+    process.env.ELECTRON_RUN_AS_NODE = '1'
+    process.env.ELECTRON_NO_ATTACH_CONSOLE = '1'
+    process.env.npm_config_cache = '/tmp/npm'
+    process.env.npm_lifecycle_event = 'dev'
+    process.env.PATH = '/usr/bin:/bin'
+  })
+
+  it('strips ELECTRON_* so a child electron-vite dev boots as Electron, not Node', () => {
+    const env = getShellEnv()
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+    expect(env.ELECTRON_NO_ATTACH_CONSOLE).toBeUndefined()
+  })
+
+  it('strips npm_* lifecycle vars from the parent npm run', () => {
+    const env = getShellEnv()
+    expect(env.npm_config_cache).toBeUndefined()
+    expect(env.npm_lifecycle_event).toBeUndefined()
+  })
+
+  it('preserves ordinary vars like PATH', () => {
+    const env = getShellEnv()
+    expect(env.PATH).toBe('/usr/bin:/bin')
+  })
+})

--- a/src/main/shellEnv.ts
+++ b/src/main/shellEnv.ts
@@ -85,6 +85,30 @@ function parseEnv(raw: string): Record<string, string> | null {
 }
 
 /**
+ * Drop env vars that belong to *this* Electron/electron-vite process and must
+ * not leak into spawned shells, terminals, or the companion daemon:
+ *
+ *  - ELECTRON_* — notably ELECTRON_RUN_AS_NODE, which we inject ourselves for
+ *    the capture spawn (and `env -0` echoes back). If it reaches a child
+ *    Electron process (e.g. a user running `electron-vite dev` in an integrated
+ *    terminal) that process boots as plain Node: `require('electron').app`
+ *    becomes undefined and the app crashes at startup.
+ *  - npm_*    — npm/electron-vite lifecycle vars from the parent `npm run` that
+ *    would otherwise pollute every terminal opened inside dev-mode Cate.
+ *
+ * This mirrors the scrub the pre-companion local PTY path applied at spawn time;
+ * doing it here keeps every consumer (companion, terminals, git, MCP) covered.
+ */
+function sanitizeEnv(env: Record<string, string>): Record<string, string> {
+  const clean: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith('ELECTRON_') || key.startsWith('npm_')) continue
+    clean[key] = value
+  }
+  return clean
+}
+
+/**
  * Initialize the shell environment resolver. Call once at app startup.
  * Safe to call multiple times — only the first call spawns a shell.
  */
@@ -108,5 +132,5 @@ export function initShellEnv(): Promise<Record<string, string>> {
  * Get the resolved shell environment. Returns process.env if not yet resolved.
  */
 export function getShellEnv(): Record<string, string> {
-  return resolvedEnv ?? ({ ...process.env } as Record<string, string>)
+  return sanitizeEnv(resolvedEnv ?? ({ ...process.env } as Record<string, string>))
 }

--- a/src/main/store.test.ts
+++ b/src/main/store.test.ts
@@ -1,17 +1,12 @@
 // =============================================================================
-// store.ts corruption resilience — a corrupt config.json must NOT break the
-// store IPC surface for the whole session. We verify store.ts's own logic:
-//   1. AppSettings now live in settings.json (see ./settingsFile), so a corrupt
-//      config.json can't affect SETTINGS_GET at all — it still returns defaults.
-//   2. getStore() (reached via a config.json-backed IPC like LAYOUT_LIST)
-//      resolves to defaults instead of rejecting when config.json is invalid
-//      JSON (it passes clearInvalidConfig: true), and preserves the corrupt file
-//      as a `config.json.corrupt-*` backup.
-//
-// electron-store is replaced with a faithful fake that reproduces its
-// clearInvalidConfig contract (reset-to-defaults on a JSON SyntaxError) — the
-// real package's Electron-runtime detection doesn't work under plain vitest,
-// and the behavior under test is store.ts's, not electron-store's internals.
+// store.ts resilience — a corrupt config.json must NOT break the store IPC
+// surface for the whole session. AppSettings live in settings.json and the
+// workspace-state keys live in their own files (see ./workspaceStateStore), so
+// neither is affected by a corrupt legacy config.json:
+//   1. SETTINGS_GET still returns defaults.
+//   2. LAYOUT_LIST (backed by layouts.json) still resolves — to [] — and the
+//      corrupt config.json is preserved as a `config.json.corrupt-*` backup
+//      instead of crashing the migration.
 // =============================================================================
 
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
@@ -37,45 +32,21 @@ vi.mock('./windowRegistry', () => ({ broadcastToAll: vi.fn() }))
 vi.mock('./logger', () => ({
   default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }))
-// settingsFile starts a chokidar watcher in registerHandlers(); stub it so the
-// test doesn't create a real filesystem watcher on the temp userData dir.
+// settingsFile + jsonStateFile start chokidar watchers; stub it so the test
+// doesn't create real filesystem watchers on the temp userData dir.
 vi.mock('chokidar', () => ({ watch: () => ({ on: vi.fn(), close: vi.fn() }) }))
-
-// Faithful electron-store fake: honors clearInvalidConfig like the real one.
-vi.mock('electron-store', () => {
-  class FakeStore {
-    private data: Record<string, any>
-    constructor(opts: any) {
-      let parsed: Record<string, any> = {}
-      if (fs.existsSync(cfgPath)) {
-        try {
-          parsed = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'))
-        } catch (err) {
-          // Real electron-store resets to defaults on SyntaxError when
-          // clearInvalidConfig is set; otherwise it rethrows.
-          if (!opts?.clearInvalidConfig) throw err
-          parsed = {}
-        }
-      }
-      this.data = { ...(opts?.defaults ?? {}), ...parsed }
-    }
-    get(key: string): unknown { return this.data[key] }
-    get store(): Record<string, any> { return this.data }
-  }
-  return { default: FakeStore }
-})
+// ./menu pulls in the auto-updater graph; stub the one function store.ts uses.
+vi.mock('./menu', () => ({ setLayoutNames: vi.fn() }))
 
 const { registerHandlers } = await import('./store')
 const { SETTINGS_GET, LAYOUT_LIST } = await import('../shared/ipc-channels')
 const { DEFAULT_SETTINGS } = await import('../shared/types')
 
 beforeAll(async () => {
-  // Corrupt config.json must exist before the first getStore() call.
+  // A corrupt config.json must be present before registerHandlers() runs the
+  // one-time migration.
   fs.writeFileSync(cfgPath, '{ this is : not valid json,,, ')
   registerHandlers()
-  // Trigger getStore() through a config.json-backed IPC so the corrupt config is
-  // detected, backed up, and reset to defaults.
-  await handlers.get(LAYOUT_LIST)?.({})
 })
 
 afterAll(() => {
@@ -84,20 +55,22 @@ afterAll(() => {
 
 describe('store corruption resilience', () => {
   test('a corrupt config.json keeps the store IPC surface working', async () => {
-    // Settings live in settings.json now → unaffected by a corrupt config.json.
+    // Settings live in settings.json → unaffected by a corrupt config.json.
     const getHandler = handlers.get(SETTINGS_GET)
     expect(getHandler).toBeTypeOf('function')
     expect(await getHandler!({}, 'warnBeforeQuit')).toBe(DEFAULT_SETTINGS.warnBeforeQuit)
-    // A config.json-backed IPC resolves to defaults instead of rejecting.
+    // A workspace-state-backed IPC resolves to defaults instead of rejecting.
     const layoutHandler = handlers.get(LAYOUT_LIST)
     expect(layoutHandler).toBeTypeOf('function')
     expect(await layoutHandler!({})).toEqual([])
   })
 
-  test('the corrupt config is preserved as a .corrupt-* backup', () => {
+  test('the corrupt config is preserved as a .corrupt-* backup and not deleted', () => {
     const backups = fs.readdirSync(userData).filter((f) => f.startsWith('config.json.corrupt-'))
     expect(backups.length).toBeGreaterThanOrEqual(1)
     const preserved = fs.readFileSync(path.join(userData, backups[0]), 'utf-8')
     expect(preserved).toContain('not valid json')
+    // A corrupt config is left in place (migration bails) for support/recovery.
+    expect(fs.existsSync(cfgPath)).toBe(true)
   })
 })

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,6 +1,11 @@
 // =============================================================================
-// Settings store and session persistence — backed by electron-store
-// electron-store v10 is ESM-only, so we use dynamic import()
+// Settings store and session persistence.
+//
+// AppSettings live in settings.json (see ./settingsFile). The workspace/session
+// state that used to sit in the opaque electron-store config.json — recent
+// projects, sidebar session, remote workspaces, saved layouts — now lives in
+// dedicated hand-editable JSON files (see ./workspaceStateStore). electron-store
+// is no longer used; config.json is migrated once on startup and removed.
 // =============================================================================
 
 import { ipcMain, app, BrowserWindow, nativeTheme } from 'electron'
@@ -29,7 +34,6 @@ import {
   LAYOUT_LOAD,
   LAYOUT_DELETE,
 } from '../shared/ipc-channels'
-import { DEFAULT_SETTINGS } from '../shared/types'
 import type { AppSettings, SidebarSession, RemoteProjectEntry } from '../shared/types'
 import { broadcastToAll } from './windowRegistry'
 import {
@@ -42,6 +46,21 @@ import {
   ensureSettingsFile,
   startWatching as startSettingsWatch,
 } from './settingsFile'
+import {
+  getRecentProjects,
+  addRecentProject,
+  removeRecentProject,
+  getSidebarSession,
+  setSidebarSession,
+  getRemoteProjects,
+  setRemoteProjects,
+  saveLayout,
+  listLayoutNames,
+  loadLayout,
+  deleteLayout,
+  startWatchingWorkspaceState,
+  migrateLegacyConfig,
+} from './workspaceStateStore'
 import { grantFileAccess } from './ipc/pathValidation'
 import { recordPersistentGrant } from './grantedPathStore'
 
@@ -49,8 +68,12 @@ import { recordPersistentGrant } from './grantedPathStore'
  *  static module graph (and anything that pulls in ./store, e.g. terminal IPC)
  *  doesn't drag in ./menu → ./auto-updater at load time. */
 async function pushLayoutNamesToMenu(names: string[]): Promise<void> {
-  const { setLayoutNames } = await import('./menu')
-  setLayoutNames(names)
+  try {
+    const { setLayoutNames } = await import('./menu')
+    setLayoutNames(names)
+  } catch (err) {
+    log.warn('Layout menu update failed: %O', err)
+  }
 }
 
 // Settings that open windows react to live (via onSettingsChanged). The
@@ -108,6 +131,18 @@ async function applySettingSideEffect(key: keyof AppSettings, value: unknown): P
       log.warn('Companion idle-suspend forward failed: %O', err)
     }
   }
+  // The wallpaper image is copied into managed app data (see DIALOG_OPEN_IMAGE).
+  // Whenever the path changes — a replacement, a clear (''), a reset, or a
+  // hand-edit pointing elsewhere — drop any managed copy that is no longer the
+  // current one so the directory doesn't accumulate orphaned images.
+  if (key === 'canvasBackgroundImagePath') {
+    try {
+      const { pruneCanvasBackgrounds } = await import('./canvasBackgroundStore')
+      pruneCanvasBackgrounds(typeof value === 'string' ? value : '')
+    } catch (err) {
+      log.warn('Canvas background prune failed: %O', err)
+    }
+  }
   // Live-toggle Sentry when the crash-reporting setting flips, so the change
   // takes effect without a relaunch.
   if (key === 'crashReportingEnabled') {
@@ -130,64 +165,6 @@ async function applySettingSideEffect(key: keyof AppSettings, value: unknown): P
       log.warn('Beta-updates live-toggle failed: %O', err)
     }
   }
-}
-
-// Lazy-loaded store instance (ESM dynamic import)
-let storeInstance: any = null
-
-/** If `config.json` is present but not valid JSON, copy it aside before
- *  electron-store (with `clearInvalidConfig`) silently overwrites it with
- *  defaults — so a user's corrupt settings are preserved for support/recovery
- *  rather than lost. Best-effort; never throws. */
-function backupConfigIfCorrupt(): void {
-  try {
-    const cfgPath = path.join(app.getPath('userData'), 'config.json')
-    if (!fsSync.existsSync(cfgPath)) return
-    const raw = fsSync.readFileSync(cfgPath, 'utf-8')
-    try {
-      JSON.parse(raw)
-    } catch {
-      const backupPath = `${cfgPath}.corrupt-${Date.now()}`
-      fsSync.copyFileSync(cfgPath, backupPath)
-      log.error('config.json is corrupt; backed up to %s and resetting to defaults', backupPath)
-    }
-  } catch (err) {
-    log.warn('Corrupt-config check failed: %O', err)
-  }
-}
-
-async function getStore(): Promise<any> {
-  if (storeInstance) return storeInstance
-  const { default: Store } = await import('electron-store')
-  // electron-store still backs the non-settings keys (recentProjects,
-  // sidebarSession, remoteProjects, layouts). AppSettings now live in their own
-  // settings.json (see ./settingsFile), so they are no longer read/written here.
-  // Preserve a corrupt config before clearInvalidConfig wipes it.
-  backupConfigIfCorrupt()
-  // clearInvalidConfig: a corrupt config.json resets to defaults instead of
-  // throwing on construction — which would otherwise reject every store IPC
-  // call (recent projects, layouts, sessions) for the whole session.
-  // projectName is set explicitly so the store never depends on Electron
-  // app-name detection (electron-store still keys the file off the userData
-  // cwd, so this doesn't change the config path — it only removes a failure
-  // mode in non-standard runtimes/tests).
-  const opts = { defaults: DEFAULT_SETTINGS, clearInvalidConfig: true, projectName: 'cate' }
-  try {
-    storeInstance = new Store<AppSettings>(opts)
-  } catch (err) {
-    // clearInvalidConfig only covers JSON SyntaxErrors. For anything else
-    // (e.g. an unreadable/locked file), move the bad file aside and retry so
-    // the store keeps working rather than failing for the entire session.
-    log.error('electron-store construction failed; quarantining config and retrying: %O', err)
-    try {
-      const cfgPath = path.join(app.getPath('userData'), 'config.json')
-      if (fsSync.existsSync(cfgPath)) fsSync.renameSync(cfgPath, `${cfgPath}.broken-${Date.now()}`)
-    } catch (mvErr) {
-      log.warn('Failed to quarantine config.json: %O', mvErr)
-    }
-    storeInstance = new Store<AppSettings>(opts)
-  }
-  return storeInstance
 }
 
 // ---------------------------------------------------------------------------
@@ -384,86 +361,76 @@ export function registerHandlers(): void {
     }
   })
 
+  // Workspace/session state files (recent projects, sidebar, remote workspaces,
+  // layouts) — migrate the legacy config.json once, then watch the new files for
+  // external edits (re-pushing the native Layouts menu when layouts.json is
+  // hand-edited). Migration runs after settings.json was seeded at startup, so
+  // removing config.json here is safe.
+  migrateLegacyConfig()
+  startWatchingWorkspaceState((names) => { void pushLayoutNamesToMenu(names) })
+
+  // Drop any orphaned managed wallpaper copies (e.g. from a crash mid-replace),
+  // keeping only the one the current setting points at.
+  void import('./canvasBackgroundStore')
+    .then(({ pruneCanvasBackgrounds }) => pruneCanvasBackgrounds(getSettingFromFile('canvasBackgroundImagePath')))
+    .catch((err) => log.warn('Canvas background startup prune failed: %O', err))
+
   // Recent Projects
   ipcMain.handle(RECENT_PROJECTS_GET, async () => {
-    const store = await getStore()
-    return store.get('recentProjects', []) as string[]
+    return getRecentProjects()
   })
 
   ipcMain.handle(RECENT_PROJECTS_ADD, async (_event, projectPath: string) => {
-    const store = await getStore()
-    const existing: string[] = store.get('recentProjects', []) as string[]
-    const filtered = existing.filter((p) => p !== projectPath)
-    const updated = [projectPath, ...filtered].slice(0, 10)
-    store.set('recentProjects', updated)
+    addRecentProject(projectPath)
   })
 
   // Drop a project from the recent list (issue #220): closing a workspace should
   // forget the project so it doesn't reappear on next launch and re-enter the
   // deferred-restore path. Without this the only way to forget a project was to
-  // hand-edit config.json.
+  // hand-edit the recent-projects file.
   ipcMain.handle(RECENT_PROJECTS_REMOVE, async (_event, projectPath: string) => {
-    const store = await getStore()
-    const existing: string[] = store.get('recentProjects', []) as string[]
-    store.set('recentProjects', existing.filter((p) => p !== projectPath))
+    removeRecentProject(projectPath)
   })
 
   // Sidebar session (workspace order + active workspace, keyed by root path)
   ipcMain.handle(SIDEBAR_SESSION_GET, async () => {
-    const store = await getStore()
-    return store.get('sidebarSession', null) as SidebarSession | null
+    return getSidebarSession()
   })
 
   ipcMain.handle(SIDEBAR_SESSION_SET, async (_event, session: SidebarSession) => {
-    const store = await getStore()
-    store.set('sidebarSession', session)
+    setSidebarSession(session)
   })
 
   // Remote projects (cate-companion:// workspaces): full restore snapshot +
   // reconnect info, since their tree lives on a companion and can't use the
   // local .cate/ project-state files.
   ipcMain.handle(REMOTE_PROJECTS_GET, async () => {
-    const store = await getStore()
-    return store.get('remoteProjects', []) as RemoteProjectEntry[]
+    return getRemoteProjects()
   })
 
   ipcMain.handle(REMOTE_PROJECTS_SET, async (_event, entries: RemoteProjectEntry[]) => {
-    const store = await getStore()
-    store.set('remoteProjects', Array.isArray(entries) ? entries : [])
+    setRemoteProjects(entries)
   })
 
   // Layouts
   ipcMain.handle(LAYOUT_SAVE, async (_event, name: string, layout: unknown) => {
-    const store = await getStore()
-    const layouts = (store.get('layouts') as Record<string, unknown>) || {}
-    layouts[name] = layout
-    store.set('layouts', layouts)
-    void pushLayoutNamesToMenu(Object.keys(layouts))
+    const names = saveLayout(name, layout)
+    void pushLayoutNamesToMenu(names)
   })
 
   ipcMain.handle(LAYOUT_LIST, async () => {
-    const store = await getStore()
-    const layouts = (store.get('layouts') as Record<string, unknown>) || {}
-    return Object.keys(layouts)
+    return listLayoutNames()
   })
 
   ipcMain.handle(LAYOUT_LOAD, async (_event, name: string) => {
-    const store = await getStore()
-    const layouts = (store.get('layouts') as Record<string, unknown>) || {}
-    return layouts[name] || null
+    return loadLayout(name)
   })
 
   ipcMain.handle(LAYOUT_DELETE, async (_event, name: string) => {
-    const store = await getStore()
-    const layouts = (store.get('layouts') as Record<string, unknown>) || {}
-    delete layouts[name]
-    store.set('layouts', layouts)
-    void pushLayoutNamesToMenu(Object.keys(layouts))
+    const names = deleteLayout(name)
+    void pushLayoutNamesToMenu(names)
   })
 
   // Seed the native Layouts menu with whatever is already saved.
-  void getStore().then((store) => {
-    const layouts = (store.get('layouts') as Record<string, unknown>) || {}
-    return pushLayoutNamesToMenu(Object.keys(layouts))
-  }).catch(() => { /* menu just stays empty until first save */ })
+  void pushLayoutNamesToMenu(listLayoutNames())
 }

--- a/src/main/uiStateStore.ts
+++ b/src/main/uiStateStore.ts
@@ -1,0 +1,46 @@
+// =============================================================================
+// uiStateStore — transient, cosmetic UI placement (minimap position/size),
+// persisted to `<userData>/ui-state.json` via ./jsonStateFile. Kept separate
+// from settings.json so the user-facing settings file stays focused on
+// preferences. Renderer reads it once on launch and writes single keys back.
+// =============================================================================
+
+import { ipcMain } from 'electron'
+import { createJsonStateFile } from './jsonStateFile'
+import { DEFAULT_UI_STATE } from '../shared/types'
+import type { UIState } from '../shared/types'
+import { UI_STATE_GET_ALL, UI_STATE_SET } from '../shared/ipc-channels'
+
+const CORNERS = new Set(['bottom-right', 'bottom-left', 'top-right', 'top-left'])
+
+const store = createJsonStateFile<UIState>({
+  filename: 'ui-state.json',
+  defaults: DEFAULT_UI_STATE,
+  normalize: (parsed, defaults) => {
+    const o = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+    const size = o.minimapSize as { w?: unknown; h?: unknown } | undefined
+    return {
+      minimapCorner: CORNERS.has(o.minimapCorner as string) ? (o.minimapCorner as UIState['minimapCorner']) : defaults.minimapCorner,
+      minimapButtonCorner: CORNERS.has(o.minimapButtonCorner as string) ? (o.minimapButtonCorner as UIState['minimapButtonCorner']) : defaults.minimapButtonCorner,
+      minimapSize: size && typeof size.w === 'number' && typeof size.h === 'number'
+        ? { w: size.w, h: size.h }
+        : defaults.minimapSize,
+    }
+  },
+})
+
+export function registerUIStateHandlers(): void {
+  ipcMain.handle(UI_STATE_GET_ALL, async () => store.get())
+  ipcMain.handle(UI_STATE_SET, async (_event, key: keyof UIState, value: unknown) => {
+    if (!(key in DEFAULT_UI_STATE)) return
+    store.update((cur) => ({ ...cur, [key]: value }))
+  })
+  // Keep the in-memory copy fresh if the file is hand-edited (no broadcast — the
+  // values are read per-window on launch; a live reload isn't worth the wiring).
+  store.startWatching(() => { /* read on demand */ })
+}
+
+/** Flush a pending debounced write synchronously (call on app quit). */
+export function flushUIStateSync(): void {
+  store.flushPendingWritesSync()
+}

--- a/src/main/workspaceStateStore.test.ts
+++ b/src/main/workspaceStateStore.test.ts
@@ -1,0 +1,70 @@
+// =============================================================================
+// workspaceStateStore — one-time migration of the legacy electron-store
+// config.json into the four discrete state files, and its idempotency.
+// =============================================================================
+
+import { afterAll, describe, expect, test, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-wsstate-test-'))
+const cfgPath = path.join(userData, 'config.json')
+
+vi.mock('electron', () => {
+  const electron = { app: { getPath: () => userData } }
+  return { ...electron, default: electron }
+})
+vi.mock('chokidar', () => ({ watch: () => ({ on: vi.fn(), close: vi.fn() }) }))
+vi.mock('./logger', () => ({
+  default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}))
+
+const store = await import('./workspaceStateStore')
+
+const readJson = (name: string) => JSON.parse(fs.readFileSync(path.join(userData, name), 'utf-8'))
+
+afterAll(() => { try { fs.rmSync(userData, { recursive: true, force: true }) } catch { /* noop */ } })
+
+describe('migrateLegacyConfig', () => {
+  test('migrates all four keys into discrete files and deletes config.json', () => {
+    fs.writeFileSync(cfgPath, JSON.stringify({
+      // a settings key that should be ignored by this migration
+      editorFontSize: 16,
+      recentProjects: ['/a', '/b'],
+      sidebarSession: { order: ['/a', '/b'], selected: '/b' },
+      remoteProjects: [{ locator: 'cate-companion://x', connection: {}, snapshot: {} }],
+      layouts: { focus: { foo: 1 } },
+    }))
+
+    store.migrateLegacyConfig()
+
+    expect(readJson('recent-projects.json')).toEqual({ projects: ['/a', '/b'] })
+    expect(readJson('sidebar.json')).toEqual({ session: { order: ['/a', '/b'], selected: '/b' } })
+    expect(readJson('remote-workspaces.json').workspaces).toHaveLength(1)
+    expect(readJson('layouts.json')).toEqual({ layouts: { focus: { foo: 1 } } })
+
+    // config.json is removed so the migration never runs again.
+    expect(fs.existsSync(cfgPath)).toBe(false)
+
+    // Accessors reflect the migrated state.
+    expect(store.getRecentProjects()).toEqual(['/a', '/b'])
+    expect(store.getSidebarSession()).toEqual({ order: ['/a', '/b'], selected: '/b' })
+    expect(store.listLayoutNames()).toEqual(['focus'])
+  })
+
+  test('is a no-op when config.json is absent', () => {
+    expect(fs.existsSync(cfgPath)).toBe(false)
+    expect(() => store.migrateLegacyConfig()).not.toThrow()
+    expect(store.getRecentProjects()).toEqual(['/a', '/b'])
+  })
+
+  test('does not clobber existing files if a stale config.json reappears', () => {
+    // A new config.json shows up (e.g. a downgrade/upgrade dance) but the new
+    // files already exist — their values must win, and config.json is removed.
+    fs.writeFileSync(cfgPath, JSON.stringify({ recentProjects: ['/should-not-win'] }))
+    store.migrateLegacyConfig()
+    expect(readJson('recent-projects.json')).toEqual({ projects: ['/a', '/b'] })
+    expect(fs.existsSync(cfgPath)).toBe(false)
+  })
+})

--- a/src/main/workspaceStateStore.ts
+++ b/src/main/workspaceStateStore.ts
@@ -1,0 +1,237 @@
+// =============================================================================
+// workspaceStateStore — the four pieces of workspace/session state that used to
+// live in the opaque electron-store `config.json`, now each in its own
+// hand-editable JSON file under `<userData>/` via ./jsonStateFile:
+//
+//   recent-projects.json   { projects: string[] }            recency-ordered list
+//   sidebar.json           { session: SidebarSession|null }  sidebar order + active
+//   remote-workspaces.json { workspaces: RemoteProjectEntry[] } cate-companion:// restore snapshots
+//   layouts.json           { layouts: Record<string, unknown> } named saved canvas layouts
+//
+// On first launch after the migration lands, the legacy config.json is read
+// once, any missing file is seeded from it, and config.json is deleted. The
+// per-key presence check makes migration idempotent; a corrupt/unparseable
+// config.json is quarantined and left in place for support rather than deleted.
+// =============================================================================
+
+import { app } from 'electron'
+import fs from 'fs'
+import path from 'path'
+import log from './logger'
+import { createJsonStateFile } from './jsonStateFile'
+import type { SidebarSession, RemoteProjectEntry } from '../shared/types'
+
+const MAX_RECENT_PROJECTS = 10
+
+// ---------------------------------------------------------------------------
+// File shapes + stores. Each top-level value is an object (never a bare array)
+// so the file is a stable JSON object the watcher/normalize can rely on.
+// ---------------------------------------------------------------------------
+
+interface RecentProjectsFile { projects: string[] }
+interface SidebarFile { session: SidebarSession | null }
+interface RemoteWorkspacesFile { workspaces: RemoteProjectEntry[] }
+interface LayoutsFile { layouts: Record<string, unknown> }
+
+function asObject(parsed: unknown): Record<string, unknown> {
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {}
+}
+
+const recentProjectsStore = createJsonStateFile<RecentProjectsFile>({
+  filename: 'recent-projects.json',
+  defaults: { projects: [] },
+  normalize: (parsed, defaults) => {
+    const o = asObject(parsed)
+    const projects = Array.isArray(o.projects) ? o.projects.filter((p): p is string => typeof p === 'string') : defaults.projects
+    return { projects }
+  },
+})
+
+const sidebarStore = createJsonStateFile<SidebarFile>({
+  filename: 'sidebar.json',
+  defaults: { session: null },
+  normalize: (parsed, defaults) => {
+    const o = asObject(parsed)
+    const s = o.session
+    if (!s || typeof s !== 'object' || Array.isArray(s)) return defaults
+    const sess = s as Record<string, unknown>
+    const order = Array.isArray(sess.order) ? sess.order.filter((p): p is string => typeof p === 'string') : []
+    const selected = typeof sess.selected === 'string' ? sess.selected : ''
+    return { session: { order, selected } }
+  },
+})
+
+const remoteWorkspacesStore = createJsonStateFile<RemoteWorkspacesFile>({
+  filename: 'remote-workspaces.json',
+  defaults: { workspaces: [] },
+  normalize: (parsed, defaults) => {
+    const o = asObject(parsed)
+    // Keep entry validation light: the renderer's restore path is already
+    // defensive about partial/legacy snapshots. We only guarantee the array shape.
+    const workspaces = Array.isArray(o.workspaces)
+      ? (o.workspaces.filter((w) => w && typeof w === 'object') as RemoteProjectEntry[])
+      : defaults.workspaces
+    return { workspaces }
+  },
+})
+
+const layoutsStore = createJsonStateFile<LayoutsFile>({
+  filename: 'layouts.json',
+  defaults: { layouts: {} },
+  normalize: (parsed, defaults) => {
+    const o = asObject(parsed)
+    const layouts = o.layouts && typeof o.layouts === 'object' && !Array.isArray(o.layouts)
+      ? (o.layouts as Record<string, unknown>)
+      : defaults.layouts
+    return { layouts }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Typed accessors — preserve the exact payload shapes the existing IPC handlers
+// and renderer consumers expect (string[], SidebarSession|null, etc.).
+// ---------------------------------------------------------------------------
+
+export function getRecentProjects(): string[] {
+  return recentProjectsStore.get().projects
+}
+
+export function addRecentProject(projectPath: string): void {
+  recentProjectsStore.update((cur) => {
+    const filtered = cur.projects.filter((p) => p !== projectPath)
+    return { projects: [projectPath, ...filtered].slice(0, MAX_RECENT_PROJECTS) }
+  })
+}
+
+export function removeRecentProject(projectPath: string): void {
+  recentProjectsStore.update((cur) => ({ projects: cur.projects.filter((p) => p !== projectPath) }))
+}
+
+export function getSidebarSession(): SidebarSession | null {
+  return sidebarStore.get().session
+}
+
+export function setSidebarSession(session: SidebarSession): void {
+  sidebarStore.set({ session })
+}
+
+export function getRemoteProjects(): RemoteProjectEntry[] {
+  return remoteWorkspacesStore.get().workspaces
+}
+
+export function setRemoteProjects(entries: RemoteProjectEntry[]): void {
+  remoteWorkspacesStore.set({ workspaces: Array.isArray(entries) ? entries : [] })
+}
+
+export function saveLayout(name: string, layout: unknown): string[] {
+  layoutsStore.update((cur) => ({ layouts: { ...cur.layouts, [name]: layout } }))
+  return listLayoutNames()
+}
+
+export function listLayoutNames(): string[] {
+  return Object.keys(layoutsStore.get().layouts)
+}
+
+export function loadLayout(name: string): unknown {
+  return layoutsStore.get().layouts[name] ?? null
+}
+
+export function deleteLayout(name: string): string[] {
+  layoutsStore.update((cur) => {
+    const layouts = { ...cur.layouts }
+    delete layouts[name]
+    return { layouts }
+  })
+  return listLayoutNames()
+}
+
+/** Start watching all four files for external edits. `onLayoutsChanged` lets the
+ *  caller re-push the native Layouts menu when layouts.json is hand-edited. */
+export function startWatchingWorkspaceState(onLayoutsChanged: (names: string[]) => void): void {
+  recentProjectsStore.startWatching(() => { /* read on demand */ })
+  sidebarStore.startWatching(() => { /* read on demand */ })
+  remoteWorkspacesStore.startWatching(() => { /* read on demand */ })
+  layoutsStore.startWatching((next) => onLayoutsChanged(Object.keys(next.layouts)))
+}
+
+/** Flush any pending debounced writes synchronously (call on app quit). */
+export function flushWorkspaceStateSync(): void {
+  recentProjectsStore.flushPendingWritesSync()
+  sidebarStore.flushPendingWritesSync()
+  remoteWorkspacesStore.flushPendingWritesSync()
+  layoutsStore.flushPendingWritesSync()
+}
+
+// ---------------------------------------------------------------------------
+// One-time migration from the legacy electron-store config.json.
+// ---------------------------------------------------------------------------
+
+function legacyConfigPath(): string {
+  return path.join(app.getPath('userData'), 'config.json')
+}
+
+/**
+ * Migrate the four workspace-state keys out of the legacy config.json into their
+ * dedicated files, then delete config.json. Idempotent (per-file presence check)
+ * and corrupt-safe (an unparseable config.json is quarantined and left in place).
+ * Must run AFTER settingsFile.loadSettingsSync(), which also reads config.json
+ * (for settings keys) on its own first run.
+ */
+export function migrateLegacyConfig(): void {
+  const cfgPath = legacyConfigPath()
+  let raw: string
+  try {
+    if (!fs.existsSync(cfgPath)) return
+    raw = fs.readFileSync(cfgPath, 'utf-8')
+  } catch (err) {
+    log.warn('[workspaceStateStore] reading legacy config.json failed: %O', err)
+    return
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    const p = JSON.parse(raw)
+    if (!p || typeof p !== 'object' || Array.isArray(p)) throw new Error('not an object')
+    parsed = p as Record<string, unknown>
+  } catch {
+    // Corrupt: preserve for support and bail without deleting.
+    try {
+      fs.copyFileSync(cfgPath, `${cfgPath}.corrupt-${Date.now()}`)
+    } catch { /* best effort */ }
+    log.error('[workspaceStateStore] legacy config.json is corrupt; skipping migration (preserved a backup)')
+    return
+  }
+
+  // Seed only files that don't exist yet, so re-running never clobbers state the
+  // user has already changed under the new files.
+  const userData = app.getPath('userData')
+  const exists = (name: string): boolean => fs.existsSync(path.join(userData, name))
+
+  if (!exists('recent-projects.json') && Array.isArray(parsed.recentProjects)) {
+    recentProjectsStore.set({
+      projects: (parsed.recentProjects as unknown[]).filter((p): p is string => typeof p === 'string'),
+    })
+  }
+  if (!exists('sidebar.json') && parsed.sidebarSession && typeof parsed.sidebarSession === 'object') {
+    setSidebarSession(parsed.sidebarSession as SidebarSession)
+  }
+  if (!exists('remote-workspaces.json') && Array.isArray(parsed.remoteProjects)) {
+    setRemoteProjects(parsed.remoteProjects as RemoteProjectEntry[])
+  }
+  if (!exists('layouts.json') && parsed.layouts && typeof parsed.layouts === 'object' && !Array.isArray(parsed.layouts)) {
+    layoutsStore.set({ layouts: parsed.layouts as Record<string, unknown> })
+  }
+
+  // Flush the seeded files to disk synchronously, then remove config.json so the
+  // migration never runs again. settings.json was already seeded earlier in
+  // startup (settingsFile), so deleting config.json here is safe.
+  flushWorkspaceStateSync()
+  try {
+    fs.unlinkSync(cfgPath)
+    log.info('[workspaceStateStore] migrated config.json to discrete state files and removed it')
+  } catch (err) {
+    log.warn('[workspaceStateStore] removing legacy config.json failed: %O', err)
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,8 @@ import {
   SETTINGS_CHANGED,
   SETTINGS_OPEN_IN_EDITOR,
   SETTINGS_RELOADED,
+  UI_STATE_GET_ALL,
+  UI_STATE_SET,
   SESSION_FLUSH_SAVE,
   SESSION_FLUSH_SAVE_DONE,
   PROJECT_STATE_SAVE,
@@ -694,6 +696,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   settingsReset(key?: string): Promise<void> {
     return ipcRenderer.invoke(SETTINGS_RESET, key)
+  },
+
+  uiStateGetAll(): Promise<unknown> {
+    return ipcRenderer.invoke(UI_STATE_GET_ALL)
+  },
+
+  uiStateSet(key: string, value: unknown): Promise<void> {
+    return ipcRenderer.invoke(UI_STATE_SET, key, value)
   },
 
   onSettingsChanged(callback: (key: keyof AppSettings, value: unknown) => void): () => void {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,7 +12,9 @@ import { DockStoreProvider } from './stores/DockStoreContext'
 import { getOrCreateWorkspaceDockStore } from './stores/workspaceStores'
 import { useStore } from 'zustand'
 import { useSettingsStore } from './stores/settingsStore'
-import { useUIStore } from './stores/uiStore'
+import { useUIStore, normalizeSidebarLayout } from './stores/uiStore'
+import { useUIStateStore } from './stores/uiStateStore'
+import { migrateLegacyLocalStorage } from './lib/migrateLegacyLocalStorage'
 import { useFileDropTracker, FileDropOverlay } from './drag/fileDropTarget'
 import { useUpdateStore, type UpdateStatus } from './stores/updateStore'
 import { useShortcuts } from './hooks/useShortcuts'
@@ -240,7 +242,17 @@ function MainApp() {
       log.info('Initializing main window...')
 
       await useSettingsStore.getState().loadSettings()
+      await useUIStateStore.getState().loadUIState()
       log.info('Settings loaded')
+
+      // One-time migration of legacy renderer localStorage prefs into the JSON
+      // stores (settings.json / ui-state.json). Centralized in one module.
+      migrateLegacyLocalStorage()
+
+      // The sidebar layout is persisted in settings.json but lives as mutable
+      // uiStore state at runtime; uiStore was created before settings loaded, so
+      // seed it from the now-loaded (and possibly just-migrated) value.
+      useUIStore.setState({ sidebarLayout: normalizeSidebarLayout(useSettingsStore.getState().sidebarLayout) })
 
       // Try to restore previous session — only the core (active workspace).
       // Detached panel/dock windows are recreated afterwards so the main

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -24,24 +24,16 @@ import { CateLogo } from '../ui/CateLogo'
 import Minimap from './Minimap'
 import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useUIStore } from '../stores/uiStore'
+import { useUIStateStore } from '../stores/uiStateStore'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { displayString, PANEL_DEFAULT_SIZES } from '../../shared/types'
 import { useAppStore } from '../stores/appStore'
 import { UpdateButton } from './UpdateButton'
 
 // The minimap pill can be docked in any of the four canvas corners. The choice
-// persists across sessions in localStorage.
+// persists across sessions in ui-state.json (via the UI-state store).
 type MinimapCorner = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
-const MINIMAP_CORNER_KEY = 'cate.minimapButton.corner'
-const loadMinimapCorner = (): MinimapCorner => {
-  try {
-    const v = localStorage.getItem(MINIMAP_CORNER_KEY)
-    if (v === 'bottom-right' || v === 'bottom-left' || v === 'top-right' || v === 'top-left') {
-      return v
-    }
-  } catch {}
-  return 'bottom-right'
-}
+const loadMinimapCorner = (): MinimapCorner => useUIStateStore.getState().minimapButtonCorner
 
 interface CanvasToolbarProps {
   canvasPanelId: string
@@ -271,7 +263,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
       window.removeEventListener('mousemove', onMove)
       window.removeEventListener('mouseup', onUp)
       if (minimapDidDragRef.current) {
-        try { localStorage.setItem(MINIMAP_CORNER_KEY, nextCorner) } catch {}
+        useUIStateStore.getState().setUIState('minimapButtonCorner', nextCorner)
       }
     }
     window.addEventListener('mousemove', onMove)

--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -5,9 +5,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useCanvasStoreContext, useCanvasStoreApi, shallow } from '../stores/CanvasStoreContext'
 import { useWorkspacePanels } from '../stores/appStore'
+import { useUIStateStore } from '../stores/uiStateStore'
 
-const MINIMAP_DEFAULT_WIDTH = 200
-const MINIMAP_DEFAULT_HEIGHT = 150
+// Default minimap size lives in DEFAULT_UI_STATE (shared/types); the floating
+// size is restored from ui-state.json.
 const MINIMAP_MIN_WIDTH = 120
 const MINIMAP_MIN_HEIGHT = 90
 const MINIMAP_MAX_WIDTH = 600
@@ -16,22 +17,10 @@ const MINIMAP_PADDING = 10
 const MINIMAP_GAP = 12
 
 type Corner = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
-const CORNER_KEY = 'cate.minimap.corner'
-const SIZE_KEY = 'cate.minimap.size'
-const loadCorner = (): Corner => {
-  const v = (typeof localStorage !== 'undefined' && localStorage.getItem(CORNER_KEY)) as Corner | null
-  return v || 'bottom-right'
-}
-const loadSize = (): { w: number; h: number } => {
-  try {
-    const raw = localStorage.getItem(SIZE_KEY)
-    if (raw) {
-      const p = JSON.parse(raw)
-      if (typeof p.w === 'number' && typeof p.h === 'number') return { w: p.w, h: p.h }
-    }
-  } catch {}
-  return { w: MINIMAP_DEFAULT_WIDTH, h: MINIMAP_DEFAULT_HEIGHT }
-}
+// Minimap placement persists in ui-state.json via the UI-state store (loaded on
+// launch, before the canvas mounts). These read the current store value.
+const loadCorner = (): Corner => useUIStateStore.getState().minimapCorner
+const loadSize = (): { w: number; h: number } => useUIStateStore.getState().minimapSize
 
 // Map a panel type to a themed CSS variable so the minimap follows the active
 // theme. Falls back to a generic surface accent for unknown types.
@@ -100,7 +89,7 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
       setSize({ w, h })
       if (sizeDebounceRef.current) clearTimeout(sizeDebounceRef.current)
       sizeDebounceRef.current = setTimeout(() => {
-        try { localStorage.setItem(SIZE_KEY, JSON.stringify({ w, h })) } catch {}
+        useUIStateStore.getState().setUIState('minimapSize', { w, h })
       }, 500)
     }
     const handleUp = () => {
@@ -124,7 +113,7 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
         if (prev === next) return prev
         if (cornerDebounceRef.current) clearTimeout(cornerDebounceRef.current)
         cornerDebounceRef.current = setTimeout(() => {
-          try { localStorage.setItem(CORNER_KEY, next) } catch {}
+          useUIStateStore.getState().setUIState('minimapCorner', next)
         }, 500)
         return next
       })

--- a/src/renderer/lib/migrateLegacyLocalStorage.test.ts
+++ b/src/renderer/lib/migrateLegacyLocalStorage.test.ts
@@ -1,0 +1,69 @@
+// =============================================================================
+// migrateLegacyLocalStorage — the single localStorage → JSON-store migration.
+// =============================================================================
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// In-memory localStorage shim.
+const store = new Map<string, string>()
+const ls = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, v) },
+  removeItem: (k: string) => { store.delete(k) },
+}
+vi.stubGlobal('localStorage', ls)
+
+const settingsSet = vi.fn()
+const uiSet = vi.fn()
+vi.mock('../stores/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ setSetting: settingsSet }) },
+}))
+vi.mock('../stores/uiStateStore', () => ({
+  useUIStateStore: { getState: () => ({ setUIState: uiSet }) },
+}))
+
+const { migrateLegacyLocalStorage } = await import('./migrateLegacyLocalStorage')
+
+beforeEach(() => { store.clear(); settingsSet.mockClear(); uiSet.mockClear() })
+afterEach(() => { store.clear() })
+
+describe('migrateLegacyLocalStorage', () => {
+  test('routes each legacy key to its store and clears it', () => {
+    store.set('cate.agent.defaultModel.v1', JSON.stringify({ provider: 'openai', model: 'gpt-x' }))
+    store.set('cate.sidebarLayout.v3', JSON.stringify({ left: ['workspaces'], right: ['git'] }))
+    store.set('cate.minimap.corner', 'top-left')
+    store.set('cate.minimapButton.corner', 'bottom-left')
+    store.set('cate.minimap.size', JSON.stringify({ w: 321, h: 222 }))
+
+    migrateLegacyLocalStorage()
+
+    expect(settingsSet).toHaveBeenCalledWith('agentDefaultModel', { provider: 'openai', model: 'gpt-x' })
+    // sidebarLayout is normalized — missing views appended to the right.
+    expect(settingsSet).toHaveBeenCalledWith('sidebarLayout', {
+      left: ['workspaces'],
+      right: ['git', 'explorer', 'parallelWork', 'search'],
+    })
+    expect(uiSet).toHaveBeenCalledWith('minimapCorner', 'top-left')
+    expect(uiSet).toHaveBeenCalledWith('minimapButtonCorner', 'bottom-left')
+    expect(uiSet).toHaveBeenCalledWith('minimapSize', { w: 321, h: 222 })
+
+    // Every legacy key is removed so the migration never runs again.
+    for (const k of store.keys()) expect(k).not.toMatch(/^cate\./)
+    expect(store.size).toBe(0)
+  })
+
+  test('is a no-op when nothing is stored', () => {
+    migrateLegacyLocalStorage()
+    expect(settingsSet).not.toHaveBeenCalled()
+    expect(uiSet).not.toHaveBeenCalled()
+  })
+
+  test('drops invalid values but still clears the key', () => {
+    store.set('cate.agent.defaultModel.v1', 'not json{{')
+    store.set('cate.minimap.corner', 'nonsense-corner')
+    migrateLegacyLocalStorage()
+    expect(settingsSet).not.toHaveBeenCalled()
+    expect(uiSet).not.toHaveBeenCalled()
+    expect(store.size).toBe(0)
+  })
+})

--- a/src/renderer/lib/migrateLegacyLocalStorage.ts
+++ b/src/renderer/lib/migrateLegacyLocalStorage.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// migrateLegacyLocalStorage — THE one place that migrates preferences out of the
+// renderer's legacy localStorage into the JSON-file model (settings.json /
+// ui-state.json). Runs once at startup after the settings + ui-state stores have
+// loaded; each entry reads its legacy key, routes the value to the right store
+// (which persists it), then clears the key so this never runs again.
+//
+// Fully guarded — a migration failure must never block startup. When every key
+// is gone (steady state) this is a handful of cheap localStorage misses.
+// =============================================================================
+
+import { useSettingsStore } from '../stores/settingsStore'
+import { useUIStateStore } from '../stores/uiStateStore'
+import { normalizeSidebarLayout } from '../stores/uiStore'
+
+const CORNERS = ['bottom-right', 'bottom-left', 'top-right', 'top-left'] as const
+type Corner = (typeof CORNERS)[number]
+const isCorner = (v: unknown): v is Corner => CORNERS.includes(v as Corner)
+
+export function migrateLegacyLocalStorage(): void {
+  if (typeof localStorage === 'undefined') return
+  const settings = useSettingsStore.getState()
+  const ui = useUIStateStore.getState()
+
+  // Pull-and-clear a legacy key. `parse` decodes the raw string; the result is
+  // routed by `apply`. The key is always removed once seen, value or not.
+  const take = (key: string, apply: (raw: string) => void): void => {
+    try {
+      const raw = localStorage.getItem(key)
+      if (raw == null) return
+      try { apply(raw) } catch { /* bad value — drop it, keep defaults */ }
+      localStorage.removeItem(key)
+    } catch { /* localStorage unavailable — ignore */ }
+  }
+
+  // → settings.json
+  take('cate.agent.defaultModel.v1', (raw) => {
+    const m = JSON.parse(raw)
+    if (m && typeof m.provider === 'string' && typeof m.model === 'string') {
+      settings.setSetting('agentDefaultModel', { provider: m.provider, model: m.model })
+    }
+  })
+  take('cate.sidebarLayout.v3', (raw) => {
+    settings.setSetting('sidebarLayout', normalizeSidebarLayout(JSON.parse(raw)))
+  })
+
+  // → ui-state.json
+  take('cate.minimap.corner', (raw) => { if (isCorner(raw)) ui.setUIState('minimapCorner', raw) })
+  take('cate.minimapButton.corner', (raw) => { if (isCorner(raw)) ui.setUIState('minimapButtonCorner', raw) })
+  take('cate.minimap.size', (raw) => {
+    const s = JSON.parse(raw)
+    if (s && typeof s.w === 'number' && typeof s.h === 'number') ui.setUIState('minimapSize', { w: s.w, h: s.h })
+  })
+}

--- a/src/renderer/lib/workspace/sidebarSession.ts
+++ b/src/renderer/lib/workspace/sidebarSession.ts
@@ -27,7 +27,7 @@ export function applySidebarSession(
   sidebarSession: SidebarSession | null | undefined,
 ): { workspaces: SessionSnapshot[]; selectedWorkspaceIndex: number } {
   // Be defensive about the persisted shape: this value comes straight from
-  // electron-store (untyped JSON) and may be partial or corrupted (crash mid
+  // sidebar.json (untyped JSON) and may be partial or corrupted (crash mid
   // write, a hand-edit, a future schema change). A bad shape must fall back to
   // defaults — never throw, since this runs inside session restore and a throw
   // would abort the whole restore, including the default-workspace fallback.

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -542,6 +542,16 @@ export default function TerminalPanel({
       // selection, which isn't happening during a resize/pan anyway.
       if (document.body.classList.contains('canvas-interacting')) return
 
+      // A middle/right press starts a canvas pan, not an xterm selection. This
+      // capture handler runs before the canvas sets canvas-interacting, so the
+      // guard above can't catch the pan's opening mousedown — we'd rewrite its
+      // clientX/Y while every follow-up move (which lands on the now
+      // pointer-events:none terminal -> canvas) stays raw. The first pan delta
+      // would then be (raw - adjusted) and jump the camera on a zoomed canvas.
+      // xterm only needs adjusted coords for left-button selection, so leave
+      // non-left presses untouched.
+      if (e.type === 'mousedown' && e.button !== 0) return
+
       const effective = zoomLevel / renderScale
       if (Math.abs(effective - 1.0) < 0.001) return
 

--- a/src/renderer/settings/ProvidersSettings.tsx
+++ b/src/renderer/settings/ProvidersSettings.tsx
@@ -1,0 +1,25 @@
+// =============================================================================
+// ProvidersSettings — the agent ProvidersView surfaced as a main-Settings
+// section. Provider credentials (auth.json) and the custom OpenAI endpoint
+// (models.json) are GLOBAL and shared across every workspace (mirrored into each
+// workspace's .cate/pi-agent/), so they belong here alongside the rest of the
+// app settings, not only in the per-panel agent settings view.
+//
+// Storage is unchanged: ProvidersView talks to the same global AUTH_* /
+// AGENT_CUSTOM_MODELS_* IPC whether it is rendered here or inside the agent
+// panel. `embedded` drops its internal header so this section owns the chrome.
+// =============================================================================
+
+import { ProvidersView } from '../../agent/renderer/ProvidersView'
+
+export function ProvidersSettings() {
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-xs text-secondary mb-2">
+        Sign in to AI providers or store API keys. These credentials are shared by
+        every workspace and copied into each one for the agent to use.
+      </p>
+      <ProvidersView embedded />
+    </div>
+  )
+}

--- a/src/renderer/settings/SettingsWindow.tsx
+++ b/src/renderer/settings/SettingsWindow.tsx
@@ -24,6 +24,7 @@ import { FileExplorerSettings } from './FileExplorerSettings'
 import { ShortcutSettings } from './ShortcutSettings'
 import { NotificationSettings } from './NotificationSettings'
 import { UpdatesSettings } from './UpdatesSettings'
+import { ProvidersSettings } from './ProvidersSettings'
 import { SettingsSearchContext } from './SettingsSearchContext'
 
 const SECTIONS = [
@@ -35,6 +36,7 @@ const SECTIONS = [
   { title: 'Sidebar', component: SidebarSettings },
   { title: 'File Explorer', component: FileExplorerSettings },
   { title: 'Notifications', component: NotificationSettings },
+  { title: 'Providers', component: ProvidersSettings },
   { title: 'Updates', component: UpdatesSettings },
   { title: 'Shortcuts', component: ShortcutSettings },
 ] as const

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -20,6 +20,9 @@ import { confirmCloseRunningTerminals } from '../lib/confirmCloseTerminal'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useUIStateStore } from '../stores/uiStateStore'
+import { useUIStore } from '../stores/uiStore'
+import { SettingsWindow } from '../settings/SettingsWindow'
 import { applyTheme } from '../lib/themeManager'
 
 import { renderPanelComponent, PANEL_REGISTRY } from '../panels/registry'
@@ -53,11 +56,17 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   // window renders with default settings and ignores the user's preferences.
   useEffect(() => {
     useSettingsStore.getState().loadSettings()
+    useUIStateStore.getState().loadUIState()
   }, [])
   const activeThemeId = useSettingsStore((s) => s.activeThemeId)
   const customThemes = useSettingsStore((s) => s.customThemes)
   const systemLightThemeId = useSettingsStore((s) => s.systemLightThemeId)
   const systemDarkThemeId = useSettingsStore((s) => s.systemDarkThemeId)
+  // A detached AgentPanel routes provider sign-in to the main Cate Settings
+  // (Providers); render the settings window here so that button works.
+  const showSettings = useUIStore((s) => s.showSettings)
+  const settingsInitialTab = useUIStore((s) => s.settingsInitialTab)
+  const closeSettings = useUIStore((s) => s.closeSettings)
   useEffect(() => {
     applyTheme(activeThemeId)
   }, [activeThemeId, customThemes, systemLightThemeId, systemDarkThemeId])
@@ -427,6 +436,7 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
           />
         </div>
         <DragOverlay />
+        <SettingsWindow isOpen={showSettings} onClose={closeSettings} initialTab={settingsInitialTab ?? undefined} />
       </div>
     </DockStoreProvider>
   )

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -12,6 +12,9 @@ import { DragOverlay, setupCrossWindowDragListeners, useDragOp } from '../drag'
 import { renderPanelComponent, getPanelDef } from '../panels/registry'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useUIStateStore } from '../stores/uiStateStore'
+import { useUIStore } from '../stores/uiStore'
+import { SettingsWindow } from '../settings/SettingsWindow'
 import { applyTheme } from '../lib/themeManager'
 import { applyCanvasChildPanels } from '../lib/canvas/applyCanvasChildPanels'
 
@@ -29,6 +32,7 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
   // appearance and settings (theme, minimap, canvas grid, etc.).
   useEffect(() => {
     useSettingsStore.getState().loadSettings()
+    useUIStateStore.getState().loadUIState()
   }, [])
   const activeThemeId = useSettingsStore((s) => s.activeThemeId)
   const customThemes = useSettingsStore((s) => s.customThemes)
@@ -138,6 +142,13 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
 
   const { handleDragStart } = useDragOp()
 
+  // A detached AgentPanel routes provider sign-in to the main Cate Settings
+  // (Providers). Render the settings window here too so that button works in
+  // this window rather than being a no-op.
+  const showSettings = useUIStore((s) => s.showSettings)
+  const settingsInitialTab = useUIStore((s) => s.settingsInitialTab)
+  const closeSettings = useUIStore((s) => s.closeSettings)
+
   // If we have panel info from query params but no transfer yet, show a loading state
   const displayPanel = panel
 
@@ -217,6 +228,8 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
           <PanelContent panel={displayPanel} workspaceId={workspaceId ?? ''} />
         </Suspense>
       </div>
+
+      <SettingsWindow isOpen={showSettings} onClose={closeSettings} initialTab={settingsInitialTab ?? undefined} />
     </div>
   )
 }

--- a/src/renderer/stores/uiStateStore.ts
+++ b/src/renderer/stores/uiStateStore.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// UI State Store — Zustand mirror of <userData>/ui-state.json (minimap
+// placement). Transient, cosmetic, per-machine UI state; kept out of
+// settings.json. Loaded once on launch; single keys are written back fire-and-
+// forget through IPC (main debounces the disk write).
+// =============================================================================
+
+import { create } from 'zustand'
+import log from '../lib/logger'
+import type { UIState } from '../../shared/types'
+import { DEFAULT_UI_STATE } from '../../shared/types'
+
+interface ElectronUIStateAPI {
+  uiStateGetAll: () => Promise<Partial<UIState>>
+  uiStateSet: (key: string, value: unknown) => Promise<void>
+}
+
+function getAPI(): ElectronUIStateAPI | null {
+  const api = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>).electronAPI : null
+  return (api as ElectronUIStateAPI) ?? null
+}
+
+interface UIStateStore extends UIState {
+  _loaded: boolean
+  loadUIState: () => Promise<void>
+  setUIState: <K extends keyof UIState>(key: K, value: UIState[K]) => void
+}
+
+export const useUIStateStore = create<UIStateStore>((set) => ({
+  ...DEFAULT_UI_STATE,
+  _loaded: false,
+
+  async loadUIState() {
+    const api = getAPI()
+    if (!api) { set({ _loaded: true }); return }
+    try {
+      const stored = await api.uiStateGetAll()
+      const merged: Partial<UIState> = {}
+      for (const key of Object.keys(DEFAULT_UI_STATE) as (keyof UIState)[]) {
+        if (key in stored && stored[key] !== undefined) (merged as Record<string, unknown>)[key] = stored[key]
+      }
+      set({ ...merged, _loaded: true })
+    } catch {
+      set({ _loaded: true })
+    }
+  },
+
+  setUIState(key, value) {
+    set({ [key]: value } as Partial<UIStateStore>)
+    const api = getAPI()
+    if (api) api.uiStateSet(key, value).catch((err) => log.warn('[uiState] save failed for %s:', key, err))
+  },
+}))

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -3,51 +3,44 @@
 // =============================================================================
 
 import { create } from 'zustand'
+import type { SidebarView, SidebarLayout } from '../../shared/types'
+import { useSettingsStore } from './settingsStore'
 
 // -----------------------------------------------------------------------------
 // Store interface
 // -----------------------------------------------------------------------------
 
-export type SidebarView = 'workspaces' | 'explorer' | 'git' | 'parallelWork' | 'search'
+// SidebarView / SidebarLayout now live in shared/types (they're persisted in
+// settings.json); re-exported here so existing `from '../stores/uiStore'`
+// imports keep working.
+export type { SidebarView, SidebarLayout }
 export type SidebarSide = 'left' | 'right'
 
 /** Active canvas interaction tool (Figma-style). */
 export type CanvasTool = 'select' | 'hand'
 
-export interface SidebarLayout {
-  left: SidebarView[]
-  right: SidebarView[]
-}
-
-const LAYOUT_STORAGE_KEY = 'cate.sidebarLayout.v3'
 const ALL_VIEWS: SidebarView[] = ['workspaces', 'explorer', 'git', 'parallelWork', 'search']
-const DEFAULT_LAYOUT: SidebarLayout = {
-  left: ['workspaces', 'explorer', 'search'],
-  right: ['git', 'parallelWork'],
+
+/** Filter to known views and ensure every view appears exactly once (missing
+ *  ones appended to the right). Tolerates partial/legacy/hand-edited shapes. */
+export function normalizeSidebarLayout(raw: Partial<SidebarLayout> | null | undefined): SidebarLayout {
+  const left = (raw?.left ?? []).filter((v) => ALL_VIEWS.includes(v))
+  const right = (raw?.right ?? []).filter((v) => ALL_VIEWS.includes(v))
+  const seen = new Set<SidebarView>([...left, ...right])
+  for (const v of ALL_VIEWS) if (!seen.has(v)) right.push(v)
+  return { left, right }
 }
 
+// The sidebar layout is persisted in settings.json (see settingsStore). At
+// store-creation time settings may not be loaded yet, so we seed from whatever
+// the settings store currently holds (defaults until loadSettings resolves) and
+// App re-syncs the loaded value via setState afterwards.
 function loadLayout(): SidebarLayout {
-  try {
-    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LAYOUT_STORAGE_KEY) : null
-    if (!raw) return DEFAULT_LAYOUT
-    const parsed = JSON.parse(raw) as SidebarLayout
-    const left = (parsed.left ?? []).filter((v) => ALL_VIEWS.includes(v))
-    const right = (parsed.right ?? []).filter((v) => ALL_VIEWS.includes(v))
-    // Ensure every view is present exactly once — append missing ones to the right.
-    const seen = new Set<SidebarView>([...left, ...right])
-    for (const v of ALL_VIEWS) if (!seen.has(v)) right.push(v)
-    return { left, right }
-  } catch {
-    return DEFAULT_LAYOUT
-  }
+  return normalizeSidebarLayout(useSettingsStore.getState().sidebarLayout)
 }
 
 function saveLayout(layout: SidebarLayout) {
-  try {
-    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout))
-  } catch {
-    // ignore
-  }
+  useSettingsStore.getState().setSetting('sidebarLayout', layout)
 }
 
 interface UIStoreState {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -2,7 +2,7 @@
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
 
-import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, CustomOpenAIProvider, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, SearchOptions, SearchResultBatch, SearchDoneEvent, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, SidebarSession, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult, RemoteConnectSpec, CompanionConnectResult, CompanionStatusEvent, CompanionConnection, CompanionPhase, RemoteProjectEntry, SshHostEntry } from './types'
+import type { AgentCreateOptions, AgentEventEnvelope, AgentExtensionUIResponse, AgentImageAttachment, AgentModelRef, AgentRpcState, AgentSessionListEntry, AgentSessionStats, AgentSlashCommand, AgentThinkingLevel, AgentToolApprovalRequest, AppSettings, AgentState, AuthProviderDescriptor, AuthProviderStatus, CateWindowParams, CustomOpenAIProvider, DockWindowInitPayload, DetachedDockWindowSnapshot, DockStateSnapshot, FileSearchOptions, FileSearchResult, FileTreeNode, GitInfo, SearchOptions, SearchResultBatch, SearchDoneEvent, NotificationAction, OAuthFlowEvent, PanelState, PanelTransferSnapshot, PanelWindowSnapshot, PerfSnapshot, Point, SessionSnapshot, SidebarSession, TerminalActivity, WorkspaceInfo, WorkspaceMutationResult, RemoteConnectSpec, CompanionConnectResult, CompanionStatusEvent, CompanionConnection, CompanionPhase, RemoteProjectEntry, SshHostEntry, UIState } from './types'
 
 export interface NativeContextMenuItem {
   id?: string
@@ -349,6 +349,12 @@ export interface ElectronAPI {
 
   /** Reset all settings to defaults. */
   settingsReset(): Promise<void>
+
+  /** Get all transient UI state (minimap placement) from ui-state.json. */
+  uiStateGetAll(): Promise<UIState>
+
+  /** Set a single UI-state value. */
+  uiStateSet<K extends keyof UIState>(key: K, value: UIState[K]): Promise<void>
 
   /** Subscribe to setting-change broadcasts from main (key + new value). Returns unsubscribe. */
   onSettingsChanged(callback: (key: keyof AppSettings, value: unknown) => void): () => void

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -98,6 +98,12 @@ export const SETTINGS_OPEN_IN_EDITOR = 'settings:openInEditor'
 // file directly). Carries the full settings object so renderers merge live.
 export const SETTINGS_RELOADED = 'settings:reloaded' // main -> renderer (broadcast)
 
+// UI state — transient cosmetic UI placement (minimap position/size) persisted
+// to <userData>/ui-state.json. Kept out of settings.json so the user-facing
+// settings file stays focused on preferences.
+export const UI_STATE_GET_ALL = 'uiState:getAll' // renderer -> main
+export const UI_STATE_SET = 'uiState:set'        // renderer -> main
+
 // Session
 export const SESSION_FLUSH_SAVE = 'session:flushSave' // main -> renderer
 export const SESSION_FLUSH_SAVE_DONE = 'session:flushSaveDone' // renderer -> main

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -852,7 +852,7 @@ export interface SessionSnapshot {
   connection?: CompanionConnection
 }
 
-/** One persisted remote workspace (electron-store `remoteProjects`). Remote
+/** One persisted remote workspace (stored in `remote-workspaces.json`). Remote
  *  workspaces can't use the local `.cate/` project-state files (their tree lives
  *  on a companion), so their full restore snapshot + reconnect info is kept here,
  *  keyed by the `cate-companion://` locator. Local workspaces never appear here —
@@ -866,7 +866,7 @@ export interface RemoteProjectEntry {
   snapshot: SessionSnapshot
 }
 
-/** Persisted sidebar arrangement (electron-store `sidebarSession`). Keyed by
+/** Persisted sidebar arrangement (stored in `sidebar.json`). Keyed by
  *  workspace root paths — workspace IDs are runtime UUIDs and can't be persisted.
  *  Separate from `recentProjects` (which stays recency-ordered for the Welcome
  *  page) so manual order and the active workspace survive a restart. */
@@ -1041,6 +1041,15 @@ export const FILE_EXCLUSIONS: string[] = [
   'Pods',
 ]
 
+/** A sidebar view (left/right rail tabs). */
+export type SidebarView = 'workspaces' | 'explorer' | 'git' | 'parallelWork' | 'search'
+
+/** Which sidebar views live in the left vs. right rail. Persisted in settings. */
+export interface SidebarLayout {
+  left: SidebarView[]
+  right: SidebarView[]
+}
+
 export interface AppSettings {
   // General
   defaultShellPath: string
@@ -1159,6 +1168,16 @@ export interface AppSettings {
    *  src/main/auto-updater.ts (autoUpdater.allowPrerelease). Off by default, so
    *  stable users and the public website download are never offered betas. */
   betaUpdatesEnabled: boolean
+
+  // Agent
+  /** The user-pinned default model applied to every new agent chat, or null for
+   *  none. Was renderer localStorage (cate.agent.defaultModel.v1) before. */
+  agentDefaultModel: AgentModelRef | null
+
+  // Layout
+  /** Which sidebar views live in the left vs. right rail. Was renderer
+   *  localStorage (cate.sidebarLayout.v3) before. */
+  sidebarLayout: SidebarLayout
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -1225,6 +1244,39 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
   // Updates
   betaUpdatesEnabled: false,
+
+  // Agent
+  agentDefaultModel: null,
+
+  // Layout — keep in sync with the sidebar's default arrangement.
+  sidebarLayout: {
+    left: ['workspaces', 'explorer', 'search'],
+    right: ['git', 'parallelWork'],
+  },
+}
+
+// -----------------------------------------------------------------------------
+// UI state — transient, cosmetic per-machine UI placement (minimap position /
+// size). Persisted to `<userData>/ui-state.json` rather than settings.json so
+// the user-facing settings file stays focused on preferences. Was renderer
+// localStorage before.
+// -----------------------------------------------------------------------------
+
+export type CanvasCorner = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left'
+
+export interface UIState {
+  /** Corner the floating minimap is docked in. */
+  minimapCorner: CanvasCorner
+  /** Floating minimap size in px. */
+  minimapSize: { w: number; h: number }
+  /** Corner the minimap toggle button (canvas toolbar) is docked in. */
+  minimapButtonCorner: CanvasCorner
+}
+
+export const DEFAULT_UI_STATE: UIState = {
+  minimapCorner: 'bottom-right',
+  minimapSize: { w: 200, h: 150 },
+  minimapButtonCorner: 'bottom-right',
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Consolidates everything Cate persists onto one model: hand-editable JSON files under `userData`. Drops `electron-store`, moves provider management and a few renderer-only preferences into that model, and folds in a couple of unrelated fixes that were in the tree.

(Supersedes #288, which auto-closed when this branch was renamed.)

## Persistence

- New `jsonStateFile` factory captures the proven `settings.json` pattern (sync load, in-memory authority, debounced atomic write, chokidar external-edit watcher, corrupt-file quarantine) for reuse.
- `electron-store` is removed. Its four keys move to discrete files under `userData`:
  - `recentProjects` -> `recent-projects.json`
  - `sidebarSession` -> `sidebar.json`
  - `remoteProjects` (remote / SSH workspaces) -> `remote-workspaces.json`
  - `layouts` -> `layouts.json`
- One-time migration: on first launch the legacy `config.json` is read, any missing file is seeded from it, then `config.json` is deleted. Idempotent and corrupt-safe (an unparseable `config.json` is quarantined and left in place).
- IPC channels and payloads are unchanged, so renderer consumers are untouched.

## Canvas background image

- Picking a wallpaper now copies it into `userData/canvas-backgrounds/<hash>.<ext>` and stores that managed path, instead of referencing the original file. It survives the source being moved or deleted and stays self-contained. Old copies are pruned on change and at startup.

## Providers

- Provider sign-in and credentials now live in the main Cate Settings under a new **Providers** section. Credentials are global and already shared across every workspace (`pi-agent/auth.json`, mirrored into each workspace), so one home makes sense.
- The agent panel no longer has a Providers tab. Its settings keep agents / prompts / skills / extensions. The "Connect {provider}" button and the model picker's "Manage" open the main Settings Providers section. Detached panel and dock windows render the settings window so those buttons work there too.
- The Providers section matches the width and padding of the other settings rows.

## Renderer preferences off localStorage

- `agentDefaultModel` and `sidebarLayout` move into `settings.json` (the settings schema gains an `object` type for nullable structured values).
- Minimap placement (corner, size, toggle-button corner) moves into a new `ui-state.json` with its own small main-side store and IPC.
- A single module migrates all five legacy `localStorage` keys once, then clears them.

## Other fixes in this branch

- `shellEnv`: strip `ELECTRON_*` and `npm_*` from the resolved shell environment so they do not leak into spawned shells, terminals, or the companion daemon (e.g. `ELECTRON_RUN_AS_NODE` booting a child Electron as plain Node, or npm lifecycle vars polluting dev-mode terminals).
- `TerminalPanel`: the coordinate-rewrite capture handler ignores non-left mouse presses, so a middle or right button canvas pan started over a terminal no longer rewrites its opening mousedown and jumps the camera on a zoomed canvas.
- Remove the obsolete legacy `Sessions/session.json` to `.cate/` migration.

## userData layout after this change

`settings.json`, `boot.json`, `recent-projects.json`, `sidebar.json`, `remote-workspaces.json`, `layouts.json`, `ui-state.json`, `canvas-backgrounds/`, plus the existing `pi-agent/`, companion SSH files, terminal logs, analytics, and grants. `config.json` is gone after migration.

## Testing

- New unit tests: `jsonStateFile`, `workspaceStateStore` migration, `canvasBackgroundStore`, `migrateLegacyLocalStorage`, plus the updated `store` resilience test.
- `npm run typecheck`, `npm test` (97 files, 887 passing), and `npm run build` all pass.
