### PR TITLE
chore: release v1.2.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.1.1",
+      "version": "1.2.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.1.1",
+  "version": "1.2.0-beta.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Bump version to 1.2.0-beta.1 so a beta release can be cut from main (which now carries the e2e + release-CI hardening from #300 and #301). Version-only change.