### PR TITLE
fix(windows): name workspaces and terminals by folder, not full path

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { useSettingsStore } from './stores/settingsStore'
 import { useUIStore } from './stores/uiStore'
 import { useUIStateStore } from './stores/uiStateStore'
 import { migrateLegacyLocalStorage } from './lib/migrateLegacyLocalStorage'
+import { workspaceDisplayName } from './lib/fs/displayPath'
 import { useFileDropTracker, FileDropOverlay } from './drag/fileDropTarget'
 import { useUpdateStore, type UpdateStatus } from './stores/updateStore'
 import { useShortcuts } from './hooks/useShortcuts'
@@ -351,7 +352,7 @@ function MainApp() {
         const stat = await window.electronAPI.fsStat(filePath)
         if (!stat.isDirectory) return
         const app = useAppStore.getState()
-        const folderName = filePath.split('/').filter(Boolean).pop() ?? 'Workspace'
+        const folderName = workspaceDisplayName(filePath) || 'Workspace'
         // If the only workspace is the untouched default (no root, empty
         // panels), reuse it rather than stacking a second empty workspace.
         const existing = app.workspaces.find((w) => w.rootPath === filePath)

--- a/src/renderer/lib/agent/agentTitleParser.test.ts
+++ b/src/renderer/lib/agent/agentTitleParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { extractAgentTitleSegment } from './agentTitleParser'
+import { extractAgentTitleSegment, shellTitleBasename } from './agentTitleParser'
 
 describe('extractAgentTitleSegment', () => {
   it('returns the middle segment of a 4-segment claude/iTerm title', () => {
@@ -32,5 +32,31 @@ describe('extractAgentTitleSegment', () => {
   it('returns empty for empty input', () => {
     expect(extractAgentTitleSegment('')).toBe('')
     expect(extractAgentTitleSegment('   ')).toBe('')
+  })
+})
+
+describe('shellTitleBasename', () => {
+  it('collapses a Windows cwd title to the folder name', () => {
+    expect(shellTitleBasename('C:\\Users\\foo\\myproject')).toBe('myproject')
+  })
+
+  it('collapses a POSIX cwd title to the folder name', () => {
+    expect(shellTitleBasename('/Users/foo/myproject')).toBe('myproject')
+  })
+
+  it('collapses a UNC path to the final segment', () => {
+    expect(shellTitleBasename('\\\\server\\share\\proj')).toBe('proj')
+  })
+
+  it('leaves a non-path title unchanged', () => {
+    expect(shellTitleBasename('✳ Claude Code')).toBe('✳ Claude Code')
+  })
+
+  it('leaves a relative title containing a slash unchanged', () => {
+    expect(shellTitleBasename('bun ‹ src/index.ts')).toBe('bun ‹ src/index.ts')
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(shellTitleBasename('')).toBe('')
   })
 })

--- a/src/renderer/lib/agent/agentTitleParser.ts
+++ b/src/renderer/lib/agent/agentTitleParser.ts
@@ -27,3 +27,17 @@ export function extractAgentTitleSegment(raw: string): string {
   }
   return trimmed
 }
+
+// A plain shell with no detected agent lets its OSC title drive the tab name.
+// On macOS/Linux that title is usually just the folder name, but Windows shells
+// (PowerShell, cmd) set it to the full working directory — "C:\Users\foo\proj" —
+// which makes the tab show the entire path. Collapse a bare absolute path to its
+// final segment so Windows matches the POSIX behavior; anything that isn't an
+// absolute path (agent status lines, custom titles) is returned untouched.
+const ABSOLUTE_PATH_PREFIX = /^([a-zA-Z]:[\\/]|\\\\|\/)/
+
+export function shellTitleBasename(title: string): string {
+  const trimmed = title.trim()
+  if (!ABSOLUTE_PATH_PREFIX.test(trimmed)) return title
+  return trimmed.split(/[\\/]/).filter(Boolean).pop() ?? title
+}

--- a/src/renderer/lib/fs/displayPath.test.ts
+++ b/src/renderer/lib/fs/displayPath.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { workspaceDisplayName } from './displayPath'
+
+describe('workspaceDisplayName', () => {
+  it('returns the folder name for a POSIX local path', () => {
+    expect(workspaceDisplayName('/Users/anton/proj')).toBe('proj')
+  })
+
+  it('returns the folder name for a Windows local path', () => {
+    expect(workspaceDisplayName('C:\\Users\\foo\\myproject')).toBe('myproject')
+  })
+
+  it('ignores a trailing separator on a Windows path', () => {
+    expect(workspaceDisplayName('C:\\Users\\foo\\myproject\\')).toBe('myproject')
+  })
+
+  it('ignores a trailing separator on a POSIX path', () => {
+    expect(workspaceDisplayName('/Users/anton/proj/')).toBe('proj')
+  })
+
+  it('returns the folder name for a remote POSIX locator', () => {
+    expect(workspaceDisplayName('cate-companion://wsl_Ubuntu/home/foo/proj')).toBe('proj')
+  })
+})

--- a/src/renderer/lib/fs/displayPath.ts
+++ b/src/renderer/lib/fs/displayPath.ts
@@ -8,7 +8,7 @@
 // These helpers decode the locator first so both local and remote paths render
 // cleanly. LOCAL output is byte-identical to the old split-based logic.
 
-import { parseLocator } from '../../../main/companion/locator'
+import { LOCAL_COMPANION_ID, parseLocator } from '../../../main/companion/locator'
 
 /** Abbreviate a macOS home-dir path to `~/...`, matching WelcomePage's legacy
  *  behavior exactly. */
@@ -24,10 +24,15 @@ export function abbreviateLocalPath(fullPath: string): string {
 
 /**
  * Basename for display. Decodes the locator and returns the last non-empty path
- * segment, for local OR remote. For a local path this is identical to
- * `raw.split('/').filter(Boolean).pop()`.
+ * segment, for local OR remote.
+ *
+ * Local paths are OS-native, so on Windows the separator is `\` — splitting only
+ * on `/` would leave the whole `C:\Users\foo\proj` string as the "folder name".
+ * Remote paths are always POSIX, where `\` is a legal filename character, so we
+ * only treat `\` as a separator for local locators.
  */
 export function workspaceDisplayName(locator: string): string {
-  const { path } = parseLocator(locator)
-  return path.split('/').filter(Boolean).pop() ?? ''
+  const { companionId, path } = parseLocator(locator)
+  const sep = companionId === LOCAL_COMPANION_ID ? /[\\/]/ : /\//
+  return path.split(sep).filter(Boolean).pop() ?? ''
 }

--- a/src/renderer/lib/terminal/terminalRegistry.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.ts
@@ -17,7 +17,7 @@ import { useStatusStore, setTerminalWorkspaceResolver } from '../../stores/statu
 import { useSettingsStore } from '../../stores/settingsStore'
 import { terminalRestoreData, replayTerminalLog } from '../workspace/session'
 import { awaitWorkspaceSync, useAppStore } from '../../stores/appStore'
-import { extractAgentTitleSegment } from '../agent/agentTitleParser'
+import { extractAgentTitleSegment, shellTitleBasename } from '../agent/agentTitleParser'
 import { titleIndicatesRunning, outputShowsBodySpinner } from '../agent/agentSpinner'
 import { noteAgentTitle, noteAgentSpinnerByte } from '../agent/agentScreenDetector'
 import { openTerminalUrl } from './terminalUrlOpen'
@@ -42,7 +42,8 @@ function applyOscTitleIfNoAgent(
   const status = useStatusStore.getState()
   const wsId = workspaceIdForPty(ptyId) ?? workspaceId
   if (status.workspaces[wsId]?.agentName[ptyId]) return
-  useAppStore.getState().updatePanelTitleFromAgent(workspaceId, panelId, title)
+  // Plain Windows shells set the OSC title to the full cwd; show just the folder.
+  useAppStore.getState().updatePanelTitleFromAgent(workspaceId, panelId, shellTitleBasename(title))
 }
 
 /** Read the configured scrollback limit, clamped to a sane range. */

--- a/src/renderer/ui/WelcomePage.tsx
+++ b/src/renderer/ui/WelcomePage.tsx
@@ -11,7 +11,7 @@ import {
   Folder,
   CloudArrowUp,
 } from '@phosphor-icons/react'
-import { abbreviateLocalPath } from '../lib/fs/displayPath'
+import { abbreviateLocalPath, workspaceDisplayName } from '../lib/fs/displayPath'
 import { parseLocator, LOCAL_COMPANION_ID } from '../../main/companion/locator'
 import { RemoteConnectDialog } from '../dialogs/RemoteConnectDialog'
 import { workspaceRuntime } from '../lib/workspace/workspaceRuntime'
@@ -146,8 +146,11 @@ export default function WelcomePage({ workspaceId }: { workspaceId: string }) {
               <div className="flex flex-col gap-0.5">
                 {recentProjects.map((projectPath) => {
                   const { companionId, path: decodedPath } = parseLocator(projectPath)
-                  const name = decodedPath.split('/').filter(Boolean).pop() ?? projectPath
-                  const parentPath = decodedPath.split('/').slice(0, -1).join('/')
+                  // Local paths are OS-native — split on `\` too so Windows paths
+                  // ("C:\Users\foo\proj") don't render as one long segment.
+                  const sep = companionId === LOCAL_COMPANION_ID ? /[\\/]/ : /\//
+                  const name = workspaceDisplayName(projectPath) || projectPath
+                  const parentPath = decodedPath.split(sep).slice(0, -1).join('/')
                   const parent = companionId === LOCAL_COMPANION_ID
                     ? abbreviateLocalPath(parentPath)
                     : `${companionId}:${parentPath}`


### PR DESCRIPTION
## Problem

On Windows, opening a folder named the **workspace** with its entire path (e.g. `C:\Users\foo\proj`) instead of just `proj`, and plain-shell **terminal tabs** showed the full working directory too.

## Root cause

Several display helpers split paths on `/` only. Windows uses `\` separators, so the whole path survived as the "name".

- The terminal case is distinct: Windows shells (PowerShell/cmd) set the OSC window title to the bare cwd, which has no `—` delimiter and so fell through `extractAgentTitleSegment` as the raw path.

## Changes

- **`workspaceDisplayName`** now splits local locators on `[\\/]`; remote paths stay POSIX-only (where `\` is a legal filename char). This is the canonical helper behind `setWorkspaceRootPath`, so **every folder-open dialog** is fixed centrally.
- **`App.tsx`** OS-forwarded open ("Open With Cate" / drag-drop) built the *stored* name with its own `split('/')` — now delegates to `workspaceDisplayName`.
- **`WelcomePage`** recent-projects list: Windows-aware name and parent path.
- **`shellTitleBasename`** (new) collapses a bare absolute OSC title — POSIX `/`, Windows drive `C:\`, or UNC `\\` — to its final segment for plain shells. Agent status lines and custom titles are left untouched (only applied in the no-detected-agent branch).

## Tests

TDD — written first and watched fail:
- `displayPath.test.ts` (new): POSIX/Windows/UNC/remote + trailing separators.
- `agentTitleParser.test.ts`: 6 new `shellTitleBasename` cases.

Full suite: 1005 passing, typecheck clean, lint 0 errors. (Two `src/main/companion` daemon-subprocess tests fail only inside the worktree checkout — environmental, unrelated to this diff; verified by stashing the changes and re-running.)