### PR TITLE
fix(layouts): apply saved layouts to the active canvas

### DIFF
--- a/docs/superpowers/specs/2026-06-07-saved-layout-apply-design.md
+++ b/docs/superpowers/specs/2026-06-07-saved-layout-apply-design.md
@@ -1,0 +1,103 @@
+# Fix: saved layouts apply to the wrong canvas (and lose sizes / agent panels)
+
+## Problem
+
+Loading a saved layout does not reproduce the layout on the canvas the user is
+looking at. Reported symptoms: the layout lands on a *different* canvas than the
+active/nested one, panels come back at default sizes, and some panels are missing.
+
+The most common trigger is opening a new, empty canvas (which shows the
+empty-canvas layout picker) and choosing a layout — the panels appear on the
+workspace's center canvas instead of the empty one.
+
+## Root cause
+
+`recreateNodes` (`src/renderer/lib/layouts.ts`) recreates each saved panel with
+**no `placement`**, so every panel routes through `placePanel` →
+`getWorkspaceCanvasOps(workspaceId)` to the workspace's **primary/center**
+canvas — regardless of which canvas the load was meant for. Setting the active
+panel (as both load functions already do) has no effect, because `placePanel`
+routes by `placement.canvasPanelId`, not by active state. The `PanelPlacement`
+type comment (`appStore.ts:165-170`) documents this exact trap: "Without it,
+placement routes to the workspace's primary canvas … wrong for an interactive
+create on a secondary/nested canvas."
+
+Two secondary defects in the same function:
+
+- **Sizes lost** — `buildLayoutSnapshot` saves `node.size`, but `recreateNodes`
+  only forwards `origin`. `addNode` already accepts a `size`, but the
+  create → `placePanel` → `addNodeAndFocus` → `addNode` chain never forwards
+  one. Passing the saved size also keeps **positions** exact, because
+  `findFreePosition` (`placement.ts:46-56`) uses the node's size for its
+  overlap/nudge check — default-sized nodes get spuriously nudged off their
+  saved origins.
+- **`agent` panels dropped** — `recreateNodes` handles only
+  `terminal`/`editor`/`document`/`browser`. The only other panel type that can
+  exist as a canvas node is `agent` (`canvas` is refused at `addNode:41`, so it
+  never appears in a snapshot). Agent panels silently vanish.
+
+## Design
+
+### 1. Thread target canvas + size through placement
+
+- `PanelPlacement` canvas variant (`appStore.ts:170`): add `size?: Size`.
+- `placePanel` (`appStore.ts:374-385`): forward `placement.size` (when
+  `target === 'canvas'`) into `ops.addNodeAndFocus(...)`.
+- `CanvasOperations.addNodeAndFocus` (`canvasBridge.ts:19,50`): accept an
+  optional `size` and pass it to `addNode` (already supports it).
+
+### 2. Make `recreateNodes` honor the target canvas, size, and agent type
+
+`recreateNodes(wsId, canvasPanelId, snap)`:
+
+- For each node, build
+  `placement = { target: 'canvas', canvasPanelId, position: node.origin, size: node.size }`
+  and pass it to the create call.
+- Add `case 'agent': createAgent(wsId, node.origin, placement)`.
+- Guard editor/document recreation on a non-empty `filePath` (skip junk).
+
+### 3. Unify both load paths to "load into the active canvas"
+
+Per product decision, the manager dialog, the native Layouts menu, and the
+empty-canvas overlay all load a layout into the **active canvas**, replacing that
+canvas's contents (other canvases and dock panels untouched).
+
+Core helper:
+
+```
+applyLayoutToCanvas(wsId, canvasPanelId, storeApi, snap):
+  // clear: dispose every panel currently on this canvas
+  const panelIds = nodes(storeApi).map(n => n.panelId)   // snapshot first
+  for (pid of panelIds) app.closePanel(wsId, pid)
+  setActivePanel(canvasPanelId)
+  recreateNodes(wsId, canvasPanelId, snap)
+  storeApi.getState().zoomToFit()
+```
+
+Public entry points:
+
+- `loadLayoutIntoActiveCanvas(name)` — resolves the active canvas via
+  `getActiveCanvasPanelId()`, gets its `storeApi` via
+  `ensureCanvasOpsForPanel(...)`, delegates to `applyLayoutToCanvas`. Used by the
+  manager dialog (`SavedLayoutsDialog`) and the native menu (`useShortcuts`).
+- `loadLayoutIntoCanvas(name, wsId, canvasPanelId, storeApi)` — kept for the
+  empty-canvas overlay (explicit target); delegates to `applyLayoutToCanvas`.
+  Clearing is a harmless no-op on an empty canvas.
+
+`loadLayoutReplacingWorkspace` (whole-workspace wipe + center rebuild) is
+removed; its two callers move to `loadLayoutIntoActiveCanvas`.
+
+Zoom/viewport: keep `zoomToFit()` (saved zoom/viewport intentionally not
+restored).
+
+## Testing (Vitest)
+
+- Save → load round-trip routes nodes onto the **target** canvas store (not the
+  workspace primary) with correct origins **and** sizes.
+- An `agent` node in a snapshot is recreated (not dropped).
+- Loading into a non-empty canvas clears the prior nodes first (no leftovers).
+
+## Out of scope
+
+- Restoring saved zoom level / viewport offset (kept as zoom-to-fit).
+- Persisting agent thread / terminal session contents (structure only).

