### PR TITLE
fix(update): restart on install + keep button visible when right sidebar empty

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1739,6 +1739,15 @@ app.on('before-quit', (event) => {
   // foreground process (dev server, editor, agent, …). Mirrors the per-terminal
   // close confirmation. Deferred async, so we prevent the quit and re-trigger it
   // once the user confirms.
+  //
+  // Exception: an update install in flight. The user already explicitly chose
+  // "Update & Restart"; quitAndInstall() has triggered this quit so it can
+  // relaunch the new version. Surfacing the running-terminal dialog here would
+  // intercept that quit (event.preventDefault) and the app would never restart.
+  // will-quit is already update-aware (isInstallingUpdate guard); mirror that.
+  if (!quitConfirmed && isInstallingUpdate()) {
+    quitConfirmed = true
+  }
   if (!quitConfirmed) {
     const running = getRunningTerminals()
     if (running.length > 0) {

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import { FileExplorer } from './FileExplorer'
 import { SearchView } from './SearchView'
 import { SourceControlView } from './SourceControlView'
 import { UpdateButton } from './UpdateButton'
+import { useUpdateStore } from '../stores/updateStore'
 import { useAppStore } from '../stores/appStore'
 import { useUIStore, useSidebarLayout } from '../stores/uiStore'
 import type { SidebarView, SidebarSide } from '../stores/uiStore'
@@ -107,6 +108,18 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
 
   const isExpanded = activeView !== null
   const isEmpty = views.length === 0
+
+  // The update affordance lives in the right activity bar. When the user has
+  // moved every view to the other side, the right sidebar would normally
+  // collapse to width 0 and hide the button — so keep the bar open (just the
+  // 40px activity strip) whenever an update is actionable, even with no views.
+  const updateState = useUpdateStore((s) => s.status.state)
+  const hasActionableUpdate =
+    side === 'right' &&
+    (updateState === 'available' ||
+      updateState === 'downloading' ||
+      updateState === 'downloaded' ||
+      updateState === 'manual')
   // When empty, the sidebar is hidden. During a drag, if the cursor enters
   // this side's half of the window, we reveal it so the user can drop here.
   const [dragRevealed, setDragRevealed] = useState(false)
@@ -375,7 +388,9 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
       style={{
         width:
           isEmpty && !dragRevealed
-            ? 0
+            ? hasActionableUpdate
+              ? BAR_WIDTH
+              : 0
             : isExpanded
               ? BAR_WIDTH + width
               : BAR_WIDTH,


### PR DESCRIPTION
## Problem

Two bugs in the update affordance:

1. **Restart did nothing.** `before-quit` gates quitting behind the running-terminal *"A terminal is still running. Quit anyway?"* confirmation. In a coding session a terminal is almost always live, so clicking **Update & Restart** triggered `quitAndInstall()` → `app.quit()`, which `before-quit` intercepted with `event.preventDefault()`. `will-quit` was already update-aware (`isInstallingUpdate()` guard), but `before-quit` was not.

2. **Button hidden when all sidebar views are on the left.** `UpdateButton` lives only in the right activity bar, which collapses to `width: 0` + `overflow-hidden` when it has no views. Moving every view to the left hid the button even with a pending update (regression from #298).

## Fix

- `before-quit` now skips the running-terminal confirmation when an update install is in flight, mirroring the existing `will-quit` behavior, so an explicit "Update & Restart" relaunches cleanly. Session-state flushing still runs.
- The right activity bar stays open at its 40px strip whenever an update is actionable (`available`/`downloading`/`downloaded`/`manual`), even with no views; it still collapses to 0 when there's no update.

## Testing

- `tsc --noEmit` clean
- `vitest run src/renderer/sidebar` — 63 passed
- Issue #2 reproducible/verifiable in dev via `npm run dev:update:button` then dragging all sidebar icons to the left.