### PR TITLE
fix(worktrees): territory shape + panning lock, sidebar active-row, beta-builds copy

### DIFF
--- a/src/renderer/canvas/worktree/WorktreeTerritoryLayer.tsx
+++ b/src/renderer/canvas/worktree/WorktreeTerritoryLayer.tsx
@@ -294,7 +294,24 @@ const WorktreeTerritoryLayer: React.FC<Props> = ({ containerWidth, containerHeig
     const ensure = () => { if (!rafRef.current) rafRef.current = requestAnimationFrame(frame) }
     ensureRef.current = ensure
 
-    const onChange = () => { dirtyRef.current = true; ensure() }
+    const onChange = () => {
+      // The world transform (Canvas.applyTransform) updates the DOM synchronously
+      // on every offset change. The GL territory draw is just one full-screen quad,
+      // so draw it synchronously in the SAME store-notification tick — phase-locked
+      // to the panels. Scheduling it on a later rAF instead makes the territory lag
+      // the panels by a frame during fast pan/zoom (very visible when zoomed out,
+      // where one pan event is a large world delta). Node-drag still uses the rAF
+      // loop (to follow the ghost), and the CPU fallback stays on rAF (its draw is
+      // far too heavy to run per pan event).
+      const dragging = useDragStore.getState().source?.origin.kind === 'canvas-node'
+      if (backendRef.current === 'gl' && !dragging) {
+        dirtyRef.current = false
+        paintGL()
+        return
+      }
+      dirtyRef.current = true
+      ensure()
+    }
     const unsubCanvas = canvasApi.subscribe(onChange) // zoom / pan / nodes / worktree map
     const unsubDrag = useDragStore.subscribe(onChange)
     const unsubUI = useUIStore.subscribe(onChange) // focus-lens dim

--- a/src/renderer/canvas/worktree/territoryConfig.ts
+++ b/src/renderer/canvas/worktree/territoryConfig.ts
@@ -19,10 +19,10 @@ export const FIELD_CELL = 6
  *  (see OUTER_REACH_SCALE). Doubles as the corner radius of the offset, so larger
  *  values balloon the short top/bottom edges into domes; kept tight so the
  *  territory hugs the panels' rectangle. */
-export const REACH = 90
+export const REACH = 70
 /** Outer terrace reach as a multiple of REACH. The outer terrace's outer radius
  *  is REACH·OUTER_REACH_SCALE, so it overhangs the inner terrace more. */
-export const OUTER_REACH_SCALE = 1.4
+export const OUTER_REACH_SCALE = 1.28
 /** Peak fill opacity of the INNER terrace shelf (right at the panels). Subtle. */
 export const INTENSITY = 0.22
 /** Base opacity of the OUTER shelf as a fraction of the inner shelf — the step
@@ -37,12 +37,12 @@ export const PANEL_CORNER = 8
  *  = tighter fusion with less of a rounded bulge ballooning out where two nearby
  *  panels meet. */
 export const SMINK = 55
-/** Half-width (canvas-space px) of the center-to-center connection capsules.
- *  Set near a panel's half-width so a connection reads as one fused blob
- *  ("fudge"), not a thin pipe between panels. Kept a touch under a panel's
- *  half-width so the territory waists slightly between stacked panels instead of
- *  ballooning into one fat rounded blob. */
-export const CONNECT_RADIUS = 210
+/** Half-width (canvas-space px) of the connection capsules that fuse same-worktree
+ *  panels. The connection's total visual width is ~2·CONNECT_RADIUS + 2·OUTER_REACH,
+ *  so a large radius balloons the bridge far wider than the panels. Kept well under
+ *  a panel half-width so a connection reads as a slim waist between panels, not a
+ *  fat blob — the terrace offset still gives it enough body to read as fused. */
+export const CONNECT_RADIUS = 110
 /** Max edge-to-edge gap (canvas-space px) between two same-worktree panels for
  *  them to fuse. Beyond this, no bridge — panels stay separate territory islands.
  *  The outer terrace stays connected nearly to this gap; the inner terrace lets
@@ -73,7 +73,7 @@ export const OUTLINE_ALPHA = 0.4
 /** Domain-warp amplitude (canvas-space px) — how far the flowing curves push the
  *  territory edge in/out. Enough to break a lone panel's halo out of a perfectly
  *  round blob into an organic sweep, without high-frequency wobble. */
-export const WARP_AMP = 32
+export const WARP_AMP = 22
 /** Domain-warp frequency — lower = larger, gentler, more flowing undulations.
  *  Wavelength ≈ 1/FREQ canvas px, so this spans roughly a panel-width per wave. */
 export const WARP_FREQ = 0.0022

--- a/src/renderer/settings/UpdatesSettings.tsx
+++ b/src/renderer/settings/UpdatesSettings.tsx
@@ -8,7 +8,7 @@ export function UpdatesSettings() {
     <div className="flex flex-col gap-1">
       <SettingRow
         label="Receive beta builds"
-        description="Get early access to staged, pre-release versions. Betas may be less stable. They never affect the public download, and turning this off won't downgrade a beta you've already installed — you'll move to stable once it catches up."
+        description="Get early access to less stable pre-release builds. Turning this off keeps any beta you've installed until stable catches up."
       >
         <Toggle
           checked={store.betaUpdatesEnabled}

--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -509,7 +509,7 @@ const WorktreeCard: React.FC<{
     >
       <div
         className="flex items-center gap-1.5 h-8 px-2 hover:bg-hover transition-colors cursor-pointer"
-        style={isLensFocused ? { boxShadow: `inset 2px 0 0 0 ${worktree.color}`, backgroundColor: `color-mix(in srgb, ${worktree.color} 10%, transparent)` } : undefined}
+        style={isLensFocused ? { backgroundColor: `color-mix(in srgb, ${worktree.color} 14%, transparent)` } : undefined}
         onClick={handleRowClick}
         onContextMenu={(e) => { e.preventDefault(); void handleMenu() }}
       >


### PR DESCRIPTION
A small batch of worktree/UI polish (follow-up to #299).

## 1. Slim down territory bulk & connection width
- `REACH` 90→70, `OUTER_REACH_SCALE` 1.4→1.28 — halo hugs the panels.
- `WARP_AMP` 32→22 — warp no longer distorts thin connection necks into fingers.
- `CONNECT_RADIUS` 210→110 — connection width is ~`2·CONNECT_RADIUS + 2·OUTER_REACH`; the fat radius made bridges ~420px wide before the offset. Now a connection reads as a slim waist instead of a balloon.

## 2. Territory no longer slides behind windows while panning
The world transform updates the DOM synchronously per pan event, but the GL territory drew on the next rAF — one event behind, very visible zoomed-out. It now draws synchronously in the same store-notification tick (rAF kept for node-drag and the CPU fallback).

## 3. Sidebar active worktree row
Remove the left border bar on the active (lens-focused) row and slightly strengthen the background tint so it still reads.

## 4. Settings copy
Condense the "Receive beta builds" description to one line and drop the em dash.

## Testing
- \`vitest run src/renderer/canvas/worktree\` — 6/6 pass
- Typecheck clean