--- a/src/renderer/dialogs/SavedLayoutsDialog.tsx
+++ b/src/renderer/dialogs/SavedLayoutsDialog.tsx
@@ -13,7 +13,7 @@ import {
   listLayouts,
   saveLayout,
   deleteLayout,
-  loadLayoutReplacingWorkspace,
+  loadLayoutIntoActiveCanvas,
 } from '../lib/layouts'
 import log from '../lib/logger'
 
@@ -72,7 +72,7 @@ export function SavedLayoutsDialog() {
   const handleLoad = useCallback(async (name: string) => {
     setBusy(true); setError(null)
     try {
-      const ok = await loadLayoutReplacingWorkspace(name)
+      const ok = await loadLayoutIntoActiveCanvas(name)
       if (ok) close()
       else setError('Layout not found')
     } finally {

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -297,10 +297,10 @@ export function useShortcuts(): void {
       runAction(action).catch(() => { /* noop */ })
     })
 
-    // Native "Layouts" menu → load a specific saved layout (replaces workspace).
+    // Native "Layouts" menu → load a saved layout into the active canvas.
     const unsubscribeLoadLayout = window.electronAPI.onMenuLoadLayout((name) => {
       import('../lib/layouts')
-        .then((m) => m.loadLayoutReplacingWorkspace(name))
+        .then((m) => m.loadLayoutIntoActiveCanvas(name))
         .catch(() => { /* best-effort */ })
     })
 

--- a/src/renderer/lib/canvas/canvasBridge.ts
+++ b/src/renderer/lib/canvas/canvasBridge.ts
@@ -6,7 +6,7 @@
 
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from '../../stores/canvasStore'
-import type { PanelType, Point, CanvasNodeId, CanvasNodeState, DockLayoutNode } from '../../../shared/types'
+import type { PanelType, Point, Size, CanvasNodeId, CanvasNodeState, DockLayoutNode } from '../../../shared/types'
 import { findNodeDockStore } from '../../panels/nodeDockRegistry'
 
 // -----------------------------------------------------------------------------
@@ -16,7 +16,7 @@ import { findNodeDockStore } from '../../panels/nodeDockRegistry'
 // -----------------------------------------------------------------------------
 
 export interface CanvasOperations {
-  addNodeAndFocus: (panelId: string, panelType: PanelType, position?: Point) => void
+  addNodeAndFocus: (panelId: string, panelType: PanelType, position?: Point, size?: Size) => void
   /** Begin interactive ghost placement. Returns true if ghosts are shown (the
    *  caller must NOT also place the node). `onCancelled` rolls the panel back. */
   beginPlacement: (
@@ -47,8 +47,8 @@ export function createCanvasOps(storeApi: StoreApi<CanvasStore>): CanvasOperatio
   return {
     storeApi,
 
-    addNodeAndFocus(panelId: string, panelType: PanelType, position?: Point) {
-      const nodeId = storeApi.getState().addNode(panelId, panelType, position)
+    addNodeAndFocus(panelId: string, panelType: PanelType, position?: Point, size?: Size) {
+      const nodeId = storeApi.getState().addNode(panelId, panelType, position, size)
       storeApi.getState().focusAndCenter(nodeId)
     },
 

--- a/src/renderer/lib/layouts.test.ts
+++ b/src/renderer/lib/layouts.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+// =============================================================================
+// Tests for applying saved layouts to a canvas.
+//
+// Regression: a saved layout used to be rebuilt onto the workspace's PRIMARY
+// (center) canvas regardless of which canvas the load targeted — restored panels
+// also came back at default sizes, and `agent` panels were silently dropped.
+// These tests pin the corrected behavior: panels land on the TARGET canvas at
+// their saved origin + size, agents survive, and a non-empty target is cleared
+// first.
+// =============================================================================
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '../stores/appStore'
+import { releaseCanvasStoreForPanel } from '../stores/canvasStore'
+import {
+  ensureCanvasOpsForPanel,
+  unregisterCanvasOps,
+  invalidateWorkspaceCanvasCache,
+} from './workspace/canvasAccess'
+import {
+  getOrCreateWorkspaceDockStore,
+  releaseWorkspaceDockStore,
+} from './workspace/dockRegistry'
+import { setActivePanel } from './activePanel'
+import { loadLayoutIntoActiveCanvas, loadLayoutIntoCanvas, type LayoutSnapshot } from './layouts'
+
+const WS = 'ws-layout'
+const PRIMARY = 'canvas-primary'
+const TARGET = 'canvas-target'
+
+type LayoutNodeInput = LayoutSnapshot['nodes'][number]
+
+function snapshot(nodes: LayoutNodeInput[]): LayoutSnapshot {
+  return { nodes, zoomLevel: 1, viewportOffset: { x: 0, y: 0 } }
+}
+
+function mockLayout(snap: LayoutSnapshot) {
+  ;(window as any).electronAPI = { layoutLoad: vi.fn().mockResolvedValue(snap) }
+}
+
+beforeEach(() => {
+  ;(window as any).electronAPI = {}
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    workspaces: [
+      {
+        id: WS,
+        rootPath: '/repo',
+        panels: {
+          [PRIMARY]: { id: PRIMARY, type: 'canvas', title: 'Canvas' },
+          [TARGET]: { id: TARGET, type: 'canvas', title: 'Canvas 2' },
+        },
+      },
+    ],
+  } as any)
+  // Dock PRIMARY into the center zone so it resolves as the workspace's primary
+  // canvas — the canvas restored nodes would WRONGLY land on before the fix.
+  getOrCreateWorkspaceDockStore(WS).getState().dockPanel(PRIMARY, 'center')
+  ensureCanvasOpsForPanel(PRIMARY)
+  ensureCanvasOpsForPanel(TARGET)
+})
+
+afterEach(() => {
+  unregisterCanvasOps(PRIMARY)
+  unregisterCanvasOps(TARGET)
+  releaseCanvasStoreForPanel(PRIMARY)
+  releaseCanvasStoreForPanel(TARGET)
+  invalidateWorkspaceCanvasCache(WS)
+  releaseWorkspaceDockStore(WS)
+  setActivePanel(null)
+  useAppStore.setState({ workspaces: [], selectedWorkspaceId: '' } as any)
+  vi.restoreAllMocks()
+})
+
+describe('loadLayoutIntoCanvas', () => {
+  it('routes restored panels onto the TARGET canvas, not the workspace primary', async () => {
+    mockLayout(
+      snapshot([{ panelType: 'terminal', origin: { x: 100, y: 100 }, size: { width: 300, height: 200 } }]),
+    )
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+    const primaryStore = ensureCanvasOpsForPanel(PRIMARY).storeApi
+
+    const ok = await loadLayoutIntoCanvas('L', WS, TARGET, targetStore)
+
+    expect(ok).toBe(true)
+    expect(Object.values(targetStore.getState().nodes)).toHaveLength(1)
+    expect(Object.values(primaryStore.getState().nodes)).toHaveLength(0)
+  })
+
+  it('restores each panel at its saved origin and size', async () => {
+    mockLayout(
+      snapshot([{ panelType: 'terminal', origin: { x: 120, y: 80 }, size: { width: 360, height: 240 } }]),
+    )
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+
+    await loadLayoutIntoCanvas('L', WS, TARGET, targetStore)
+
+    const node = Object.values(targetStore.getState().nodes)[0]
+    expect(node.origin).toEqual({ x: 120, y: 80 })
+    expect(node.size).toEqual({ width: 360, height: 240 })
+  })
+
+  it('recreates agent panels instead of dropping them', async () => {
+    mockLayout(
+      snapshot([{ panelType: 'agent', origin: { x: 200, y: 200 }, size: { width: 400, height: 300 } }]),
+    )
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+
+    await loadLayoutIntoCanvas('L', WS, TARGET, targetStore)
+
+    const nodes = Object.values(targetStore.getState().nodes)
+    expect(nodes).toHaveLength(1)
+    const panelId = nodes[0].panelId
+    const ws = useAppStore.getState().workspaces.find((w) => w.id === WS)
+    expect(ws?.panels[panelId]?.type).toBe('agent')
+  })
+
+  it('clears the target canvas (and its panel records) before applying', async () => {
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+    // Pre-seed an existing editor panel on the target canvas.
+    useAppStore
+      .getState()
+      .createEditor(WS, undefined, { x: 0, y: 0 }, { target: 'canvas', canvasPanelId: TARGET })
+    expect(Object.values(targetStore.getState().nodes)).toHaveLength(1)
+    const stalePanelId = Object.values(targetStore.getState().nodes)[0].panelId
+
+    mockLayout(
+      snapshot([{ panelType: 'terminal', origin: { x: 100, y: 100 }, size: { width: 300, height: 200 } }]),
+    )
+    await loadLayoutIntoCanvas('L', WS, TARGET, targetStore)
+
+    const nodes = Object.values(targetStore.getState().nodes)
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].panelId).not.toBe(stalePanelId)
+    const ws = useAppStore.getState().workspaces.find((w) => w.id === WS)
+    expect(ws?.panels[stalePanelId]).toBeUndefined()
+  })
+
+  it('returns false when the layout does not exist', async () => {
+    ;(window as any).electronAPI = { layoutLoad: vi.fn().mockResolvedValue(null) }
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+
+    const ok = await loadLayoutIntoCanvas('missing', WS, TARGET, targetStore)
+
+    expect(ok).toBe(false)
+  })
+})
+
+describe('loadLayoutIntoActiveCanvas', () => {
+  it('loads into the active canvas (not the workspace primary)', async () => {
+    // Make TARGET the active canvas; PRIMARY remains the workspace primary.
+    setActivePanel(TARGET)
+    mockLayout(
+      snapshot([{ panelType: 'terminal', origin: { x: 140, y: 60 }, size: { width: 320, height: 220 } }]),
+    )
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+    const primaryStore = ensureCanvasOpsForPanel(PRIMARY).storeApi
+
+    const ok = await loadLayoutIntoActiveCanvas('L')
+
+    expect(ok).toBe(true)
+    expect(Object.values(targetStore.getState().nodes)).toHaveLength(1)
+    expect(Object.values(primaryStore.getState().nodes)).toHaveLength(0)
+  })
+
+  it('falls back to the workspace primary canvas when no panel is active', async () => {
+    setActivePanel(null)
+    mockLayout(
+      snapshot([{ panelType: 'terminal', origin: { x: 100, y: 100 }, size: { width: 300, height: 200 } }]),
+    )
+    const targetStore = ensureCanvasOpsForPanel(TARGET).storeApi
+    const primaryStore = ensureCanvasOpsForPanel(PRIMARY).storeApi
+
+    const ok = await loadLayoutIntoActiveCanvas('L')
+
+    expect(ok).toBe(true)
+    expect(Object.values(primaryStore.getState().nodes)).toHaveLength(1)
+    expect(Object.values(targetStore.getState().nodes)).toHaveLength(0)
+  })
+})

--- a/src/renderer/lib/layouts.ts
+++ b/src/renderer/lib/layouts.ts
@@ -3,20 +3,21 @@
 //
 // Backed by the main-process electron-store (window.electronAPI.layout*). Used
 // by SavedLayoutsDialog, the empty-canvas overlay, the native Layouts menu, and
-// useShortcuts. Two restore modes:
-//   • loadLayoutReplacingWorkspace — wipes the whole workspace and rebuilds it
-//     from the snapshot (dialog / native-menu pick).
-//   • loadLayoutIntoCanvas — populates one specific (empty) canvas without
-//     touching the rest of the workspace (empty-canvas overlay).
+// useShortcuts. A layout always loads into ONE canvas, replacing that canvas's
+// contents (other canvases and dock panels are left untouched):
+//   • loadLayoutIntoActiveCanvas — targets the active canvas, resolved from the
+//     canonical active panel (dialog / native-menu pick).
+//   • loadLayoutIntoCanvas — targets one explicit canvas (empty-canvas overlay).
+// Both clear the target canvas first, then rebuild the saved nodes onto it.
 // =============================================================================
 
 import type { StoreApi } from 'zustand'
 import type { Point } from '../../shared/types'
 import type { CanvasStore } from '../stores/canvasStore'
+import type { PanelPlacement } from '../stores/appStore'
 import {
   useAppStore,
-  getWorkspaceCanvasStore,
-  getWorkspaceCanvasPanelId,
+  getActiveCanvasPanelId,
   ensureCanvasOpsForPanel,
 } from '../stores/appStore'
 import { setActivePanel } from './activePanel'
@@ -82,57 +83,75 @@ async function fetchSnapshot(name: string): Promise<LayoutSnapshot | null> {
   return (snap as LayoutSnapshot | null) ?? null
 }
 
-/** Recreate a snapshot's panels into whichever canvas is currently active. */
-function recreateNodes(wsId: string, snap: LayoutSnapshot): void {
+/** Recreate a snapshot's panels onto a SPECIFIC canvas. Pins each create to
+ *  `canvasPanelId` (so nodes land on the target canvas, not the workspace's
+ *  primary one) and to the saved size (so geometry — and, because the placement
+ *  search keys off size, position — is reproduced exactly). */
+function recreateNodes(wsId: string, canvasPanelId: string, snap: LayoutSnapshot): void {
   const app = useAppStore.getState()
   for (const node of snap.nodes ?? []) {
+    const placement: PanelPlacement = {
+      target: 'canvas',
+      canvasPanelId,
+      position: node.origin,
+      size: node.size,
+    }
     switch (node.panelType) {
-      case 'terminal': app.createTerminal(wsId, undefined, node.origin); break
+      case 'terminal': app.createTerminal(wsId, undefined, node.origin, placement); break
+      case 'agent':    app.createAgent(wsId, node.origin, placement); break
+      case 'browser':  app.createBrowser(wsId, node.url, node.origin, placement); break
       case 'document':
-      case 'editor':   openFileAsPanel(wsId, node.filePath ?? '', node.origin); break
-      case 'browser':  app.createBrowser(wsId, node.url, node.origin); break
+      case 'editor':
+        if (node.filePath) openFileAsPanel(wsId, node.filePath, node.origin, placement)
+        break
     }
   }
 }
 
+/** Replace one canvas's contents with the snapshot: clear it, rebuild the saved
+ *  nodes onto it, and zoom to fit. Shared by both public load entry points. */
+function applyLayoutToCanvas(
+  wsId: string,
+  canvasPanelId: string,
+  canvasApi: StoreApi<CanvasStore>,
+  snap: LayoutSnapshot,
+): void {
+  const app = useAppStore.getState()
+  app.clearCanvas(wsId, canvasPanelId)
+  // The React CanvasPanel that registers ops / marks the canvas active may not
+  // be mounted (a just-opened canvas, or a background restore). Register + mark
+  // active synchronously so create* calls resolve to this canvas.
+  ensureCanvasOpsForPanel(canvasPanelId)
+  setActivePanel(canvasPanelId)
+  recreateNodes(wsId, canvasPanelId, snap)
+  canvasApi.getState().zoomToFit()
+}
+
 /**
- * Replace the entire active workspace with the named layout. Mirrors the
- * original dialog behavior: wipe every panel, recreate the center canvas, then
- * rebuild nodes and zoom to fit.
+ * Load the named layout into the ACTIVE canvas (resolved from the canonical
+ * active panel, falling back to the workspace's primary canvas), replacing that
+ * canvas's contents. Used by the manager dialog and the native Layouts menu.
  */
-export async function loadLayoutReplacingWorkspace(name: string): Promise<boolean> {
+export async function loadLayoutIntoActiveCanvas(name: string): Promise<boolean> {
   try {
     const snap = await fetchSnapshot(name)
     if (!snap) return false
 
     const wsId = useAppStore.getState().selectedWorkspaceId
-    const app = useAppStore.getState()
-    app.closeAllPanels(wsId)
-    // closeAllPanels wipes every panel — including the 'canvas' host panel that
-    // owns the dock center zone. Recreate it before adding nodes.
-    app.ensureCenterCanvas(wsId)
-    // The React CanvasPanel that would register the canvas store + mark it
-    // active hasn't mounted yet. Register synchronously so create* calls below
-    // resolve to the *new* canvas, not the disposed one.
-    const newCanvasId = getWorkspaceCanvasPanelId(wsId)
-    if (newCanvasId) {
-      ensureCanvasOpsForPanel(newCanvasId)
-      setActivePanel(newCanvasId)
-    }
+    const canvasPanelId = getActiveCanvasPanelId()
+    if (!canvasPanelId) return false
 
-    recreateNodes(wsId, snap)
-
-    const freshCanvas = getWorkspaceCanvasStore(wsId)
-    freshCanvas?.getState().zoomToFit()
+    const ops = ensureCanvasOpsForPanel(canvasPanelId)
+    applyLayoutToCanvas(wsId, canvasPanelId, ops.storeApi, snap)
     return true
   } catch (err) {
-    log.error('[layouts] load (replace) failed', err)
+    log.error('[layouts] load (active canvas) failed', err)
     return false
   }
 }
 
 /**
- * Populate one specific (typically empty) canvas with the named layout without
+ * Load the named layout into one specific canvas, replacing its contents without
  * disturbing the rest of the workspace. Used by the empty-canvas overlay.
  */
 export async function loadLayoutIntoCanvas(
@@ -145,13 +164,7 @@ export async function loadLayoutIntoCanvas(
     const snap = await fetchSnapshot(name)
     if (!snap) return false
 
-    // Route new nodes into this canvas specifically.
-    ensureCanvasOpsForPanel(canvasPanelId)
-    setActivePanel(canvasPanelId)
-
-    recreateNodes(wsId, snap)
-
-    canvasApi.getState().zoomToFit()
+    applyLayoutToCanvas(wsId, canvasPanelId, canvasApi, snap)
     return true
   } catch (err) {
     log.error('[layouts] load (into canvas) failed', err)

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -166,8 +166,10 @@ export type PanelPlacement =
   /** `canvasPanelId` pins the create to a SPECIFIC canvas (the one the toolbar /
    *  right-click menu / drop originated from). Without it, placement routes to
    *  the workspace's primary canvas — correct for session restore and auto
-   *  creates, but wrong for an interactive create on a secondary/nested canvas. */
-  | { target: 'canvas'; position?: Point; canvasPanelId?: string }
+   *  creates, but wrong for an interactive create on a secondary/nested canvas.
+   *  `size` pins the node's size (used by layout restore to reproduce the saved
+   *  geometry exactly); without it the panel type's default size is used. */
+  | { target: 'canvas'; position?: Point; canvasPanelId?: string; size?: Size }
   /** `stackId` docks the panel as a new tab in a SPECIFIC stack (the one the
    *  user is working in — e.g. the focused pane of a split). Without it the
    *  panel lands in the zone's default stack. A stale stackId falls back to the
@@ -302,6 +304,10 @@ interface AppStoreActions {
   renameWorkspace: (wsId: string, name: string) => void
   duplicateWorkspace: (wsId: string) => string
   closeAllPanels: (wsId: string) => void
+  /** Remove every panel currently living on one canvas (dispose terminals, drop
+   *  their records, empty the canvas store) without touching the rest of the
+   *  workspace. Used by layout restore to replace a single canvas's contents. */
+  clearCanvas: (wsId: string, canvasPanelId: string) => void
   reorderWorkspaces: (fromIndex: number, toIndex: number) => void
   addAdditionalRoot: (wsId: string, rootPath: string) => void
   removeAdditionalRoot: (wsId: string, rootPath: string) => void
@@ -372,6 +378,7 @@ function placePanel(
   const ops = pinnedCanvasId ? ensureCanvasOpsForPanel(pinnedCanvasId) : getWorkspaceCanvasOps(workspaceId)
   if (!ops) return
   const canvasPosition = placement?.target === 'canvas' ? placement.position ?? position : position
+  const canvasSize = placement?.target === 'canvas' ? placement.size : undefined
   // Ambiguous create (no explicit position) on the active workspace: when the
   // recommendation picker is enabled, show ghost candidates and let the user
   // choose where the node lands (deferred until commit; onGhostCancel rolls the
@@ -382,7 +389,7 @@ function placePanel(
     const shown = ops.beginPlacement(panelId, panelType, onGhostCancel)
     if (shown) return
   }
-  ops.addNodeAndFocus(panelId, panelType, canvasPosition)
+  ops.addNodeAndFocus(panelId, panelType, canvasPosition, canvasSize)
 }
 
 type AppSet = StoreApi<AppStore>['setState']
@@ -1316,6 +1323,32 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // fresh canvas panel for the center zone.
     getOrCreateWorkspaceDockStore(wsId).getState().restoreSnapshot(createCleanDockSnapshot())
     get().ensureCenterCanvas(wsId)
+  },
+
+  clearCanvas(wsId, canvasPanelId) {
+    const ops = ensureCanvasOpsForPanel(canvasPanelId)
+    const storeApi = ops.storeApi
+    const state = storeApi.getState()
+    const panelIds = Object.values(state.nodes).map((n) => n.panelId)
+    if (panelIds.length === 0) return
+
+    // Empty the canvas store in one synchronous step (no per-node exit
+    // animation, which would otherwise leave the old nodes mid-transition).
+    storeApi.getState().loadWorkspaceCanvas({}, state.viewportOffset, state.zoomLevel)
+
+    // Dispose terminals and drop the now-orphaned panel records.
+    const ws = get().workspaces.find((w) => w.id === wsId)
+    for (const pid of panelIds) {
+      if (ws?.panels[pid]?.type === 'terminal') terminalRegistry.dispose(pid)
+    }
+    set((s) => ({
+      workspaces: s.workspaces.map((w) => {
+        if (w.id !== wsId) return w
+        const panels = { ...w.panels }
+        for (const pid of panelIds) delete panels[pid]
+        return { ...w, panels }
+      }),
+    }))
   },
 
   // --- Cross-window sync ---


### PR DESCRIPTION
## Problem

Loading a saved layout didn't reproduce it on the canvas the user was looking at. Most visibly: opening a new, empty canvas (which shows the layout picker) and choosing a layout dropped the panels onto the workspace's **center** canvas instead. Restored panels also came back at **default sizes**, and **agent** panels silently vanished.

## Root cause

`recreateNodes` recreated each saved panel with **no `placement`**, so every panel routed through `placePanel` → `getWorkspaceCanvasOps` to the workspace's **primary/center** canvas — regardless of the intended target. Setting the active panel had no effect because placement routes by `canvasPanelId`, not active state. The `PanelPlacement` type comment already documented this exact trap.

Two secondary defects in the same function: saved `size` was never forwarded to `addNode` (default sizes; also nudged positions, since `findFreePosition` keys its overlap check off size), and only `terminal`/`editor`/`document`/`browser` were handled (`agent` dropped).

## Fix

- Thread the target `canvasPanelId` **and** saved `size` through `PanelPlacement` → `placePanel` → `addNodeAndFocus` → `addNode`.
- `recreateNodes` pins each node to the target canvas + size and handles `agent` panels.
- Unify both load paths to **load into the active canvas**, replacing only that canvas's contents (other canvases and dock panels untouched):
  - `loadLayoutIntoActiveCanvas` — manager dialog + native Layouts menu (active canvas via `getActiveCanvasPanelId`).
  - `loadLayoutIntoCanvas` — empty-canvas overlay (explicit target).
  - New `appStore.clearCanvas` action empties one canvas synchronously (dispose terminals, drop records).
- Remove `loadLayoutReplacingWorkspace` (whole-workspace wipe).

Saved zoom/viewport is intentionally not restored (zoom-to-fit), matching prior behavior.

## Tests

New `src/renderer/lib/layouts.test.ts` (7 tests): restored nodes land on the **target** canvas (not the primary) at correct **origins + sizes**, `agent` panels survive, a non-empty target is **cleared** first, and the active-canvas path resolves/falls back correctly.

- `npx tsc --noEmit` → clean
- Full vitest suite green except 2 pre-existing, environment-dependent `src/main/companion/*` subprocess tests (verified failing identically on a clean tree).

Design spec: `docs/superpowers/specs/2026-06-07-saved-layout-apply-design.md`