### PR TITLE
Theme-track agent UI colors + preview snap-to-grid drop

### DIFF
--- a/src/agent/renderer/AgentChatInput.tsx
+++ b/src/agent/renderer/AgentChatInput.tsx
@@ -152,7 +152,7 @@ export function ChatInput({
         className={`relative rounded-2xl border bg-surface-3 transition-colors ${
           dragOver
             ? 'border-agent-light ring-2 ring-agent-light/40'
-            : 'border-white/10 focus-within:border-agent/50'
+            : 'border-strong focus-within:border-agent/50'
         }`}
       >
         {popupOpen && (
@@ -218,7 +218,7 @@ export function ChatInput({
             className={`p-1.5 rounded-md ${
               planModeActive
                 ? 'bg-agent/25 text-primary'
-                : 'text-primary/80 hover:bg-white/5'
+                : 'text-primary/80 hover:bg-hover'
             }`}
             title="Plan mode: agent investigates with parallel scouts, proposes a plan, then waits for your approval."
           >
@@ -261,7 +261,7 @@ export function ChatInput({
             <button
               onClick={onSubmit}
               disabled={!canSend}
-              className="p-1.5 rounded-full bg-agent hover:bg-agent-light disabled:bg-white/10 disabled:text-muted text-white"
+              className="p-1.5 rounded-full bg-agent hover:bg-agent-light disabled:bg-[var(--surface-hover-strong)] disabled:text-muted text-white"
               title="Send"
             >
               <PaperPlaneRight size={12} weight="fill" />
@@ -319,7 +319,7 @@ function CompactButton({
         ref={btnRef}
         onClick={() => setOpen((v) => !v)}
         disabled={compactionActive}
-        className={`p-1.5 rounded-md hover:bg-white/5 disabled:opacity-50 ${
+        className={`p-1.5 rounded-md hover:bg-hover disabled:opacity-50 ${
           autoCompactionEnabled ? 'text-primary/80' : 'text-muted/50'
         }`}
         title="Compact context"
@@ -329,24 +329,24 @@ function CompactButton({
       {open && pos && portalTarget && createPortal(
         <div
           ref={popoverRef}
-          className="absolute w-[200px] rounded-lg border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-[9999] overflow-hidden"
+          className="absolute w-[200px] rounded-lg border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-[9999] overflow-hidden"
           style={{ top: pos.top, left: pos.left, transform: 'translateY(-100%)' }}
         >
           <button
             onClick={() => { setOpen(false); onManualCompact() }}
             disabled={compactionActive}
-            className="w-full text-left px-3 py-2 text-[12px] text-primary hover:bg-white/5 disabled:opacity-50"
+            className="w-full text-left px-3 py-2 text-[12px] text-primary hover:bg-hover disabled:opacity-50"
           >
             Compact now
           </button>
-          <div className="border-t border-white/5">
+          <div className="border-t border-subtle">
             <button
               onClick={() => onToggleAutoCompaction()}
-              className="w-full flex items-center justify-between px-3 py-2 text-[12px] text-primary hover:bg-white/5"
+              className="w-full flex items-center justify-between px-3 py-2 text-[12px] text-primary hover:bg-hover"
             >
               <span>Auto-compact</span>
               <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                autoCompactionEnabled ? 'bg-agent/20 text-agent-light' : 'bg-white/5 text-muted'
+                autoCompactionEnabled ? 'bg-agent/20 text-agent-light' : 'bg-hover text-muted'
               }`}>
                 {autoCompactionEnabled ? 'on' : 'off'}
               </span>
@@ -367,7 +367,7 @@ function ContextRing({ percent, size = 14, stroke = 1.5 }: { percent: number; si
   const r = (size - stroke) / 2
   const circ = 2 * Math.PI * r
   const filled = circ * (Math.min(percent, 100) / 100)
-  const color = percent > 85 ? '#f87171' : percent > 65 ? '#fbbf24' : 'currentColor'
+  const color = percent > 85 ? 'var(--git-deleted)' : percent > 65 ? 'var(--activity-orange)' : 'currentColor'
   return (
     <svg width={size} height={size} className="shrink-0 -rotate-90">
       <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="currentColor" strokeWidth={stroke} className="opacity-20" />
@@ -419,21 +419,21 @@ function StatsChip({
     pctRounded == null
       ? 'text-muted/70'
       : pctRounded > 85
-      ? 'text-red-300'
+      ? 'text-danger'
       : pctRounded > 65
-      ? 'text-amber-300'
+      ? 'text-warning'
       : 'text-muted/70'
   const fmtCost = (c: number) =>
     c >= 1 ? `$${c.toFixed(2)}` : c >= 0.01 ? `$${c.toFixed(3)}` : `$${c.toFixed(4)}`
   const barPct = pctRounded ?? 0
-  const barColor = barPct > 85 ? 'bg-red-400' : barPct > 65 ? 'bg-amber-400' : 'bg-agent-light'
+  const barColor = barPct > 85 ? 'bg-danger' : barPct > 65 ? 'bg-warning' : 'bg-agent-light'
   return (
     <>
       <button
         ref={btnRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10.5px] font-mono ${tone} hover:bg-white/5`}
+        className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10.5px] font-mono ${tone} hover:bg-hover`}
         title="Conversation stats"
       >
         {pctRounded != null ? <ContextRing percent={pctRounded} /> : <span>-</span>}
@@ -441,10 +441,10 @@ function StatsChip({
       {open && pos && portalTarget && createPortal(
         <div
           ref={popoverRef}
-          className="absolute w-[260px] rounded-lg border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-[9999] text-[11.5px] text-primary font-mono"
+          className="absolute w-[260px] rounded-lg border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-[9999] text-[11.5px] text-primary font-mono"
           style={{ top: pos.top, left: pos.left, transform: 'translateY(-100%)' }}
         >
-          <div className="px-3 pt-3 pb-2 border-b border-white/5">
+          <div className="px-3 pt-3 pb-2 border-b border-subtle">
             <div className="flex justify-between items-baseline mb-1.5">
               <span className="text-muted text-[10px] uppercase tracking-wider font-semibold">Context window</span>
               <span>
@@ -452,11 +452,11 @@ function StatsChip({
                 {ctxWindow ? <span className="text-muted"> / {formatTokensShort(ctxWindow)}</span> : ''}
               </span>
             </div>
-            <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+            <div className="h-1.5 rounded-full bg-hover-strong overflow-hidden">
               <div className={`h-full rounded-full ${barColor} transition-all`} style={{ width: `${barPct}%` }} />
             </div>
           </div>
-          <div className="px-3 pt-2 pb-2 border-b border-white/5 space-y-1">
+          <div className="px-3 pt-2 pb-2 border-b border-subtle space-y-1">
             <div className="text-muted text-[10px] uppercase tracking-wider font-semibold mb-1">Billed tokens</div>
             <div className="flex justify-between gap-3">
               <span className="text-muted">Input</span>
@@ -504,8 +504,8 @@ const SOURCE_LABEL: Record<AgentSlashCommand['source'], string> = {
 
 const SOURCE_COLOR: Record<AgentSlashCommand['source'], string> = {
   skill: 'text-agent-light bg-agent/10',
-  prompt: 'text-muted bg-white/5',
-  extension: 'text-muted bg-white/5',
+  prompt: 'text-muted bg-hover',
+  extension: 'text-muted bg-hover',
 }
 
 function SlashPopup({
@@ -520,7 +520,7 @@ function SlashPopup({
   onHover: (idx: number) => void
 }) {
   return (
-    <div className="absolute bottom-full left-0 right-0 mb-1.5 max-h-[240px] overflow-y-auto rounded-xl border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-20">
+    <div className="absolute bottom-full left-0 right-0 mb-1.5 max-h-[240px] overflow-y-auto rounded-xl border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-20">
       {commands.map((cmd, i) => {
         const active = i === selectedIdx
         return (
@@ -529,7 +529,7 @@ function SlashPopup({
             onMouseEnter={() => onHover(i)}
             onMouseDown={(e) => { e.preventDefault(); onPick(cmd) }}
             className={`w-full text-left px-3 py-2 flex items-start gap-2 ${
-              active ? 'bg-white/10' : 'hover:bg-white/5'
+              active ? 'bg-hover-strong' : 'hover:bg-hover'
             }`}
           >
             <span className={`shrink-0 mt-[1px] px-1.5 py-[1px] rounded text-[9px] uppercase tracking-wider font-semibold ${SOURCE_COLOR[cmd.source]}`}>

--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -863,7 +863,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
           {!sidebarOpen && (
             <button
               onClick={() => setSidebarOpen(true)}
-              className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-white/5"
+              className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-hover"
               title="Open sidebar"
             >
               <SidebarIcon size={14} />
@@ -875,7 +875,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
               <button
                 onMouseDown={(e) => e.stopPropagation()}
                 onClick={() => { setModelPickerOpen((v) => { if (!v) void refreshModels(); return !v }) }}
-                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] text-primary hover:bg-white/5"
+                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] text-primary hover:bg-hover"
               >
                 <CateLogo size={12} className="text-agent-light" />
                 <span className="truncate max-w-[220px]">

--- a/src/agent/renderer/AgentPanelChrome.tsx
+++ b/src/agent/renderer/AgentPanelChrome.tsx
@@ -54,7 +54,7 @@ export function QueueBadges({
         <span
           key={`f${i}`}
           title={s}
-          className="px-1.5 py-0.5 rounded bg-white/10 text-primary/80 max-w-[200px] truncate"
+          className="px-1.5 py-0.5 rounded bg-hover-strong text-primary/80 max-w-[200px] truncate"
         >
           after: {s}
         </span>
@@ -73,9 +73,9 @@ export function ExtensionStatusBar({ entries }: { entries: ExtensionStatusEntry[
   const visible = entries.filter((e) => e.key !== 'plan-mode')
   if (visible.length === 0) return null
   return (
-    <div className="flex flex-wrap gap-2 px-3 py-1 border-t border-white/5 bg-black/15 text-[11px] text-muted">
+    <div className="flex flex-wrap gap-2 px-3 py-1 border-t border-subtle bg-surface-0 text-[11px] text-muted">
       {visible.map((e) => (
-        <span key={e.key} className="px-1.5 py-0.5 rounded bg-white/5 font-mono">
+        <span key={e.key} className="px-1.5 py-0.5 rounded bg-hover font-mono">
           {e.text}
         </span>
       ))}
@@ -93,7 +93,7 @@ export function ExtensionWidget({
   const filtered = widgets.filter((w) => w.placement === placement)
   if (filtered.length === 0) return null
   return (
-    <div className="px-3 py-1.5 space-y-2 text-[11.5px] text-primary/90 border-t border-white/5 bg-black/15">
+    <div className="px-3 py-1.5 space-y-2 text-[11.5px] text-primary/90 border-t border-subtle bg-surface-0">
       {filtered.map((w) => (
         <div key={w.key} className="font-mono whitespace-pre">
           {w.lines.join('\n')}
@@ -145,7 +145,7 @@ export function ExtensionDialog({
             <button
               key={opt}
               onClick={() => onRespond({ id: request.id, value: opt })}
-              className="w-full text-left px-3 py-1.5 rounded-md bg-white/5 hover:bg-agent/30 text-primary text-[12px]"
+              className="w-full text-left px-3 py-1.5 rounded-md bg-hover hover:bg-agent/30 text-primary text-[12px]"
             >
               {opt}
             </button>
@@ -161,7 +161,7 @@ export function ExtensionDialog({
         <div className="flex items-center gap-2 justify-end">
           <button
             onClick={() => onRespond({ id: request.id, confirmed: false })}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
+            className="px-2.5 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary text-[12px]"
           >
             No
           </button>
@@ -191,13 +191,13 @@ export function ExtensionDialog({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={String(request.placeholder ?? '')}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
+            className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex items-center gap-2 justify-end">
             <button
               type="button"
               onClick={() => onRespond({ id: request.id, cancelled: true })}
-              className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
+              className="px-2.5 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary text-[12px]"
             >
               Cancel
             </button>
@@ -221,12 +221,12 @@ export function ExtensionDialog({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           rows={8}
-          className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-2 text-[12px] text-primary outline-none focus:border-agent/60 font-mono resize-y"
+          className="w-full bg-surface-3 border border-strong rounded-md px-2 py-2 text-[12px] text-primary outline-none focus:border-agent/60 font-mono resize-y"
         />
         <div className="flex items-center gap-2 justify-end mt-2">
           <button
             onClick={() => onRespond({ id: request.id, cancelled: true })}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
+            className="px-2.5 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary text-[12px]"
           >
             Cancel
           </button>
@@ -336,7 +336,7 @@ export function ImageAttachButton({ onPick }: { onPick: (img: AgentImageAttachme
       <button
         type="button"
         onClick={() => inputRef.current?.click()}
-        className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-white/5"
+        className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-hover"
         title="Attach image"
       >
         <ImageIcon size={13} />
@@ -466,7 +466,7 @@ export function ThinkingLevelPicker({
         ref={btnRef}
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 px-1.5 py-1 rounded-md text-[10.5px] text-muted/70 hover:text-primary hover:bg-white/5 disabled:opacity-50"
+        className="flex items-center gap-1 px-1.5 py-1 rounded-md text-[10.5px] text-muted/70 hover:text-primary hover:bg-hover disabled:opacity-50"
         title={`Reasoning effort: ${current}`}
       >
         <ThinkingBars count={bars} />
@@ -474,16 +474,16 @@ export function ThinkingLevelPicker({
       {open && pos && portalTarget && createPortal(
         <div
           ref={popoverRef}
-          className="absolute w-[160px] rounded-lg border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-[9999] overflow-hidden"
+          className="absolute w-[160px] rounded-lg border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-[9999] overflow-hidden"
           style={{ top: pos.top, left: pos.left, transform: 'translateY(-100%)' }}
         >
-          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider font-semibold text-muted/70 border-b border-white/5">Thinking level</div>
+          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider font-semibold text-muted/70 border-b border-subtle">Thinking level</div>
           {THINKING_LEVELS.map((lv) => (
             <button
               key={lv}
               onClick={() => { setOpen(false); onChange(lv) }}
               className={`w-full flex items-center justify-between px-3 py-1.5 text-[12px] capitalize ${
-                lv === current ? 'bg-white/10 text-primary' : 'text-primary hover:bg-white/5'
+                lv === current ? 'bg-hover-strong text-primary' : 'text-primary hover:bg-hover'
               }`}
             >
               <span>{lv}</span>

--- a/src/agent/renderer/AgentSettingsView.tsx
+++ b/src/agent/renderer/AgentSettingsView.tsx
@@ -19,8 +19,8 @@ const TAB_BADGE: Record<'agents' | 'prompts' | 'skills', string> = {
 }
 
 const TAB_BADGE_COLOR: Record<'agents' | 'prompts' | 'skills', string> = {
-  agents: 'text-muted bg-white/5',
-  prompts: 'text-muted bg-white/5',
+  agents: 'text-muted bg-hover',
+  prompts: 'text-muted bg-hover',
   skills: 'text-agent-light bg-agent/10',
 }
 
@@ -143,13 +143,13 @@ export function SettingsView({
         )}
         <button
           onClick={() => window.electronAPI.agentOpenSkillsFolder(cwd, kind).catch(() => {})}
-          className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
+          className="flex items-center gap-1 px-2.5 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary text-[12px]"
         >
           <FolderOpen size={11} /> Open folder
         </button>
       </div>
       {creating === kind && (
-        <div className="rounded-lg bg-white/[0.03] p-2 flex items-center gap-2 mt-2">
+        <div className="rounded-lg bg-hover p-2 flex items-center gap-2 mt-2">
           <input
             autoFocus
             value={newName}
@@ -159,7 +159,7 @@ export function SettingsView({
               if (e.key === 'Escape') { setCreating(null); setNewName(''); setError(null) }
             }}
             placeholder={`${kind.slice(0, -1)} name`}
-            className="flex-1 bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 font-mono"
+            className="flex-1 bg-surface-3 border border-strong rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 font-mono"
           />
           <button
             onClick={() => handleCreate(kind)}
@@ -177,7 +177,7 @@ export function SettingsView({
         </div>
       )}
       {creating === kind && error && <div className="text-[12px] text-primary mt-1">{error}</div>}
-      <div className="rounded-lg bg-white/[0.02] overflow-hidden mt-2">
+      <div className="rounded-lg bg-hover overflow-hidden mt-2">
         {files.length === 0 && (kind !== 'skills' || packageSkills.length === 0) ? (
           <div className="px-3 py-4 text-center text-[12px] text-muted">
             No {kind} yet.
@@ -203,7 +203,7 @@ export function SettingsView({
                 name={c.name}
                 description={c.description}
                 badge="Built-in"
-                badgeClass="text-muted bg-white/5"
+                badgeClass="text-muted bg-hover"
                 filePath={c.path}
                 deletable={false}
                 onOpen={() => handleOpen(c.path)}
@@ -230,7 +230,7 @@ export function SettingsView({
               onClick={() => scrollTo(id)}
               className={`text-left px-2 py-1 rounded-md text-[12px] ${
                 activeSection === id
-                  ? 'text-primary bg-white/10'
+                  ? 'text-primary bg-hover-strong'
                   : 'text-muted hover:text-primary'
               }`}
             >
@@ -261,7 +261,7 @@ export function SettingsView({
             <div className="text-[13px] font-semibold text-primary">Extensions</div>
             <button
               onClick={() => setRefreshNonce((n) => n + 1)}
-              className="p-1 rounded-md text-muted hover:text-primary hover:bg-white/5"
+              className="p-1 rounded-md text-muted hover:text-primary hover:bg-hover"
               title="Refresh"
             >
               <ArrowsClockwise size={12} />
@@ -414,7 +414,7 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
   return (
     <div className="space-y-4">
       {error && (
-        <div className="rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-[12px] text-rose-100 whitespace-pre-wrap break-words">
+        <div className="rounded-md border border-danger bg-danger-tint px-3 py-2 text-[12px] text-primary whitespace-pre-wrap break-words">
           {error}
         </div>
       )}
@@ -423,7 +423,7 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
         <div className="flex items-center justify-between mb-1.5">
           <div className="text-[11px] uppercase tracking-wider text-muted">Installed</div>
         </div>
-        <div className="rounded-lg bg-white/[0.02] overflow-hidden">
+        <div className="rounded-lg bg-hover overflow-hidden">
           {installed.length === 0 ? (
             <div className="px-3 py-6 text-center text-[12px] text-muted">
               No extensions installed.
@@ -464,7 +464,7 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
                 setSort(e.target.value as MarketplaceSortValue)
                 setPage(1)
               }}
-              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
+              className="bg-surface-3 border border-strong rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60"
             >
               <option value="downloads">Most downloads</option>
               <option value="recent">Recently published</option>
@@ -474,11 +474,11 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
               value={queryInput}
               onChange={(e) => setQueryInput(e.target.value)}
               placeholder="Search..."
-              className="bg-surface-3 border border-white/10 rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 w-[180px]"
+              className="bg-surface-3 border border-strong rounded-md px-2 py-1 text-[12px] text-primary outline-none focus:border-agent/60 w-[180px]"
             />
           </div>
         </div>
-        <div className="rounded-lg bg-white/[0.02] overflow-hidden">
+        <div className="rounded-lg bg-hover overflow-hidden">
           {!loaded ? (
             <div className="px-3 py-6 text-center text-[12px] text-muted">Loading…</div>
           ) : filtered.length === 0 ? (
@@ -512,7 +512,7 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={browseLoading || page <= 1}
-              className="px-2 py-1 rounded-md bg-white/5 hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
+              className="px-2 py-1 rounded-md bg-hover hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-[var(--surface-hover)] disabled:hover:text-muted"
             >
               « Prev
             </button>
@@ -522,7 +522,7 @@ function ExtensionsTab({ cwd, refreshNonce = 0 }: { cwd: string; refreshNonce?: 
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={browseLoading || page >= totalPages}
-              className="px-2 py-1 rounded-md bg-white/5 hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-white/5 disabled:hover:text-muted"
+              className="px-2 py-1 rounded-md bg-hover hover:bg-agent/20 hover:text-primary disabled:opacity-40 disabled:cursor-default disabled:hover:bg-[var(--surface-hover)] disabled:hover:text-muted"
             >
               Next »
             </button>
@@ -560,10 +560,10 @@ function ExtensionRow({
     actionTone === 'primary'
       ? 'bg-agent hover:bg-agent-light text-white'
       : actionTone === 'danger'
-      ? 'bg-white/5 hover:bg-rose-500/30 text-rose-100'
-      : 'bg-white/5 text-muted'
+      ? 'bg-hover hover:bg-danger-tint text-danger'
+      : 'bg-hover text-muted'
   return (
-    <div className="flex items-start gap-2 px-3 py-2 border-b border-white/5 last:border-0 hover:bg-white/[0.04]">
+    <div className="flex items-start gap-2 px-3 py-2 border-b border-subtle last:border-0 hover:bg-hover">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-[12.5px] text-primary font-mono truncate">{name}</span>
@@ -626,7 +626,7 @@ function SkillRow({
     <div
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className="group flex items-center gap-2 px-3 py-2 border-b border-white/5 last:border-0 hover:bg-white/[0.04]"
+      className="group flex items-center gap-2 px-3 py-2 border-b border-subtle last:border-0 hover:bg-hover"
     >
       <button
         onClick={onOpen}
@@ -646,7 +646,7 @@ function SkillRow({
       {hovered && deletable && (
         <button
           onClick={(e) => { e.stopPropagation(); onDelete() }}
-          className="p-1 rounded-md text-muted hover:text-primary hover:bg-white/10"
+          className="p-1 rounded-md text-muted hover:text-primary hover:bg-hover-strong"
           title="Delete"
         >
           <Trash size={11} />

--- a/src/agent/renderer/AgentSidebar.tsx
+++ b/src/agent/renderer/AgentSidebar.tsx
@@ -45,11 +45,11 @@ export function AgentSidebar({
   const grouped = useMemo(() => groupChats(chats), [chats])
 
   return (
-    <div className="w-[200px] shrink-0 flex flex-col border-r border-subtle bg-black/15 min-h-0">
+    <div className="w-[200px] shrink-0 flex flex-col border-r border-subtle bg-surface-0 min-h-0">
       <div className="flex items-center gap-1 px-2 h-10 border-b border-subtle shrink-0">
         <button
           onClick={onCollapse}
-          className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-white/5"
+          className="p-1.5 rounded-md text-muted hover:text-primary hover:bg-hover"
           title="Collapse sidebar"
         >
           <SidebarIcon size={14} />
@@ -65,7 +65,7 @@ export function AgentSidebar({
       </div>
 
       <div className="px-2 pt-2 pb-2 shrink-0">
-        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-black/20 border border-white/5">
+        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface-0 border border-subtle">
           <MagnifyingGlass size={11} className="text-muted shrink-0" />
           <input
             value={search}
@@ -106,8 +106,8 @@ export function AgentSidebar({
           onClick={onOpenSettings}
           className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[12px] ${
             settingsActive
-              ? 'bg-white/10 text-primary'
-              : 'text-muted hover:bg-white/5 hover:text-primary'
+              ? 'bg-hover-strong text-primary'
+              : 'text-muted hover:bg-hover hover:text-primary'
           }`}
         >
           <Gear size={12} />
@@ -132,7 +132,7 @@ function ChatRow({
   return (
     <div
       className={`group flex items-center gap-1 px-1 rounded-md ${
-        active ? 'bg-white/10' : 'hover:bg-white/5'
+        active ? 'bg-hover-strong' : 'hover:bg-hover'
       }`}
     >
       <button
@@ -145,7 +145,7 @@ function ChatRow({
       </button>
       <button
         onClick={(e) => { e.stopPropagation(); onDelete() }}
-        className="p-1 rounded-md text-muted hover:text-primary hover:bg-white/10 opacity-0 group-hover:opacity-100"
+        className="p-1 rounded-md text-muted hover:text-primary hover:bg-hover-strong opacity-0 group-hover:opacity-100"
         title="Delete chat"
       >
         <Trash size={10} />

--- a/src/agent/renderer/ChatThread.tsx
+++ b/src/agent/renderer/ChatThread.tsx
@@ -238,7 +238,7 @@ export function ChatThread({ messages, pendingApprovals, onApproval, running, fo
         onClick={() => { scrollToBottom(true); setAtBottom(true) }}
         title="Scroll to bottom"
         aria-label="Scroll to bottom"
-        className="absolute bottom-3 right-3 z-10 p-2 rounded-full bg-surface-2 border border-white/10 text-muted hover:text-primary shadow-lg cate-fade-in"
+        className="absolute bottom-3 right-3 z-10 p-2 rounded-full bg-surface-2 border border-strong text-muted hover:text-primary shadow-lg cate-fade-in"
       >
         <ArrowDown size={14} weight="bold" />
       </button>
@@ -251,20 +251,20 @@ function RetryIndicator({ state, onAbort }: { state: RetryState; onAbort?: () =>
   if (state.active) {
     const delay = state.delayMs != null ? `${Math.round(state.delayMs / 1000)}s` : '…'
     return (
-      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-[12px]">
-        <ArrowClockwise size={13} className="text-amber-400 animate-spin shrink-0" />
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-warning-tint border border-warning text-[12px]">
+        <ArrowClockwise size={13} className="text-warning animate-spin shrink-0" />
         <div className="flex-1 min-w-0">
-          <span className="text-amber-200">
+          <span className="text-warning">
             Retrying ({state.attempt ?? '?'}/{state.maxAttempts ?? '?'}) in {delay}
           </span>
           {state.errorMessage && (
-            <div className="text-[11px] text-amber-200/60 mt-0.5 truncate">{state.errorMessage}</div>
+            <div className="text-[11px] text-warning opacity-70 mt-0.5 truncate">{state.errorMessage}</div>
           )}
         </div>
         {onAbort && (
           <button
             onClick={onAbort}
-            className="px-2 py-0.5 rounded-md bg-white/5 hover:bg-white/10 text-amber-200 text-[11px] shrink-0"
+            className="px-2 py-0.5 rounded-md bg-hover hover:bg-hover-strong text-warning text-[11px] shrink-0"
           >
             Abort
           </button>
@@ -273,9 +273,9 @@ function RetryIndicator({ state, onAbort }: { state: RetryState; onAbort?: () =>
     )
   }
   return (
-    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-[12px]">
-      <WarningCircle size={13} weight="fill" className="text-red-400 shrink-0" />
-      <span className="text-red-300">
+    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-danger-tint border border-danger text-[12px]">
+      <WarningCircle size={13} weight="fill" className="text-danger shrink-0" />
+      <span className="text-danger">
         Retries exhausted{state.finalError ? `: ${state.finalError.length > 120 ? state.finalError.slice(0, 120) + '…' : state.finalError}` : ''}
       </span>
     </div>
@@ -317,14 +317,14 @@ function MessageRow({
   if (msg.type === 'user') {
     return (
       <div className="flex flex-col items-end gap-1">
-        <div className="max-w-[85%] px-3.5 py-2 rounded-2xl rounded-br-md bg-white/[0.08] text-primary text-[13px] whitespace-pre-wrap break-words select-text cursor-text">
+        <div className="max-w-[85%] px-3.5 py-2 rounded-2xl rounded-br-md bg-hover-strong text-primary text-[13px] whitespace-pre-wrap break-words select-text cursor-text">
           {msg.text}
         </div>
         <div className="flex items-center gap-0.5 text-muted">
           <button
             onClick={() => { void navigator.clipboard.writeText(msg.text) }}
             title="Copy message"
-            className="p-1 rounded-md hover:text-primary hover:bg-white/10"
+            className="p-1 rounded-md hover:text-primary hover:bg-hover-strong"
           >
             <Copy size={11} />
           </button>
@@ -348,12 +348,12 @@ function MessageRow({
             <button
               onClick={() => { void navigator.clipboard.writeText(msg.text) }}
               title="Copy message"
-              className="p-1 rounded-md hover:text-primary hover:bg-white/10"
+              className="p-1 rounded-md hover:text-primary hover:bg-hover-strong"
             >
               <Copy size={11} />
             </button>
             {(msg.model || msg.createdAt) && (
-              <span className="text-[10.5px] text-zinc-500 ml-1">
+              <span className="text-[10.5px] text-muted ml-1">
                 {msg.model}
                 {msg.model && msg.createdAt ? ' · ' : ''}
                 {msg.createdAt ? formatTime(msg.createdAt) : ''}
@@ -367,9 +367,9 @@ function MessageRow({
   if (msg.type === 'system') {
     const tone =
       msg.kind === 'error'
-        ? 'text-red-300'
+        ? 'text-danger'
         : msg.kind === 'warning'
-        ? 'text-amber-300'
+        ? 'text-warning'
         : 'text-muted'
     return <div className={`text-center text-[11px] italic ${tone}`}>{msg.text}</div>
   }
@@ -445,7 +445,7 @@ function Markdown({ text }: { text: string }) {
               {children}
             </blockquote>
           ),
-          hr: () => <hr className="border-white/10 my-2" />,
+          hr: () => <hr className="border-strong my-2" />,
           strong: ({ children }) => <strong className="font-semibold text-primary">{children}</strong>,
           em: ({ children }) => <em className="italic">{children}</em>,
           code: ({ className, children, ...props }) => {
@@ -458,26 +458,26 @@ function Markdown({ text }: { text: string }) {
               )
             }
             return (
-              <code className="font-mono text-[11.5px] px-1 py-[1px] rounded bg-black/30 text-agent-light" {...props}>
+              <code className="font-mono text-[11.5px] px-1 py-[1px] rounded bg-surface-0 text-agent-light" {...props}>
                 {children}
               </code>
             )
           },
           pre: ({ children }) => (
-            <pre className="rounded-md bg-black/40 border border-white/10 px-3 py-2 overflow-x-auto text-[11.5px] leading-snug">
+            <pre className="rounded-md bg-surface-0 border border-strong px-3 py-2 overflow-x-auto text-[11.5px] leading-snug">
               {children}
             </pre>
           ),
           table: ({ children }) => (
             <div className="overflow-x-auto">
-              <table className="min-w-full text-[12px] border border-white/10 rounded-md">{children}</table>
+              <table className="min-w-full text-[12px] border border-strong rounded-md">{children}</table>
             </div>
           ),
           th: ({ children }) => (
-            <th className="text-left px-2 py-1 border-b border-white/10 bg-white/[0.04] font-medium">{children}</th>
+            <th className="text-left px-2 py-1 border-b border-strong bg-hover font-medium">{children}</th>
           ),
           td: ({ children }) => (
-            <td className="px-2 py-1 border-b border-white/5 align-top">{children}</td>
+            <td className="px-2 py-1 border-b border-subtle align-top">{children}</td>
           ),
         }}
       >
@@ -649,7 +649,7 @@ function ToolCard({ msg, shimmer }: { msg: ToolMessage; shimmer?: boolean }) {
               {isRunning && <span className="inline-block w-[2px] h-[1em] align-middle bg-primary/80 ml-0.5 animate-pulse" />}
             </pre>
             {msg.error && (
-              <pre className="text-rose-300/90 whitespace-pre-wrap break-words">
+              <pre className="text-danger whitespace-pre-wrap break-words">
                 {msg.error}
               </pre>
             )}
@@ -694,7 +694,7 @@ function ToolCard({ msg, shimmer }: { msg: ToolMessage; shimmer?: boolean }) {
             </pre>
           )}
           {msg.error && (
-            <pre className="text-[11px] text-rose-300/90 whitespace-pre-wrap break-words font-mono leading-snug">
+            <pre className="text-[11px] text-danger whitespace-pre-wrap break-words font-mono leading-snug">
               {msg.error}
             </pre>
           )}
@@ -769,7 +769,7 @@ function SubagentCard({ msg, shimmer }: { msg: ToolMessage; shimmer?: boolean })
             results.map((r, i) => <SubagentResultRow key={i} result={r} parentRunning={running} />)
           )}
           {msg.error && (
-            <pre className="text-[11px] text-rose-300/90 whitespace-pre-wrap break-words font-mono leading-snug">
+            <pre className="text-[11px] text-danger whitespace-pre-wrap break-words font-mono leading-snug">
               {msg.error}
             </pre>
           )}
@@ -821,7 +821,7 @@ function SubagentResultRow({
             onClick={(e) => e.stopPropagation()}
           >
             <Info size={11} className="text-muted hover:text-primary/70 cursor-help" />
-            <span className="absolute bottom-full right-0 mb-1 hidden group-hover/info:block whitespace-nowrap text-[10px] text-primary/90 font-mono bg-surface-2 border border-white/10 rounded px-1.5 py-1 shadow-lg z-10">
+            <span className="absolute bottom-full right-0 mb-1 hidden group-hover/info:block whitespace-nowrap text-[10px] text-primary/90 font-mono bg-surface-2 border border-strong rounded px-1.5 py-1 shadow-lg z-10">
               {usageBits.join(' · ')}{result.model ? ` · ${result.model}` : ''}
             </span>
           </span>
@@ -848,7 +848,7 @@ function SubagentResultRow({
             return null
           })}
           {result.errorMessage && (
-            <pre className="text-[11px] text-rose-300/90 whitespace-pre-wrap break-words font-mono leading-snug">
+            <pre className="text-[11px] text-danger whitespace-pre-wrap break-words font-mono leading-snug">
               {result.errorMessage}
             </pre>
           )}
@@ -1027,20 +1027,20 @@ function PlanReadyCard({
           disabled={!!effectiveLocked}
           rows={2}
           placeholder="Refine: type the changes you want…"
-          className="w-full rounded-md bg-black/20 border border-agent/20 focus:border-agent-light/60 outline-none px-2.5 py-2 text-[12px] text-primary placeholder:text-muted resize-none disabled:opacity-50"
+          className="w-full rounded-md bg-surface-0 border border-agent/20 focus:border-agent-light/60 outline-none px-2.5 py-2 text-[12px] text-primary placeholder:text-muted resize-none disabled:opacity-50"
         />
         <div className="flex items-center gap-2 flex-wrap">
           <button
             onClick={handleRefine}
             disabled={!!effectiveLocked || refineText.trim().length === 0}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
+            className="px-2.5 py-1 rounded-md bg-hover hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-[var(--surface-hover)]"
           >
             {lockLabel('Refine plan', 'refine')}
           </button>
           <button
             onClick={handleClear}
             disabled={!!effectiveLocked}
-            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-white/5"
+            className="px-2.5 py-1 rounded-md bg-hover hover:bg-agent/20 text-primary text-[11.5px] font-medium disabled:opacity-50 disabled:cursor-default disabled:hover:bg-[var(--surface-hover)]"
           >
             {lockLabel('Clear context & implement', 'clear')}
           </button>
@@ -1148,23 +1148,23 @@ function DiffView({ diff }: { diff: DiffInfo }) {
             key={i}
             className={`flex ${
               l.kind === 'add'
-                ? 'bg-emerald-500/[0.08]'
+                ? 'bg-diff-add'
                 : l.kind === 'del'
-                ? 'bg-rose-500/[0.08]'
+                ? 'bg-diff-del'
                 : ''
             }`}
           >
             <span className="w-5 text-right pr-1.5 select-none text-muted/30 shrink-0">{ln}</span>
             <span className={`w-3 text-center select-none shrink-0 ${
-              l.kind === 'add' ? 'text-emerald-400/70' : l.kind === 'del' ? 'text-rose-400/70' : 'text-transparent'
+              l.kind === 'add' ? 'text-diff-add' : l.kind === 'del' ? 'text-diff-del' : 'text-transparent'
             }`}>
               {l.kind === 'add' ? '+' : l.kind === 'del' ? '-' : ' '}
             </span>
             <span className={`whitespace-pre-wrap break-words flex-1 pr-2 ${
               l.kind === 'add'
-                ? 'text-emerald-300/90'
+                ? 'text-diff-add'
                 : l.kind === 'del'
-                ? 'text-rose-300/70 line-through decoration-rose-400/20'
+                ? 'text-diff-del line-through'
                 : 'text-primary/50'
             }`}>{l.text || ' '}</span>
           </div>
@@ -1193,7 +1193,7 @@ function ApprovalCard({
           Allow <strong className="font-mono">{req.toolName}</strong>?
         </span>
       </div>
-      <pre className="text-[11px] text-primary/80 whitespace-pre-wrap break-words font-mono max-h-[160px] overflow-auto bg-black/20 rounded p-2 select-text cursor-text">
+      <pre className="text-[11px] text-primary/80 whitespace-pre-wrap break-words font-mono max-h-[160px] overflow-auto bg-surface-0 rounded p-2 select-text cursor-text">
         {prettyArgs(req.args)}
       </pre>
       <div className="flex items-center gap-2">
@@ -1205,7 +1205,7 @@ function ApprovalCard({
         </button>
         <button
           onClick={() => onDecide('deny')}
-          className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[11px] font-medium"
+          className="px-2.5 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary text-[11px] font-medium"
         >
           Deny
         </button>

--- a/src/agent/renderer/ModelPicker.tsx
+++ b/src/agent/renderer/ModelPicker.tsx
@@ -75,10 +75,10 @@ export function ModelPicker({
   return (
     <div
       ref={wrapRef}
-      className="absolute top-full left-0 mt-1 w-[280px] max-h-[360px] flex flex-col rounded-lg border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-20"
+      className="absolute top-full left-0 mt-1 w-[280px] max-h-[360px] flex flex-col rounded-lg border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-20"
     >
-      <div className="px-2 py-2 border-b border-white/10 shrink-0">
-        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-black/20 border border-white/5">
+      <div className="px-2 py-2 border-b border-strong shrink-0">
+        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface-0 border border-subtle">
           <MagnifyingGlass size={11} className="text-muted shrink-0" />
           <input
             ref={searchRef}
@@ -118,7 +118,7 @@ export function ModelPicker({
                     key={`${m.provider}:${m.model}`}
                     onClick={() => onPick(m)}
                     className={`w-full text-left px-3 py-1.5 text-[12px] flex items-center gap-2 ${
-                      isSelected ? 'bg-white/10 text-primary' : 'text-primary hover:bg-white/5'
+                      isSelected ? 'bg-hover-strong text-primary' : 'text-primary hover:bg-hover'
                     }`}
                   >
                     <span className="truncate flex-1">{m.label ?? m.model}</span>
@@ -131,10 +131,10 @@ export function ModelPicker({
         })
       )}
       </div>
-      <div className="border-t border-white/10 shrink-0">
+      <div className="border-t border-strong shrink-0">
         <button
           onClick={onManage}
-          className="w-full text-left px-3 py-1.5 text-[12px] text-agent-light hover:bg-white/5"
+          className="w-full text-left px-3 py-1.5 text-[12px] text-agent-light hover:bg-hover"
         >
           Manage providers…
         </button>

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -152,7 +152,7 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false, avai
       <div className="flex items-center gap-2 px-3 h-9 border-b border-subtle shrink-0">
         <button
           onClick={() => onBack?.()}
-          className="p-1 -ml-1 rounded-md text-muted hover:text-primary hover:bg-white/5"
+          className="p-1 -ml-1 rounded-md text-muted hover:text-primary hover:bg-hover"
           title="Back to chat"
         >
           <ArrowLeft size={14} />
@@ -189,11 +189,11 @@ function CustomOpenAIRow({
 
   const configured = !!cfg && !!cfg.baseUrl && cfg.models.length > 0
   return (
-    <div className="border-b border-white/5 last:border-0">
+    <div className="border-b border-subtle last:border-0">
       <button
         onClick={onToggle}
         aria-expanded={expanded}
-        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-white/[0.04]"
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-hover"
       >
         <span className="flex-1 truncate text-[12.5px] text-primary">Custom OpenAI endpoint</span>
         {configured ? (
@@ -208,7 +208,7 @@ function CustomOpenAIRow({
           : <CaretRight size={10} className="text-muted/60" />}
       </button>
       {expanded && (
-        <div className="p-2.5 border-t border-white/5 bg-black/10">
+        <div className="p-2.5 border-t border-subtle bg-surface-0">
           <CustomOpenAIForm cfg={cfg} onSaved={setCfg} />
         </div>
       )}
@@ -272,7 +272,7 @@ function CustomOpenAIForm({
         autoComplete="off"
         spellCheck={false}
         placeholder="Base URL (e.g. http://localhost:11434/v1)"
-        className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+        className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
       />
       <div className="relative">
         <input
@@ -282,7 +282,7 @@ function CustomOpenAIForm({
           autoComplete="off"
           spellCheck={false}
           placeholder="API key (optional for local servers)"
-          className="w-full bg-surface-3 border border-white/10 rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+          className="w-full bg-surface-3 border border-strong rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
         />
         <button
           type="button"
@@ -300,7 +300,7 @@ function CustomOpenAIForm({
         autoComplete="off"
         spellCheck={false}
         placeholder="Model ids, comma-separated (e.g. llama3.1:8b)"
-        className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+        className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
       />
       <div className="text-[11px] text-muted leading-relaxed">
         Any OpenAI-compatible server.
@@ -318,14 +318,14 @@ function CustomOpenAIForm({
           <button
             disabled={saving}
             onClick={handleRemove}
-            className="text-[11px] text-muted hover:text-rose-200"
+            className="text-[11px] text-muted hover:text-danger"
           >
             Remove
           </button>
         )}
       </div>
 
-      {error && <div className="text-[11px] text-rose-300">{error}</div>}
+      {error && <div className="text-[11px] text-danger">{error}</div>}
       {savedAt && !error && (
         <div className="flex items-center gap-1 text-[11px] text-agent-light">
           <CheckCircle size={12} weight="fill" /> Saved.
@@ -345,7 +345,7 @@ function Section({ label, children }: { label: string; children: React.ReactNode
       <div className="mb-1 text-[10px] uppercase tracking-wider text-muted/70 font-semibold">
         {label}
       </div>
-      <div className="rounded-lg border border-white/5 bg-white/[0.02] overflow-hidden">
+      <div className="rounded-lg border border-subtle bg-white/[0.02] overflow-hidden">
         {children}
       </div>
     </div>
@@ -367,11 +367,11 @@ function ProviderAccordionRow({
 }) {
   const connected = !!status?.connected
   return (
-    <div className="border-b border-white/5 last:border-0">
+    <div className="border-b border-subtle last:border-0">
       <button
         onClick={onToggle}
         aria-expanded={expanded}
-        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-white/[0.04]"
+        className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-hover"
       >
         <span className="flex-1 truncate text-[12.5px] text-primary">{provider.name}</span>
         {connected ? (
@@ -386,7 +386,7 @@ function ProviderAccordionRow({
           : <CaretRight size={10} className="text-muted/60" />}
       </button>
       {expanded && (
-        <div className="p-2.5 border-t border-white/5 bg-black/10">
+        <div className="p-2.5 border-t border-subtle bg-surface-0">
           <ProviderDetail provider={provider} status={status} onRefresh={onRefresh} />
         </div>
       )}
@@ -502,13 +502,13 @@ function OAuthForm({
         <div className="flex items-center gap-2">
           <button
             onClick={handleStart}
-            className="flex-1 px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-primary text-[12px]"
+            className="flex-1 px-3 py-1.5 rounded-md bg-hover hover:bg-hover-strong text-primary text-[12px]"
           >
             Re-authenticate
           </button>
           <button
             onClick={handleDisconnect}
-            className="shrink-0 px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-[12px] text-rose-300 hover:text-rose-200"
+            className="shrink-0 px-3 py-1.5 rounded-md bg-hover hover:bg-hover-strong text-[12px] text-danger hover:text-danger"
           >
             Disconnect
           </button>
@@ -520,7 +520,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'deviceCode' && (
-        <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
+        <div className="space-y-3 rounded-md border border-strong bg-hover p-2.5">
           <div className="text-[12px] text-primary">
             Enter this code in your browser at{' '}
             <a href={phase.verificationUri} target="_blank" rel="noreferrer" className="underline text-agent-light">
@@ -529,12 +529,12 @@ function OAuthForm({
             :
           </div>
           <div className="flex items-center gap-2">
-            <code className="flex-1 text-center font-mono text-[18px] tracking-[0.3em] py-2 rounded-md bg-black/30 text-primary">
+            <code className="flex-1 text-center font-mono text-[18px] tracking-[0.3em] py-2 rounded-md bg-surface-0 text-primary">
               {phase.userCode}
             </code>
             <button
               onClick={() => { try { navigator.clipboard.writeText(phase.userCode) } catch { /* */ } }}
-              className="p-2 rounded-md bg-white/5 hover:bg-white/10 text-primary"
+              className="p-2 rounded-md bg-hover hover:bg-hover-strong text-primary"
               title="Copy code"
             >
               <Copy size={12} />
@@ -556,7 +556,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'prompt' && (
-        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
+        <div className="space-y-2 rounded-md border border-strong bg-hover p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <input
             type="text"
@@ -565,7 +565,7 @@ function OAuthForm({
             onChange={(e) => setPromptValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handlePromptSubmit(phase.promptId, promptValue) }}
             placeholder={phase.placeholder ?? ''}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
+            className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex justify-end">
             <button
@@ -580,14 +580,14 @@ function OAuthForm({
       )}
 
       {phase.type === 'select' && (
-        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
+        <div className="space-y-2 rounded-md border border-strong bg-hover p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <div className="flex flex-col gap-1">
             {phase.options.map((opt) => (
               <button
                 key={opt.id}
                 onClick={() => handlePromptSubmit(phase.promptId, opt.id)}
-                className="text-left px-2 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-[12px] text-primary"
+                className="text-left px-2 py-1.5 rounded-md bg-hover hover:bg-hover-strong text-[12px] text-primary"
               >
                 {opt.label}
               </button>
@@ -597,7 +597,7 @@ function OAuthForm({
       )}
 
       {phase.type === 'manualCode' && (
-        <div className="space-y-2 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
+        <div className="space-y-2 rounded-md border border-strong bg-hover p-2.5">
           <div className="text-[12px] text-primary">
             Sign in completes automatically when the browser callback fires.
             If it doesn't, paste the code (or full redirect URL) here:
@@ -608,7 +608,7 @@ function OAuthForm({
             value={promptValue}
             onChange={(e) => setPromptValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handlePromptSubmit(phase.promptId, promptValue) }}
-            className="w-full bg-surface-3 border border-white/10 rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
+            className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
           />
           <div className="flex justify-end">
             <button
@@ -629,11 +629,11 @@ function OAuthForm({
       )}
 
       {phase.type === 'error' && (
-        <div className="space-y-2 rounded-md border border-white/10 bg-white/5 p-2.5">
+        <div className="space-y-2 rounded-md border border-strong bg-hover p-2.5">
           <div className="text-[12px] text-primary">{phase.message}</div>
           <button
             onClick={handleStart}
-            className="px-3 py-1.5 rounded-md bg-white/10 hover:bg-white/15 text-primary text-[12px]"
+            className="px-3 py-1.5 rounded-md bg-hover-strong hover:bg-hover-strong text-primary text-[12px]"
           >
             Retry
           </button>
@@ -645,7 +645,7 @@ function OAuthForm({
 
 function AuthUrlCard({ url, instructions }: { url: string; instructions?: string }) {
   return (
-    <div className="space-y-3 rounded-md border border-white/10 bg-white/[0.03] p-2.5">
+    <div className="space-y-3 rounded-md border border-strong bg-hover p-2.5">
       <div className="flex items-center gap-2 text-[12px] text-primary">
         <CloudArrowUp size={14} className="text-agent-light" />
         Browser opened for sign in.
@@ -660,13 +660,13 @@ function AuthUrlCard({ url, instructions }: { url: string; instructions?: string
           href={url}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-1 text-[12px] px-2 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary"
+          className="inline-flex items-center gap-1 text-[12px] px-2 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary"
         >
           <ArrowSquareOut size={12} /> Open URL again
         </a>
         <button
           onClick={() => { try { navigator.clipboard.writeText(url) } catch { /* */ } }}
-          className="inline-flex items-center gap-1 text-[12px] px-2 py-1 rounded-md bg-white/5 hover:bg-white/10 text-primary"
+          className="inline-flex items-center gap-1 text-[12px] px-2 py-1 rounded-md bg-hover hover:bg-hover-strong text-primary"
         >
           <Copy size={12} /> Copy URL
         </button>
@@ -732,7 +732,7 @@ function ApiKeyForm({
             autoComplete="off"
             spellCheck={false}
             placeholder={status?.connected ? '••••••••••••' : `Paste your ${provider.name} key`}
-            className="w-full bg-surface-3 border border-white/10 rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
+            className="w-full bg-surface-3 border border-strong rounded-md pl-2 pr-8 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono"
           />
           <button
             type="button"
@@ -752,7 +752,7 @@ function ApiKeyForm({
         </button>
       </div>
 
-      {error && <div className="text-[11px] text-rose-300">{error}</div>}
+      {error && <div className="text-[11px] text-danger">{error}</div>}
       {savedAt && !error && (
         <div className="flex items-center gap-1 text-[11px] text-agent-light">
           <CheckCircle size={12} weight="fill" /> Saved.
@@ -761,7 +761,7 @@ function ApiKeyForm({
       {status?.connected && (
         <button
           onClick={handleDisconnect}
-          className="text-[11px] text-muted hover:text-rose-200"
+          className="text-[11px] text-muted hover:text-danger"
         >
           Disconnect
         </button>
@@ -800,7 +800,7 @@ function DefaultModelSection({ models }: { models: Array<{ provider: string; mod
       <div className="relative">
         <button
           onClick={() => setOpen((v) => !v)}
-          className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md bg-white/[0.04] border border-white/10 text-[12.5px] text-primary hover:bg-white/[0.06] focus:outline-none focus:border-agent-light/50"
+          className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md bg-hover border border-strong text-[12.5px] text-primary hover:bg-hover-strong focus:outline-none focus:border-agent-light/50"
         >
           <CateLogo size={12} className="text-agent-light shrink-0" />
           <span className="truncate flex-1 text-left">
@@ -887,10 +887,10 @@ function DefaultModelPicker({
   return (
     <div
       ref={wrapRef}
-      className="absolute top-full left-0 mt-1 w-full max-h-[320px] flex flex-col rounded-lg border border-white/10 bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_rgba(0,0,0,0.45)] z-20"
+      className="absolute top-full left-0 mt-1 w-full max-h-[320px] flex flex-col rounded-lg border border-strong bg-surface-4/98 backdrop-blur-xl shadow-[0_12px_32px_var(--shadow-node)] z-20"
     >
-      <div className="px-2 py-2 border-b border-white/10 shrink-0">
-        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-black/20 border border-white/5">
+      <div className="px-2 py-2 border-b border-strong shrink-0">
+        <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface-0 border border-subtle">
           <MagnifyingGlass size={11} className="text-muted shrink-0" />
           <input
             ref={searchRef}
@@ -905,7 +905,7 @@ function DefaultModelPicker({
         <button
           onClick={() => onPick(null)}
           className={`w-full text-left px-3 py-1.5 text-[12px] flex items-center gap-2 ${
-            !selected ? 'bg-white/10 text-primary' : 'text-muted hover:bg-white/5'
+            !selected ? 'bg-hover-strong text-primary' : 'text-muted hover:bg-hover'
           }`}
         >
           <span className="truncate flex-1">First available</span>
@@ -939,7 +939,7 @@ function DefaultModelPicker({
                       key={`${m.provider}:${m.model}`}
                       onClick={() => onPick(m)}
                       className={`w-full text-left px-3 py-1.5 text-[12px] flex items-center gap-2 ${
-                        isSelected ? 'bg-white/10 text-primary' : 'text-primary hover:bg-white/5'
+                        isSelected ? 'bg-hover-strong text-primary' : 'text-primary hover:bg-hover'
                       }`}
                     >
                       <span className="truncate flex-1">{m.label ?? m.model}</span>

--- a/src/renderer/drag/Overlay.tsx
+++ b/src/renderer/drag/Overlay.tsx
@@ -39,11 +39,16 @@ export default function DragOverlay() {
       ? (target.canvasStoreApi.getState().zoomLevel ?? ghostZoom)
       : ghostZoom
 
-  // The ghost free-tracks the cursor 1:1 even when snap-to-grid is active — the
-  // panel should move freely under the pointer and only snap to the grid on
-  // release. The committed origin (target.origin) is still snapped, so the drop
-  // lands on the grid; we just don't preview that snap mid-drag.
-  const rect = ghostScreenRect(cursor.client, grab, ghostSize, renderZoom)
+  // When snap-to-grid is active and the cursor is over a canvas, resolveDrop
+  // attaches `ghostRect` — the screen-px rect of the snapped landing cell — so
+  // the ghost previews where the panel will actually land (visibly stepping
+  // between grid cells as you drag). Otherwise the ghost free-tracks the cursor
+  // 1:1, mirroring the panel under the pointer.
+  const snappedRect =
+    target && (target.kind === 'canvas-reposition' || target.kind === 'canvas-add')
+      ? target.ghostRect
+      : undefined
+  const rect = snappedRect ?? ghostScreenRect(cursor.client, grab, ghostSize, renderZoom)
 
   return createPortal(
     <div data-drag-overlay="true" style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 10000 }}>

--- a/src/renderer/drag/resolve.test.ts
+++ b/src/renderer/drag/resolve.test.ts
@@ -515,11 +515,12 @@ describe('resolveDrop — canvas surface', () => {
     })
   })
 
-  it('snap=true rounds the reposition origin to the grid (ghost still free-tracks)', () => {
-    // The committed origin snaps to the grid; the ghost free-tracks the cursor
-    // during the drag (see Overlay), so no snapped preview rect is attached.
-    // Expectations derive from snapToGrid so they stay correct if the grid size
-    // changes. zoom=1, offset=0, container at (0,0) → raw origin is cursor - grab.
+  it('snap=true rounds the reposition origin to the grid and previews the snapped cell', () => {
+    // The committed origin snaps to the grid; with snap on, resolveDrop also
+    // attaches a screen-px ghostRect so the overlay previews the snapped landing
+    // cell. Expectations derive from snapToGrid so they stay correct if the grid
+    // size changes. zoom=1, offset=0, container at (0,0) → raw origin is
+    // cursor - grab, and the snapped screen rect is just the snapped origin.
     const cursor = { x: 300, y: 200 }
     const grabOffset = { x: 50, y: 25 }
     const rawOrigin = { x: cursor.x - grabOffset.x, y: cursor.y - grabOffset.y }
@@ -544,10 +545,16 @@ describe('resolveDrop — canvas surface', () => {
       canvasStoreApi: CANVAS_STORE_A,
       nodeId: 'node-A',
       origin,
+      ghostRect: {
+        left: origin.x,
+        top: origin.y,
+        width: ghostSize.width,
+        height: ghostSize.height,
+      },
     })
   })
 
-  it('snap=true snaps canvas-add origin (no snapped ghost rect attached)', () => {
+  it('snap=true snaps canvas-add origin and previews the snapped cell at the canvas zoom', () => {
     // zoom=2, offset {30,40}, container at {10,20}, grab 0.
     // cursor → canvas: ((300-10)-30)/2, ((200-20)-40)/2 = (130, 70) before snap.
     const zoom = 2
@@ -577,6 +584,13 @@ describe('resolveDrop — canvas surface', () => {
       canvasStoreApi: zoomed,
       origin,
       size: ghostSize,
+      // screen rect = containerRect + (origin * zoom + offset), sized at zoom.
+      ghostRect: {
+        left: containerRect.left + origin.x * zoom + offset.x,
+        top: containerRect.top + origin.y * zoom + offset.y,
+        width: ghostSize.width * zoom,
+        height: ghostSize.height * zoom,
+      },
     })
   })
 

--- a/src/renderer/drag/resolve.ts
+++ b/src/renderer/drag/resolve.ts
@@ -21,6 +21,7 @@ import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { findNodeIdForDockStore } from '../panels/nodeDockRegistry'
 import { getDefaultSession } from './session'
 import { cursorToCanvasOrigin } from './geometry'
+import { canvasToView } from '../lib/canvas/coordinates'
 import { findTabStackAcrossZones } from '../stores/dockTreeUtils'
 import { snapToGrid, CANVAS_GRID_SIZE } from '../canvas/layoutEngine'
 import type { WindowDockState } from '../../shared/types'
@@ -205,10 +206,14 @@ function resolveCanvasHit(
     state.viewportOffset,
     grab,
   )
-  // Snap the committed origin to the grid when snap-to-grid is active. The ghost
-  // still free-tracks the cursor during the drag (see Overlay) — the panel moves
-  // freely and only snaps to the grid on release.
+  // Snap the committed origin to the grid when snap-to-grid is active. When
+  // snapping, also compute the screen-px rect for the snapped landing position so
+  // the overlay can preview it (the ghost previews the grid cell the panel will
+  // land in rather than free-tracking the cursor 1:1).
   const origin = snap ? snapToGrid(rawOrigin, CANVAS_GRID_SIZE) : rawOrigin
+  const ghostRect = snap
+    ? snappedGhostScreenRect(origin, rect, state.zoomLevel, state.viewportOffset, ghostSize)
+    : undefined
 
   // Source is a canvas-node already on this canvas → reposition (move existing).
   if (source.origin.kind === 'canvas-node' && source.origin.canvasStoreApi === canvasStoreApi) {
@@ -217,6 +222,7 @@ function resolveCanvasHit(
       canvasStoreApi: source.origin.canvasStoreApi,
       nodeId: source.origin.nodeId,
       origin,
+      ghostRect,
     }
   }
 
@@ -230,5 +236,25 @@ function resolveCanvasHit(
     canvasStoreApi,
     origin,
     size: ghostSize,
+    ghostRect,
+  }
+}
+
+/** Screen-px rect for a canvas-space origin + ghost size, given the canvas
+ *  container's client rect and its zoom/pan. Used to preview the snapped landing
+ *  position during a snap-to-grid drag. */
+function snappedGhostScreenRect(
+  origin: Point,
+  containerRect: DOMRect,
+  zoom: number,
+  viewportOffset: Point,
+  ghostSize: Size,
+): { left: number; top: number; width: number; height: number } {
+  const view = canvasToView(origin, zoom, viewportOffset)
+  return {
+    left: containerRect.left + view.x,
+    top: containerRect.top + view.y,
+    width: ghostSize.width * zoom,
+    height: ghostSize.height * zoom,
   }
 }

--- a/src/renderer/drag/types.ts
+++ b/src/renderer/drag/types.ts
@@ -63,18 +63,30 @@ export type DragSource = {
       }
 }
 
+/** Screen-px rectangle for the snapped drag ghost, attached to canvas targets
+ *  only when snap-to-grid is active so the overlay can preview the landing
+ *  position on the grid instead of free-tracking the cursor. */
+export interface GhostRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
 export type DropTarget =
   | {
       kind: 'canvas-reposition'
       canvasStoreApi: StoreApi<CanvasStore>
       nodeId: string
       origin: Point
+      ghostRect?: GhostRect
     }
   | {
       kind: 'canvas-add'
       canvasStoreApi: StoreApi<CanvasStore>
       origin: Point
       size: Size
+      ghostRect?: GhostRect
     }
   | {
       kind: 'dock-split'

--- a/src/renderer/hooks/useCanvasInteraction.ts
+++ b/src/renderer/hooks/useCanvasInteraction.ts
@@ -372,6 +372,21 @@ export function useCanvasInteraction(
         document.body.classList.add('canvas-interacting')
         e.preventDefault()
       } else if (e.button === 0) {
+        // During deferred ghost placement: a left-click that misses every ghost
+        // cancels placement (same as Esc), as long as free mode isn't armed —
+        // armed mode owns its own full-canvas surface and commits on click.
+        // Handled here on mousedown because empty canvas background never reaches
+        // the 1x1 world div that hosts the click-to-cancel fallback.
+        const placement = canvasStoreApi.getState().pendingPlacement
+        if (placement && !placement.freeArmed) {
+          const t = e.target as HTMLElement
+          if (!t.closest('[data-ghost-candidate]') && !t.closest('[data-placement-surface]')) {
+            canvasStoreApi.getState().cancelPlacement()
+            e.preventDefault()
+            return
+          }
+        }
+
         // Hand tool (or Space-hold): left-drag pans the canvas, even when the
         // press lands on a node (nodes let the event bubble here under Hand).
         // No context menu, no inertia, no marquee — just a straight pan.

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -87,6 +87,31 @@
   .placeholder\:text-muted::placeholder { color: var(--text-muted); }
   .placeholder\:text-secondary::placeholder { color: var(--text-secondary); }
 
+  /* Opacity variants for the hand-written text-color utilities. Tailwind's
+     `/NN` alpha modifier only works on real palette colors, not these custom
+     classes — without these rules a class like `text-muted/70` matches NOTHING,
+     so the element sets no color and inherits its parent's (an SVG fill or icon
+     then renders white regardless of theme). color-mix toward transparent
+     reproduces the intended alpha while tracking the active theme. */
+  .text-primary\/50 { color: color-mix(in srgb, var(--text-primary) 50%, transparent); }
+  .text-primary\/70 { color: color-mix(in srgb, var(--text-primary) 70%, transparent); }
+  .text-primary\/75 { color: color-mix(in srgb, var(--text-primary) 75%, transparent); }
+  .text-primary\/80 { color: color-mix(in srgb, var(--text-primary) 80%, transparent); }
+  .text-primary\/85 { color: color-mix(in srgb, var(--text-primary) 85%, transparent); }
+  .text-primary\/90 { color: color-mix(in srgb, var(--text-primary) 90%, transparent); }
+  .hover\:text-primary\/70:hover { color: color-mix(in srgb, var(--text-primary) 70%, transparent); }
+  .text-secondary\/70 { color: color-mix(in srgb, var(--text-secondary) 70%, transparent); }
+  .text-muted\/30 { color: color-mix(in srgb, var(--text-muted) 30%, transparent); }
+  .text-muted\/40 { color: color-mix(in srgb, var(--text-muted) 40%, transparent); }
+  .text-muted\/50 { color: color-mix(in srgb, var(--text-muted) 50%, transparent); }
+  .text-muted\/60 { color: color-mix(in srgb, var(--text-muted) 60%, transparent); }
+  .text-muted\/70 { color: color-mix(in srgb, var(--text-muted) 70%, transparent); }
+  .text-muted\/80 { color: color-mix(in srgb, var(--text-muted) 80%, transparent); }
+
+  /* `bg-primary` = the primary text color as a fill (used by the blink cursor). */
+  .bg-primary { background-color: var(--text-primary); }
+  .bg-primary\/80 { background-color: color-mix(in srgb, var(--text-primary) 80%, transparent); }
+
   .bg-hover { background-color: var(--surface-hover); }
   .bg-hover-strong { background-color: var(--surface-hover-strong); }
 
@@ -97,6 +122,26 @@
   .hover\:bg-hover-strong:hover { background-color: var(--surface-hover-strong); }
   .active\:bg-hover-strong:active { background-color: var(--surface-hover-strong); }
   .group:hover .group-hover\:bg-hover { background-color: var(--surface-hover); }
+
+  /* Semantic status colors. Agent error/warning UI maps onto the theme's
+     palette (the canonical red/orange) instead of fixed Tailwind shades, so it
+     tracks the active theme — including light themes. */
+  .text-danger { color: var(--git-deleted); }
+  .text-warning { color: var(--activity-orange); }
+  .hover\:text-danger:hover { color: var(--git-deleted); }
+  .bg-danger { background-color: var(--git-deleted); }
+  .bg-warning { background-color: var(--activity-orange); }
+  .bg-danger-tint { background-color: color-mix(in srgb, var(--git-deleted) 14%, transparent); }
+  .bg-warning-tint { background-color: color-mix(in srgb, var(--activity-orange) 14%, transparent); }
+  .hover\:bg-danger-tint:hover { background-color: color-mix(in srgb, var(--git-deleted) 26%, transparent); }
+  .border-danger { border-color: color-mix(in srgb, var(--git-deleted) 36%, transparent); }
+  .border-warning { border-color: color-mix(in srgb, var(--activity-orange) 30%, transparent); }
+
+  /* Inline diff add/remove rows — themed via the git add/delete colors. */
+  .bg-diff-add { background-color: color-mix(in srgb, var(--git-added) 12%, transparent); }
+  .bg-diff-del { background-color: color-mix(in srgb, var(--git-deleted) 12%, transparent); }
+  .text-diff-add { color: var(--git-added); }
+  .text-diff-del { color: var(--git-deleted); }
 }
 
 @layer base {


### PR DESCRIPTION
## Agent UI theming
Agent renderer panels hardcoded Tailwind shades (`white/x`, `black/x`, `red`/`amber`/`rose`/`emerald`) that ignored the active theme and looked broken on light themes. Replaced with theme-driven tokens (`border-strong`, `bg-hover`, `text-danger`/`warning`, `diff-add`/`del`, `shadow-node`) and added the matching utility classes in `globals.css`, including `color-mix` opacity variants so the `/NN` alpha modifier resolves on the hand-written text-color utilities.

## Drag snap preview
With snap-to-grid on, the drag ghost now previews the snapped landing cell (`resolveDrop` attaches a screen-px `ghostRect`) instead of free-tracking the cursor 1:1. Also cancels deferred ghost placement on a left-click that misses every ghost, handled on mousedown since empty canvas background never reaches the world div.

## Test plan
- `npm test` (997 pass, 3 skipped)
- resolve.test.ts updated for the new `ghostRect` previews