### PR TITLE
chore: release v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Version bump to 1.2.3. Merge, then push tag `v1.2.3` to trigger the release build.