### PR TITLE
feat(canvas): rename Pi Agent to Cate agent, fix toolbar tooltips & tool shortcuts

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -485,13 +485,16 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
         items.push(
           { id: 'new-editor', label: 'New Editor' },
           { id: 'new-browser', label: 'New Browser' },
-          { id: 'new-agent', label: 'New Pi Agent' },
+          { id: 'new-agent', label: 'New Cate agent' },
           { id: 'new-canvas', label: 'New Canvas' },
           { type: 'separator' as const },
         )
       }
       items.push(
         { id: 'new-region', label: 'New Region' },
+        { type: 'separator' as const },
+        { id: 'auto-layout', label: 'Auto Layout' },
+        { id: 'zoom-to-fit', label: 'Zoom to Fit' },
       )
       const id = await window.electronAPI.showContextMenu(items)
       if (cancelled) return
@@ -534,6 +537,12 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
         case 'new-canvas': onCreateAtPoint?.('canvas', point); break
         case 'new-region':
           canvasApi.getState().addRegion('Region', point, { width: 400, height: 300 })
+          break
+        case 'auto-layout':
+          canvasApi.getState().autoLayout()
+          break
+        case 'zoom-to-fit':
+          canvasApi.getState().zoomToFit()
           break
       }
     }

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -3,7 +3,7 @@
 // Ported from CanvasToolbar.swift.
 // =============================================================================
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Terminal,
@@ -12,9 +12,6 @@ import {
   Minus,
   Plus,
   Square,
-  ArrowsOutSimple,
-  DotsThree,
-  SquaresFour,
   MapTrifold,
   Cursor,
   Hand,
@@ -29,6 +26,7 @@ import { useShortcutStore } from '../stores/shortcutStore'
 import { displayString, PANEL_DEFAULT_SIZES } from '../../shared/types'
 import { useAppStore } from '../stores/appStore'
 import { UpdateButton } from './UpdateButton'
+import { Tooltip } from '../sidebar/Tooltip'
 
 // The minimap pill can be docked in any of the four canvas corners. The choice
 // persists across sessions in ui-state.json (via the UI-state store).
@@ -44,8 +42,6 @@ interface CanvasToolbarProps {
   onNewAgent: () => void
   onNewCanvas: () => void
   onNewRegion: () => void
-  onAutoLayout: () => void
-  onZoomToFit: () => void
   onZoomIn: () => void
   onZoomOut: () => void
 }
@@ -61,16 +57,18 @@ const ToolbarButton: React.FC<{
   const sizeClass = size === 'panel' ? 'w-9 h-9' : 'w-8 h-8'
   const activeClass = active ? 'bg-hover-strong' : 'bg-transparent'
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      onMouseDown={onMouseDown}
-      title={title}
-      style={{ WebkitTapHighlightColor: 'transparent' }}
-      className={`${sizeClass} ${activeClass} flex items-center justify-center rounded-full text-secondary hover:text-primary hover:bg-hover-strong active:bg-hover-strong active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100`}
-    >
-      {children}
-    </button>
+    <Tooltip label={title} placement="top">
+      <button
+        type="button"
+        onClick={onClick}
+        onMouseDown={onMouseDown}
+        aria-label={title}
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+        className={`${sizeClass} ${activeClass} flex items-center justify-center rounded-full text-secondary hover:text-primary hover:bg-hover-strong active:bg-hover-strong active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100`}
+      >
+        {children}
+      </button>
+    </Tooltip>
   )
 }
 
@@ -164,49 +162,29 @@ const TerminalSpawnButton: React.FC<{ onClick: () => void; canvasPanelId: string
   )
 }
 
