### PR TITLE
fix: friendly error messages app-wide

### DIFF
--- a/src/renderer/lib/errorMessage.test.ts
+++ b/src/renderer/lib/errorMessage.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { errorMessage } from './errorMessage'
+
+describe('errorMessage', () => {
+  it('strips the Electron IPC wrapper and maps the companion error', () => {
+    const raw =
+      `Error invoking remote method 'git:init': Error: No companion registered for id "srv_cd1df3a429"`
+    expect(errorMessage(new Error(raw))).toBe(
+      'The companion isn’t connected on this host yet. Install it and try again.',
+    )
+  })
+
+  it('strips the IPC wrapper and leftover Error: prefix for unknown messages', () => {
+    const raw = `Error invoking remote method 'git:status': Error: fatal: not a git repository`
+    expect(errorMessage(new Error(raw))).toBe('fatal: not a git repository')
+  })
+
+  it('peels stacked Error: prefixes', () => {
+    expect(errorMessage('Error: Error: boom')).toBe('boom')
+  })
+
+  it('maps filesystem and network errors', () => {
+    expect(errorMessage(new Error('ENOENT: no such file or directory, open foo'))).toBe(
+      'That file or folder no longer exists.',
+    )
+    expect(errorMessage(new Error('connect ECONNREFUSED 127.0.0.1:22'))).toBe(
+      'Couldn’t reach the host. Check your connection and try again.',
+    )
+  })
+
+  it('accepts strings, plain objects, and Error instances', () => {
+    expect(errorMessage('plain string')).toBe('plain string')
+    expect(errorMessage({ message: 'object message' })).toBe('object message')
+    expect(errorMessage(new Error('real error'))).toBe('real error')
+  })
+
+  it('falls back when there is no usable message', () => {
+    expect(errorMessage(null)).toBe('Something went wrong.')
+    expect(errorMessage(undefined)).toBe('Something went wrong.')
+    expect(errorMessage('', 'custom fallback')).toBe('custom fallback')
+  })
+})

--- a/src/renderer/lib/errorMessage.ts
+++ b/src/renderer/lib/errorMessage.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// errorMessage — turn an unknown thrown value into a clean, human-readable
+// string fit for the UI.
+//
+// Errors that cross Electron's IPC boundary arrive wrapped:
+//   "Error invoking remote method 'git:init': Error: No companion registered…"
+// and internal errors often carry jargon the user can't act on. This strips the
+// IPC plumbing and maps known technical messages to friendly equivalents so we
+// never surface raw errors like that screenshot again.
+// =============================================================================
+
+// Electron prefixes every rejected ipcRenderer.invoke with this.
+const IPC_WRAPPER = /^Error invoking remote method '[^']*':\s*/
+// Leading "Error:" / "TypeError:" / "Error Error:" left over after unwrapping.
+const ERROR_NAME_PREFIX = /^(?:[A-Z][a-zA-Z]*Error|Error):\s*/
+
+// Known internal messages → what the user should actually read. Matched against
+// the cleaned message; first hit wins.
+const FRIENDLY: ReadonlyArray<{ match: RegExp; message: string }> = [
+  {
+    match: /No companion registered for id/i,
+    message: 'The companion isn’t connected on this host yet. Install it and try again.',
+  },
+  {
+    match: /ENOENT|no such file or directory/i,
+    message: 'That file or folder no longer exists.',
+  },
+  {
+    match: /EACCES|permission denied/i,
+    message: 'Permission denied.',
+  },
+  {
+    match: /ECONNREFUSED|ETIMEDOUT|ENOTFOUND|network|socket hang up/i,
+    message: 'Couldn’t reach the host. Check your connection and try again.',
+  },
+]
+
+/** Pull a raw message string out of any thrown value. */
+function rawMessage(err: unknown): string {
+  if (err == null) return ''
+  if (typeof err === 'string') return err
+  if (err instanceof Error) return err.message
+  if (typeof err === 'object' && 'message' in err && typeof (err as any).message === 'string') {
+    return (err as any).message
+  }
+  return String(err)
+}
+
+/** Strip Electron IPC wrapping and any leftover "Error:" name prefixes. */
+function unwrap(message: string): string {
+  let out = message.replace(IPC_WRAPPER, '').trim()
+  // Unwrapping the IPC layer can expose a stacked "Error: Error: …"; peel each.
+  let prev: string
+  do {
+    prev = out
+    out = out.replace(ERROR_NAME_PREFIX, '').trim()
+  } while (out !== prev)
+  return out
+}
+
+/**
+ * Format an unknown error for display. Strips IPC noise, maps known technical
+ * errors to friendly text, and falls back to the cleaned message. Pass
+ * `fallback` for the empty / unrecognised case.
+ */
+export function errorMessage(err: unknown, fallback = 'Something went wrong.'): string {
+  const cleaned = unwrap(rawMessage(err))
+  if (!cleaned) return fallback
+  for (const { match, message } of FRIENDLY) {
+    if (match.test(cleaned)) return message
+  }
+  return cleaned
+}

