### PR TITLE
feat(window): frameless chrome + custom controls on Windows/Linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { SHELL_SHOW_IN_FOLDER, WEBVIEW_SCREENSHOT, BROWSER_SET_PROXY, NATIVE_FILE_DRAG, CAPTURE_PAGE, DIALOG_OPEN_FOLDER, DIALOG_OPEN_IMAGE, DIALOG_SAVE_FILE, DIALOG_CONFIRM_UNSAVED, DIALOG_CONFIRM_CLOSE_TERMINAL, DIALOG_CONFIRM_CLOSE_CANVAS, DIALOG_CONFIRM_IMPORT, DIALOG_CONFIRM_RELOAD_WORKSPACE, DIALOG_TERMINAL_LINK_OPEN, CANVAS_READ_BACKGROUND_IMAGE, APP_OPEN_PATH } from '../shared/ipc-channels'
 import {
   WINDOW_SET_TITLE,
+  WINDOW_MINIMIZE, WINDOW_TOGGLE_MAXIMIZE, WINDOW_CLOSE, WINDOW_IS_MAXIMIZED, WINDOW_MAXIMIZE_STATE,
   PANEL_TRANSFER, PANEL_RECEIVE, PANEL_TRANSFER_ACK,
   PANEL_WINDOWS_LIST, PANEL_WINDOW_DOCK_BACK, PANEL_WINDOW_SYNC_PTY, PANEL_WINDOW_SYNC_META,
   DRAG_START, DRAG_DETACH, DRAG_END,
@@ -38,7 +39,7 @@ import { AgentManager } from '../agent/main/agentManager'
 // Shared singletons for pi agent + auth.
 const agentManager = new AgentManager(authManager)
 import { writeDragTempFile, cleanupDragTempFile, createDragGhostImage } from './ipc/drag'
-import { registerWindow, getWindowType, sendToWindow, broadcastToAll, broadcastToAllExcept, setPanelWindowMeta, setPanelWindowTerminalPtyId, listPanelWindows, getWindow, setDockWindowState, listDockWindows, focusWindow } from './windowRegistry'
+import { registerWindow, getWindowType, sendToWindow, broadcastToAll, broadcastToAllExcept, setPanelWindowMeta, setPanelWindowTerminalPtyId, listPanelWindows, getWindow, setDockWindowState, listDockWindows, focusWindow, windowFromEvent } from './windowRegistry'
 import { registerWorkspaceHandlers } from './workspaceManager'
 import { addAllowedRoot, clearFileGrantsForWindow, clearScopedWriteAllowancesForWindow, grantFileAccess, validatePath } from './ipc/pathValidation'
 import { isLocalLocator } from './companion/locator'
@@ -266,19 +267,26 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
     minWidth: isDock ? 400 : isPanel ? undefined : 800,
     minHeight: isDock ? 300 : isPanel ? undefined : 600,
     title: isDock ? 'Cate' : isPanel ? 'Cate Panel' : 'Cate',
-    // Main + dock windows hide the native title bar and draw a themed strip in
-    // its place (the macOS native bar can't be tinted to a theme color — only
-    // dark/light — so we always use `hiddenInset` and render TitlebarStrip).
-    titleBarStyle: isPanel ? 'hidden' : 'hiddenInset',
+    // macOS: hide the native title bar and draw a themed strip in its place (the
+    // macOS native bar can't be tinted to a theme color — only dark/light — so we
+    // always use `hiddenInset`/`hidden` and render TitlebarStrip).
+    // Windows/Linux: go fully frameless and draw our own window controls in the
+    // renderer (WindowControls), so the chrome matches the theme. `titleBarStyle`
+    // is irrelevant once `frame:false`.
+    titleBarStyle: process.platform === 'darwin' ? (isPanel ? 'hidden' : 'hiddenInset') : 'default',
     // Align traffic lights with our 28px themed TitlebarStrip on macOS. Apple's
     // standard NSWindow title bar is ~28pt with lights at y≈7; matching that
     // here makes the themed bar visually identical to a native title bar.
-    trafficLightPosition: isDock
-      ? { x: 12, y: 11 }
-      : (process.platform === 'darwin' && windowType === 'main')
-        ? { x: 10, y: 6 }
-        : undefined,
-    frame: !(isPanel || isDock),
+    trafficLightPosition: process.platform !== 'darwin'
+      ? undefined
+      : isDock
+        ? { x: 12, y: 11 }
+        : windowType === 'main'
+          ? { x: 10, y: 6 }
+          : undefined,
+    // macOS main windows keep a (hidden-inset) native frame; everything else —
+    // all panel/dock windows, and every window on Windows/Linux — is frameless.
+    frame: process.platform === 'darwin' ? !(isPanel || isDock) : false,
     backgroundColor: bgColor,
     icon: nativeImage.createFromPath(iconPath),
     webPreferences: {
@@ -443,6 +451,17 @@ function createWindow(params?: CateWindowParams): BrowserWindow {
   ;(win as unknown as { on: (e: string, fn: () => void) => void }).on('will-enter-full-screen', broadcastEntering)
   ;(win as unknown as { on: (e: string, fn: () => void) => void }).on('will-leave-full-screen', broadcastLeaving)
   win.webContents.once('did-finish-load', broadcastFullscreenState)
+
+  // Push this window's own maximize state to its renderer so the custom window
+  // controls (WindowControls, Windows/Linux) can swap the maximize/restore glyph.
+  // Per-window (not broadcast): each window's maximize state is independent.
+  const sendMaximizeState = (): void => {
+    if (win.isDestroyed()) return
+    try { win.webContents.send(WINDOW_MAXIMIZE_STATE, win.isMaximized()) } catch { /* noop */ }
+  }
+  win.on('maximize', sendMaximizeState)
+  win.on('unmaximize', sendMaximizeState)
+  win.webContents.once('did-finish-load', sendMaximizeState)
 
   // Build query string from params
   const queryParts: string[] = []
@@ -991,6 +1010,24 @@ function registerWindowAndDialogHandlers(): void {
     if (typeof title === 'string' && title.length > 0) {
       win.setTitle(title)
     }
+  })
+
+  // Custom window controls (frameless Windows/Linux chrome). Per-window: resolve
+  // the calling window from the IPC sender so a panel/dock window controls itself.
+  ipcMain.handle(WINDOW_MINIMIZE, (event) => {
+    windowFromEvent(event)?.minimize()
+  })
+  ipcMain.handle(WINDOW_TOGGLE_MAXIMIZE, (event) => {
+    const win = windowFromEvent(event)
+    if (!win) return
+    if (win.isMaximized()) win.unmaximize()
+    else win.maximize()
+  })
+  ipcMain.handle(WINDOW_CLOSE, (event) => {
+    windowFromEvent(event)?.close()
+  })
+  ipcMain.on(WINDOW_IS_MAXIMIZED, (event) => {
+    event.returnValue = windowFromEvent(event)?.isMaximized() ?? false
   })
 
   // Panel transfer protocol

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -120,6 +120,11 @@ import {
   NOTIFY_OS,
   NOTIFY_ACTION,
   WINDOW_SET_TITLE,
+  WINDOW_MINIMIZE,
+  WINDOW_TOGGLE_MAXIMIZE,
+  WINDOW_CLOSE,
+  WINDOW_IS_MAXIMIZED,
+  WINDOW_MAXIMIZE_STATE,
   PANEL_TRANSFER,
   PANEL_RECEIVE,
   PANEL_TRANSFER_ACK,
@@ -243,6 +248,23 @@ function fullscreenLiveCheck(): boolean {
     return cachedFullscreen
   } catch {
     return cachedFullscreen
+  }
+}
+
+// This window's own maximize state, pushed by main on maximize/unmaximize. Cached
+// so the custom window controls can render synchronously on first paint, with a
+// `sendSync` pull as the authoritative fallback (mirrors the fullscreen pattern).
+let cachedMaximized = false
+ipcRenderer.on(WINDOW_MAXIMIZE_STATE, (_event, value: boolean) => {
+  cachedMaximized = Boolean(value)
+})
+function maximizedLiveCheck(): boolean {
+  try {
+    const v = ipcRenderer.sendSync(WINDOW_IS_MAXIMIZED)
+    cachedMaximized = Boolean(v)
+    return cachedMaximized
+  } catch {
+    return cachedMaximized
   }
 }
 
@@ -1002,6 +1024,32 @@ contextBridge.exposeInMainWorld('electronAPI', {
    *  call this on every mousemove — that's fine at ~60 Hz. */
   isMainWindowFullscreen(): boolean {
     return fullscreenLiveCheck()
+  },
+
+  // Custom window controls (frameless Windows/Linux chrome). Each acts on the
+  // calling window. No-ops visually on macOS, where native chrome is used.
+  windowMinimize(): Promise<void> {
+    return ipcRenderer.invoke(WINDOW_MINIMIZE)
+  },
+  windowToggleMaximize(): Promise<void> {
+    return ipcRenderer.invoke(WINDOW_TOGGLE_MAXIMIZE)
+  },
+  windowClose(): Promise<void> {
+    return ipcRenderer.invoke(WINDOW_CLOSE)
+  },
+  /** Is the calling window currently maximized? Uses the cached push value and
+   *  falls back to a sync IPC for the authoritative answer. */
+  isWindowMaximized(): boolean {
+    return maximizedLiveCheck()
+  },
+  /** Subscribe to this window's maximize-state changes. Fires with the new
+   *  boolean whenever the window is maximized or restored. */
+  onWindowMaximizeChange(callback: (isMaximized: boolean) => void): () => void {
+    const listener = (_event: Electron.IpcRendererEvent, value: boolean): void => {
+      callback(Boolean(value))
+    }
+    ipcRenderer.on(WINDOW_MAXIMIZE_STATE, listener)
+    return () => { ipcRenderer.removeListener(WINDOW_MAXIMIZE_STATE, listener) }
   },
 
   onDragEnd(callback: () => void): () => void {

--- a/src/renderer/drag/__tests__/setup.ts
+++ b/src/renderer/drag/__tests__/setup.ts
@@ -48,5 +48,11 @@ function createElectronAPIStub() {
     isMainWindowFullscreen: vi.fn().mockReturnValue(false),
     onCrossWindowDragUpdate: vi.fn(() => () => {}),
     onDragEnd: vi.fn(() => () => {}),
+    // Custom window controls (frameless Windows/Linux chrome).
+    windowMinimize: vi.fn().mockResolvedValue(undefined),
+    windowToggleMaximize: vi.fn().mockResolvedValue(undefined),
+    windowClose: vi.fn().mockResolvedValue(undefined),
+    isWindowMaximized: vi.fn().mockReturnValue(false),
+    onWindowMaximizeChange: vi.fn(() => () => {}),
   } as unknown as Window['electronAPI']
 }

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -24,10 +24,13 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStateStore } from '../stores/uiStateStore'
 import { useUIStore } from '../stores/uiStore'
 import { SettingsWindow } from '../settings/SettingsWindow'
+import WindowControls from './WindowControls'
 import { applyTheme } from '../lib/themeManager'
 
 import { renderPanelComponent, PANEL_REGISTRY } from '../panels/registry'
 const CanvasPanel = PANEL_REGISTRY.canvas.Component
+
+const IS_MAC = navigator.userAgent.includes('Mac')
 
 interface DockWindowShellProps {
   workspaceId?: string
@@ -377,22 +380,31 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
 
   return (
     <DockStoreProvider store={dockStore}>
-      <div className="dock-window-root h-screen w-screen flex flex-col bg-surface-4 overflow-hidden">
-        {/* Reserve 78px on the left of the top tab bar for the macOS traffic
-            lights and make it the window drag region. Override inside any
-            canvas-node ([data-node-id]) so nested mini-dock tab bars don't
-            inherit the indent or become drag handles. */}
+      <div className="dock-window-root relative h-screen w-screen flex flex-col bg-surface-4 overflow-hidden">
+        {/* Make the top tab bar the window drag region. On macOS reserve 78px on
+            the left for the traffic lights; on Windows/Linux reserve 132px on the
+            right for our custom WindowControls overlay (below). Override inside any
+            canvas-node ([data-node-id]) so nested mini-dock tab bars don't inherit
+            the indent or become drag handles. */}
         <style>{`
           .dock-window-root .dock-tab-bar {
-            padding-left: 78px;
+            ${IS_MAC ? 'padding-left: 78px;' : 'padding-right: 132px;'}
             -webkit-app-region: drag;
           }
           .dock-window-root .dock-tab-bar > * { -webkit-app-region: no-drag; }
           .dock-window-root [data-node-id] .dock-tab-bar {
             padding-left: 0;
+            padding-right: 0;
             -webkit-app-region: no-drag;
           }
         `}</style>
+        {/* Frameless Windows/Linux: custom window controls pinned to the top-right,
+            over the tab bar's reserved right padding. */}
+        {!IS_MAC && (
+          <div className="absolute top-0 right-0 z-30 h-9">
+            <WindowControls />
+          </div>
+        )}
         {/* Full content area — center zone only */}
         <div className="flex-1 min-h-0 min-w-0 relative overflow-hidden">
           <DockZone

--- a/src/renderer/shells/PanelWindowShell.tsx
+++ b/src/renderer/shells/PanelWindowShell.tsx
@@ -15,9 +15,12 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useUIStateStore } from '../stores/uiStateStore'
 import { useUIStore } from '../stores/uiStore'
 import { SettingsWindow } from '../settings/SettingsWindow'
+import WindowControls from './WindowControls'
 import { applyTheme } from '../lib/themeManager'
 import { ensurePanelsInAppStore } from '../lib/canvas/applyCanvasChildPanels'
 import { useAppStore } from '../stores/appStore'
+
+const IS_MAC = navigator.userAgent.includes('Mac')
 
 interface PanelWindowShellProps {
   panelType?: string
@@ -226,14 +229,20 @@ export default function PanelWindowShell({ panelType, panelId, workspaceId }: Pa
           <PanelTypeIcon type={displayPanel.type} />
         </div>
         <span className="text-xs text-secondary truncate flex-1 min-w-0">{displayPanel.title}</span>
-        <button
-          className="w-5 h-5 flex items-center justify-center rounded hover:bg-hover text-muted hover:text-primary transition-colors"
-          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-          onClick={handleClose}
-          title="Close"
-        >
-          <X size={10} />
-        </button>
+        {IS_MAC ? (
+          // macOS has no native controls on this hidden-titlebar window, so keep
+          // an app-level close. Windows/Linux gets full controls below.
+          <button
+            className="w-5 h-5 flex items-center justify-center rounded hover:bg-hover text-muted hover:text-primary transition-colors"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            onClick={handleClose}
+            title="Close"
+          >
+            <X size={10} />
+          </button>
+        ) : (
+          <WindowControls />
+        )}
       </div>
 
       <DragOverlay />

--- a/src/renderer/shells/TitlebarStrip.tsx
+++ b/src/renderer/shells/TitlebarStrip.tsx
@@ -1,16 +1,21 @@
 // =============================================================================
-// TitlebarStrip — themed drag region rendered at the top of the main window on
-// macOS (titleBarStyle: 'hiddenInset'). Reserves space for the traffic lights
-// and gives the window a drag region matched to the app theme. macOS always
-// uses the hidden-inset title bar — the native bar can't be tinted to a theme
-// color, only dark/light.
+// TitlebarStrip — themed drag region rendered at the top of the main window.
 //
-// In native macOS fullscreen the traffic lights are hidden by the OS, so the
-// strip would otherwise show as a 28px dead zone at the top — subscribe to
-// fullscreen state and collapse while fullscreen is active.
+// macOS (titleBarStyle: 'hiddenInset'): reserves space for the native traffic
+// lights and provides a themed drag region. The native bar can't be tinted to a
+// theme color, only dark/light, so we always use hidden-inset + this strip.
+//
+// Windows/Linux (frame: false): the window is fully frameless, so this strip is
+// the entire title bar — a themed drag region with our custom WindowControls
+// (minimize/maximize/close) on the right and double-click-to-maximize.
+//
+// In native fullscreen the OS hides its chrome, so the strip would otherwise be
+// a dead zone at the top — subscribe to fullscreen state and collapse while it's
+// active (on every platform).
 // =============================================================================
 
 import { useEffect, useState } from 'react'
+import WindowControls from './WindowControls'
 
 const IS_MAC = navigator.userAgent.includes('Mac')
 
@@ -20,16 +25,29 @@ export default function TitlebarStrip() {
   )
 
   useEffect(() => {
-    if (!IS_MAC) return
     return window.electronAPI.onFullscreenChange?.((value) => setIsFullscreen(value))
   }, [])
 
-  if (!IS_MAC || isFullscreen) return null
+  if (isFullscreen) return null
 
+  // macOS: empty strip, padded for the native traffic lights.
+  if (IS_MAC) {
+    return (
+      <div
+        className="titlebar-drag shrink-0 bg-titlebar-bg select-none"
+        style={{ paddingLeft: 80, height: 28 }}
+      />
+    )
+  }
+
+  // Windows/Linux: full title bar with custom controls on the right.
   return (
     <div
-      className="titlebar-drag shrink-0 bg-titlebar-bg select-none"
-      style={{ paddingLeft: 80, height: 28 }}
-    />
+      className="titlebar-drag shrink-0 bg-titlebar-bg select-none flex items-stretch justify-end"
+      style={{ height: 28 }}
+      onDoubleClick={() => window.electronAPI.windowToggleMaximize?.()}
+    >
+      <WindowControls />
+    </div>
   )
 }

--- a/src/renderer/shells/WindowControls.test.tsx
+++ b/src/renderer/shells/WindowControls.test.tsx
@@ -1,0 +1,96 @@
+// =============================================================================
+// Tests for WindowControls — the custom min/max/close buttons used by the
+// frameless Windows/Linux window chrome.
+//
+// jsdom's navigator.userAgent is not "Mac", so the component renders here (on
+// macOS it returns null and these buttons never mount). Verifies each button
+// calls the matching electronAPI method and that the maximize/restore label
+// swaps when an onWindowMaximizeChange callback fires.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+import WindowControls from './WindowControls'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+})
+
+function render() {
+  act(() => { root.render(<WindowControls />) })
+  return host
+}
+
+function button(el: HTMLElement, label: string): HTMLButtonElement {
+  const btn = el.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+  if (!btn) throw new Error(`button "${label}" not found`)
+  return btn
+}
+
+function click(btn: HTMLButtonElement) {
+  act(() => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+}
+
+describe('WindowControls', () => {
+  it('renders the three controls on non-mac', () => {
+    const el = render()
+    expect(el.querySelector('button[aria-label="Minimize"]')).not.toBeNull()
+    expect(el.querySelector('button[aria-label="Maximize"]')).not.toBeNull()
+    expect(el.querySelector('button[aria-label="Close"]')).not.toBeNull()
+  })
+
+  it('minimize button calls windowMinimize', () => {
+    const el = render()
+    click(button(el, 'Minimize'))
+    expect(window.electronAPI.windowMinimize).toHaveBeenCalledTimes(1)
+  })
+
+  it('maximize button calls windowToggleMaximize', () => {
+    const el = render()
+    click(button(el, 'Maximize'))
+    expect(window.electronAPI.windowToggleMaximize).toHaveBeenCalledTimes(1)
+  })
+
+  it('close button calls windowClose', () => {
+    const el = render()
+    click(button(el, 'Close'))
+    expect(window.electronAPI.windowClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('seeds maximized state from isWindowMaximized', () => {
+    vi.mocked(window.electronAPI.isWindowMaximized).mockReturnValue(true)
+    const el = render()
+    // When maximized the control offers Restore instead of Maximize.
+    expect(el.querySelector('button[aria-label="Restore"]')).not.toBeNull()
+    expect(el.querySelector('button[aria-label="Maximize"]')).toBeNull()
+  })
+
+  it('swaps Maximize↔Restore when onWindowMaximizeChange fires', () => {
+    let push: ((v: boolean) => void) | undefined
+    vi.mocked(window.electronAPI.onWindowMaximizeChange).mockImplementation((cb) => {
+      push = cb
+      return () => {}
+    })
+    const el = render()
+    expect(button(el, 'Maximize')).toBeTruthy()
+
+    act(() => { push?.(true) })
+    expect(el.querySelector('button[aria-label="Restore"]')).not.toBeNull()
+
+    act(() => { push?.(false) })
+    expect(el.querySelector('button[aria-label="Maximize"]')).not.toBeNull()
+  })
+})

--- a/src/renderer/shells/WindowControls.tsx
+++ b/src/renderer/shells/WindowControls.tsx
@@ -1,0 +1,62 @@
+// =============================================================================
+// WindowControls — custom minimize / maximize / close buttons for the frameless
+// window chrome on Windows & Linux. macOS uses native traffic lights, so this
+// renders nothing there (the parent strips can mount it unconditionally).
+//
+// Buttons are flat and theme-driven (titlebar bg, --text-secondary, surface
+// hover); the close button gets a destructive red hover, matching platform
+// convention. Each button is a `no-drag` island inside the draggable titlebar.
+// =============================================================================
+
+import { useEffect, useState } from 'react'
+import { Minus, Square, Copy, X } from '@phosphor-icons/react'
+
+const IS_MAC = navigator.userAgent.includes('Mac')
+
+const NO_DRAG: React.CSSProperties = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
+
+export default function WindowControls() {
+  const [isMaximized, setIsMaximized] = useState<boolean>(
+    () => window.electronAPI.isWindowMaximized?.() ?? false,
+  )
+
+  useEffect(() => {
+    if (IS_MAC) return
+    return window.electronAPI.onWindowMaximizeChange?.((value) => setIsMaximized(value))
+  }, [])
+
+  // Native chrome on macOS — render nothing.
+  if (IS_MAC) return null
+
+  return (
+    <div className="flex items-center h-full shrink-0" style={NO_DRAG}>
+      <button
+        type="button"
+        aria-label="Minimize"
+        title="Minimize"
+        className="h-full w-11 flex items-center justify-center text-secondary hover:bg-surface-hover hover:text-primary transition-colors"
+        onClick={() => window.electronAPI.windowMinimize?.()}
+      >
+        <Minus size={15} weight="bold" />
+      </button>
+      <button
+        type="button"
+        aria-label={isMaximized ? 'Restore' : 'Maximize'}
+        title={isMaximized ? 'Restore' : 'Maximize'}
+        className="h-full w-11 flex items-center justify-center text-secondary hover:bg-surface-hover hover:text-primary transition-colors"
+        onClick={() => window.electronAPI.windowToggleMaximize?.()}
+      >
+        {isMaximized ? <Copy size={13} weight="bold" /> : <Square size={12} weight="bold" />}
+      </button>
+      <button
+        type="button"
+        aria-label="Close"
+        title="Close"
+        className="h-full w-11 flex items-center justify-center text-secondary hover:bg-red-600 hover:text-white transition-colors"
+        onClick={() => window.electronAPI.windowClose?.()}
+      >
+        <X size={15} weight="bold" />
+      </button>
+    </div>
+  )
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -536,6 +536,24 @@ export interface ElectronAPI {
   // Window management
   // ---------------------------------------------------------------------------
 
+  /** Minimize the calling window. Used by the custom window controls on the
+   *  frameless Windows/Linux chrome. */
+  windowMinimize(): Promise<void>
+
+  /** Toggle maximize/restore on the calling window. */
+  windowToggleMaximize(): Promise<void>
+
+  /** Close the calling window. */
+  windowClose(): Promise<void>
+
+  /** Synchronous cached check: is the calling window maximized? Backs the
+   *  maximize/restore glyph swap in the custom window controls. */
+  isWindowMaximized(): boolean
+
+  /** Subscribe to the calling window's maximize-state changes. Fires with the
+   *  new boolean whenever the window is maximized or restored. */
+  onWindowMaximizeChange(callback: (isMaximized: boolean) => void): () => void
+
   // ---------------------------------------------------------------------------
   // Panel transfer (cross-window)
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -235,6 +235,13 @@ export const NOTIFY_ACTION = 'notify:action' // main -> renderer (OS notificatio
 
 // Window management
 export const WINDOW_SET_TITLE = 'window:setTitle'
+// Custom window controls (frameless Windows/Linux chrome). Each is per-window —
+// the handler resolves the calling window from the IPC event sender.
+export const WINDOW_MINIMIZE = 'window:minimize'              // renderer -> main
+export const WINDOW_TOGGLE_MAXIMIZE = 'window:toggleMaximize' // renderer -> main
+export const WINDOW_CLOSE = 'window:close'                    // renderer -> main
+export const WINDOW_IS_MAXIMIZED = 'window:isMaximized'       // renderer -> main (sync pull)
+export const WINDOW_MAXIMIZE_STATE = 'window:maximizeState'   // main -> renderer (push)
 
 // Panel transfer (cross-window)
 export const PANEL_TRANSFER = 'panel:transfer'


### PR DESCRIPTION
## Summary

On Windows and Linux the main window still rendered the native OS title bar, so it didn't match the themed, minimal chrome Cate has on macOS. This makes the **main, panel, and dock** windows fully frameless on Win/Linux and draws our own **minimize / maximize / close** controls in the renderer — flat, theme-driven, right-aligned. **macOS is unchanged** (native traffic lights + existing strips).

## Changes

- **Main process** (`src/main/index.ts`): `frame:false` on non-darwin; per-window IPC handlers (`minimize` / `toggleMaximize` / `close` / sync `isMaximized`) resolved via `windowFromEvent`; per-window `maximize`/`unmaximize` events push state to that window's renderer.
- **IPC + bridge + types**: 5 new `window:*` channels; preload methods mirroring the existing fullscreen cache+sync+subscribe pattern; signatures added to `electron-api.d.ts`.
- **Renderer**: new `WindowControls.tsx` (returns `null` on macOS) wired into `TitlebarStrip`, `PanelWindowShell`, and `DockWindowShell`. `TitlebarStrip` becomes the full title bar on Win/Linux with double-click-to-maximize; fullscreen-collapse now applies on all platforms. Panel keeps its `X` only on macOS.

## Deferred (by design)

- **Snap Layouts hover** — needs native `WM_NCHITTEST` handling; out of scope.
- The now-hidden Win/Linux menu bar — accelerators still fire and actions remain reachable via shortcuts / command palette.

## Testing

- `npm test` — 1014 passed, 3 skipped (incl. new `WindowControls.test.tsx`, 6 tests)
- `npm run typecheck` — clean
- `npm run build` — succeeds
- `eslint` on touched files — 0 errors

⚠️ Windows/Linux visuals were not verified locally (dev box is macOS); the macOS path is inert by construction. Relying on the 3-OS CI matrix.