-// A tool-mode button with an always-on corner key badge that fills when active.
+// A tool-mode button that fills when active. The bound shortcut is surfaced on
+// hover via the shared Tooltip (native `title` tooltips are flaky in Electron).
 const ModeButton: React.FC<{
   onClick: () => void
   title: string
   active: boolean
-  badge: string
   children: React.ReactNode
-}> = ({ onClick, title, active, badge, children }) => {
+}> = ({ onClick, title, active, children }) => {
   const activeClass = active ? 'bg-hover-strong' : 'bg-transparent'
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      style={{ WebkitTapHighlightColor: 'transparent' }}
-      className={`group relative w-9 h-9 ${activeClass} flex items-center justify-center rounded-full ${active ? 'text-primary' : 'text-secondary'} hover:text-primary hover:bg-hover-strong active:bg-hover-strong active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100`}
-    >
-      {children}
-      <span
-        className="absolute bottom-0 right-0.5 font-mono leading-none pointer-events-none select-none opacity-0 group-hover:opacity-100 transition-opacity duration-100"
-        style={{ fontSize: 7, color: 'var(--text-muted)' }}
+    <Tooltip label={title} placement="top">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={title}
+        style={{ WebkitTapHighlightColor: 'transparent' }}
+        className={`w-9 h-9 ${activeClass} flex items-center justify-center rounded-full ${active ? 'text-primary' : 'text-secondary'} hover:text-primary hover:bg-hover-strong active:bg-hover-strong active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100`}
       >
-        {badge}
-      </span>
-    </button>
+        {children}
+      </button>
+    </Tooltip>
   )
 }
-
-const MenuItem: React.FC<{
-  onClick: () => void
-  icon: React.ReactNode
-  label: string
-}> = ({ onClick, icon, label }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    style={{ WebkitTapHighlightColor: 'transparent' }}
-    className="group w-full flex items-center justify-between gap-3 px-2.5 py-1 rounded-md text-left text-[13px] text-primary bg-transparent hover:bg-focus-blue hover:text-inverse focus:outline-none focus-visible:outline-none transition-colors"
-  >
-    <span>{label}</span>
-    <span className="w-4 h-4 flex items-center justify-center opacity-80 group-hover:opacity-100">{icon}</span>
-  </button>
-)
 
 const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   canvasPanelId,
@@ -217,8 +195,6 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   onNewAgent,
   onNewCanvas,
   onNewRegion,
-  onAutoLayout,
-  onZoomToFit,
   onZoomIn,
   onZoomOut,
 }) => {
@@ -229,10 +205,12 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   const setActiveTool = useUIStore((s) => s.setActiveTool)
   const selectKey = useShortcutStore((s) => displayString(s.shortcuts.toolSelect))
   const handKey = useShortcutStore((s) => displayString(s.shortcuts.toolHand))
+  const newBrowserKey = useShortcutStore((s) => displayString(s.shortcuts.newBrowser))
+  const newEditorKey = useShortcutStore((s) => displayString(s.shortcuts.newEditor))
+  const zoomInKey = useShortcutStore((s) => displayString(s.shortcuts.zoomIn))
+  const zoomOutKey = useShortcutStore((s) => displayString(s.shortcuts.zoomOut))
+  const zoomResetKey = useShortcutStore((s) => displayString(s.shortcuts.zoomReset))
   const zoomText = `${Math.round(zoom * 100)}%`
-
-  const [menuOpen, setMenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement | null>(null)
 
   // Minimap pill docking corner + drag-to-dock handling. The toggle button
   // doubles as a drag handle: a click toggles the map, a drag past a small
@@ -279,30 +257,6 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
     toggleMinimapOpen()
   }
 
-  // Close drop-up on outside click / Escape
-  useEffect(() => {
-    if (!menuOpen) return
-    const onDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false)
-      }
-    }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setMenuOpen(false)
-    }
-    window.addEventListener('mousedown', onDown)
-    window.addEventListener('keydown', onKey)
-    return () => {
-      window.removeEventListener('mousedown', onDown)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [menuOpen])
-
-  const pick = (fn: () => void) => () => {
-    fn()
-    setMenuOpen(false)
-  }
-
   return (
     <>
     <div
@@ -312,32 +266,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
         right: 'var(--cate-right-sidebar-width, 0px)',
       }}
     >
