### PR TITLE
feat(canvas): theme placement picker and worktree color palette

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -85,8 +85,8 @@ function injectCanvasInteractingStyle(): void {
 const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <kbd style={{
     display: 'inline-block', minWidth: 18, padding: '1px 5px', margin: '0 1px',
-    borderRadius: 5, background: 'rgba(255,255,255,0.14)',
-    border: '1px solid rgba(255,255,255,0.12)', borderBottomWidth: 2,
+    borderRadius: 5, background: 'var(--surface-4)', color: 'var(--text-primary)',
+    border: '1px solid var(--border-strong)', borderBottomWidth: 2,
     fontSize: 11, fontWeight: 600, textAlign: 'center', lineHeight: '16px',
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
   }}>{children}</kbd>
@@ -112,10 +112,10 @@ const PlacementHint: React.FC<{ canvasRef: React.RefObject<HTMLDivElement> }> = 
         position: 'fixed', left: (visLeft + visRight) / 2, top: r.top + 16, transform: 'translateX(-50%)',
         zIndex: 2147483000, display: 'flex', alignItems: 'center', gap: 14,
         padding: '9px 9px 9px 16px', borderRadius: 999,
-        background: 'rgba(20, 24, 32, 0.95)', border: '1px solid rgba(255,255,255,0.08)',
-        boxShadow: '0 10px 30px rgba(0,0,0,0.5)', color: 'rgba(255,255,255,0.92)',
+        // Match the bottom toolbar so the bar adapts to the active theme.
+        background: 'var(--surface-0)', border: '1px solid var(--border-subtle)',
+        boxShadow: '0 8px 24px -6px var(--shadow-node)', color: 'var(--text-primary)',
         fontSize: 13, fontWeight: 500, fontFamily: 'system-ui, -apple-system, sans-serif',
-        backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)',
         animation: 'ghostHintIn 200ms ease both', userSelect: 'none', whiteSpace: 'nowrap',
       }}>
         <span>
@@ -129,8 +129,8 @@ const PlacementHint: React.FC<{ canvasRef: React.RefObject<HTMLDivElement> }> = 
           onClick={() => api.getState().cancelPlacement()}
           style={{
             display: 'flex', alignItems: 'center', gap: 6, padding: '5px 12px', borderRadius: 999,
-            border: 'none', cursor: 'pointer', background: 'rgba(255,255,255,0.1)',
-            color: 'rgba(255,255,255,0.9)', fontSize: 12.5, fontWeight: 600, fontFamily: 'inherit',
+            border: 'none', cursor: 'pointer', background: 'var(--surface-hover-strong)',
+            color: 'var(--text-secondary)', fontSize: 12.5, fontWeight: 600, fontFamily: 'inherit',
           }}
         >
           Cancel <Kbd>Esc</Kbd>

--- a/src/renderer/canvas/GhostPlacementLayer.tsx
+++ b/src/renderer/canvas/GhostPlacementLayer.tsx
@@ -15,7 +15,11 @@
 import React, { useEffect, useRef } from 'react'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 
