### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Promotes `1.2.0-beta.1` → `1.2.0` (stable). Bumps `package.json` + `package-lock.json` only, matching the beta release (#303).

After this squash-merges and the 3-OS CI is green, push the `v1.2.0` tag on `main` to trigger `release.yml` (builds/signs mac/win/linux, drafts the GitHub Release).