-      <div ref={menuRef} data-onboarding="toolbar" className="relative pointer-events-auto">
-        {/* Drop-up menu */}
-        {menuOpen && (
-          <div
-            data-theme="dark-warm"
-            className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 min-w-[200px] rounded-lg border border-subtle bg-surface-4/95 backdrop-blur-xl backdrop-saturate-150 shadow-[0_10px_30px_-10px_var(--shadow-node)] p-1"
-          >
-            <MenuItem
-              onClick={pick(onNewRegion)}
-              icon={<Square size={16} />}
-              label="New Region"
-            />
-            <div className="h-px bg-surface-5 my-1" />
-            <MenuItem
-              onClick={pick(onAutoLayout)}
-              icon={<SquaresFour size={16} />}
-              label="Auto Layout"
-            />
-            <MenuItem
-              onClick={pick(onZoomToFit)}
-              icon={<ArrowsOutSimple size={16} />}
-              label="Zoom to Fit"
-            />
-          </div>
-        )}
-
+      <div data-onboarding="toolbar" className="relative pointer-events-auto">
         <div className="rounded-full border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
           <div className="flex items-center gap-0.5 px-1 py-1">
             {/* Interaction tools (Select / Hand) */}
@@ -345,7 +274,6 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
               onClick={() => setActiveTool('select')}
               title={`Select tool (${selectKey})`}
               active={activeTool === 'select'}
-              badge={selectKey}
             >
               <Cursor size={18} />
             </ModeButton>
@@ -353,7 +281,6 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
               onClick={() => setActiveTool('hand')}
               title={`Hand tool — pan (${handKey})`}
               active={activeTool === 'hand'}
-              badge={handKey}
             >
               <Hand size={18} />
             </ModeButton>
@@ -363,43 +290,40 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
 
             {/* Basic panel buttons */}
             <TerminalSpawnButton onClick={onNewTerminal} canvasPanelId={canvasPanelId} />
-            <ToolbarButton onClick={onNewBrowser} title="Browser" size="panel">
+            <ToolbarButton onClick={onNewBrowser} title={`Browser (${newBrowserKey})`} size="panel">
               <Globe size={18} />
             </ToolbarButton>
-            <ToolbarButton onClick={onNewEditor} title="Editor" size="panel">
+            <ToolbarButton onClick={onNewEditor} title={`Editor (${newEditorKey})`} size="panel">
               <FileText size={18} />
             </ToolbarButton>
-            <ToolbarButton onClick={onNewAgent} title="Pi Agent" size="panel">
+            <ToolbarButton onClick={onNewAgent} title="Cate agent" size="panel">
               <CateLogo size={18} />
+            </ToolbarButton>
+
+            {/* Add Region */}
+            <ToolbarButton onClick={onNewRegion} title="Add Region" size="panel">
+              <Square size={18} />
             </ToolbarButton>
 
             {/* Divider */}
             <div className="w-px h-5 bg-surface-5 mx-1" />
 
-            {/* More — opens drop-up with extra creators */}
-            <ToolbarButton
-              onClick={() => setMenuOpen((v) => !v)}
-              title="More…"
-              size="panel"
-              active={menuOpen}
-            >
-              <DotsThree size={18} />
-            </ToolbarButton>
-
             {/* Zoom controls */}
-            <ToolbarButton onClick={onZoomOut} title="Zoom Out" size="zoom">
+            <ToolbarButton onClick={onZoomOut} title={`Zoom Out (${zoomOutKey})`} size="zoom">
               <Minus size={16} />
             </ToolbarButton>
-            <button
-              type="button"
-              onClick={() => canvasApi.getState().animateZoomTo(1.0)}
-              title="Reset zoom to 100%"
-              style={{ WebkitTapHighlightColor: 'transparent' }}
-              className="text-[11px] font-mono text-secondary hover:text-primary min-w-[40px] text-center select-none rounded-full bg-transparent hover:bg-hover-strong active:bg-hover-strong cursor-pointer px-1.5 py-1 focus:outline-none focus-visible:outline-none transition-all duration-100"
-            >
-              {zoomText}
-            </button>
-            <ToolbarButton onClick={onZoomIn} title="Zoom In" size="zoom">
+            <Tooltip label={`Reset zoom to 100% (${zoomResetKey})`} placement="top">
+              <button
+                type="button"
+                onClick={() => canvasApi.getState().animateZoomTo(1.0)}
+                aria-label={`Reset zoom to 100% (${zoomResetKey})`}
+                style={{ WebkitTapHighlightColor: 'transparent' }}
+                className="text-[11px] font-mono text-secondary hover:text-primary min-w-[40px] text-center select-none rounded-full bg-transparent hover:bg-hover-strong active:bg-hover-strong cursor-pointer px-1.5 py-1 focus:outline-none focus-visible:outline-none transition-all duration-100"
+              >
+                {zoomText}
+              </button>
+            </Tooltip>
+            <ToolbarButton onClick={onZoomIn} title={`Zoom In (${zoomInKey})`} size="zoom">
               <Plus size={16} />
             </ToolbarButton>
           </div>

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -13,9 +13,6 @@ import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import { confirmDeleteRegion } from '../lib/confirmDeleteRegion'
 import { confirmClosePanels } from '../lib/confirmClosePanels'
 
