### PR TITLE
chore: release v1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Release v1.2.2.

Bumps `package.json` + `package-lock.json` to `1.2.2`. Tag `v1.2.2` will be pushed once this merges, triggering the 3-OS release build.

### Included since v1.2.1
- fix(update): switch to stock electron-updater, remove custom UI, fix macOS trap (#318)
- fix(dock): size tabs to content so titles aren't truncated without the worktree pill (#317)
- feat(canvas): theme placement picker and worktree color palette (#316)
- feat(window): frameless chrome + custom controls on Windows/Linux (#315)
- fix(layouts): apply saved layouts to the active canvas (#314)
- fix(windows): derive workspace and terminal names from folder, not full path (#313)