--- a/src/renderer/lib/terminal/terminalRegistry.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.ts
@@ -8,6 +8,7 @@
 
 import { Terminal } from '@xterm/xterm'
 import log from '../logger'
+import { errorMessage } from '../errorMessage'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { SearchAddon } from '@xterm/addon-search'
@@ -656,13 +657,7 @@ async function getOrCreate(panelId: string, opts: CreateOpts): Promise<RegistryE
   } catch (err) {
     // Tear down the half-built entry so retry() can rebuild from scratch
     // instead of leaving a permanent tombstone with the red error frozen in it.
-    const message =
-      err instanceof Error
-        ? err.message
-        : typeof err === 'string'
-          ? err
-          : String(err)
-    failures.set(panelId, message)
+    failures.set(panelId, errorMessage(err, 'Terminal failed to start'))
     if (registry.get(panelId) === entry) {
       registry.delete(panelId)
       try { terminal.dispose() } catch { /* ignore */ }

--- a/src/renderer/panels/DocumentPanel.tsx
+++ b/src/renderer/panels/DocumentPanel.tsx
@@ -3,6 +3,7 @@ import * as pdfjsLib from 'pdfjs-dist'
 import type { PanelProps } from './types'
 import { useAppStore } from '../stores/appStore'
 import { ArrowLeft, ArrowRight, Minus, Plus } from '@phosphor-icons/react'
+import { errorMessage } from '../lib/errorMessage'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
   'pdfjs-dist/build/pdf.worker.min.mjs',
@@ -217,7 +218,7 @@ function DocxViewer({ data }: { data: Uint8Array }) {
       mammoth.convertToHtml({ arrayBuffer: (data.buffer as ArrayBuffer).slice(data.byteOffset, data.byteOffset + data.byteLength) }).then((result) => {
         if (!cancelled) setHtml(result.value)
       }).catch((err) => {
-        if (!cancelled) setError(String(err))
+        if (!cancelled) setError(errorMessage(err, 'Failed to render document'))
       })
     })
     return () => { cancelled = true }
@@ -300,7 +301,7 @@ export default function DocumentPanel({ panelId, workspaceId }: PanelProps) {
       }
     }).catch((err) => {
       if (!cancelled) {
-        setError(String(err))
+        setError(errorMessage(err, 'Failed to load file'))
         setLoading(false)
       }
     })

--- a/src/renderer/settings/AppearanceSettings.tsx
+++ b/src/renderer/settings/AppearanceSettings.tsx
@@ -5,6 +5,7 @@ import { SettingRow, Select, NumberInput, SearchableBlock } from './SettingsComp
 import type { Theme } from '../../shared/types'
 import { validateTheme } from '../../shared/theme'
 import { BASE_DARK, BASE_LIGHT, BUILT_IN_THEMES } from '../../shared/themes'
+import { errorMessage } from '../lib/errorMessage'
 
 const SKILL_GUIDE_URL = 'https://github.com/0-AI-UG/cate/blob/main/skills/cate-theme/SKILL.md'
 