-// Single-key (no-modifier) tool shortcuts (V, H) — suppressed while typing.
-const TOOL_ACTIONS = new Set<ShortcutAction>(['toolSelect', 'toolHand'])
-
 // Cmd+Arrow panel navigation — moves the selection cursor between nodes.
 const NAVIGATE_ACTIONS = new Set<ShortcutAction>([
   'navigateUp', 'navigateDown', 'navigateLeft', 'navigateRight',
@@ -389,11 +386,10 @@ export function useShortcuts(): void {
       // When panel switcher is open, only handle the toggle shortcut
       const ui = useUIStore.getState()
 
-      // Single-key tool shortcuts (V, H) must not fire while typing in a
-      // terminal/editor.
-      if (TOOL_ACTIONS.has(action)) {
-        if (terminalHasFocus || isTextSurfaceFocused()) return
-      }
+      // Tool shortcuts (Select/Hand) are ⌘⇧ combos, so they intentionally fire
+      // even while a terminal/editor is focused — we intercept and preventDefault
+      // before the surface sees the chord. No typing-suppression needed: a bare
+      // letter is never consumed for tool switching.
 
       // Cmd+Arrow navigation / Shift+Arrow panning.
       if (NAVIGATE_ACTIONS.has(action) || PAN_ACTIONS.has(action)) {

--- a/src/renderer/onboarding/steps.ts
+++ b/src/renderer/onboarding/steps.ts
@@ -43,7 +43,7 @@ export const ONBOARDING_STEPS: OnboardingStep[] = [
     // (which only appears once the canvas has panels, e.g. on replay).
     target: '[data-onboarding="welcome-actions"], [data-onboarding="toolbar"]',
     title: 'Add anything',
-    body: 'Spin up a terminal, editor, browser, or Pi agent from here or the bottom toolbar. Drag one straight onto the canvas to place it exactly where you want.',
+    body: 'Spin up a terminal, editor, browser, or Cate agent from here or the bottom toolbar. Drag one straight onto the canvas to place it exactly where you want.',
   },
   {
     id: 'sidebar',

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -270,10 +270,6 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
     store.getState().animateZoomTo(zoomLevel - 0.1)
   }, [zoomLevel, store])
 
-  const onZoomToFit = useCallback(() => {
-    store.getState().zoomToFit()
-  }, [store])
-
   // Compute the current canvas-space center of the viewport so newly created
   // items appear where the user is currently looking.
   const getViewCenter = useCallback((): Point => {
@@ -298,10 +294,6 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
   const onNewRegion = useCallback(() => {
     store.getState().addRegion('Region', getViewCenter(), { width: 400, height: 300 })
   }, [store, getViewCenter])
-
-  const onAutoLayout = useCallback(() => {
-    store.getState().autoLayout()
-  }, [store])
 
   return (
     <CanvasStoreProvider store={store}>
@@ -346,8 +338,6 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
             onNewAgent={onNewAgent}
             onNewCanvas={onNewCanvas}
             onNewRegion={onNewRegion}
-            onAutoLayout={onAutoLayout}
-            onZoomToFit={onZoomToFit}
             onZoomIn={onZoomIn}
             onZoomOut={onZoomOut}
           />

--- a/src/renderer/sidebar/Tooltip.tsx
+++ b/src/renderer/sidebar/Tooltip.tsx
@@ -9,10 +9,11 @@ import { createPortal } from 'react-dom'
 
 interface TooltipProps {
   label: string
+  placement?: 'top' | 'bottom'
   children: React.ReactNode
 }
 
-export const Tooltip: React.FC<TooltipProps> = ({ label, children }) => {
+export const Tooltip: React.FC<TooltipProps> = ({ label, placement = 'bottom', children }) => {
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -24,7 +25,7 @@ export const Tooltip: React.FC<TooltipProps> = ({ label, children }) => {
     const el = (host.firstElementChild as HTMLElement | null) ?? host
     const r = el.getBoundingClientRect()
     const left = r.left + r.width / 2
-    const top = r.bottom + 4
+    const top = placement === 'top' ? r.top - 4 : r.bottom + 4
     timer.current = setTimeout(() => setPos({ top, left }), 250)
   }
   const hide = (): void => {
@@ -39,8 +40,12 @@ export const Tooltip: React.FC<TooltipProps> = ({ label, children }) => {
       {pos &&
         createPortal(
           <div
-            className="fixed z-[100] -translate-x-1/2 pointer-events-none px-1.5 py-0.5 rounded bg-surface-2 border border-subtle text-[11px] text-primary whitespace-nowrap shadow-lg"
-            style={{ top: pos.top, left: pos.left }}
+            className="fixed z-[100] pointer-events-none px-1.5 py-0.5 rounded bg-surface-2 border border-subtle text-[11px] text-primary whitespace-nowrap shadow-lg"
+            style={{
+              top: pos.top,
+              left: pos.left,
+              transform: placement === 'top' ? 'translate(-50%, -100%)' : 'translateX(-50%)',
+            }}
           >
             {label}
           </div>,

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -153,7 +153,7 @@ export const CommandPalette: React.FC = () => {
       },
       {
         id: 'newAgent',
-        title: 'New Pi Agent',
+        title: 'New Cate agent',
         shortcutText: '',
         icon: <AgentIcon />,
         action: () => createAgent(selectedWorkspaceId, undefined, dockCenter),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -665,8 +665,10 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   undo: storedShortcut('z', { command: true }),
   redo: storedShortcut('z', { command: true, shift: true }),
   deleteNode: storedShortcut('Backspace', { command: true }),
-  toolSelect: storedShortcut('v'),
-  toolHand: storedShortcut('h'),
+  // Modifier combos (not bare V/H) so they switch tools even while typing in a
+  // terminal/editor — and ⌘⇧D avoids the macOS ⌘H "Hide Application" clash.
+  toolSelect: storedShortcut('s', { command: true, shift: true }),
+  toolHand: storedShortcut('d', { command: true, shift: true }),
   navigateUp: storedShortcut('↑', { command: true }),
   navigateDown: storedShortcut('↓', { command: true }),
   navigateLeft: storedShortcut('←', { command: true }),


### PR DESCRIPTION
## Summary
- Rename **"Pi Agent" → "Cate agent"** across user-facing surfaces (toolbar tooltip, command palette, canvas right-click menu, onboarding). Internal `// Pi agent` RPC comments left unchanged.
- Render toolbar tooltips via the portal-based `Tooltip` (new `placement="top"`) instead of the native `title` attribute, which is unreliable in Electron; tooltips now surface the bound shortcut.
- Drop the toolbar **"More…"** drop-up: promote **Add Region** to a direct toolbar button and move **Auto Layout** / **Zoom to Fit** into the canvas right-click menu.
- Rebind the tool shortcuts to typing-safe modifier combos: **Select ⇧⌘S**, **Hand ⇧⌘D**. The previous bare V/H were suppressed while a panel was focused (and ⌘H collides with the macOS "Hide Application" shortcut). The new combos switch tools even while a terminal/editor is focused — the capture-phase handler intercepts them before the surface sees the chord — while a bare letter is never hijacked.

## Notes
- Tool shortcuts aren't in the native macOS menu bar (the old V/H weren't either); they're handled in-app. Can add menu entries for discoverability if wanted.
- Shortcut bindings aren't persisted, so the new defaults take effect on next launch.

## Test plan
- `npm run typecheck` clean for changed files.
- Shortcut unit tests pass (`useShortcuts.activeCanvas.test.tsx`).
- Manual: hover toolbar buttons → tooltips show with shortcuts; ⇧⌘S / ⇧⌘D switch Select/Hand tools while a terminal is focused.