### PR TITLE
fix(dock): size tabs to content so titles aren't truncated without the worktree pill

### DIFF
--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -190,7 +190,7 @@ export function DockTabBar(props: DockTabBarProps) {
             panelId={panelId}
             className={`
               group relative flex items-center gap-1.5 whitespace-nowrap
-              cursor-grab select-none min-w-0 flex-1 max-w-[200px]
+              cursor-grab select-none min-w-0 shrink max-w-[200px]
               ${compact ? 'pl-2 pr-1.5 text-[11px]' : 'pl-3 pr-2 text-xs'}
               ${isActive ? 'text-secondary font-medium' : 'text-muted hover:text-secondary'}
             `}


### PR DESCRIPTION
## Problem

Dock tab titles truncated to "Te…" even on inactive tabs where the worktree pill isn't shown and there's visibly free space to the right.

## Cause

The tab pill used `flex-1`, but the trailing draggable spacer in the tab bar is **also** `flex-1`. Because `flex-1` is `flex: 1 1 0%`, the tab and spacer split the bar by grow ratio, so a lone tab only ever got ~50% of the width — too narrow for short titles like "Terminal".

## Fix

Swap `flex-1` → `shrink` on the tab pill. Tabs now size to their content (icon + title + optional pill + close), stay capped at `max-w-[200px]`, and shrink only when the bar is genuinely too narrow. The `flex-1` spacer absorbs the leftover width. Multi-tab overflow still truncates correctly via the retained `min-w-0`.

Typecheck passes.