@@ -69,12 +70,12 @@ export function AppearanceSettings() {
           if (valid.length === 0) return
           store.setSetting('customThemes', [...customThemes, ...valid])
         } catch (err) {
-          setImportError(err instanceof Error ? err.message : 'Failed to parse JSON')
+          setImportError(errorMessage(err, 'Failed to parse JSON'))
         }
       }
       input.click()
     } catch (err) {
-      setImportError(err instanceof Error ? err.message : 'Import failed')
+      setImportError(errorMessage(err, 'Import failed'))
     }
   }
 

--- a/src/renderer/sidebar/ParallelWorkTab.tsx
+++ b/src/renderer/sidebar/ParallelWorkTab.tsx
@@ -33,6 +33,7 @@ import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeade
 import type { WorktreeMeta } from '../../shared/types'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import log from '../lib/logger'
+import { errorMessage } from '../lib/errorMessage'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -220,7 +221,7 @@ const CreateForm: React.FC<{
         await onSubmit(name.trim(), baseRef || undefined)
       }
     } catch (err: any) {
-      setError(err?.message || 'Failed to create')
+      setError(errorMessage(err, 'Failed to create'))
     } finally {
       setBusy(false)
     }
@@ -701,7 +702,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       } catch (err: any) {
         if (!cancelled) {
           log.warn('[parallel-work] status fetch failed', err)
-          setError(err?.message || 'Failed to load parallel branches')
+          setError(errorMessage(err, 'Failed to load parallel branches'))
         }
       } finally {
         if (!cancelled) setRefreshing(false)
@@ -846,13 +847,13 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
           try {
             await window.electronAPI.gitBranchDelete(rootPath, wt.branch, true)
           } catch (err: any) {
-            setError(`Removed, but branch ${wt.branch} could not be deleted: ${err?.message || err}`)
+            setError(`Removed, but branch ${wt.branch} could not be deleted: ${errorMessage(err)}`)
           }
         }
         removeWorktree(selectedWorkspaceId, wt.id)
         void reconcile()
       } catch (err: any) {
-        setError(err?.message || 'Discard failed')
+        setError(errorMessage(err, 'Discard failed'))
       }
     },
     [rootPath, selectedWorkspaceId, removeWorktree, reconcile, statusByPath],
@@ -871,14 +872,14 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       try {
         const result = await window.electronAPI.gitWorktreeMergeTo(rootPath, wt.branch, target)
         if (!result.ok) {
-          setError(`Merge ${wt.branch} → ${target}: ${result.message}`)
+          setError(`Merge ${wt.branch} → ${target}: ${errorMessage(result.message)}`)
         } else {
           setError(null)
           setNotice(`Merged ${wt.branch} into ${target}`)
           void reconcile()
         }
       } catch (err: any) {
-        setError(err?.message || 'Merge failed')
+        setError(errorMessage(err, 'Merge failed'))
       }
     },
     [rootPath, primaryLabel, reconcile],
@@ -894,7 +895,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
           setError(
             result.conflict
               ? `Conflicts updating from ${target}. Open a terminal here to resolve them.`
-              : `Update from ${target}: ${result.message}`,
+              : `Update from ${target}: ${errorMessage(result.message)}`,
           )
         } else {
           setError(null)
@@ -902,7 +903,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
           void reconcile()
         }
       } catch (err: any) {
-        setError(err?.message || 'Update failed')
+        setError(errorMessage(err, 'Update failed'))
       }
     },
     [primaryLabel, reconcile],
@@ -918,7 +919,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       void reconcile()
     } catch (err: any) {
       setNotice(null)
-      setError(`Publish failed: ${err?.message || err}`)
+      setError(`Publish failed: ${errorMessage(err)}`)
     }
   }, [reconcile])
 
@@ -940,11 +941,11 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
         setPrNonce((n) => n + 1)
       } else {
         setNotice(null)
-        setError(res.message)
+        setError(errorMessage(res.message))
       }
     } catch (err: any) {
       setNotice(null)
-      setError(`Could not create pull request: ${err?.message || err}`)
+      setError(`Could not create pull request: ${errorMessage(err)}`)
     }
   }, [])
 
