### PR TITLE
feat(canvas): Enter focuses the Cmd+Arrow-selected panel

### DIFF
--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -359,6 +359,29 @@ export function useShortcuts(): void {
         }
       }
 
+      // Enter — activate (focus) the selected-but-unfocused node. Cmd+Arrow
+      // navigation selects + centres a node without grabbing keyboard focus so
+      // jumps can be chained; Enter is the deliberate "step into this panel"
+      // gesture. Skipped while typing, in a terminal, or when a list/overlay
+      // owns the key, and only fires when exactly one node is selected and it
+      // isn't already focused.
+      if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        if (terminalHasFocus || isTextSurfaceFocused()) return
+        if (isKeyNavFocused() || isSidebarKeyNavFocused()) return
+        const uiNow = useUIStore.getState()
+        if (uiNow.showCommandPalette || uiNow.showNodeSwitcher) return
+        const state = canvasStore()
+        if (state.selectedNodeIds.size === 1) {
+          const id = [...state.selectedNodeIds][0]
+          if (id !== state.focusedNodeId && state.nodes[id]) {
+            e.preventDefault()
+            e.stopPropagation()
+            canvasStore().focusNode(id)
+            return
+          }
+        }
+      }
+
       // --- Shortcut matching ---
       const action = shortcutStore().matchEvent(e)
       if (!action) return


### PR DESCRIPTION
Cmd+Arrow jumps between panels by selecting and centring them without grabbing keyboard focus, so jumps can be chained. This adds **Enter** as the deliberate "step into this panel" gesture: it focuses the single selected, not-yet-focused node.

Stands down while typing, in a terminal, when a keyboard-nav list or the sidebar owns the key, or when an overlay (command palette / node switcher) is open. Only fires when exactly one node is selected and it isn't already focused.

## Test
- Cmd+Arrow to a panel, press Enter, panel focuses and takes keyboard input
- Enter does nothing while a terminal/editor/input is focused, or with no/multi selection