### PR TITLE
fix(skills): open PR for index rebuild instead of pushing to protected main

### DIFF
--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: skills-index
@@ -29,14 +30,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/build-skills-index.mjs
-      - name: Commit updated index
-        run: |
-          if [ -n "$(git status --porcelain registry/skills-index.json)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add registry/skills-index.json
-            git commit -m "chore(skills): rebuild skills index"
-            git push
-          else
-            echo "No changes to skills index."
-          fi
+      # main is protected (changes must go through a PR), so we can't push the
+      # rebuilt index directly. Open/refresh a PR instead; an admin or auto-merge
+      # lands it. No-op when the crawl produced no diff.
+      - name: Open PR with updated index
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: registry/skills-index.json
+          branch: skills-index-update
+          commit-message: "chore(skills): rebuild skills index"
+          title: "chore(skills): rebuild skills index"
+          body: "Automated rebuild of `registry/skills-index.json` from `registry/sources.json`."
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
The Build skills index workflow failed on the #321 merge: it git-pushes the rebuilt index straight to `main`, which the branch rule rejects (changes must go through a PR).

The crawl/rebuild step works fine; only the push fails. Switch the final step to open a PR via peter-evans/create-pull-request, and add the `pull-requests: write` permission.

Note: PRs opened with the default GITHUB_TOKEN don't trigger the required status checks, so the index PR will need an admin merge (or a PAT) to satisfy branch protection.