@@ -955,7 +956,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       await window.electronAPI.gitInit(rootPath)
       await reconcile()
     } catch (err: any) {
-      setError(`Could not initialize git: ${err?.message || err}`)
+      setError(`Could not initialize git: ${errorMessage(err)}`)
     }
   }, [rootPath, reconcile])
 
@@ -976,7 +977,7 @@ export const ParallelWorkTab: React.FC<ParallelWorkTabProps> = ({ rootPath }) =>
       }
       void reconcile()
     } catch (err: any) {
-      setError(err?.message || 'Cleanup failed')
+      setError(errorMessage(err, 'Cleanup failed'))
     }
   }, [rootPath, selectedWorkspaceId, removeWorktree, reconcile])
 

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -389,19 +389,14 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
         // that anything underneath changes (a major sustained WindowServer cost
         // given the canvas/terminals behind it). A near-opaque tint reads as the
         // same frosted surface without the per-frame compositing.
-        backgroundColor:
-          side === 'right'
-            ? 'color-mix(in srgb, var(--surface-0) 96%, transparent)'
-            : 'color-mix(in srgb, var(--surface-1) 96%, transparent)',
+        backgroundColor: 'color-mix(in srgb, var(--surface-1) 96%, transparent)',
       }}
     >
       {/* Opaque top strip — matches the dock tab bar height (36px) so the
-          sidebar chrome lines up with the canvas tab bar. The right sidebar
-          uses a darker shade to stand out against the tab-bar chrome it sits
-          beside. */}
+          sidebar chrome lines up with the canvas tab bar. */}
       <div
         className="pointer-events-none absolute top-0 left-0 right-0 h-9"
-        style={{ backgroundColor: side === 'right' ? 'var(--surface-0)' : 'var(--surface-1)' }}
+        style={{ backgroundColor: 'var(--surface-1)' }}
       />
       {side === 'left' ? (
         <>

--- a/src/renderer/sidebar/SourceControlView.tsx
+++ b/src/renderer/sidebar/SourceControlView.tsx
@@ -23,6 +23,7 @@ import { useUIStore } from '../stores/uiStore'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
 import { useGitStatusSnapshot, gitStatusStore } from '../stores/gitStatusStore'
 import { useWorktrees } from '../stores/useWorktrees'
+import { errorMessage } from '../lib/errorMessage'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -233,7 +234,7 @@ const BranchPicker: React.FC<{
       setIsOpen(false)
       onSwitch()
     } catch (err: any) {
-      setError(err?.message || 'Checkout failed')
+      setError(errorMessage(err, 'Checkout failed'))
     }
   }, [rootPath, onSwitch])
 
@@ -245,7 +246,7 @@ const BranchPicker: React.FC<{
       setIsOpen(false)
       onSwitch()
     } catch (err: any) {
-      setError(err?.message || 'Create failed')
+      setError(errorMessage(err, 'Create failed'))
     }
   }, [rootPath, newBranchName, onSwitch])
 
@@ -257,7 +258,7 @@ const BranchPicker: React.FC<{
       await window.electronAPI.gitBranchDelete(rootPath, name)
       loadBranches()
     } catch (err: any) {
-      setError(err?.message || 'Delete failed')
+      setError(errorMessage(err, 'Delete failed'))
     }
   }, [rootPath, currentBranch, loadBranches])
 
@@ -458,7 +459,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitDiscardFile(rootPath, filePath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Discard failed')
+      setActionError(errorMessage(err, 'Discard failed'))
     }
   }, [rootPath, refresh])
 
@@ -485,7 +486,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       setCommitMessage('')
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Commit failed')
+      setActionError(errorMessage(err, 'Commit failed'))
     } finally {
       setCommitting(false)
     }
@@ -499,7 +500,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitPush(rootPath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Push failed')
+      setActionError(errorMessage(err, 'Push failed'))
     } finally {
       setPushing(false)
     }
@@ -513,7 +514,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitPull(rootPath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Pull failed')
+      setActionError(errorMessage(err, 'Pull failed'))
     } finally {
       setPulling(false)
     }
@@ -527,7 +528,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitFetch(rootPath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Fetch failed')
+      setActionError(errorMessage(err, 'Fetch failed'))
     } finally {
       setFetching(false)
     }