-const ACCENT = '74, 158, 255'
+// Theme accent — ghosts track the active theme's --focus-blue rather than a
+// hardcoded blue, so they recolor with the IDE theme. color-mix gives us a
+// per-stop alpha (the same technique the dock drop-target ghosts use in
+// DockTabBar). `accent(100)` is the solid accent.
+const accent = (pct: number) => `color-mix(in srgb, var(--focus-blue) ${pct}%, transparent)`
 
 let stylesInjected = false
 function injectStyles() {
@@ -128,9 +132,9 @@ const GhostPlacementLayer: React.FC = () => {
             position: 'absolute',
             left: free.point.x, top: free.point.y,
             width: free.size.width, height: free.size.height,
-            border: `1.5px dashed rgba(${ACCENT}, 0.7)`,
+            border: `1.5px dashed ${accent(70)}`,
             borderRadius: 8,
-            background: `rgba(${ACCENT}, 0.08)`,
+            background: accent(8),
             zIndex: 49000,
             pointerEvents: 'none',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -158,11 +162,11 @@ const GhostPlacementLayer: React.FC = () => {
               position: 'absolute',
               left: c.point.x, top: c.point.y,
               width: c.size.width, height: c.size.height,
-              border: `${isBest ? 2.5 : 1.5}px solid rgba(${ACCENT}, ${hovered || isBest ? 0.95 : 0.6})`,
+              border: `${isBest ? 2.5 : 1.5}px solid ${accent(hovered || isBest ? 95 : 60)}`,
               borderRadius: 8,
-              background: `rgba(${ACCENT}, ${hovered ? 0.2 : isBest ? 0.13 : 0.08})`,
+              background: accent(hovered ? 20 : isBest ? 13 : 8),
               boxShadow: hovered
-                ? `0 12px 32px rgba(0,0,0,0.4), 0 0 0 4px rgba(${ACCENT}, 0.18)`
+                ? `0 12px 32px rgba(0,0,0,0.4), 0 0 0 4px ${accent(18)}`
                 : isBest ? '0 8px 24px rgba(0,0,0,0.32)' : undefined,
               cursor: 'pointer',
               pointerEvents: 'auto',
@@ -184,7 +188,7 @@ const GhostPlacementLayer: React.FC = () => {
                 style={{
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                   width: 42, height: 42, borderRadius: 21,
-                  background: `rgba(${ACCENT}, ${hovered || isBest ? 1 : 0.85})`,
+                  background: accent(hovered || isBest ? 100 : 85),
                   color: '#fff', fontWeight: 700, fontSize: 19,
                   fontFamily: 'system-ui, -apple-system, sans-serif',
                   boxShadow: '0 3px 10px rgba(0,0,0,0.35)',
@@ -193,7 +197,7 @@ const GhostPlacementLayer: React.FC = () => {
                 {i + 1}
               </div>
               {isBest && (
-                <div style={{ padding: '2px 8px', borderRadius: 6, background: `rgba(${ACCENT}, 0.95)`,
+                <div style={{ padding: '2px 8px', borderRadius: 6, background: accent(95),
                   color: '#fff', fontSize: 10.5, fontWeight: 600, letterSpacing: 0.3,
                   fontFamily: 'system-ui, -apple-system, sans-serif', textTransform: 'uppercase' }}>
                   Best

--- a/src/renderer/canvas/WorktreeToolbarMenu.tsx
+++ b/src/renderer/canvas/WorktreeToolbarMenu.tsx
@@ -32,7 +32,7 @@ import { CreateWorktreeForm } from '../sidebar/CreateWorktreeForm'
 import { useWorktrees, type JoinedWorktree } from '../stores/useWorktrees'
 import { useGitStatusSnapshot, gitStatusStore } from '../stores/gitStatusStore'
 import { useUIStore } from '../stores/uiStore'
-import { useAppStore, WORKTREE_COLOR_PALETTE } from '../stores/appStore'
+import { useAppStore, getWorktreeColorPalette } from '../stores/appStore'
 import { useParallelWork, runWorktreeContextMenu, type CardCallbacks } from '../stores/useParallelWork'
 import { useWorktreeStatuses, humanStatus, type PrStatus } from '../stores/useWorktreeStatuses'
 
@@ -532,7 +532,7 @@ const WorktreeRow: React.FC<{
 
       {recoloring && (
         <div className="flex items-center gap-1.5 flex-wrap mt-1 pl-5 pr-1">
-          {WORKTREE_COLOR_PALETTE.map((c) => (
+          {getWorktreeColorPalette().map((c) => (
             <button
               key={c}
               onClick={(e) => { e.stopPropagation(); cb.onRecolor(c); setRecoloring(false) }}

--- a/src/renderer/stores/appStore.ts
+++ b/src/renderer/stores/appStore.ts
@@ -26,6 +26,8 @@ import type {
 } from '../../shared/types'
 import { PANEL_DEFAULT_SIZES, ZOOM_DEFAULT, ALL_ZONES } from '../../shared/types'
 import { ACCENT_COLORS } from '../../shared/colors'
+import { BASE_DARK, BASE_LIGHT } from '../../shared/themes'
+import { getActiveTheme } from '../lib/themeManager'
 import { pathKey } from '../../shared/pathUtils'
 import type { StoreApi } from 'zustand'
 import { terminalRegistry } from '../lib/terminal/terminalRegistry'
@@ -180,28 +182,94 @@ export type PanelPlacement =
   | { target: 'none' }
 
 // -----------------------------------------------------------------------------
-// Worktree colors — fixed palette assigned round-robin to new worktrees.
-// Picked to be visually distinct in both light and dark themes.
+// Worktree colors — a multi-color palette derived from the ACTIVE theme rather
+// than a fixed hardcoded set, so the swatches look native to whatever theme is
+// loaded. Source is the theme's terminal ANSI palette (a rich, vivid, multi-hue
+// set every theme defines, and — unlike the git/panel app colors — not tied to
+// other UI meaning).
+//
+// The theme accent (--focus-blue) is excluded DYNAMICALLY: we drop whichever
+// ANSI hue is closest to it, so a worktree color is never confused with focus/
+// selection chrome. The accent isn't always blue — in a red-accented theme it's
+// the red entry that drops, in a green-accented one the green entry, etc.
+//
+// Picked colors are resolved to concrete #rrggbb and stored on the worktree, so
+// they keep working in the canvas territory renderer (which parses hex) and a
+// worktree keeps its color across later theme switches.
 // -----------------------------------------------------------------------------
 
-export const WORKTREE_COLOR_PALETTE: string[] = [
-  '#3b82f6', // blue
-  '#10b981', // emerald
-  '#f59e0b', // amber
-  '#ec4899', // pink
-  '#8b5cf6', // violet
-  '#14b8a6', // teal
-  '#ef4444', // red
-  '#84cc16', // lime
-  '#06b6d4', // cyan
-  '#f97316', // orange
-]
+/** Vivid ANSI hue slots, ordered rainbow-ish (base + brighter shade per hue).
+ *  Blacks/whites/grays are omitted. Blue is kept here on purpose — only the hue
+ *  closest to the *actual* accent is dropped below, so in a non-blue-accent
+ *  theme blue stays available (and in the usual blue-accent themes it drops). */
+const WORKTREE_ANSI_KEYS = [
+  'red', 'brightRed',
+  'yellow', 'brightYellow',
+  'green', 'brightGreen',
+  'cyan', 'brightCyan',
+  'blue', 'brightBlue',
+  'magenta', 'brightMagenta',
+] as const
+
+/** Squared-RGB distance below which a hue is treated as "the accent" (dropped). */
+const ACCENT_EXCLUDE_DIST2 = 10000
+/** Squared-RGB distance below which two hues are treated as duplicates. */
+const DUP_EXCLUDE_DIST2 = 800
+
+/** Safety net if a theme somehow yields too few usable hues (no blue). */
+const FALLBACK_WORKTREE_COLORS = ['#10b981', '#f59e0b', '#ec4899', '#8b5cf6', '#ef4444']
+
+/** Parse #rgb / #rrggbb / #rrggbbaa or rgb()/rgba() into [r,g,b], else null. */
+function parseRgb(color: string): [number, number, number] | null {
+  const s = color.trim()
+  const hex = /^#?([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.exec(s)
+  if (hex) {
+    let h = hex[1]
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2]
+    const n = parseInt(h.slice(0, 6), 16)
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+  }
+  const rgb = /^rgba?\(\s*(\d+)\D+(\d+)\D+(\d+)/i.exec(s)
+  if (rgb) return [Number(rgb[1]) & 255, Number(rgb[2]) & 255, Number(rgb[3]) & 255]
+  return null
+}
+
+function toHex([r, g, b]: [number, number, number]): string {
+  return '#' + [r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')
+}
+
+function dist2(a: [number, number, number], b: [number, number, number]): number {
+  const dr = a[0] - b[0], dg = a[1] - b[1], db = a[2] - b[2]
+  return dr * dr + dg * dg + db * db
+}
+
+/** The current theme's worktree color palette: vivid ANSI hues, accent-hue and
+ *  near-duplicates removed, resolved to concrete #rrggbb. Reflects the active
+ *  theme each time it's called (cheap — call at pick / when rendering swatches). */
+export function getWorktreeColorPalette(): string[] {
+  const theme = getActiveTheme()
+  const base = theme.type === 'light' ? BASE_LIGHT : BASE_DARK
+  const accent = parseRgb(theme.app['focus-blue'] ?? base['focus-blue'])
+
+  const out: string[] = []
+  const chosen: [number, number, number][] = []
+  for (const key of WORKTREE_ANSI_KEYS) {
+    const rgb = parseRgb(theme.terminal[key])
+    if (!rgb) continue
+    if (accent && dist2(rgb, accent) < ACCENT_EXCLUDE_DIST2) continue
+    if (chosen.some((c) => dist2(c, rgb) < DUP_EXCLUDE_DIST2)) continue
+    chosen.push(rgb)
+    out.push(toHex(rgb))
+  }
+  return out.length >= 3 ? out : FALLBACK_WORKTREE_COLORS
+}
 
 export function pickWorktreeColor(existing: { color: string }[]): string {
+  const palette = getWorktreeColorPalette()
   const used = new Set(existing.map((w) => w.color))
-  for (const c of WORKTREE_COLOR_PALETTE) if (!used.has(c)) return c
+  for (const c of palette) if (!used.has(c)) return c
   // Wrap around if more worktrees than palette entries.
-  return WORKTREE_COLOR_PALETTE[existing.length % WORKTREE_COLOR_PALETTE.length]
+  return palette[existing.length % palette.length]
 }
 
 /** A fully-reset dock layout: all side zones hidden, an empty visible center.

--- a/src/renderer/stores/worktreeColors.test.tsx
+++ b/src/renderer/stores/worktreeColors.test.tsx
@@ -1,0 +1,100 @@
+// =============================================================================
+// Tests for the theme-derived worktree color palette (appStore).
+//
+// The palette is built from the ACTIVE theme's terminal ANSI hues, with the
+// theme accent (--focus-blue) excluded DYNAMICALLY — whichever hue is closest to
+// the accent drops, so a worktree color never reads as focus/selection chrome.
+// The accent isn't always blue, so we assert exclusion tracks the accent hue:
+// a blue-accent theme drops blue/cyan, a red-accent theme drops red.
+// =============================================================================
+
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Theme } from '../../shared/types'
+import { applyTheme } from '../lib/themeManager'
+import { useSettingsStore } from './settingsStore'
+import { getWorktreeColorPalette, pickWorktreeColor } from './appStore'
+
+const HEX6 = /^#[0-9a-f]{6}$/
+
+function rgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+function dist2(a: string, b: string): number {
+  const [ar, ag, ab] = rgb(a), [br, bg, bb] = rgb(b)
+  return (ar - br) ** 2 + (ag - bg) ** 2 + (ab - bb) ** 2
+}
+function nearest(palette: string[], target: string): number {
+  return Math.min(...palette.map((c) => dist2(c, target)))
+}
+
+// A full terminal palette with well-separated hues so each named slot is a
+// distinct color the palette logic can keep or drop independently.
+const ANSI = {
+  background: '#101010', foreground: '#e0e0e0',
+  black: '#000000', red: '#d03030', green: '#30b050', yellow: '#d0c030',
+  blue: '#3060d0', magenta: '#b040b0', cyan: '#30b0c0', white: '#d0d0d0',
+  brightBlack: '#606060', brightRed: '#f05050', brightGreen: '#50d070',
+  brightYellow: '#f0e050', brightBlue: '#5080f0', brightMagenta: '#d060d0',
+  brightCyan: '#50d0e0', brightWhite: '#ffffff',
+}
+
+function makeTheme(id: string, focusBlue: string): Theme {
+  return {
+    version: 1, id, name: id, type: 'dark',
+    app: { 'focus-blue': focusBlue, 'border-focus': focusBlue },
+    terminal: { ...ANSI },
+    editor: { base: 'vs-dark', colors: {}, tokens: [] },
+  }
+}
+
+function loadTheme(theme: Theme): void {
+  useSettingsStore.setState({ customThemes: [theme] })
+  applyTheme(theme.id)
+}
+
+afterEach(() => {
+  useSettingsStore.setState({ customThemes: [] })
+})
+
+describe('getWorktreeColorPalette', () => {
+  it('returns several distinct, concrete #rrggbb hues', () => {
+    loadTheme(makeTheme('blue-accent', '#4a9eff'))
+    const palette = getWorktreeColorPalette()
+    expect(palette.length).toBeGreaterThanOrEqual(3)
+    for (const c of palette) expect(c).toMatch(HEX6)
+    expect(new Set(palette).size).toBe(palette.length) // no duplicates
+  })
+
+  it('excludes the accent hue when the accent is blue', () => {
+    loadTheme(makeTheme('blue-accent', '#4a9eff'))
+    const palette = getWorktreeColorPalette()
+    // Nothing should land near the blue accent (blue/cyan ANSI dropped).
+    expect(nearest(palette, '#4a9eff')).toBeGreaterThan(10000)
+    // Other hues survive.
+    expect(nearest(palette, ANSI.red)).toBeLessThan(2000)
+    expect(nearest(palette, ANSI.green)).toBeLessThan(2000)
+  })
+
+  it('excludes the accent hue when the accent is red', () => {
+    loadTheme(makeTheme('red-accent', '#e03030'))
+    const palette = getWorktreeColorPalette()
+    // The red ANSI hue is dropped because it now matches the accent...
+    expect(nearest(palette, '#e03030')).toBeGreaterThan(10000)
+    // ...while blue/green remain available.
+    expect(nearest(palette, ANSI.blue)).toBeLessThan(2000)
+    expect(nearest(palette, ANSI.green)).toBeLessThan(2000)
+  })
+})
+
+describe('pickWorktreeColor', () => {
+  it('assigns unused palette colors before repeating', () => {
+    loadTheme(makeTheme('blue-accent', '#4a9eff'))
+    const palette = getWorktreeColorPalette()
+    const first = pickWorktreeColor([])
+    expect(palette).toContain(first)
+    const second = pickWorktreeColor([{ color: first }])
+    expect(second).not.toBe(first)
+    expect(palette).toContain(second)
+  })
+})


### PR DESCRIPTION
## Summary

Recolor the placement picker and worktree swatches off the hardcoded blue so they track the active IDE theme.

### Placement selection view
- The placement ghosts (numbered candidates, **Best**, the free-placement preview) now derive from `--focus-blue` via `color-mix` — the same technique the dock drop-target ghosts use — instead of a literal `rgba(74,158,255,…)`.
- The "Pick a spot" bar now uses theme surface/border/text tokens (matching the bottom toolbar), so the bar and keycaps stay legible in light themes too.

### Worktree colors
- The selectable palette is now derived from the **active theme's terminal ANSI hues** (a rich, multi-color, per-theme set) rather than a fixed list of generic hexes.
- **Theme-derived, fixed at pick:** swatches reflect the current theme; a pick resolves to a concrete `#rrggbb` and is stored on the worktree, so the canvas territory renderer (which parses hex) keeps working and a worktree keeps its color across later theme switches.
- **Accent excluded dynamically:** whichever ANSI hue is closest to `--focus-blue` is dropped, so a worktree color is never confused with focus/selection chrome. The accent isn't always blue — a red-accent theme drops red, a green-accent theme drops green, etc.

## Tests
- New `worktreeColors.test.tsx` asserts the palette is valid multi-color hex and that the dynamic accent exclusion works both ways (blue-accent → no near-blue swatch; red-accent → red dropped, blue/green kept).
- `tsc`, `lint` clean; full vitest suite green apart from the pre-existing flaky `daemon-subprocess` FS-watch tests (environmental, unrelated to these renderer-only changes).