### PR TITLE
feat(sidebar): push the dock instead of overlaying it

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -543,14 +543,19 @@ function MainApp() {
     >
       <TitlebarStrip />
       <div className="relative flex-1 min-h-0 min-w-0">
-      {/* Main window shell fills the viewport so the canvas extends edge to
-          edge under the translucent sidebars. The top-level dock tab bar
-          insets itself via CSS vars (--cate-left/right-sidebar-width) so the
-          Canvas tab pill stays next to the sidebar.
+      {/* Layout row: left sidebar | shell | right sidebar. The sidebars are real
+          flex items that push the shell rather than overlaying it; their own
+          outer width (collapsing to 0 when empty) drives the layout. Kept in its
+          own row so the overlay/modal layer below never participates in flex. */}
+      <div className="absolute inset-0 flex flex-row">
+      <div data-app-sidebar="left" className="flex-shrink-0 h-full"><Sidebar /></div>
+
+      {/* Main window shell — fills the space between the two sidebars.
 
           Wrapped in the active workspace's dock store and KEYED by the
           workspace id so the whole dock/canvas subtree remounts on switch and
           reads that workspace's own stores — full per-workspace isolation. */}
+      <div className="relative flex-1 min-h-0 min-w-0">
       <DockStoreProvider store={activeDockStore}>
       <MainWindowShell
         key={selectedWorkspaceId}
@@ -560,17 +565,14 @@ function MainApp() {
       />
       </DockStoreProvider>
 
-      {/* Companion lock: covers the canvas area (z-10, beneath the z-20 sidebars
-          so workspace switching stays live) when the selected remote workspace's
-          companion is down. Renders nothing for local/healthy workspaces. */}
+      {/* Companion lock: covers the canvas area when the selected remote
+          workspace's companion is down. Sits inside the shell wrapper so it
+          never covers the sidebars. Renders nothing for local/healthy ws. */}
       <CompanionLockOverlay />
-
-      {/* Sidebars: absolutely-positioned overlays on top of the shell */}
-      <div className="absolute inset-y-0 left-0 z-20 flex pointer-events-none">
-        <div data-app-sidebar="left" className="pointer-events-auto h-full"><Sidebar /></div>
       </div>
-      <div className="absolute inset-y-0 right-0 z-20 flex pointer-events-none">
-        <div data-app-sidebar="right" className="pointer-events-auto h-full"><RightSidebar /></div>
+
+      {/* Right sidebar — real flex item, pushes the shell from the right. */}
+      <div data-app-sidebar="right" className="flex-shrink-0 h-full"><RightSidebar /></div>
       </div>
 
       {/* Single shared file-drag drop indicator (canvas / dock / agent) */}

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -127,11 +127,10 @@ const PlacementHint: React.FC<{ canvasRef: React.RefObject<HTMLDivElement> }> = 
   if (!pending) return null
   const r = canvasRef.current?.getBoundingClientRect()
   if (!r) return null
-  const sb = (side: 'left' | 'right') =>
-    (document.querySelector(`[data-app-sidebar="${side}"]`) as HTMLElement | null)?.getBoundingClientRect()
-  const left = sb('left'); const right = sb('right')
-  const visLeft = left && left.width > 0 ? left.right : r.left
-  const visRight = right && right.width > 0 ? right.left : r.right
+  // The sidebars now push the canvas rather than overlaying it, so the canvas
+  // rect itself is the visible region.
+  const visLeft = r.left
+  const visRight = r.right
   const count = pending.candidates.length
   const armed = pending.freeArmed
 
@@ -299,10 +298,23 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
     }
   }, [])
 