@@ -539,7 +540,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitStash(rootPath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Stash failed')
+      setActionError(errorMessage(err, 'Stash failed'))
     }
   }, [rootPath, refresh])
 
@@ -549,7 +550,7 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
       await window.electronAPI.gitStashPop(rootPath)
       refresh()
     } catch (err: any) {
-      setActionError(err?.message || 'Stash pop failed')
+      setActionError(errorMessage(err, 'Stash pop failed'))
     }
   }, [rootPath, refresh])
 

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -8,6 +8,7 @@ import { create } from 'zustand'
 import { useStoreWithEqualityFn } from 'zustand/traditional'
 import { shallow } from 'zustand/shallow'
 import log from '../lib/logger'
+import { errorMessage } from '../lib/errorMessage'
 import type {
   WorkspaceState,
   WorkspaceInfo,
@@ -975,7 +976,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }))
     return syncUpdateToMain(wsId, { rootPath, name: desiredName }).then((result) => {
       if (!result?.ok) {
-        const message = result?.error?.message ?? 'Failed to update workspace root'
+        const message = errorMessage(result?.error, 'Failed to update workspace root')
         set((state) => ({
           workspaces: state.workspaces.map((candidate) => (
             candidate.id === wsId
@@ -999,9 +1000,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   setWorkspaceCompanionPhase(wsId, phase, error) {
+    const clean = error == null ? null : errorMessage(error)
     set((state) => ({
       workspaces: state.workspaces.map((c) =>
-        c.id === wsId ? { ...c, companion: { phase, ...(error != null ? { error } : {}) } } : c,
+        c.id === wsId ? { ...c, companion: { phase, ...(clean != null ? { error: clean } : {}) } } : c,
       ),
     }))
   },

--- a/src/renderer/stores/searchStore.ts
+++ b/src/renderer/stores/searchStore.ts
@@ -8,6 +8,7 @@
 
 import { create } from 'zustand'
 import type { SearchFileResult } from '../../shared/types'
+import { errorMessage } from '../lib/errorMessage'
 
 export type SearchStatus = 'idle' | 'searching' | 'done'
 
@@ -136,7 +137,7 @@ export const createSearchStore = () =>
 
     finishSearch: (searchId, stats, error) => {
       if (searchId !== get().currentSearchId) return // stale
-      set({ status: 'done', truncated: stats.truncated, error: error ?? null })
+      set({ status: 'done', truncated: stats.truncated, error: error ? errorMessage(error) : null })
     },
 
     clearResults: () =>


### PR DESCRIPTION
Raw errors were reaching the UI. The screenshot case showed the full Electron IPC wrapper: `Could not initialize git: Error invoking remote method 'git:init': Error: No companion registered for id "srv_..."`.

## What changed
- New `src/renderer/lib/errorMessage.ts`: strips Electron IPC wrappers, peels `Error:` name prefixes, and maps known technical errors (companion not connected, ENOENT, EACCES, network) to friendly text. Unknown messages pass through cleaned, not swallowed.
- Routed every user-facing error display through it (24 sites): `SourceControlView` (10 git actions), `ParallelWorkTab` (init/create/merge/update/PR/etc.), `DocumentPanel`, `AppearanceSettings`, `terminalRegistry` startup failures.
- Cleaned at the store boundary so all downstream consumers benefit at once: `appStore` (companion phase errors feeding the lock overlay / workspace tooltip / remote-connect dialog, plus workspace-root update failures) and `searchStore`.

That screenshot error now reads: "Could not initialize git: The companion isn't connected on this host yet. Install it and try again."

## Not included
- React error boundaries keep showing message + stack on purpose (crash debugging; no IPC wrapper to strip).
- Follow-up: on a remote workspace with no companion, "Initialize git repository" still always fails. The real fix is showing the install-prompt state there instead of a button that can't succeed.

## Tests
- New `errorMessage.test.ts` (6 cases: IPC unwrap, stacked prefixes, fs/network mapping, input shapes, fallback).
- `tsc --noEmit` clean, full vitest suite 997 passed / 3 skipped, eslint 0 errors.