-  // Track container size for grid visibility calculations
+  // Track container size for grid visibility, and keep canvas content anchored
+  // to whichever container edge stayed put when the OTHER edge moves — so a
+  // sidebar (or dock split) opening pushes content by its full width instead of
+  // letting it slide under the newly covered edge.
+  //
+  // One symmetric rule, no knowledge of sidebars: the world transform is
+  // anchored to the container's top-left, so a moving LEFT edge already drags
+  // content along; we only need to add the RIGHT edge's movement when the left
+  // edge held still (the right sidebar / a split divider). A window resize moves
+  // the right edge too but should NOT chase content, so we gate on the window
+  // width being unchanged. Pure translations don't change size and never fire.
   useEffect(() => {
     const el = canvasRef.current
     if (!el) return
+
+    let prevRect = el.getBoundingClientRect()
+    let prevWindowWidth = window.innerWidth
 
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -312,6 +324,16 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
         }
         setContainerSize(size)
         canvasApi.getState().setContainerSize(size)
+      }
+      const rect = el.getBoundingClientRect()
+      const windowResized = window.innerWidth !== prevWindowWidth
+      const dLeft = rect.left - prevRect.left
+      const dRight = rect.right - prevRect.right
+      prevRect = rect
+      prevWindowWidth = window.innerWidth
+      if (!windowResized && Math.abs(dLeft) < 0.5 && Math.abs(dRight) > 0.5) {
+        const { viewportOffset } = canvasApi.getState()
+        canvasApi.setState({ viewportOffset: { x: viewportOffset.x + dRight, y: viewportOffset.y } })
       }
     })
 

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -259,13 +259,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
 
   return (
     <>
-    <div
-      className="absolute bottom-4 z-50 flex justify-center pointer-events-none"
-      style={{
-        left: 'var(--cate-left-sidebar-width, 0px)',
-        right: 'var(--cate-right-sidebar-width, 0px)',
-      }}
-    >
+    <div className="absolute inset-x-0 bottom-4 z-50 flex justify-center pointer-events-none">
       <div data-onboarding="toolbar" className="relative pointer-events-auto">
         <div className="rounded-full border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
           <div className="flex items-center gap-0.5 px-1 py-1">
@@ -340,9 +334,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
       className="absolute z-50 flex gap-2"
       style={{
         ...(mmBottom ? { bottom: '1rem' } : { top: '1rem' }),
-        ...(mmRight
-          ? { right: 'calc(1rem + var(--cate-right-sidebar-width, 0px))' }
-          : { left: 'calc(1rem + var(--cate-left-sidebar-width, 0px))' }),
+        ...(mmRight ? { right: '1rem' } : { left: '1rem' }),
         // Keep the pill hard against the docked corner; the UpdateButton sits inboard.
         flexDirection: mmRight ? 'row' : 'row-reverse',
         alignItems: mmBottom ? 'flex-end' : 'flex-start',

--- a/src/renderer/docking/DockSplitContainer.tsx
+++ b/src/renderer/docking/DockSplitContainer.tsx
@@ -10,22 +10,12 @@ import DockResizeHandle from './DockResizeHandle'
 
 interface DockSplitContainerProps {
   node: DockSplitNode
-  renderNode: (
-    node: import('../../shared/types').DockLayoutNode,
-    leftEdge: boolean,
-    rightEdge: boolean,
-  ) => React.ReactNode
-  /** True if this split's left edge sits on the viewport's left edge. */
-  leftEdge?: boolean
-  /** True if this split's right edge sits on the viewport's right edge. */
-  rightEdge?: boolean
+  renderNode: (node: import('../../shared/types').DockLayoutNode) => React.ReactNode
 }
 
 export default function DockSplitContainer({
   node,
   renderNode,
-  leftEdge = false,
-  rightEdge = false,
 }: DockSplitContainerProps) {
   const setSplitRatio = useDockStoreContext((s) => s.setSplitRatio)
   const isHorizontal = node.direction === 'horizontal'
@@ -69,13 +59,6 @@ export default function DockSplitContainer({
       className={`flex h-full w-full min-h-0 min-w-0 ${isHorizontal ? 'flex-row' : 'flex-col'}`}
     >
       {node.children.map((child, i) => {
-        // Vertical splits stack top/bottom, so every child still touches the
-        // viewport's left/right edges. Horizontal splits only let the first
-        // child touch the left edge and the last touch the right edge.
-        const childLeftEdge = isHorizontal ? leftEdge && i === 0 : leftEdge
-        const childRightEdge = isHorizontal
-          ? rightEdge && i === node.children.length - 1
-          : rightEdge
         return (
         <React.Fragment key={child.type === 'tabs' ? child.id : child.id}>
           <div
@@ -84,7 +67,7 @@ export default function DockSplitContainer({
             }}
             className="min-h-0 min-w-0 overflow-hidden"
           >
-            {renderNode(child, childLeftEdge, childRightEdge)}
+            {renderNode(child)}
           </div>
           {i < node.children.length - 1 && (
             <DockResizeHandle

--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -44,14 +44,12 @@ interface DockTabStackProps {
   localOnly?: boolean
   /** When true, render a slimmer tab bar (used by canvas-node mini-docks). */
   compact?: boolean
-  leftEdge?: boolean
-  rightEdge?: boolean
   /** When true, this stack's drop-zone returns a null rect so it can't be
    *  hit-tested as a target. */
   dropDisabled?: boolean
 }
 
-export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPanelTitle, onClosePanel, getPanel: getPanelProp, workspaceId: workspaceIdProp, onPanelRemoved, onPanelRenamed, excludePanelTypes, trailingControls, onTabBarMouseDown, localOnly, compact, leftEdge, rightEdge, dropDisabled }: DockTabStackProps) {
+export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPanelTitle, onClosePanel, getPanel: getPanelProp, workspaceId: workspaceIdProp, onPanelRemoved, onPanelRenamed, excludePanelTypes, trailingControls, onTabBarMouseDown, localOnly, compact, dropDisabled }: DockTabStackProps) {
   const dockStoreApi = useDockStoreApi()
   const stackRef = useRef<HTMLDivElement>(null)
 
@@ -229,12 +227,6 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         style={{
           backgroundColor: 'var(--node-chrome-bg, var(--surface-1))',
           ...(onTabBarMouseDown ? { cursor: 'grab' } : null),
-          ...(zoneProp === 'center' && leftEdge
-            ? { marginLeft: 'var(--cate-left-sidebar-width, 0px)' }
-            : null),
-          ...(zoneProp === 'center' && rightEdge
-            ? { marginRight: 'var(--cate-right-sidebar-width, 0px)' }
-            : null),
         }}
         onContextMenu={onEmptyContextMenu}
         onMouseDown={(e) => {
@@ -326,17 +318,7 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
       </div>
 
       {/* Active panel content */}
-      <div
-        className="flex-1 min-h-0 overflow-hidden"
-        style={{
-          ...(zoneProp === 'center' && leftEdge && activePanel?.type !== 'canvas'
-            ? { marginLeft: 'var(--cate-left-sidebar-width, 0px)' }
-            : null),
-          ...(zoneProp === 'center' && rightEdge && activePanel?.type !== 'canvas'
-            ? { marginRight: 'var(--cate-right-sidebar-width, 0px)' }
-            : null),
-        }}
-      >
+      <div className="flex-1 min-h-0 overflow-hidden">
         {activePanelId ? renderPanel(activePanelId) : (
           <div className="flex items-center justify-center h-full text-muted text-sm">
             No panel

--- a/src/renderer/docking/DockZone.tsx
+++ b/src/renderer/docking/DockZone.tsx
@@ -95,15 +95,13 @@ export default function DockZone({ position, renderPanel, getPanelTitle, onClose
   )
 
   const renderNode = useCallback(
-    (node: DockLayoutNode, leftEdge = false, rightEdge = false): React.ReactNode => {
+    (node: DockLayoutNode): React.ReactNode => {
       if (node.type === 'tabs') {
         return (
           <DockTabStack
             key={node.id}
             stack={node}
             zone={position}
-            leftEdge={leftEdge}
-            rightEdge={rightEdge}
             renderPanel={renderPanel}
             getPanelTitle={getPanelTitle}
             onClosePanel={onClosePanel}
@@ -118,8 +116,6 @@ export default function DockZone({ position, renderPanel, getPanelTitle, onClose
         <DockSplitContainer
           key={node.id}
           node={node}
-          leftEdge={leftEdge}
-          rightEdge={rightEdge}
           renderNode={renderNode}
         />
       )
@@ -149,7 +145,7 @@ export default function DockZone({ position, renderPanel, getPanelTitle, onClose
       onDragOver={handleFileDragOver}
       onDrop={handleFileDrop}
     >
-      {zone.layout ? renderNode(zone.layout, true, true) : (
+      {zone.layout ? renderNode(zone.layout) : (
         // Empty center zone — show background
         isCenter && <div className="w-full h-full" />
       )}

--- a/src/renderer/drag/fileDropTarget.tsx
+++ b/src/renderer/drag/fileDropTarget.tsx
@@ -58,14 +58,7 @@ export function useFileDropTracker(): void {
       // Avoid churn: only recompute the rect when the target element changes.
       if (store.target && store.target.kind === kind && store.target.id === id) return
       const r = host.getBoundingClientRect()
-      // Clamp horizontally so the indicator doesn't slide under the open
-      // sidebars (which are absolute overlays spanning the canvas full-width).
-      const cs = getComputedStyle(document.documentElement)
-      const leftInset = parseFloat(cs.getPropertyValue('--cate-left-sidebar-width')) || 0
-      const rightInset = parseFloat(cs.getPropertyValue('--cate-right-sidebar-width')) || 0
-      const left = Math.max(r.left, leftInset)
-      const right = Math.min(r.right, window.innerWidth - rightInset)
-      store.set({ kind, id, rect: { left, top: r.top, width: Math.max(0, right - left), height: r.height } })
+      store.set({ kind, id, rect: { left: r.left, top: r.top, width: r.width, height: r.height } })
     }
     const clear = (): void => {
       if (useFileDropStore.getState().target) useFileDropStore.getState().set(null)

--- a/src/renderer/panels/EmptyCanvasOverlay.tsx
+++ b/src/renderer/panels/EmptyCanvasOverlay.tsx
@@ -56,13 +56,7 @@ export function EmptyCanvasOverlay({
   if (!visible) return null
 
   return (
-    <div
-      className="absolute top-0 bottom-0 flex items-center justify-center pointer-events-none z-10"
-      style={{
-        left: 'var(--cate-left-sidebar-width, 0px)',
-        right: 'var(--cate-right-sidebar-width, 0px)',
-      }}
-    >
+    <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
       <div className="pointer-events-auto w-[360px] max-w-[90%] rounded-xl bg-surface-2/95 backdrop-blur-xl border border-strong shadow-[0_16px_48px_rgba(0,0,0,0.45)] overflow-hidden">
         <div className="flex items-center justify-between pl-3.5 pr-2 pt-2 pb-1">
           <span className="text-[10px] font-semibold uppercase tracking-wider text-muted">

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -133,18 +133,6 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
   const startXRef = useRef(0)
   const startWidthRef = useRef(0)
 
-  // Publish current total sidebar width to a CSS variable so the dock tab bar
-  // can inset itself and keep the tab pills next to (not under) the sidebar.
-  const totalWidth =
-    isEmpty && !dragRevealed ? 0 : isExpanded ? BAR_WIDTH + width : BAR_WIDTH
-  useEffect(() => {
-    const cssVar = side === 'left' ? '--cate-left-sidebar-width' : '--cate-right-sidebar-width'
-    document.documentElement.style.setProperty(cssVar, `${totalWidth}px`)
-    return () => {
-      document.documentElement.style.setProperty(cssVar, '0px')
-    }
-  }, [side, totalWidth])
-
   // Drop indicator: index where the drop would land. Mirrored in a ref so the
   // drop handler reads the latest value (state updates from dragOver may not
   // have flushed by the time drop fires).

--- a/src/renderer/ui/WelcomePage.tsx
+++ b/src/renderer/ui/WelcomePage.tsx
@@ -83,13 +83,7 @@ export default function WelcomePage({ workspaceId }: { workspaceId: string }) {
   }, [workspaceId])
 
   return (
-    <div
-      className="absolute top-0 bottom-0 flex items-center justify-center pointer-events-none z-10"
-      style={{
-        left: 'var(--cate-left-sidebar-width, 0px)',
-        right: 'var(--cate-right-sidebar-width, 0px)',
-      }}
-    >
+    <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
       <div className="pointer-events-auto max-w-2xl w-full px-8">
         {/* Header */}
         <div className="flex flex-col items-center mb-10">


### PR DESCRIPTION
## What

The left and right sidebars used to be absolutely-positioned overlays sitting on top of a full-width shell. The canvas rendered edge to edge behind the translucent sidebars, and ~6 components manually inset themselves via `--cate-*-sidebar-width` CSS vars so their content was not hidden.

This replaces the overlay with a real flex layout: the sidebars are siblings of the shell and genuinely narrow it, so opening one pushes the dock/canvas instead of covering it.

## Changes

- **Layout** (`App.tsx`): `left sidebar | shell | right sidebar` in a flex row. The overlay/modal layer is kept in its own absolute layer so it never participates in the flex flow.
- **Remove the overlay scaffolding**: the CSS-var insets in `DockTabStack` (tab bar + content), `CanvasToolbar`, `EmptyCanvasOverlay`, `WelcomePage`, and `fileDropTarget`, the `--cate-*-sidebar-width` publishing in `Sidebar`, and the now-dead `leftEdge`/`rightEdge` prop chain through `DockZone` / `DockSplitContainer` / `DockTabStack`.
- **Canvas push**: a sidebar narrows the canvas from one edge. The world transform is anchored to the container's top-left, so a moving left edge drags content along for free but a moving right edge does not. A single symmetric rule in the canvas `ResizeObserver` follows whichever container edge moved (gated on `window.innerWidth` being unchanged, so window resizes do not chase content), making both sidebars push canvas content equally. No sidebar knowledge in the canvas, frame-perfect during the open/close animation.

## Scope notes

- The canvas push is horizontal only. The bottom dock has the same physics but was never an overlay, so its top-anchored behavior is left as is.
- The "follow the moving edge" rule also applies to a dock-split divider moving a canvas pane, which is consistent with the sidebar behavior.

## Testing

- `npm run typecheck`, `npm run lint` (0 new warnings), `npm run build` all pass.
- `npm test` for canvas / docking / onboarding / store suites passes, including the onboarding "spotlight clipped between sidebars" test.
- Verified manually in the running app: both sidebars push and shift canvas content symmetrically.