### PR TITLE
fix(skills): fix search showing stale/all rows (dedup index + unique row keys)

### DIFF
--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-07T20:35:46.477Z",
+  "generatedAt": "2026-06-07T20:50:31.126Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
@@ -12,7 +12,7 @@
         "ref": "main",
         "path": "academic-paper"
       },
-      "stars": 28502,
+      "stars": 28504,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -28,7 +28,7 @@
         "ref": "main",
         "path": "academic-paper-reviewer"
       },
-      "stars": 28502,
+      "stars": 28504,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -44,7 +44,7 @@
         "ref": "main",
         "path": "academic-pipeline"
       },
-      "stars": 28502,
+      "stars": 28504,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -60,7 +60,7 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 28502,
+      "stars": 28504,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -76,7 +76,7 @@
         "ref": "main",
         "path": "skills/api-and-interface-design"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -92,7 +92,7 @@
         "ref": "main",
         "path": "skills/browser-testing-with-devtools"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -108,7 +108,7 @@
         "ref": "main",
         "path": "skills/ci-cd-and-automation"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -124,7 +124,7 @@
         "ref": "main",
         "path": "skills/code-review-and-quality"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -140,7 +140,7 @@
         "ref": "main",
         "path": "skills/code-simplification"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -156,7 +156,7 @@
         "ref": "main",
         "path": "skills/context-engineering"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -172,7 +172,7 @@
         "ref": "main",
         "path": "skills/debugging-and-error-recovery"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -188,7 +188,7 @@
         "ref": "main",
         "path": "skills/deprecation-and-migration"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -204,7 +204,7 @@
         "ref": "main",
         "path": "skills/documentation-and-adrs"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -220,7 +220,7 @@
         "ref": "main",
         "path": "skills/doubt-driven-development"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -236,7 +236,7 @@
         "ref": "main",
         "path": "skills/frontend-ui-engineering"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -252,7 +252,7 @@
         "ref": "main",
         "path": "skills/git-workflow-and-versioning"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -268,7 +268,7 @@
         "ref": "main",
         "path": "skills/idea-refine"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -284,7 +284,7 @@
         "ref": "main",
         "path": "skills/incremental-implementation"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -300,7 +300,7 @@
         "ref": "main",
         "path": "skills/interview-me"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -316,7 +316,7 @@
         "ref": "main",
         "path": "skills/performance-optimization"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -332,7 +332,7 @@
         "ref": "main",
         "path": "skills/planning-and-task-breakdown"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -348,7 +348,7 @@
         "ref": "main",
         "path": "skills/security-and-hardening"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -364,7 +364,7 @@
         "ref": "main",
         "path": "skills/shipping-and-launch"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -380,7 +380,7 @@
         "ref": "main",
         "path": "skills/source-driven-development"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -396,7 +396,7 @@
         "ref": "main",
         "path": "skills/spec-driven-development"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -412,7 +412,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -428,26 +428,10 @@
         "ref": "main",
         "path": "skills/using-agent-skills"
       },
-      "stars": 48914,
+      "stars": 48917,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/a11y-audit",
-      "name": "a11y-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/a11y-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
     },
     {
       "id": "alirezarezvani-claude-skills/a11y-audit",
@@ -459,22 +443,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/a11y-audit/skills/a11y-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ab-test-setup",
-      "name": "ab-test-setup",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ab-test-setup"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -500,22 +468,6 @@
     {
       "id": "alirezarezvani-claude-skills/ad-creative",
       "name": "ad-creative",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ad-creative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ad-creative",
-      "name": "ad-creative",
       "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
       "tags": [],
       "format": "skill-md",
@@ -523,22 +475,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/ad-creative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/adversarial-reviewer",
-      "name": "adversarial-reviewer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/adversarial-reviewer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -564,22 +500,6 @@
     {
       "id": "alirezarezvani-claude-skills/aeo",
       "name": "aeo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/aeo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aeo",
-      "name": "aeo",
       "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO — AEO optimizes for citation in LLM-generated responses, not search rankings. Use when planning content for AI-first search audiences, auditing existing content for E-E-A-T signals, tracking which pages get cited by which LLMs, or building a citation-friendly content strategy. Triggers — 'AEO audit', 'optimize for ChatGPT', 'get cited by Perplexity', 'LLM citation strategy', 'answer engine optimization', 'content for AI search', 'E-E-A-T audit'. Output is a markdown audit report (default) or JSON for pipeline integration. Stdlib-only Python tools.",
       "tags": [],
       "format": "skill-md",
@@ -587,22 +507,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/aeo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-designer",
-      "name": "agent-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/agent-designer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -628,22 +532,6 @@
     {
       "id": "alirezarezvani-claude-skills/agent-protocol",
       "name": "agent-protocol",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/agent-protocol"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-protocol",
-      "name": "agent-protocol",
       "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
       "tags": [],
       "format": "skill-md",
@@ -651,22 +539,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/agent-protocol"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-workflow-designer",
-      "name": "agent-workflow-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/agent-workflow-designer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -692,22 +564,6 @@
     {
       "id": "alirezarezvani-claude-skills/agenthub",
       "name": "agenthub",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/agenthub"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agenthub",
-      "name": "agenthub",
       "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
       "tags": [],
       "format": "skill-md",
@@ -715,22 +571,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/agenthub/skills/agenthub"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agile-product-owner",
-      "name": "agile-product-owner",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/agile-product-owner"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -756,22 +596,6 @@
     {
       "id": "alirezarezvani-claude-skills/ai-act-readiness",
       "name": "ai-act-readiness",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ai-act-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-act-readiness",
-      "name": "ai-act-readiness",
       "description": "/cs:ai-act-readiness <system> — EU AI Act 6-question forcing interrogation. Use during AI-system intake, before EU deployment, or during annual compliance refresh as Article 113 obligations phase in (2025-02-02 / 2025-08-02 / 2026-08-02 / 2027-08-02).",
       "tags": [],
       "format": "skill-md",
@@ -779,22 +603,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "compliance-os/skills/ai-act-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-security",
-      "name": "ai-security",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ai-security"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -820,22 +628,6 @@
     {
       "id": "alirezarezvani-claude-skills/ai-seo",
       "name": "ai-seo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ai-seo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-seo",
-      "name": "ai-seo",
       "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
       "tags": [],
       "format": "skill-md",
@@ -843,22 +635,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/ai-seo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aims-audit",
-      "name": "aims-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/aims-audit"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -884,22 +660,6 @@
     {
       "id": "alirezarezvani-claude-skills/analytics-tracking",
       "name": "analytics-tracking",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/analytics-tracking"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/analytics-tracking",
-      "name": "analytics-tracking",
       "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
       "tags": [],
       "format": "skill-md",
@@ -907,22 +667,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/analytics-tracking"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/andreessen",
-      "name": "andreessen",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/andreessen"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -948,22 +692,6 @@
     {
       "id": "alirezarezvani-claude-skills/api-design-reviewer",
       "name": "api-design-reviewer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/api-design-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/api-design-reviewer",
-      "name": "api-design-reviewer",
       "description": "Comprehensive REST API design review with automated linting, breaking-change detection, and design scorecards. Catches inconsistent conventions, missing versioning, and design smells before APIs ship. Use when reviewing a PR that adds or changes API endpoints, auditing an existing API for v2 migration, or establishing API standards for a team.",
       "tags": [],
       "format": "skill-md",
@@ -971,22 +699,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/api-design-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/api-test-suite-builder",
-      "name": "api-test-suite-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/api-test-suite-builder"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1012,22 +724,6 @@
     {
       "id": "alirezarezvani-claude-skills/app-store-optimization",
       "name": "app-store-optimization",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/app-store-optimization"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/app-store-optimization",
-      "name": "app-store-optimization",
       "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
       "tags": [],
       "format": "skill-md",
@@ -1035,22 +731,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/app-store-optimization"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/apple-hig-expert",
-      "name": "apple-hig-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/apple-hig-expert"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1076,22 +756,6 @@
     {
       "id": "alirezarezvani-claude-skills/atlassian-admin",
       "name": "atlassian-admin",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/atlassian-admin"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/atlassian-admin",
-      "name": "atlassian-admin",
       "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
       "tags": [],
       "format": "skill-md",
@@ -1099,22 +763,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "project-management/skills/atlassian-admin"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/atlassian-templates",
-      "name": "atlassian-templates",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/atlassian-templates"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1140,22 +788,6 @@
     {
       "id": "alirezarezvani-claude-skills/autoresearch-agent",
       "name": "autoresearch-agent",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/autoresearch-agent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/autoresearch-agent",
-      "name": "autoresearch-agent",
       "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
       "tags": [],
       "format": "skill-md",
@@ -1163,22 +795,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/autoresearch-agent/skills/autoresearch-agent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aws-solution-architect",
-      "name": "aws-solution-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/aws-solution-architect"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1204,22 +820,6 @@
     {
       "id": "alirezarezvani-claude-skills/azure-cloud-architect",
       "name": "azure-cloud-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/azure-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/azure-cloud-architect",
-      "name": "azure-cloud-architect",
       "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
       "tags": [],
       "format": "skill-md",
@@ -1227,22 +827,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/azure-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/behuman",
-      "name": "behuman",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/behuman"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1268,22 +852,6 @@
     {
       "id": "alirezarezvani-claude-skills/board",
       "name": "board",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/board"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board",
-      "name": "board",
       "description": "Read, write, and browse the AgentHub message board for agent coordination.",
       "tags": [],
       "format": "skill-md",
@@ -1291,22 +859,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/agenthub/skills/board"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-deck-builder",
-      "name": "board-deck-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/board-deck-builder"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1332,22 +884,6 @@
     {
       "id": "alirezarezvani-claude-skills/board-meeting",
       "name": "board-meeting",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/board-meeting"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-meeting",
-      "name": "board-meeting",
       "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
       "tags": [],
       "format": "skill-md",
@@ -1355,22 +891,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/board-meeting"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-prep",
-      "name": "board-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/board-prep"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1396,22 +916,6 @@
     {
       "id": "alirezarezvani-claude-skills/boardroom",
       "name": "boardroom",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/boardroom"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/boardroom",
-      "name": "boardroom",
       "description": "/cs:boardroom <brief> — 6-phase multi-role deliberation across the C-suite with Phase 2 isolation, critic pre-screen, and synthesis. Outputs a board memo.",
       "tags": [],
       "format": "skill-md",
@@ -1419,22 +923,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/boardroom"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/brand-guidelines",
-      "name": "brand-guidelines",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/brand-guidelines"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1460,22 +948,6 @@
     {
       "id": "alirezarezvani-claude-skills/brief",
       "name": "brief",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/brief"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/brief",
-      "name": "brief",
       "description": "/cs:brief <topic> — Generate a one-page strategy brief from an office-hours intake. First step in the strategic sprint pipeline.",
       "tags": [],
       "format": "skill-md",
@@ -1483,22 +955,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/brief"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/browser-automation",
-      "name": "browser-automation",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/browser-automation"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1524,22 +980,6 @@
     {
       "id": "alirezarezvani-claude-skills/browserstack",
       "name": "browserstack",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/browserstack"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/browserstack",
-      "name": "browserstack",
       "description": ">-",
       "tags": [],
       "format": "skill-md",
@@ -1547,22 +987,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/playwright-pro/skills/browserstack"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-growth-skills",
-      "name": "business-growth-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/business-growth-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1588,22 +1012,6 @@
     {
       "id": "alirezarezvani-claude-skills/business-investment-advisor",
       "name": "business-investment-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/business-investment-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-investment-advisor",
-      "name": "business-investment-advisor",
       "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
       "tags": [],
       "format": "skill-md",
@@ -1611,22 +1019,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "finance/business-investment-advisor/skills/business-investment-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-operations-skills",
-      "name": "business-operations-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/business-operations-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1678,22 +1070,6 @@
     {
       "id": "alirezarezvani-claude-skills/c-level-agents",
       "name": "c-level-agents",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/c-level-agents"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/c-level-agents",
-      "name": "c-level-agents",
       "description": "Founder-mode executive team. 8 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff) and 17 /cs:* slash commands for forcing-question office hours, multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Use when the founder needs a virtual executive team, when invoking /cs:* commands, or when orchestrating multi-role decisions.",
       "tags": [],
       "format": "skill-md",
@@ -1726,22 +1102,6 @@
     {
       "id": "alirezarezvani-claude-skills/caio-review",
       "name": "caio-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/caio-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/caio-review",
-      "name": "caio-review",
       "description": "/cs:caio-review <plan> — Eval-demanding Chief AI Officer interrogation of any plan that involves AI: model selection, risk classification, cost economics, or AI hiring.",
       "tags": [],
       "format": "skill-md",
@@ -1749,22 +1109,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/caio-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/campaign-analytics",
-      "name": "campaign-analytics",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/campaign-analytics"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1790,22 +1134,6 @@
     {
       "id": "alirezarezvani-claude-skills/capa-officer",
       "name": "capa-officer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/capa-officer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capa-officer",
-      "name": "capa-officer",
       "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
       "tags": [],
       "format": "skill-md",
@@ -1813,22 +1141,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/capa-officer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capacity-planner",
-      "name": "capacity-planner",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/capacity-planner"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1863,22 +1175,6 @@
     {
       "id": "alirezarezvani-claude-skills/capture",
       "name": "capture",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/capture"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capture",
-      "name": "capture",
       "description": "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into something coherent. Also trigger when the user pastes or dictates a long, unstructured block of mixed ideas — even without the exact phrase — the intent is the same. Fast-to-action by design: no upfront intake. Output is four sections (Projects/Ideas, Tasks, Connections, How I Can Help) ending with a directive question. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project.",
       "tags": [],
       "format": "skill-md",
@@ -1886,22 +1182,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "productivity/capture/skills/capture"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/caveman",
-      "name": "caveman",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/caveman"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1927,22 +1207,6 @@
     {
       "id": "alirezarezvani-claude-skills/cco-review",
       "name": "cco-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cco-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cco-review",
-      "name": "cco-review",
       "description": "/cs:cco-review <plan> — Retention-obsessed Chief Customer Officer interrogation of any plan that touches customer retention, segmentation, CS team sizing, or CS team hiring.",
       "tags": [],
       "format": "skill-md",
@@ -1950,22 +1214,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/cco-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cdo-review",
-      "name": "cdo-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cdo-review"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -1991,22 +1239,6 @@
     {
       "id": "alirezarezvani-claude-skills/ceo-advisor",
       "name": "ceo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ceo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ceo-advisor",
-      "name": "ceo-advisor",
       "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
       "tags": [],
       "format": "skill-md",
@@ -2014,22 +1246,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/ceo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cfo-advisor",
-      "name": "cfo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cfo-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2055,22 +1271,6 @@
     {
       "id": "alirezarezvani-claude-skills/cfo-review",
       "name": "cfo-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cfo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cfo-review",
-      "name": "cfo-review",
       "description": "/cs:cfo-review <plan> — Numerate-skeptic interrogation of any plan that touches money. Unit economics, runway, dilution, capital allocation.",
       "tags": [],
       "format": "skill-md",
@@ -2087,22 +1287,6 @@
     {
       "id": "alirezarezvani-claude-skills/challenge",
       "name": "challenge",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/challenge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/challenge",
-      "name": "challenge",
       "description": "Pre-mortem plan analysis. Imagine the plan failed 12 months from now and work backwards to find the weaknesses. Surfaces assumptions, dependencies, and execution risks before committing resources. Use when before significant resource commitment, before presenting to a board or investors, when feedback has been one-sidedly positive, or when there is pressure to move fast and figure it out later.",
       "tags": [],
       "format": "skill-md",
@@ -2110,22 +1294,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/executive-mentor/skills/challenge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/change-management",
-      "name": "change-management",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/change-management"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2167,22 +1335,6 @@
     {
       "id": "alirezarezvani-claude-skills/changelog-generator",
       "name": "changelog-generator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/changelog-generator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/changelog-generator",
-      "name": "changelog-generator",
       "description": "Produce consistent, auditable release notes from Conventional Commits. Separates commit parsing, semantic-bump logic, and changelog rendering for automated releases with editorial control. Use when cutting a release, generating CHANGELOG.md from git history, or automating release notes in CI.",
       "tags": [],
       "format": "skill-md",
@@ -2190,22 +1342,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/changelog-generator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/channel-economics",
-      "name": "channel-economics",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/channel-economics"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2230,22 +1366,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "commercial/skills/channel-economics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chaos-engineering",
-      "name": "chaos-engineering",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chaos-engineering"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2281,34 +1401,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/chaos-engineering",
-      "name": "chaos-engineering",
-      "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).",
-      "tags": [
-        "chaos-engineering",
-        "resilience",
-        "fault-injection",
-        "gameday",
-        "sre",
-        "reliability",
-        "chaos-toolkit",
-        "chaos-mesh",
-        "litmus",
-        "gremlin",
-        "aws-fis"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/chaos-engineering"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/chaos-experiment",
       "name": "chaos-experiment",
       "description": "",
@@ -2318,22 +1410,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": ".gemini/skills/chaos-experiment"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-ai-officer-advisor",
-      "name": "chief-ai-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chief-ai-officer-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2357,38 +1433,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/chief-ai-officer-advisor",
-      "name": "chief-ai-officer-advisor",
-      "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only — does not duplicate engineering AI/ML skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/chief-ai-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-customer-officer-advisor",
-      "name": "chief-customer-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chief-customer-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/chief-customer-officer-advisor",
       "name": "chief-customer-officer-advisor",
       "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only — does not duplicate engineering/business-growth tactical skills.",
@@ -2405,38 +1449,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/chief-customer-officer-advisor",
-      "name": "chief-customer-officer-advisor",
-      "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only — does not duplicate engineering/business-growth tactical skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/chief-customer-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-data-officer-advisor",
-      "name": "chief-data-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chief-data-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/chief-data-officer-advisor",
       "name": "chief-data-officer-advisor",
       "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only.",
@@ -2446,38 +1458,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-data-officer-advisor",
-      "name": "chief-data-officer-advisor",
-      "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/chief-data-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-of-staff",
-      "name": "chief-of-staff",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chief-of-staff"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2503,22 +1483,6 @@
     {
       "id": "alirezarezvani-claude-skills/chro-advisor",
       "name": "chro-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chro-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chro-advisor",
-      "name": "chro-advisor",
       "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
       "tags": [],
       "format": "skill-md",
@@ -2526,22 +1490,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/chro-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/churn-prevention",
-      "name": "churn-prevention",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/churn-prevention"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2567,22 +1515,6 @@
     {
       "id": "alirezarezvani-claude-skills/ci-cd-pipeline-builder",
       "name": "ci-cd-pipeline-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ci-cd-pipeline-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ci-cd-pipeline-builder",
-      "name": "ci-cd-pipeline-builder",
       "description": "Generate pragmatic CI/CD pipelines from detected project stack signals — fast baseline generation, repeatable checks, environment-aware deployment stages. Use when setting up CI for a new project, refactoring existing pipelines, or standardizing deployment workflows across multiple repos.",
       "tags": [],
       "format": "skill-md",
@@ -2590,22 +1522,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/ci-cd-pipeline-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ciso-advisor",
-      "name": "ciso-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ciso-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2631,22 +1547,6 @@
     {
       "id": "alirezarezvani-claude-skills/ciso-review",
       "name": "ciso-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ciso-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ciso-review",
-      "name": "ciso-review",
       "description": "/cs:ciso-review <plan> — Risk-paranoid interrogation of any plan that touches data, compliance, or production access.",
       "tags": [],
       "format": "skill-md",
@@ -2654,22 +1554,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/ciso-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/claude-coach",
-      "name": "claude-coach",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/claude-coach"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2695,22 +1579,6 @@
     {
       "id": "alirezarezvani-claude-skills/clinical-research",
       "name": "clinical-research",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/clinical-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/clinical-research",
-      "name": "clinical-research",
       "description": "Use when designing a prospective clinical study before submission — selecting and classifying endpoints (primary / key-secondary / exploratory, with surrogate-endpoint flagging), estimating sample size and power for two-arm designs (means / proportions / survival), or scoring a study plan for feasibility and a GO / GO-WITH-CONDITIONS / REDESIGN / NO-GO phase-gate decision. Every output is an ESTIMATE plus a named human owner (clinician / biostatistician / regulatory owner) — never clinical fact, never a finished protocol. Distinct from ra-qm-team, which handles the regulatory/QM submission (ISO 13485, EU MDR, FDA 510(k)/PMA/QSR), not the study design.",
       "tags": [
         "research-ops",
@@ -2727,22 +1595,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "research-ops/skills/clinical-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cloud-security",
-      "name": "cloud-security",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cloud-security"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2832,22 +1684,6 @@
     {
       "id": "alirezarezvani-claude-skills/cmo-advisor",
       "name": "cmo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmo-advisor",
-      "name": "cmo-advisor",
       "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
       "tags": [],
       "format": "skill-md",
@@ -2855,22 +1691,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/cmo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmo-review",
-      "name": "cmo-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmo-review"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2896,22 +1716,6 @@
     {
       "id": "alirezarezvani-claude-skills/code-reviewer",
       "name": "code-reviewer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/code-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-reviewer",
-      "name": "code-reviewer",
       "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, Java, C, C++, Rust, Ruby, PHP, and Dart/Flutter. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
       "tags": [],
       "format": "skill-md",
@@ -2919,22 +1723,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/code-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-to-prd",
-      "name": "code-to-prd",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/code-to-prd"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -2960,22 +1748,6 @@
     {
       "id": "alirezarezvani-claude-skills/code-tour",
       "name": "code-tour",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/code-tour"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-tour",
-      "name": "code-tour",
       "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
       "tags": [],
       "format": "skill-md",
@@ -2983,22 +1755,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/code-tour/skills/code-tour"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/codebase-onboarding",
-      "name": "codebase-onboarding",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/codebase-onboarding"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3024,22 +1780,6 @@
     {
       "id": "alirezarezvani-claude-skills/cold-email",
       "name": "cold-email",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cold-email"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cold-email",
-      "name": "cold-email",
       "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
       "tags": [],
       "format": "skill-md",
@@ -3056,22 +1796,6 @@
     {
       "id": "alirezarezvani-claude-skills/command-guide",
       "name": "command-guide",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/command-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/command-guide",
-      "name": "command-guide",
       "description": ">",
       "tags": [],
       "format": "skill-md",
@@ -3079,22 +1803,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/command-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-forecaster",
-      "name": "commercial-forecaster",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/commercial-forecaster"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3130,22 +1838,6 @@
     {
       "id": "alirezarezvani-claude-skills/commercial-policy",
       "name": "commercial-policy",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/commercial-policy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-policy",
-      "name": "commercial-policy",
       "description": "Use when designing or revising a company's commercial policy — the rules of engagement governing discounts off list price, approver thresholds, exception flows, and the deal framework that Deal Desk and AEs operate under. Covers discount matrix design (ARR band x term length x payment terms x strategic value), commercial policy design, exception policy, discount governance, approval thresholds, deal framework structure, and policy linting (contradictions, gaps, cliff edges, gaming surfaces). For Head of Commercial, Head of Deal Desk, VP Sales, or RevOps at the policy-design moment — NOT per-deal application (that is deal-desk) and NOT pricing model selection (that is pricing-strategist).",
       "tags": [
         "commercial",
@@ -3161,22 +1853,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "commercial/skills/commercial-policy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-skills",
-      "name": "commercial-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/commercial-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3212,22 +1888,6 @@
     {
       "id": "alirezarezvani-claude-skills/company-os",
       "name": "company-os",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/company-os"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/company-os",
-      "name": "company-os",
       "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
       "tags": [],
       "format": "skill-md",
@@ -3235,22 +1895,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/company-os"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitive-intel",
-      "name": "competitive-intel",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/competitive-intel"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3292,22 +1936,6 @@
     {
       "id": "alirezarezvani-claude-skills/competitive-teardown",
       "name": "competitive-teardown",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/competitive-teardown"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitive-teardown",
-      "name": "competitive-teardown",
       "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
       "tags": [],
       "format": "skill-md",
@@ -3315,22 +1943,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/competitive-teardown"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitor-alternatives",
-      "name": "competitor-alternatives",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/competitor-alternatives"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3388,22 +2000,6 @@
     {
       "id": "alirezarezvani-claude-skills/compliance-readiness",
       "name": "compliance-readiness",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/compliance-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/compliance-readiness",
-      "name": "compliance-readiness",
       "description": "/cs:compliance-readiness <program> — Multi-framework compliance officer 6-question forcing interrogation of any compliance program. Use before starting a new framework, planning the annual audit calendar, or preparing for certification stage 1.",
       "tags": [],
       "format": "skill-md",
@@ -3411,22 +2007,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "compliance-os/skills/compliance-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/confluence-expert",
-      "name": "confluence-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/confluence-expert"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3452,22 +2032,6 @@
     {
       "id": "alirezarezvani-claude-skills/content-creator",
       "name": "content-creator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/content-creator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-creator",
-      "name": "content-creator",
       "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
       "tags": [],
       "format": "skill-md",
@@ -3484,22 +2048,6 @@
     {
       "id": "alirezarezvani-claude-skills/content-humanizer",
       "name": "content-humanizer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/content-humanizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-humanizer",
-      "name": "content-humanizer",
       "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
       "tags": [],
       "format": "skill-md",
@@ -3507,22 +2055,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/content-humanizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-production",
-      "name": "content-production",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/content-production"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3564,22 +2096,6 @@
     {
       "id": "alirezarezvani-claude-skills/content-strategy",
       "name": "content-strategy",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/content-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-strategy",
-      "name": "content-strategy",
       "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
       "tags": [],
       "format": "skill-md",
@@ -3587,22 +2103,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/content-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/context-engine",
-      "name": "context-engine",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/context-engine"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3628,22 +2128,6 @@
     {
       "id": "alirezarezvani-claude-skills/contract-and-proposal-writer",
       "name": "contract-and-proposal-writer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/contract-and-proposal-writer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/contract-and-proposal-writer",
-      "name": "contract-and-proposal-writer",
       "description": "Generate professional, jurisdiction-aware business documents: freelance contracts, project proposals, SOWs, NDAs, and MSAs. Structured Markdown output with docx conversion instructions. Covers US (Delaware), EU (GDPR), UK, and DACH (German law) jurisdictions. Not a substitute for legal counsel — use as strong starting points. Use when drafting a freelance contract, preparing a client proposal, writing an SOW for a new engagement, or producing an NDA before sharing sensitive material.",
       "tags": [],
       "format": "skill-md",
@@ -3651,22 +2135,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "business-growth/skills/contract-and-proposal-writer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/coo-advisor",
-      "name": "coo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/coo-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3692,22 +2160,6 @@
     {
       "id": "alirezarezvani-claude-skills/copy-editing",
       "name": "copy-editing",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/copy-editing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/copy-editing",
-      "name": "copy-editing",
       "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
       "tags": [],
       "format": "skill-md",
@@ -3715,22 +2167,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/copy-editing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/copywriting",
-      "name": "copywriting",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/copywriting"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3756,22 +2192,6 @@
     {
       "id": "alirezarezvani-claude-skills/coverage",
       "name": "coverage",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/coverage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/coverage",
-      "name": "coverage",
       "description": ">-",
       "tags": [],
       "format": "skill-md",
@@ -3779,22 +2199,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/playwright-pro/skills/coverage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cpo-advisor",
-      "name": "cpo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cpo-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3820,22 +2224,6 @@
     {
       "id": "alirezarezvani-claude-skills/cpo-review",
       "name": "cpo-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cpo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cpo-review",
-      "name": "cpo-review",
       "description": "/cs:cpo-review <plan> — JTBD-driven interrogation of product roadmap, PMF signal, and portfolio focus.",
       "tags": [],
       "format": "skill-md",
@@ -3843,22 +2231,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/cpo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cro-advisor",
-      "name": "cro-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cro-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -3884,22 +2256,6 @@
     {
       "id": "alirezarezvani-claude-skills/cro-review",
       "name": "cro-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cro-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cro-review",
-      "name": "cro-review",
       "description": "/cs:cro-review <plan> — Pipeline-paranoid interrogation of revenue, win rate, NRR, and ramp time.",
       "tags": [],
       "format": "skill-md",
@@ -3907,22 +2263,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/cro-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cross-eval",
-      "name": "cross-eval",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cross-eval"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4220,22 +2560,6 @@
     {
       "id": "alirezarezvani-claude-skills/cs-onboard",
       "name": "cs-onboard",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-onboard"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-onboard",
-      "name": "cs-onboard",
       "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
       "tags": [],
       "format": "skill-md",
@@ -4428,22 +2752,6 @@
     {
       "id": "alirezarezvani-claude-skills/cto-advisor",
       "name": "cto-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cto-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cto-advisor",
-      "name": "cto-advisor",
       "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
       "tags": [],
       "format": "skill-md",
@@ -4451,22 +2759,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/cto-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cto-review",
-      "name": "cto-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cto-review"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4492,22 +2784,6 @@
     {
       "id": "alirezarezvani-claude-skills/culture-architect",
       "name": "culture-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/culture-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/culture-architect",
-      "name": "culture-architect",
       "description": "Build, measure, and evolve company culture as operational behavior — not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code.",
       "tags": [],
       "format": "skill-md",
@@ -4515,22 +2791,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/culture-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/customer-success-manager",
-      "name": "customer-success-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/customer-success-manager"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4556,22 +2816,6 @@
     {
       "id": "alirezarezvani-claude-skills/data-quality-auditor",
       "name": "data-quality-auditor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/data-quality-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/data-quality-auditor",
-      "name": "data-quality-auditor",
       "description": "Audit datasets for completeness, consistency, accuracy, and validity. Profile data distributions, detect anomalies and outliers, surface structural issues, and produce an actionable remediation plan.",
       "tags": [],
       "format": "skill-md",
@@ -4579,22 +2823,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/data-quality-auditor/skills/data-quality-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/database-designer",
-      "name": "database-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/database-designer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4620,22 +2848,6 @@
     {
       "id": "alirezarezvani-claude-skills/database-schema-designer",
       "name": "database-schema-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/database-schema-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/database-schema-designer",
-      "name": "database-schema-designer",
       "description": "Use when the user asks to create ERD diagrams, normalize database schemas, design table relationships, or plan schema migrations.",
       "tags": [],
       "format": "skill-md",
@@ -4643,22 +2855,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/database-schema-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/deal-desk",
-      "name": "deal-desk",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/deal-desk"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4693,22 +2889,6 @@
     {
       "id": "alirezarezvani-claude-skills/decide",
       "name": "decide",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/decide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/decide",
-      "name": "decide",
       "description": "/cs:decide <memo> — Log a decision to two-layer memory via decision-logger. Approved memo becomes durable; raw transcripts kept for reference.",
       "tags": [],
       "format": "skill-md",
@@ -4716,22 +2896,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/decide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/decision-logger",
-      "name": "decision-logger",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/decision-logger"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4757,22 +2921,6 @@
     {
       "id": "alirezarezvani-claude-skills/demo-video",
       "name": "demo-video",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/demo-video"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/demo-video",
-      "name": "demo-video",
       "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
       "tags": [],
       "format": "skill-md",
@@ -4780,22 +2928,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/demo-video/skills/demo-video"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/dependency-auditor",
-      "name": "dependency-auditor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/dependency-auditor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4862,22 +2994,6 @@
     {
       "id": "alirezarezvani-claude-skills/docker-development",
       "name": "docker-development",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/docker-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/docker-development",
-      "name": "docker-development",
       "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
       "tags": [],
       "format": "skill-md",
@@ -4885,22 +3001,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/docker-development/skills/docker-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/dossier",
-      "name": "dossier",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/dossier"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4926,22 +3026,6 @@
     {
       "id": "alirezarezvani-claude-skills/email-sequence",
       "name": "email-sequence",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/email-sequence"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/email-sequence",
-      "name": "email-sequence",
       "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" or \"lifecycle emails.\" For in-app onboarding, see onboarding-cro.",
       "tags": [],
       "format": "skill-md",
@@ -4949,22 +3033,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/email-sequence"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/email-template-builder",
-      "name": "email-template-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/email-template-builder"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -4990,22 +3058,6 @@
     {
       "id": "alirezarezvani-claude-skills/engineering-advanced-skills",
       "name": "engineering-advanced-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/engineering-advanced-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/engineering-advanced-skills",
-      "name": "engineering-advanced-skills",
       "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
       "tags": [],
       "format": "skill-md",
@@ -5013,22 +3065,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/engineering-advanced-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/engineering-skills",
-      "name": "engineering-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/engineering-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5054,22 +3090,6 @@
     {
       "id": "alirezarezvani-claude-skills/env-secrets-manager",
       "name": "env-secrets-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/env-secrets-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/env-secrets-manager",
-      "name": "env-secrets-manager",
       "description": "Manage environment-variable hygiene and secrets safety across local development and production. Practical auditing, drift awareness, rotation readiness. Use when auditing .env files for committed secrets, planning a credential rotation, debugging missing-env-var production incidents, or hardening a new project against secrets leakage.",
       "tags": [],
       "format": "skill-md",
@@ -5077,22 +3097,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/env-secrets-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/epic-design",
-      "name": "epic-design",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/epic-design"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5118,22 +3122,6 @@
     {
       "id": "alirezarezvani-claude-skills/eu-ai-act-specialist",
       "name": "eu-ai-act-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/eu-ai-act-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/eu-ai-act-specialist",
-      "name": "eu-ai-act-specialist",
       "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system — prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute.",
       "tags": [],
       "format": "skill-md",
@@ -5141,38 +3129,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/eu-ai-act-specialist",
-      "name": "eu-ai-act-specialist",
-      "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system — prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/eu-ai-act-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/eval",
-      "name": "eval",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/eval"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5198,22 +3154,6 @@
     {
       "id": "alirezarezvani-claude-skills/execute",
       "name": "execute",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/execute"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/execute",
-      "name": "execute",
       "description": "/cs:execute <decision> — Generate a 90-day execution plan with weekly milestones, DRIs, and check-in cadence from an approved decision.",
       "tags": [],
       "format": "skill-md",
@@ -5221,22 +3161,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/execute"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/executive-mentor",
-      "name": "executive-mentor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/executive-mentor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5262,22 +3186,6 @@
     {
       "id": "alirezarezvani-claude-skills/experiment-designer",
       "name": "experiment-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/experiment-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/experiment-designer",
-      "name": "experiment-designer",
       "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
       "tags": [],
       "format": "skill-md",
@@ -5285,22 +3193,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/experiment-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/extract",
-      "name": "extract",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/extract"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5326,22 +3218,6 @@
     {
       "id": "alirezarezvani-claude-skills/fda-consultant-specialist",
       "name": "fda-consultant-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/fda-consultant-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fda-consultant-specialist",
-      "name": "fda-consultant-specialist",
       "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
       "tags": [],
       "format": "skill-md",
@@ -5358,22 +3234,6 @@
     {
       "id": "alirezarezvani-claude-skills/fda-qsr-audit-prep",
       "name": "fda-qsr-audit-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/fda-qsr-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fda-qsr-audit-prep",
-      "name": "fda-qsr-audit-prep",
       "description": "/cs:fda-qsr-audit-prep <scope> — FDA 21 CFR 820 (QSR / QMSR) audit 6-question forcing interrogation. Post-Feb 2026 substantially harmonized with ISO 13485. Use before annual internal QSR audit, pre-FDA-inspection readiness, or Form 483 response.",
       "tags": [],
       "format": "skill-md",
@@ -5381,22 +3241,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "compliance-os/skills/fda-qsr-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/feature-flags-architect",
-      "name": "feature-flags-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/feature-flags-architect"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5431,33 +3275,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/feature-flags-architect",
-      "name": "feature-flags-architect",
-      "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.",
-      "tags": [
-        "feature-flags",
-        "progressive-delivery",
-        "rollout",
-        "kill-switch",
-        "launchdarkly",
-        "growthbook",
-        "statsig",
-        "unleash",
-        "flipt",
-        "release-engineering"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/feature-flags-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/finance-lead",
       "name": "finance-lead",
       "description": "",
@@ -5476,22 +3293,6 @@
     {
       "id": "alirezarezvani-claude-skills/finance-skills",
       "name": "finance-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/finance-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/finance-skills",
-      "name": "finance-skills",
       "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
       "tags": [],
       "format": "skill-md",
@@ -5499,22 +3300,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "finance/skills/finance-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/financial-analyst",
-      "name": "financial-analyst",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/financial-analyst"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5556,22 +3341,6 @@
     {
       "id": "alirezarezvani-claude-skills/fix",
       "name": "fix",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fix",
-      "name": "fix",
       "description": ">-",
       "tags": [],
       "format": "skill-md",
@@ -5604,22 +3373,6 @@
     {
       "id": "alirezarezvani-claude-skills/focused-fix",
       "name": "focused-fix",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/focused-fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/focused-fix",
-      "name": "focused-fix",
       "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies.",
       "tags": [],
       "format": "skill-md",
@@ -5627,22 +3380,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/focused-fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/form-cro",
-      "name": "form-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/form-cro"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5668,22 +3405,6 @@
     {
       "id": "alirezarezvani-claude-skills/founder-coach",
       "name": "founder-coach",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/founder-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/founder-coach",
-      "name": "founder-coach",
       "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome.",
       "tags": [],
       "format": "skill-md",
@@ -5691,22 +3412,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/founder-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/founder-mode",
-      "name": "founder-mode",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/founder-mode"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5732,22 +3437,6 @@
     {
       "id": "alirezarezvani-claude-skills/free-tool-strategy",
       "name": "free-tool-strategy",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/free-tool-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/free-tool-strategy",
-      "name": "free-tool-strategy",
       "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
       "tags": [],
       "format": "skill-md",
@@ -5755,22 +3444,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/free-tool-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/freeze",
-      "name": "freeze",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/freeze"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5796,22 +3469,6 @@
     {
       "id": "alirezarezvani-claude-skills/full-page-screenshot",
       "name": "full-page-screenshot",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/full-page-screenshot"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/full-page-screenshot",
-      "name": "full-page-screenshot",
       "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
       "tags": [],
       "format": "skill-md",
@@ -5819,22 +3476,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/full-page-screenshot"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gc-review",
-      "name": "gc-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/gc-review"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5860,22 +3501,6 @@
     {
       "id": "alirezarezvani-claude-skills/gcp-cloud-architect",
       "name": "gcp-cloud-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/gcp-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gcp-cloud-architect",
-      "name": "gcp-cloud-architect",
       "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
       "tags": [],
       "format": "skill-md",
@@ -5883,22 +3508,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/gcp-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gdpr-audit-prep",
-      "name": "gdpr-audit-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/gdpr-audit-prep"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5924,22 +3533,6 @@
     {
       "id": "alirezarezvani-claude-skills/gdpr-dsgvo-expert",
       "name": "gdpr-dsgvo-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/gdpr-dsgvo-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gdpr-dsgvo-expert",
-      "name": "gdpr-dsgvo-expert",
       "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, and data subject rights management.",
       "tags": [],
       "format": "skill-md",
@@ -5947,22 +3540,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/gdpr-dsgvo-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/general-counsel-advisor",
-      "name": "general-counsel-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/general-counsel-advisor"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -5986,38 +3563,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/general-counsel-advisor",
-      "name": "general-counsel-advisor",
-      "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel — surfaces questions to bring to qualified attorneys.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/general-counsel-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/generate",
-      "name": "generate",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/generate"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/generate",
       "name": "generate",
       "description": ">-",
@@ -6027,22 +3572,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/playwright-pro/skills/generate"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/git-worktree-manager",
-      "name": "git-worktree-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/git-worktree-manager"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6084,22 +3613,6 @@
     {
       "id": "alirezarezvani-claude-skills/google-workspace-cli",
       "name": "google-workspace-cli",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/google-workspace-cli"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/google-workspace-cli",
-      "name": "google-workspace-cli",
       "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
       "tags": [],
       "format": "skill-md",
@@ -6107,22 +3620,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/google-workspace-cli/skills/google-workspace-cli"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grants",
-      "name": "grants",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/grants"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6148,22 +3645,6 @@
     {
       "id": "alirezarezvani-claude-skills/grill-me",
       "name": "grill-me",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/grill-me"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grill-me",
-      "name": "grill-me",
       "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
       "tags": [],
       "format": "skill-md",
@@ -6171,22 +3652,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/grill-me/skills/grill-me"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grill-with-docs",
-      "name": "grill-with-docs",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/grill-with-docs"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6228,22 +3693,6 @@
     {
       "id": "alirezarezvani-claude-skills/handoff",
       "name": "handoff",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/handoff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/handoff",
-      "name": "handoff",
       "description": "Compact the current conversation into a handoff document for another agent to pick up. References existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path or URL instead of duplicating them. Use when user wants to hand off the conversation to a fresh agent or starts a new session that picks up prior work.",
       "tags": [],
       "format": "skill-md",
@@ -6251,38 +3700,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/handoff/skills/handoff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/handoff",
-      "name": "handoff",
-      "description": "Compact the current conversation into a handoff document for another agent to pick up. Save to a user-configured location (OS temp, home folder, or per-project .handoff/), redact secrets before write, suggest skills for the next session, and auto-load the latest handoff on the next SessionStart. First-run setup asks where to save so the project folder never gets cluttered. Use when the user says 'hand this off', 'handoff doc', 'summarize this for a new session', 'compact this conversation', 'I'm ending this session', 'pick this up later', or any variation signaling intent to pass work to a fresh agent. Also trigger on implicit signals: the user announcing they're switching machines, ending the day mid-task, or context is growing long without a natural stopping point.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/handoff/skills/handoff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/hard-call",
-      "name": "hard-call",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/hard-call"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6308,22 +3725,6 @@
     {
       "id": "alirezarezvani-claude-skills/helm-chart-builder",
       "name": "helm-chart-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/helm-chart-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/helm-chart-builder",
-      "name": "helm-chart-builder",
       "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test.",
       "tags": [],
       "format": "skill-md",
@@ -6331,22 +3732,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/helm-chart-builder/skills/helm-chart-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/inbox-setup",
-      "name": "inbox-setup",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/inbox-setup"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6372,22 +3757,6 @@
     {
       "id": "alirezarezvani-claude-skills/inbox-triage",
       "name": "inbox-triage",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/inbox-triage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/inbox-triage",
-      "name": "inbox-triage",
       "description": "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run with KB-default preferences); asks at most 2 grill-me override questions when invocation is outside normal cadence or includes category-skip intent. Searches recent emails, classifies them via the user's taxonomy, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report in the user's preferred format, and updates the knowledge base with learnings. Designed to run on a recurring schedule (1-3x daily) or on demand. Triggers: 'triage my inbox', 'inbox triage', 'check my email', 'run email triage', 'process my inbox', 'what's new in my email', 'handle my email', 'email triage', or any variation where the user wants their inbox processed. Requires the inbox-setup skill to have been run first.",
       "tags": [],
       "format": "skill-md",
@@ -6395,22 +3764,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "productivity/email/skills/inbox-triage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/incident-commander",
-      "name": "incident-commander",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/incident-commander"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6436,22 +3789,6 @@
     {
       "id": "alirezarezvani-claude-skills/incident-response",
       "name": "incident-response",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/incident-response"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/incident-response",
-      "name": "incident-response",
       "description": "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle.",
       "tags": [],
       "format": "skill-md",
@@ -6459,22 +3796,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/incident-response"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/information-security-manager-iso27001",
-      "name": "information-security-manager-iso27001",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/information-security-manager-iso27001"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6500,22 +3821,6 @@
     {
       "id": "alirezarezvani-claude-skills/init",
       "name": "init",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/init",
-      "name": "init",
       "description": ">-",
       "tags": [],
       "format": "skill-md",
@@ -6523,38 +3828,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/playwright-pro/skills/init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/init",
-      "name": "init",
-      "description": "Create a new AgentHub collaboration session with task, agent count, and evaluation criteria.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/internal-comms",
-      "name": "internal-comms",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/internal-comms"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6589,22 +3862,6 @@
     {
       "id": "alirezarezvani-claude-skills/internal-narrative",
       "name": "internal-narrative",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/internal-narrative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/internal-narrative",
-      "name": "internal-narrative",
       "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
       "tags": [],
       "format": "skill-md",
@@ -6612,22 +3869,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/internal-narrative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/interview-system-designer",
-      "name": "interview-system-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/interview-system-designer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6653,22 +3894,6 @@
     {
       "id": "alirezarezvani-claude-skills/intl-expansion",
       "name": "intl-expansion",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/intl-expansion"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/intl-expansion",
-      "name": "intl-expansion",
       "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams.",
       "tags": [],
       "format": "skill-md",
@@ -6676,22 +3901,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/intl-expansion"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/isms-audit-expert",
-      "name": "isms-audit-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/isms-audit-expert"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6717,22 +3926,6 @@
     {
       "id": "alirezarezvani-claude-skills/iso13485-audit-prep",
       "name": "iso13485-audit-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/iso13485-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso13485-audit-prep",
-      "name": "iso13485-audit-prep",
       "description": "/cs:iso13485-audit-prep <scope> — ISO 13485 QMS audit 6-question forcing interrogation. Design controls + CAPA + post-market focused. Use before Clause 8.2.4 internal audit, MDR / FDA QSR alignment review, or product-launch DHF closure audit.",
       "tags": [],
       "format": "skill-md",
@@ -6740,22 +3933,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "compliance-os/skills/iso13485-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso27001-audit-prep",
-      "name": "iso27001-audit-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/iso27001-audit-prep"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6781,22 +3958,6 @@
     {
       "id": "alirezarezvani-claude-skills/iso42001-specialist",
       "name": "iso42001-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/iso42001-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso42001-specialist",
-      "name": "iso42001-specialist",
       "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act).",
       "tags": [],
       "format": "skill-md",
@@ -6804,38 +3965,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso42001-specialist",
-      "name": "iso42001-specialist",
-      "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/iso42001-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/jira-expert",
-      "name": "jira-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/jira-expert"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6877,22 +4006,6 @@
     {
       "id": "alirezarezvani-claude-skills/karpathy-coder",
       "name": "karpathy-coder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/karpathy-coder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/karpathy-coder",
-      "name": "karpathy-coder",
       "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
       "tags": [
         "code-quality",
@@ -6908,22 +4021,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/karpathy-coder/skills/karpathy-coder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/knowledge-ops",
-      "name": "knowledge-ops",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/knowledge-ops"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -6958,22 +4055,6 @@
     {
       "id": "alirezarezvani-claude-skills/kubernetes-operator",
       "name": "kubernetes-operator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/kubernetes-operator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/kubernetes-operator",
-      "name": "kubernetes-operator",
       "description": "Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
       "tags": [
         "kubernetes",
@@ -6999,49 +4080,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/kubernetes-operator",
-      "name": "kubernetes-operator",
-      "description": "Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
-      "tags": [
-        "kubernetes",
-        "operator",
-        "crd",
-        "controller-runtime",
-        "kubebuilder",
-        "operator-sdk",
-        "metacontroller",
-        "kopf",
-        "reconcile",
-        "devops"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/kubernetes-operator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/landing",
-      "name": "landing",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/landing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/landing",
       "name": "landing",
       "description": "Generates a premium single-page HTML landing page with 3D CSS animations, GSAP scroll effects, and mouse-parallax depth. Forcing intake (product + elevator pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written, so the page reflects the actual product rather than generic boilerplate. Use whenever the user says 'landing for X', 'create a landing page', 'build a landing page', 'make a landing page for X', 'I need a web page for Y', or provides product/service details and wants a polished website. Also triggers on 'promotional page', 'product page', 'one-pager', 'web presence', 'sales page'. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai). Supports configurable brand colors via CSS custom property overrides.",
@@ -7051,22 +4089,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing/landing/skills/landing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/landing-page-generator",
-      "name": "landing-page-generator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/landing-page-generator"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7092,22 +4114,6 @@
     {
       "id": "alirezarezvani-claude-skills/launch-strategy",
       "name": "launch-strategy",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/launch-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/launch-strategy",
-      "name": "launch-strategy",
       "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum.",
       "tags": [],
       "format": "skill-md",
@@ -7115,22 +4121,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/launch-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/litreview",
-      "name": "litreview",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/litreview"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7156,22 +4146,6 @@
     {
       "id": "alirezarezvani-claude-skills/llm-cost-optimizer",
       "name": "llm-cost-optimizer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/llm-cost-optimizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/llm-cost-optimizer",
-      "name": "llm-cost-optimizer",
       "description": "Use proactively whenever LLM API costs come up -- or should. Triggers include: 'my AI costs are too high', 'optimize token usage', 'which model should I use', 'LLM spend is out of control', 'implement prompt caching', 'we're about to launch an AI feature', 'build me an AI endpoint'. Don't wait for an explicit cost complaint -- if someone is building an AI feature, designing an LLM endpoint, or choosing between models, cost architecture belongs in the conversation. Apply immediately when any of these are true: a system prompt appears that exceeds a few hundred tokens, all requests are hitting the same model, max_tokens is not set, or no per-feature cost logging exists. NOT for RAG pipeline design (use rag-architect). NOT for improving prompt quality or effectiveness (use senior-prompt-engineer).",
       "tags": [],
       "format": "skill-md",
@@ -7179,22 +4153,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/llm-cost-optimizer/skills/llm-cost-optimizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/llm-wiki",
-      "name": "llm-wiki",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/llm-wiki"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7229,22 +4187,6 @@
     {
       "id": "alirezarezvani-claude-skills/loop",
       "name": "loop",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/loop"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/loop",
-      "name": "loop",
       "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
       "tags": [],
       "format": "skill-md",
@@ -7252,22 +4194,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/autoresearch-agent/skills/loop"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ma-playbook",
-      "name": "ma-playbook",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ma-playbook"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7318,22 +4244,6 @@
     {
       "id": "alirezarezvani-claude-skills/market-research",
       "name": "market-research",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/market-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/market-research",
-      "name": "market-research",
       "description": "Use when doing upstream market-research methodology — sizing a market as TAM/SAM/SOM computed BOTH top-down and bottoms-up (never a single unsourced number), planning a survey sample size with finite-population correction and per-segment minimums, or scoring candidate market segments against Kotler's measurable/substantial/accessible/differentiable/actionable criteria. Outputs always show the method and the assumptions. For market-research analysts and product-marketing at the sizing/survey/segmentation moment. Distinct from marketing-skill (campaign analytics, attribution, demand-gen) — this is the evidence-building methodology, not live-campaign optimization.",
       "tags": [
         "research-ops",
@@ -7359,22 +4269,6 @@
     {
       "id": "alirezarezvani-claude-skills/marketing-context",
       "name": "marketing-context",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-context"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-context",
-      "name": "marketing-context",
       "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills.",
       "tags": [],
       "format": "skill-md",
@@ -7382,22 +4276,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/marketing-context"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-demand-acquisition",
-      "name": "marketing-demand-acquisition",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-demand-acquisition"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7423,22 +4301,6 @@
     {
       "id": "alirezarezvani-claude-skills/marketing-ideas",
       "name": "marketing-ideas",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-ideas"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-ideas",
-      "name": "marketing-ideas",
       "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category.",
       "tags": [],
       "format": "skill-md",
@@ -7446,22 +4308,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/marketing-ideas"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-ops",
-      "name": "marketing-ops",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-ops"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7487,22 +4333,6 @@
     {
       "id": "alirezarezvani-claude-skills/marketing-psychology",
       "name": "marketing-psychology",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-psychology"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-psychology",
-      "name": "marketing-psychology",
       "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
       "tags": [],
       "format": "skill-md",
@@ -7510,22 +4340,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/marketing-psychology"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-skills",
-      "name": "marketing-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7551,22 +4365,6 @@
     {
       "id": "alirezarezvani-claude-skills/marketing-strategy-pmm",
       "name": "marketing-strategy-pmm",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/marketing-strategy-pmm"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-strategy-pmm",
-      "name": "marketing-strategy-pmm",
       "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
       "tags": [],
       "format": "skill-md",
@@ -7574,22 +4372,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/marketing-strategy-pmm"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/mcp-server-builder",
-      "name": "mcp-server-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/mcp-server-builder"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7693,22 +4475,6 @@
     {
       "id": "alirezarezvani-claude-skills/mdr-745-specialist",
       "name": "mdr-745-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/mdr-745-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/mdr-745-specialist",
-      "name": "mdr-745-specialist",
       "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
       "tags": [],
       "format": "skill-md",
@@ -7716,22 +4482,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/mdr-745-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/meeting-analyzer",
-      "name": "meeting-analyzer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/meeting-analyzer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7757,22 +4507,6 @@
     {
       "id": "alirezarezvani-claude-skills/merge",
       "name": "merge",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/merge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/merge",
-      "name": "merge",
       "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees.",
       "tags": [],
       "format": "skill-md",
@@ -7780,22 +4514,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/agenthub/skills/merge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/migrate",
-      "name": "migrate",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/migrate"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7821,22 +4539,6 @@
     {
       "id": "alirezarezvani-claude-skills/migration-architect",
       "name": "migration-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/migration-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/migration-architect",
-      "name": "migration-architect",
       "description": "Zero-downtime migration planning, compatibility validation, and rollback strategy generation. Tools for system, database, and infrastructure migrations with minimal business impact. Use when planning a database migration, infrastructure cutover, system replacement, or any high-risk transition that needs explicit rollback paths.",
       "tags": [],
       "format": "skill-md",
@@ -7844,22 +4546,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/migration-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/monorepo-navigator",
-      "name": "monorepo-navigator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/monorepo-navigator"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7885,22 +4571,6 @@
     {
       "id": "alirezarezvani-claude-skills/ms365-tenant-manager",
       "name": "ms365-tenant-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ms365-tenant-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ms365-tenant-manager",
-      "name": "ms365-tenant-manager",
       "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation.",
       "tags": [],
       "format": "skill-md",
@@ -7908,22 +4578,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/ms365-tenant-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/notebooklm",
-      "name": "notebooklm",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/notebooklm"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -7949,22 +4603,6 @@
     {
       "id": "alirezarezvani-claude-skills/observability-designer",
       "name": "observability-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/observability-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/observability-designer",
-      "name": "observability-designer",
       "description": "Design production-ready observability strategies combining metrics, logs, and traces. Includes SLI/SLO design, golden-signals monitoring, alert optimization. Use when adding observability to a new service, refactoring alerting that is too noisy, or designing an SLO program before scaling production load.",
       "tags": [],
       "format": "skill-md",
@@ -7972,22 +4610,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/observability-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/office-hours",
-      "name": "office-hours",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/office-hours"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8029,22 +4651,6 @@
     {
       "id": "alirezarezvani-claude-skills/onboard",
       "name": "onboard",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/onboard"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/onboard",
-      "name": "onboard",
       "description": "/cs:onboard — Founder interview that populates ~/.claude/company-context.md. The first command to run when starting with c-level-agents.",
       "tags": [],
       "format": "skill-md",
@@ -8052,22 +4658,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/c-level-agents/skills/onboard"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/onboarding-cro",
-      "name": "onboarding-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/onboarding-cro"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8109,22 +4699,6 @@
     {
       "id": "alirezarezvani-claude-skills/org-health-diagnostic",
       "name": "org-health-diagnostic",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/org-health-diagnostic"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/org-health-diagnostic",
-      "name": "org-health-diagnostic",
       "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard.",
       "tags": [],
       "format": "skill-md",
@@ -8132,22 +4706,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/org-health-diagnostic"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/page-cro",
-      "name": "page-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/page-cro"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8173,22 +4731,6 @@
     {
       "id": "alirezarezvani-claude-skills/paid-ads",
       "name": "paid-ads",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/paid-ads"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/paid-ads",
-      "name": "paid-ads",
       "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization.",
       "tags": [],
       "format": "skill-md",
@@ -8196,22 +4738,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/paid-ads"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/partnerships-architect",
-      "name": "partnerships-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/partnerships-architect"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8246,22 +4772,6 @@
     {
       "id": "alirezarezvani-claude-skills/patent",
       "name": "patent",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/patent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/patent",
-      "name": "patent",
       "description": "Patent prior-art and landscape intelligence skill — not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice — always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
       "tags": [],
       "format": "skill-md",
@@ -8278,22 +4788,6 @@
     {
       "id": "alirezarezvani-claude-skills/paywall-upgrade-cro",
       "name": "paywall-upgrade-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/paywall-upgrade-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/paywall-upgrade-cro",
-      "name": "paywall-upgrade-cro",
       "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.",
       "tags": [],
       "format": "skill-md",
@@ -8301,22 +4795,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/paywall-upgrade-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/performance-profiler",
-      "name": "performance-profiler",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/performance-profiler"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8406,22 +4884,6 @@
     {
       "id": "alirezarezvani-claude-skills/pm-skills",
       "name": "pm-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pm-skills",
-      "name": "pm-skills",
       "description": "6 project management agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Senior PM, scrum master, Jira expert (JQL), Confluence expert, Atlassian admin, template creator. MCP integration for live Jira/Confluence automation.",
       "tags": [],
       "format": "skill-md",
@@ -8429,22 +4891,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "project-management/skills/pm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/popup-cro",
-      "name": "popup-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/popup-cro"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8470,22 +4916,6 @@
     {
       "id": "alirezarezvani-claude-skills/post-mortem",
       "name": "post-mortem",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/post-mortem"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/post-mortem",
-      "name": "post-mortem",
       "description": "/cs:post-mortem <decision> — Honest retrospective on an executed decision, scored against original assumptions and dissent. Closes the strategic sprint loop.",
       "tags": [],
       "format": "skill-md",
@@ -8502,22 +4932,6 @@
     {
       "id": "alirezarezvani-claude-skills/postmortem",
       "name": "postmortem",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/postmortem"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/postmortem",
-      "name": "postmortem",
       "description": "/em -postmortem — Honest Analysis of What Went Wrong",
       "tags": [],
       "format": "skill-md",
@@ -8525,22 +4939,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/executive-mentor/skills/postmortem"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pr-review-expert",
-      "name": "pr-review-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pr-review-expert"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8582,22 +4980,6 @@
     {
       "id": "alirezarezvani-claude-skills/pricing-strategist",
       "name": "pricing-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pricing-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pricing-strategist",
-      "name": "pricing-strategist",
       "description": "Use when designing or revisiting product pricing — selecting a pricing model (subscription seat-based, usage-based, value-based, freemium, or hybrid), running Van Westendorp Price Sensitivity Meter analysis on WTP survey data, or designing Good/Better/Best packaging tiers. Recommends a model and a price range with trade-offs, never a single number. For Commercial leads, Product Marketing, and CMOs at the pricing-design moment — not deal-by-deal discounting, not brand positioning.",
       "tags": [
         "commercial",
@@ -8622,22 +5004,6 @@
     {
       "id": "alirezarezvani-claude-skills/pricing-strategy",
       "name": "pricing-strategy",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pricing-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pricing-strategy",
-      "name": "pricing-strategy",
       "description": "Design, optimize, and communicate SaaS pricing — tier structure, value metrics, pricing pages, and price increase strategy. Use when building a pricing model from scratch, redesigning existing pricing, planning a price increase, or improving a pricing page. Trigger keywords: pricing tiers, pricing page, price increase, packaging, value metric, per seat pricing, usage-based pricing, freemium, good-better-best, pricing strategy, monetization, pricing page conversion, Van Westendorp. NOT for broader product strategy — use product-strategist for that. NOT for customer success or renewals — use customer-success-manager for expansion revenue.",
       "tags": [],
       "format": "skill-md",
@@ -8645,22 +5011,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/pricing-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/process-mapper",
-      "name": "process-mapper",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/process-mapper"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8695,22 +5045,6 @@
     {
       "id": "alirezarezvani-claude-skills/procurement-optimizer",
       "name": "procurement-optimizer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/procurement-optimizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/procurement-optimizer",
-      "name": "procurement-optimizer",
       "description": "Use when running an annual SaaS audit, doing category-level spend review, or rationalizing the supplier base — when the user needs to do a spend audit, spend categorization (UNSPSC-aligned), purchasing-cycle analysis, or risk-balanced supplier consolidation. Triggers on \"spend audit\", \"SaaS audit\", \"spend categorization\", \"supplier rationalization\", \"supplier consolidation\", \"purchasing cycle\", \"procurement review\", \"category strategy\", \"duplicate SaaS\", \"renewal cluster\". Ships 3 stdlib-only Python tools (UNSPSC-aligned spend categorizer with Pareto breakdown and industry profiles, purchasing-cycle analyzer that surfaces bottleneck categories per Goldratt's Theory of Constraints, supplier-consolidation planner that refuses single-source recommendations for tier-1 categories without a documented break-glass plan), 3 reference docs each citing 7+ authoritative sources (A.T. Kearney / Hackett / Spend Matters / UNSPSC / Productiv / Vendr / Tropic / IACCM / ISM / BCG), and a 20-minute spend-intake template. Distinct from sibling vendor-management (performance scoring of vendors you keep paying), finance/financial-analysis (close + report, not category strategy), and c-level-advisor/general-counsel-advisor (contract law, not category rationalization).",
       "tags": [
         "bizops",
@@ -8735,22 +5069,6 @@
     {
       "id": "alirezarezvani-claude-skills/product-analytics",
       "name": "product-analytics",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-analytics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-analytics",
-      "name": "product-analytics",
       "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages.",
       "tags": [],
       "format": "skill-md",
@@ -8758,22 +5076,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/product-analytics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-discovery",
-      "name": "product-discovery",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-discovery"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8815,22 +5117,6 @@
     {
       "id": "alirezarezvani-claude-skills/product-manager-toolkit",
       "name": "product-manager-toolkit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-manager-toolkit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-manager-toolkit",
-      "name": "product-manager-toolkit",
       "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research synthesis, requirement documentation, and product strategy development.",
       "tags": [],
       "format": "skill-md",
@@ -8838,22 +5124,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/product-manager-toolkit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-research",
-      "name": "product-research",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-research"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -8888,22 +5158,6 @@
     {
       "id": "alirezarezvani-claude-skills/product-skills",
       "name": "product-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-skills",
-      "name": "product-skills",
       "description": "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only).",
       "tags": [],
       "format": "skill-md",
@@ -8920,22 +5174,6 @@
     {
       "id": "alirezarezvani-claude-skills/product-strategist",
       "name": "product-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-strategist",
-      "name": "product-strategist",
       "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
       "tags": [],
       "format": "skill-md",
@@ -8943,22 +5181,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/product-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/programmatic-seo",
-      "name": "programmatic-seo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/programmatic-seo"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9000,22 +5222,6 @@
     {
       "id": "alirezarezvani-claude-skills/promote",
       "name": "promote",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/promote"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/promote",
-      "name": "promote",
       "description": "Graduate a proven pattern from auto-memory (MEMORY.md) to CLAUDE.md or .claude/rules/ for permanent enforcement.",
       "tags": [],
       "format": "skill-md",
@@ -9023,22 +5229,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/self-improving-agent/skills/promote"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/prompt-engineer-toolkit",
-      "name": "prompt-engineer-toolkit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/prompt-engineer-toolkit"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9064,22 +5254,6 @@
     {
       "id": "alirezarezvani-claude-skills/prompt-governance",
       "name": "prompt-governance",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/prompt-governance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/prompt-governance",
-      "name": "prompt-governance",
       "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production AI features. Triggers: 'manage prompts in production', 'prompt versioning', 'prompt regression', 'prompt A/B test', 'prompt registry', 'eval pipeline'. NOT for writing or improving individual prompts (use senior-prompt-engineer). NOT for RAG pipeline design (use rag-architect). NOT for LLM cost reduction (use llm-cost-optimizer).",
       "tags": [],
       "format": "skill-md",
@@ -9087,22 +5261,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/prompt-governance/skills/prompt-governance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pulse",
-      "name": "pulse",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pulse"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9144,22 +5302,6 @@
     {
       "id": "alirezarezvani-claude-skills/qms-audit-expert",
       "name": "qms-audit-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/qms-audit-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/qms-audit-expert",
-      "name": "qms-audit-expert",
       "description": "ISO 13485 internal audit expertise for medical device QMS. Covers audit planning, execution, nonconformity classification, and CAPA verification. Use for internal audit planning, audit execution, finding classification, external audit preparation, or audit program management.",
       "tags": [],
       "format": "skill-md",
@@ -9167,22 +5309,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/qms-audit-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-documentation-manager",
-      "name": "quality-documentation-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/quality-documentation-manager"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9208,22 +5334,6 @@
     {
       "id": "alirezarezvani-claude-skills/quality-manager-qmr",
       "name": "quality-manager-qmr",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/quality-manager-qmr"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-manager-qmr",
-      "name": "quality-manager-qmr",
       "description": "Senior Quality Manager Responsible Person (QMR) for HealthTech and MedTech companies. Provides quality system governance, management review leadership, regulatory compliance oversight, and quality performance monitoring per ISO 13485 Clause 5.5.2.",
       "tags": [],
       "format": "skill-md",
@@ -9231,22 +5341,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/quality-manager-qmr"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-manager-qms-iso13485",
-      "name": "quality-manager-qms-iso13485",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/quality-manager-qms-iso13485"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9272,22 +5366,6 @@
     {
       "id": "alirezarezvani-claude-skills/ra-qm-skills",
       "name": "ra-qm-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ra-qm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ra-qm-skills",
-      "name": "ra-qm-skills",
       "description": "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only).",
       "tags": [],
       "format": "skill-md",
@@ -9295,22 +5373,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/ra-qm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/rag-architect",
-      "name": "rag-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/rag-architect"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9352,22 +5414,6 @@
     {
       "id": "alirezarezvani-claude-skills/red-team",
       "name": "red-team",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/red-team"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/red-team",
-      "name": "red-team",
       "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting.",
       "tags": [],
       "format": "skill-md",
@@ -9375,22 +5421,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/red-team"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/referral-program",
-      "name": "referral-program",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/referral-program"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9416,22 +5446,6 @@
     {
       "id": "alirezarezvani-claude-skills/reflect",
       "name": "reflect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/reflect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/reflect",
-      "name": "reflect",
       "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck — that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
       "tags": [],
       "format": "skill-md",
@@ -9439,22 +5453,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "productivity/reflect/skills/reflect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/regulatory-affairs-head",
-      "name": "regulatory-affairs-head",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/regulatory-affairs-head"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9480,22 +5478,6 @@
     {
       "id": "alirezarezvani-claude-skills/release-manager",
       "name": "release-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/release-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/release-manager",
-      "name": "release-manager",
       "description": "Use when the user asks to plan releases, manage changelogs, coordinate deployments, create release branches, or automate versioning.",
       "tags": [],
       "format": "skill-md",
@@ -9512,22 +5494,6 @@
     {
       "id": "alirezarezvani-claude-skills/remember",
       "name": "remember",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/remember"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/remember",
-      "name": "remember",
       "description": "Explicitly save important knowledge to auto-memory with timestamp and context. Use when a discovery is too important to rely on auto-capture.",
       "tags": [],
       "format": "skill-md",
@@ -9535,22 +5501,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/self-improving-agent/skills/remember"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/report",
-      "name": "report",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/report"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9608,22 +5558,6 @@
     {
       "id": "alirezarezvani-claude-skills/research-finance",
       "name": "research-finance",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/research-finance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-finance",
-      "name": "research-finance",
       "description": "Use when managing the money for an internal R&D program or portfolio — building a multi-period program budget with the F&A (indirect) split, tracking burn rate and runway against value-inflection milestones, or routing R&D cost items to a capitalize-vs-expense determination. Every budget output surfaces its assumptions block; capitalize-vs-expense is decision-support only and routes to a named finance owner — it never books an entry or decides accounting treatment. Distinct from finance/financial-analysis (corporate DCF, close, valuation) and research/grants (funding discovery — this manages money already won).",
       "tags": [
         "research-ops",
@@ -9640,22 +5574,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "research-ops/skills/research-finance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-ops-skills",
-      "name": "research-ops-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/research-ops-skills"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9689,22 +5607,6 @@
     {
       "id": "alirezarezvani-claude-skills/research-summarizer",
       "name": "research-summarizer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/research-summarizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-summarizer",
-      "name": "research-summarizer",
       "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw.",
       "tags": [],
       "format": "skill-md",
@@ -9712,22 +5614,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/research-summarizer/skills/research-summarizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/resume",
-      "name": "resume",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/resume"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9769,22 +5655,6 @@
     {
       "id": "alirezarezvani-claude-skills/revenue-operations",
       "name": "revenue-operations",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/revenue-operations"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/revenue-operations",
-      "name": "revenue-operations",
       "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams.",
       "tags": [],
       "format": "skill-md",
@@ -9801,22 +5671,6 @@
     {
       "id": "alirezarezvani-claude-skills/review",
       "name": "review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/review",
-      "name": "review",
       "description": ">-",
       "tags": [],
       "format": "skill-md",
@@ -9824,38 +5678,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/playwright-pro/skills/review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/review",
-      "name": "review",
-      "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/rfp-responder",
-      "name": "rfp-responder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/rfp-responder"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9907,22 +5729,6 @@
     {
       "id": "alirezarezvani-claude-skills/risk-management-specialist",
       "name": "risk-management-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/risk-management-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/risk-management-specialist",
-      "name": "risk-management-specialist",
       "description": "Medical device risk management specialist implementing ISO 14971 throughout product lifecycle. Provides risk analysis, risk evaluation, risk control, and post-production information analysis. Use when user mentions risk management, ISO 14971, risk analysis, FMEA, fault tree analysis, hazard identification, risk control, risk matrix, benefit-risk analysis, residual risk, risk acceptability, or post-market risk.",
       "tags": [],
       "format": "skill-md",
@@ -9930,22 +5736,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/risk-management-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/roadmap-communicator",
-      "name": "roadmap-communicator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/roadmap-communicator"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -9971,22 +5761,6 @@
     {
       "id": "alirezarezvani-claude-skills/run",
       "name": "run",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/run"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/run",
-      "name": "run",
       "description": "One-shot lifecycle command that chains init → baseline → spawn → eval → merge in a single invocation.",
       "tags": [],
       "format": "skill-md",
@@ -9994,38 +5768,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/agenthub/skills/run"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/run",
-      "name": "run",
-      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/run"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/runbook-generator",
-      "name": "runbook-generator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/runbook-generator"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10067,22 +5809,6 @@
     {
       "id": "alirezarezvani-claude-skills/saas-metrics-coach",
       "name": "saas-metrics-coach",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/saas-metrics-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/saas-metrics-coach",
-      "name": "saas-metrics-coach",
       "description": "SaaS financial health advisor. Use when a user shares revenue or customer numbers, or mentions ARR, MRR, churn, LTV, CAC, NRR, or asks how their SaaS business is doing.",
       "tags": [],
       "format": "skill-md",
@@ -10099,22 +5825,6 @@
     {
       "id": "alirezarezvani-claude-skills/saas-scaffolder",
       "name": "saas-scaffolder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/saas-scaffolder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/saas-scaffolder",
-      "name": "saas-scaffolder",
       "description": "Generates complete, production-ready SaaS project boilerplate including authentication, database schemas, billing integration, API routes, and a working dashboard using Next.js 14+ App Router, TypeScript, Tailwind CSS, shadcn/ui, Drizzle ORM, and Stripe. Use when the user wants to create a new SaaS app, start a subscription-based web project, scaffold a Next.js application, or mentions terms like starter template, boilerplate, new project, or wiring up auth and payments.",
       "tags": [],
       "format": "skill-md",
@@ -10122,22 +5832,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/saas-scaffolder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sales-engineer",
-      "name": "sales-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/sales-engineer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10177,38 +5871,6 @@
       "sourceId": "alirezarezvani-claude-skills"
     },
     {
-      "id": "alirezarezvani-claude-skills/sample-skill",
-      "name": "sample-skill",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/skill-tester/assets/sample-skill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/scenario-war-room",
-      "name": "scenario-war-room",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/scenario-war-room"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
       "id": "alirezarezvani-claude-skills/scenario-war-room",
       "name": "scenario-war-room",
       "description": "Cross-functional what-if modeling for cascading multi-variable scenarios. Unlike single-assumption stress testing, this models compound adversity across all business functions simultaneously. Use when facing complex risk scenarios, strategic decisions with major downside, or when the user asks 'what if X AND Y both happen?'",
@@ -10218,22 +5880,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/scenario-war-room"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/schema-markup",
-      "name": "schema-markup",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/schema-markup"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10259,22 +5905,6 @@
     {
       "id": "alirezarezvani-claude-skills/scrum-master",
       "name": "scrum-master",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/scrum-master"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/scrum-master",
-      "name": "scrum-master",
       "description": "Advanced Scrum Master skill for data-driven agile team analysis and coaching. Use when the user asks about sprint planning, velocity tracking, retrospectives, standup facilitation, backlog grooming, story points, burndown charts, blocker resolution, or agile team health. Runs Python scripts to analyse sprint JSON exports from Jira or similar tools: velocity_analyzer.py for Monte Carlo sprint forecasting, sprint_health_scorer.py for multi-dimension health scoring, and retrospective_analyzer.py for action-item and theme tracking. Produces confidence-interval forecasts, health grade reports, and improvement-velocity trends for high-performing Scrum teams.",
       "tags": [],
       "format": "skill-md",
@@ -10282,22 +5912,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "project-management/skills/scrum-master"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/secrets-vault-manager",
-      "name": "secrets-vault-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/secrets-vault-manager"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10323,22 +5937,6 @@
     {
       "id": "alirezarezvani-claude-skills/security-guidance",
       "name": "security-guidance",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/security-guidance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/security-guidance",
-      "name": "security-guidance",
       "description": "PreToolUse security-anti-pattern hook for Claude Code. Catches 12 common security risks (command injection, XSS, SQL injection, unsafe deserialization, GitHub Actions workflow injection, eval/new Function code injection) BEFORE the Edit/Write/MultiEdit operation completes. Session-state caching prevents duplicate warnings on the same file+rule combo. Stdlib only — no dependencies. Use when you want a safety net during Claude Code sessions that touch security-sensitive code (auth, payments, user input handling, IaC). Disable with ENABLE_SECURITY_REMINDER=0 if you need to perform a verified-safe operation that would otherwise trip a pattern. Triggers — \"add security hook\", \"block unsafe code\", \"detect command injection before write\", \"prevent SQL injection patterns\", \"security warning hook\".",
       "tags": [],
       "format": "skill-md",
@@ -10346,22 +5944,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/security-guidance/skills/security-guidance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/security-pen-testing",
-      "name": "security-pen-testing",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/security-pen-testing"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10387,22 +5969,6 @@
     {
       "id": "alirezarezvani-claude-skills/self-eval",
       "name": "self-eval",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/self-eval"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/self-eval",
-      "name": "self-eval",
       "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions.",
       "tags": [],
       "format": "skill-md",
@@ -10410,22 +5976,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/self-eval"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/self-improving-agent",
-      "name": "self-improving-agent",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/self-improving-agent"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10451,22 +6001,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-architect",
       "name": "senior-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-architect",
-      "name": "senior-architect",
       "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format.",
       "tags": [],
       "format": "skill-md",
@@ -10474,22 +6008,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-backend",
-      "name": "senior-backend",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-backend"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10515,22 +6033,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-computer-vision",
       "name": "senior-computer-vision",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-computer-vision"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-computer-vision",
-      "name": "senior-computer-vision",
       "description": "Computer vision engineering skill for object detection, image segmentation, and visual AI systems. Covers CNN and Vision Transformer architectures, YOLO/Faster R-CNN/DETR detection, Mask R-CNN/SAM segmentation, and production deployment with ONNX/TensorRT. Includes PyTorch, torchvision, Ultralytics, Detectron2, and MMDetection frameworks. Use when building detection pipelines, training custom models, optimizing inference, or deploying vision systems.",
       "tags": [],
       "format": "skill-md",
@@ -10538,22 +6040,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-computer-vision"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-data-engineer",
-      "name": "senior-data-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-data-engineer"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10579,22 +6065,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-data-scientist",
       "name": "senior-data-scientist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-data-scientist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-data-scientist",
-      "name": "senior-data-scientist",
       "description": "World-class senior data scientist skill specialising in statistical modeling, experiment design, causal inference, and predictive analytics. Covers A/B testing (sample sizing, two-proportion z-tests, Bonferroni correction), difference-in-differences, feature engineering pipelines (Scikit-learn, XGBoost), cross-validated model evaluation (AUC-ROC, AUC-PR, SHAP), and MLflow experiment tracking — using Python (NumPy, Pandas, Scikit-learn), R, and SQL. Use when designing or analysing controlled experiments, building and evaluating classification or regression models, performing causal analysis on observational data, engineering features for structured tabular datasets, or translating statistical findings into data-driven business decisions.",
       "tags": [],
       "format": "skill-md",
@@ -10602,22 +6072,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-data-scientist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-devops",
-      "name": "senior-devops",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-devops"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10643,22 +6097,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-frontend",
       "name": "senior-frontend",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-frontend"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-frontend",
-      "name": "senior-frontend",
       "description": "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality.",
       "tags": [],
       "format": "skill-md",
@@ -10666,22 +6104,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-frontend"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-fullstack",
-      "name": "senior-fullstack",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-fullstack"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10707,22 +6129,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-ml-engineer",
       "name": "senior-ml-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-ml-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-ml-engineer",
-      "name": "senior-ml-engineer",
       "description": "ML engineering skill for productionizing models, building MLOps pipelines, and integrating LLMs. Covers model deployment, feature stores, drift monitoring, RAG systems, and cost optimization. Use when the user asks about deploying ML models to production, setting up MLOps infrastructure (MLflow, Kubeflow, Kubernetes, Docker), monitoring model performance or drift, building RAG pipelines, or integrating LLM APIs with retry logic and cost controls. Focused on production and operational concerns rather than model research or initial training.",
       "tags": [],
       "format": "skill-md",
@@ -10730,22 +6136,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-ml-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-pm",
-      "name": "senior-pm",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-pm"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10771,22 +6161,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-prompt-engineer",
       "name": "senior-prompt-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-prompt-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-prompt-engineer",
-      "name": "senior-prompt-engineer",
       "description": "This skill should be used when the user asks to \"optimize prompts\", \"design prompt templates\", \"evaluate LLM outputs\", \"build agentic systems\", \"implement RAG\", \"create few-shot examples\", \"analyze token usage\", or \"design AI workflows\". Use for prompt engineering patterns, LLM evaluation frameworks, agent architectures, and structured output design.",
       "tags": [],
       "format": "skill-md",
@@ -10794,22 +6168,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-prompt-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-qa",
-      "name": "senior-qa",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-qa"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10835,22 +6193,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-secops",
       "name": "senior-secops",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-secops"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-secops",
-      "name": "senior-secops",
       "description": "Senior SecOps engineer skill for application security, vulnerability management, compliance verification, and secure development practices. Runs SAST/DAST scans, generates CVE remediation plans, checks dependency vulnerabilities, creates security policies, enforces secure coding patterns, and automates compliance checks against SOC2, PCI-DSS, HIPAA, and GDPR. Use when conducting a security review or audit, responding to a CVE or security incident, hardening infrastructure, implementing authentication or secrets management, running penetration test prep, checking OWASP Top 10 exposure, or enforcing security controls in CI/CD pipelines.",
       "tags": [],
       "format": "skill-md",
@@ -10867,22 +6209,6 @@
     {
       "id": "alirezarezvani-claude-skills/senior-security",
       "name": "senior-security",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/senior-security"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-security",
-      "name": "senior-security",
       "description": "Security engineering toolkit for threat modeling, vulnerability analysis, secure architecture, and penetration testing. Includes STRIDE analysis, OWASP guidance, cryptography patterns, and security scanning tools. Use when the user asks about security reviews, threat analysis, vulnerability assessments, secure coding practices, security audits, attack surface analysis, CVE remediation, or security best practices.",
       "tags": [],
       "format": "skill-md",
@@ -10890,22 +6216,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/senior-security"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/seo-audit",
-      "name": "seo-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/seo-audit"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -10947,22 +6257,6 @@
     {
       "id": "alirezarezvani-claude-skills/setup",
       "name": "setup",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/setup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/setup",
-      "name": "setup",
       "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator.",
       "tags": [],
       "format": "skill-md",
@@ -10970,22 +6264,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/autoresearch-agent/skills/setup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ship-gate",
-      "name": "ship-gate",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ship-gate"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11011,22 +6289,6 @@
     {
       "id": "alirezarezvani-claude-skills/signup-flow-cro",
       "name": "signup-flow-cro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/signup-flow-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/signup-flow-cro",
-      "name": "signup-flow-cro",
       "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" or \"account creation flow.\" For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
       "tags": [],
       "format": "skill-md",
@@ -11034,22 +6296,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/signup-flow-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/site-architecture",
-      "name": "site-architecture",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/site-architecture"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11075,22 +6321,6 @@
     {
       "id": "alirezarezvani-claude-skills/skill-security-auditor",
       "name": "skill-security-auditor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skill-security-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skill-security-auditor",
-      "name": "skill-security-auditor",
       "description": ">",
       "tags": [],
       "format": "skill-md",
@@ -11098,22 +6328,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/skill-security-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skill-tester",
-      "name": "skill-tester",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skill-tester"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11411,22 +6625,6 @@
     {
       "id": "alirezarezvani-claude-skills/slo-architect",
       "name": "slo-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/slo-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/slo-architect",
-      "name": "slo-architect",
       "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline.",
       "tags": [
         "slo",
@@ -11444,32 +6642,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/slo-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/slo-architect",
-      "name": "slo-architect",
-      "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline.",
-      "tags": [
-        "slo",
-        "sli",
-        "sla",
-        "error-budget",
-        "burn-rate",
-        "sre",
-        "reliability",
-        "google-sre-workbook",
-        "observability"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/slo-architect/skills/slo-architect"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11495,22 +6667,6 @@
     {
       "id": "alirezarezvani-claude-skills/snowflake-development",
       "name": "snowflake-development",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/snowflake-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/snowflake-development",
-      "name": "snowflake-development",
       "description": "Use when writing Snowflake SQL, building data pipelines with Dynamic Tables or Streams/Tasks, using Cortex AI functions, creating Cortex Agents, writing Snowpark Python, configuring dbt for Snowflake, or troubleshooting Snowflake errors.",
       "tags": [],
       "format": "skill-md",
@@ -11518,22 +6674,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/snowflake-development/skills/snowflake-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/soc2-audit-prep",
-      "name": "soc2-audit-prep",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/soc2-audit-prep"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11559,22 +6699,6 @@
     {
       "id": "alirezarezvani-claude-skills/soc2-compliance",
       "name": "soc2-compliance",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/soc2-compliance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/soc2-compliance",
-      "name": "soc2-compliance",
       "description": "Use when the user asks to prepare for SOC 2 audits, map Trust Service Criteria, build control matrices, collect audit evidence, perform gap analysis, or assess SOC 2 Type I vs Type II readiness.",
       "tags": [],
       "format": "skill-md",
@@ -11582,22 +6706,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "ra-qm-team/skills/soc2-compliance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-content",
-      "name": "social-content",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/social-content"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11623,22 +6731,6 @@
     {
       "id": "alirezarezvani-claude-skills/social-media-analyzer",
       "name": "social-media-analyzer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/social-media-analyzer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-media-analyzer",
-      "name": "social-media-analyzer",
       "description": "Social media campaign analysis and performance tracking. Calculates engagement rates, ROI, and benchmarks across platforms. Use for analyzing social media performance, calculating engagement rate, measuring campaign ROI, comparing platform metrics, or benchmarking against industry standards.",
       "tags": [],
       "format": "skill-md",
@@ -11646,22 +6738,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "marketing-skill/skills/social-media-analyzer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-media-manager",
-      "name": "social-media-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/social-media-manager"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11703,22 +6779,6 @@
     {
       "id": "alirezarezvani-claude-skills/spawn",
       "name": "spawn",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/spawn"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spawn",
-      "name": "spawn",
       "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task.",
       "tags": [],
       "format": "skill-md",
@@ -11735,22 +6795,6 @@
     {
       "id": "alirezarezvani-claude-skills/spec-driven-workflow",
       "name": "spec-driven-workflow",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/spec-driven-workflow"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spec-driven-workflow",
-      "name": "spec-driven-workflow",
       "description": "Use when the user asks to write specs before code, define acceptance criteria, plan features before implementation, generate tests from specifications, or follow spec-first development practices.",
       "tags": [],
       "format": "skill-md",
@@ -11758,22 +6802,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/spec-driven-workflow"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spec-to-repo",
-      "name": "spec-to-repo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/spec-to-repo"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -11831,22 +6859,6 @@
     {
       "id": "alirezarezvani-claude-skills/sql-database-assistant",
       "name": "sql-database-assistant",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/sql-database-assistant"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sql-database-assistant",
-      "name": "sql-database-assistant",
       "description": "Use when the user asks to write SQL queries, optimize database performance, generate migrations, explore database schemas, or work with ORMs like Prisma, Drizzle, TypeORM, or SQLAlchemy.",
       "tags": [],
       "format": "skill-md",
@@ -11879,22 +6891,6 @@
     {
       "id": "alirezarezvani-claude-skills/statistical-analyst",
       "name": "statistical-analyst",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/statistical-analyst"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/statistical-analyst",
-      "name": "statistical-analyst",
       "description": "Run hypothesis tests, analyze A/B experiment results, calculate sample sizes, and interpret statistical significance with effect sizes. Use when you need to validate whether observed differences are real, size an experiment correctly before launch, or interpret test results with confidence.",
       "tags": [],
       "format": "skill-md",
@@ -11911,22 +6907,6 @@
     {
       "id": "alirezarezvani-claude-skills/status",
       "name": "status",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/status",
-      "name": "status",
       "description": "Memory health dashboard showing line counts, topic files, capacity, stale entries, and recommendations.",
       "tags": [],
       "format": "skill-md",
@@ -11934,54 +6914,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/self-improving-agent/skills/status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/status",
-      "name": "status",
-      "description": "Show DAG state, agent progress, and branch status for an AgentHub session.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/status",
-      "name": "status",
-      "description": "Show experiment dashboard with results, active loops, and progress.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/strategic-alignment",
-      "name": "strategic-alignment",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/strategic-alignment"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12007,22 +6939,6 @@
     {
       "id": "alirezarezvani-claude-skills/stress-test",
       "name": "stress-test",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/stress-test"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/stress-test",
-      "name": "stress-test",
       "description": "/em -stress-test — Business Assumption Stress Testing",
       "tags": [],
       "format": "skill-md",
@@ -12039,22 +6955,6 @@
     {
       "id": "alirezarezvani-claude-skills/stripe-integration-expert",
       "name": "stripe-integration-expert",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/stripe-integration-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/stripe-integration-expert",
-      "name": "stripe-integration-expert",
       "description": "Production-grade Stripe integrations: subscriptions with trials and proration, one-time payments, usage-based billing, checkout sessions, idempotent webhook handlers, customer portal, and invoicing. Covers Next.js, Express, and Django patterns. Use when integrating Stripe for the first time, debugging webhook reliability issues, migrating from a different payment provider, or adding usage-based billing to an existing subscription product.",
       "tags": [],
       "format": "skill-md",
@@ -12062,22 +6962,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/stripe-integration-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/syllabus",
-      "name": "syllabus",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/syllabus"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12119,22 +7003,6 @@
     {
       "id": "alirezarezvani-claude-skills/tc-tracker",
       "name": "tc-tracker",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tc-tracker"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tc-tracker",
-      "name": "tc-tracker",
       "description": "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers init/create/update/status/resume/close/export workflows for structured code change documentation.",
       "tags": [],
       "format": "skill-md",
@@ -12167,22 +7035,6 @@
     {
       "id": "alirezarezvani-claude-skills/tdd-guide",
       "name": "tdd-guide",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tdd-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tdd-guide",
-      "name": "tdd-guide",
       "description": "Test-driven development skill for writing unit tests, generating test fixtures and mocks, analyzing coverage gaps, and guiding red-green-refactor workflows across Jest, Pytest, JUnit, Vitest, and Mocha. Use when the user asks to write tests, improve test coverage, practice TDD, generate mocks or stubs, or mentions testing frameworks like Jest, pytest, or JUnit.",
       "tags": [],
       "format": "skill-md",
@@ -12190,22 +7042,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/tdd-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/team-communications",
-      "name": "team-communications",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/team-communications"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12247,22 +7083,6 @@
     {
       "id": "alirezarezvani-claude-skills/tech-debt-tracker",
       "name": "tech-debt-tracker",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tech-debt-tracker"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tech-debt-tracker",
-      "name": "tech-debt-tracker",
       "description": "Scan codebases for technical debt, score severity, track trends, and generate prioritized remediation plans. Use when users mention tech debt, code quality, refactoring priority, debt scoring, cleanup sprints, or code health assessment. Also use for legacy code modernization planning and maintenance cost estimation.",
       "tags": [],
       "format": "skill-md",
@@ -12270,22 +7090,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/skills/tech-debt-tracker"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tech-stack-evaluator",
-      "name": "tech-stack-evaluator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tech-stack-evaluator"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12327,22 +7131,6 @@
     {
       "id": "alirezarezvani-claude-skills/terraform-patterns",
       "name": "terraform-patterns",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/terraform-patterns"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/terraform-patterns",
-      "name": "terraform-patterns",
       "description": "Terraform infrastructure-as-code agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Covers module design patterns, state management strategies, provider configuration, security hardening, policy-as-code with Sentinel/OPA, and CI/CD plan/apply workflows. Use when: user wants to design Terraform modules, manage state backends, review Terraform security, implement multi-region deployments, or follow IaC best practices.",
       "tags": [],
       "format": "skill-md",
@@ -12350,22 +7138,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/terraform-patterns/skills/terraform-patterns"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/testrail",
-      "name": "testrail",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/testrail"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12391,22 +7163,6 @@
     {
       "id": "alirezarezvani-claude-skills/threat-detection",
       "name": "threat-detection",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/threat-detection"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/threat-detection",
-      "name": "threat-detection",
       "description": "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization.",
       "tags": [],
       "format": "skill-md",
@@ -12414,22 +7170,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering-team/skills/threat-detection"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ui-design-system",
-      "name": "ui-design-system",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ui-design-system"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12487,22 +7227,6 @@
     {
       "id": "alirezarezvani-claude-skills/ux-researcher-designer",
       "name": "ux-researcher-designer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/ux-researcher-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ux-researcher-designer",
-      "name": "ux-researcher-designer",
       "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation.",
       "tags": [],
       "format": "skill-md",
@@ -12510,22 +7234,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "product-team/skills/ux-researcher-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vendor-management",
-      "name": "vendor-management",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/vendor-management"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12559,22 +7267,6 @@
     {
       "id": "alirezarezvani-claude-skills/video-content-strategist",
       "name": "video-content-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/video-content-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/video-content-strategist",
-      "name": "video-content-strategist",
       "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. Triggers: 'start a YouTube channel', 'video content strategy', 'write a video script', 'repurpose into video', 'YouTube SEO', 'short-form video'. NOT for written blog content (use content-production). NOT for social captions without video (use social-media-manager).",
       "tags": [],
       "format": "skill-md",
@@ -12591,22 +7283,6 @@
     {
       "id": "alirezarezvani-claude-skills/vpe-advisor",
       "name": "vpe-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/vpe-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vpe-advisor",
-      "name": "vpe-advisor",
       "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing → screen → onsite → offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) — VPE owns delivery operations and how the team ships.",
       "tags": [],
       "format": "skill-md",
@@ -12614,38 +7290,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "c-level-advisor/skills/vpe-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vpe-advisor",
-      "name": "vpe-advisor",
-      "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing → screen → onsite → offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) — VPE owns delivery operations and how the team ships.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/vpe-advisor/skills/vpe-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vpe-review",
-      "name": "vpe-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/vpe-review"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12767,22 +7411,6 @@
     {
       "id": "alirezarezvani-claude-skills/workflow-builder",
       "name": "workflow-builder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/workflow-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/workflow-builder",
-      "name": "workflow-builder",
       "description": "Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants to build, create, author, scaffold, or run a custom Claude Code workflow, orchestrate sub-agents (fan-out, pipeline, loop, judge-panel), or automate a repeatable multi-step task across fresh-context agents.",
       "tags": [],
       "format": "skill-md",
@@ -12799,22 +7427,6 @@
     {
       "id": "alirezarezvani-claude-skills/write-a-skill",
       "name": "write-a-skill",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/write-a-skill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/write-a-skill",
-      "name": "write-a-skill",
       "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, build, or author a new skill.",
       "tags": [],
       "format": "skill-md",
@@ -12822,22 +7434,6 @@
         "repo": "alirezarezvani/claude-skills",
         "ref": "main",
         "path": "engineering/write-a-skill/skills/write-a-skill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/x-twitter-growth",
-      "name": "x-twitter-growth",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/x-twitter-growth"
       },
       "stars": 17408,
       "updatedAt": "2026-06-07T04:15:18Z",
@@ -12887,7 +7483,7 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12903,7 +7499,7 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12919,7 +7515,7 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12935,7 +7531,7 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12951,7 +7547,7 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12967,7 +7563,7 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12983,7 +7579,7 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -12999,7 +7595,7 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13015,7 +7611,7 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13031,7 +7627,7 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13047,7 +7643,7 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13063,7 +7659,7 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13079,7 +7675,7 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13095,7 +7691,7 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13111,7 +7707,7 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13127,7 +7723,7 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13143,7 +7739,7 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13159,7 +7755,7 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147549,
+      "stars": 147552,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -13175,7 +7771,7 @@
         "ref": "main",
         "path": "skills/ab-testing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13191,7 +7787,7 @@
         "ref": "main",
         "path": "skills/ad-creative"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13207,7 +7803,7 @@
         "ref": "main",
         "path": "skills/ads"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13223,7 +7819,7 @@
         "ref": "main",
         "path": "skills/ai-seo"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13239,7 +7835,7 @@
         "ref": "main",
         "path": "skills/analytics"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13255,7 +7851,7 @@
         "ref": "main",
         "path": "skills/aso"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13271,7 +7867,7 @@
         "ref": "main",
         "path": "skills/churn-prevention"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13287,7 +7883,7 @@
         "ref": "main",
         "path": "skills/co-marketing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13303,7 +7899,7 @@
         "ref": "main",
         "path": "skills/cold-email"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13319,7 +7915,7 @@
         "ref": "main",
         "path": "skills/community-marketing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13335,7 +7931,7 @@
         "ref": "main",
         "path": "skills/competitor-profiling"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13351,7 +7947,7 @@
         "ref": "main",
         "path": "skills/competitors"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13367,7 +7963,7 @@
         "ref": "main",
         "path": "skills/content-strategy"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13383,7 +7979,7 @@
         "ref": "main",
         "path": "skills/copy-editing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13399,7 +7995,7 @@
         "ref": "main",
         "path": "skills/copywriting"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13415,7 +8011,7 @@
         "ref": "main",
         "path": "skills/cro"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13431,7 +8027,7 @@
         "ref": "main",
         "path": "skills/customer-research"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13447,7 +8043,7 @@
         "ref": "main",
         "path": "skills/directory-submissions"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13463,7 +8059,7 @@
         "ref": "main",
         "path": "skills/emails"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13479,7 +8075,7 @@
         "ref": "main",
         "path": "skills/free-tools"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13495,7 +8091,7 @@
         "ref": "main",
         "path": "skills/image"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13511,7 +8107,7 @@
         "ref": "main",
         "path": "skills/launch"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13527,7 +8123,7 @@
         "ref": "main",
         "path": "skills/lead-magnets"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13543,7 +8139,7 @@
         "ref": "main",
         "path": "skills/marketing-ideas"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13559,7 +8155,7 @@
         "ref": "main",
         "path": "skills/marketing-plan"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13575,7 +8171,7 @@
         "ref": "main",
         "path": "skills/marketing-psychology"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13591,7 +8187,7 @@
         "ref": "main",
         "path": "skills/onboarding"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13607,7 +8203,7 @@
         "ref": "main",
         "path": "skills/paywalls"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13623,7 +8219,7 @@
         "ref": "main",
         "path": "skills/popups"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13639,7 +8235,7 @@
         "ref": "main",
         "path": "skills/pricing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13655,7 +8251,7 @@
         "ref": "main",
         "path": "skills/product-marketing"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13671,7 +8267,7 @@
         "ref": "main",
         "path": "skills/programmatic-seo"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13687,7 +8283,7 @@
         "ref": "main",
         "path": "skills/prospecting"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13703,7 +8299,7 @@
         "ref": "main",
         "path": "skills/referrals"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13719,7 +8315,7 @@
         "ref": "main",
         "path": "skills/revops"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13735,7 +8331,7 @@
         "ref": "main",
         "path": "skills/sales-enablement"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13751,7 +8347,7 @@
         "ref": "main",
         "path": "skills/schema"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13767,7 +8363,7 @@
         "ref": "main",
         "path": "skills/seo-audit"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13783,7 +8379,7 @@
         "ref": "main",
         "path": "skills/signup"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13799,7 +8395,7 @@
         "ref": "main",
         "path": "skills/site-architecture"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13815,7 +8411,7 @@
         "ref": "main",
         "path": "skills/sms"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13831,7 +8427,7 @@
         "ref": "main",
         "path": "skills/social"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -13847,7 +8443,7 @@
         "ref": "main",
         "path": "skills/video"
       },
-      "stars": 32322,
+      "stars": 32325,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -14839,7 +9435,7 @@
         "ref": "main",
         "path": "agency-docs-updater"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14855,7 +9451,7 @@
         "ref": "main",
         "path": "agency-meetup-publish"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14871,7 +9467,7 @@
         "ref": "main",
         "path": "agency-socials"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14887,7 +9483,7 @@
         "ref": "main",
         "path": "agent-cli"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14903,7 +9499,7 @@
         "ref": "main",
         "path": "confide/skills/annotate"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14919,7 +9515,7 @@
         "ref": "main",
         "path": "confide/skills/anon"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14935,7 +9531,7 @@
         "ref": "main",
         "path": "confide/skills/audit"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14951,7 +9547,7 @@
         "ref": "main",
         "path": "balanced"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14967,7 +9563,7 @@
         "ref": "main",
         "path": "brand-agency"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14983,7 +9579,7 @@
         "ref": "main",
         "path": "browser-mate"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -14999,7 +9595,7 @@
         "ref": "main",
         "path": "browsing-history"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15015,7 +9611,7 @@
         "ref": "main",
         "path": "chrome-history"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15031,7 +9627,7 @@
         "ref": "main",
         "path": "coaching-session-summarizer"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15047,7 +9643,7 @@
         "ref": "main",
         "path": "codex"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15063,7 +9659,7 @@
         "ref": "main",
         "path": "context-builder"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15079,7 +9675,7 @@
         "ref": "main",
         "path": "cull"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15095,7 +9691,7 @@
         "ref": "main",
         "path": "daydream"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15111,7 +9707,7 @@
         "ref": "main",
         "path": "decision-toolkit"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15127,7 +9723,7 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15143,7 +9739,7 @@
         "ref": "main",
         "path": "skills/disk-cleanup"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15159,7 +9755,7 @@
         "ref": "main",
         "path": "doctorg"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15175,7 +9771,7 @@
         "ref": "main",
         "path": "ecosystem"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15191,7 +9787,7 @@
         "ref": "main",
         "path": "elevenlabs-tts"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15207,7 +9803,7 @@
         "ref": "main",
         "path": "fathom"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15223,7 +9819,7 @@
         "ref": "main",
         "path": "firecrawl-research"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15239,7 +9835,7 @@
         "ref": "main",
         "path": "github-gist"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15255,7 +9851,7 @@
         "ref": "main",
         "path": "gmail"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15271,7 +9867,7 @@
         "ref": "main",
         "path": "google-image-search"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15287,7 +9883,7 @@
         "ref": "main",
         "path": "gpt-image-2"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15303,7 +9899,7 @@
         "ref": "main",
         "path": "granola"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15319,7 +9915,7 @@
         "ref": "main",
         "path": "gws"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15335,7 +9931,7 @@
         "ref": "main",
         "path": "health-data"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15351,7 +9947,7 @@
         "ref": "main",
         "path": "insight-extractor"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15367,7 +9963,7 @@
         "ref": "main",
         "path": "skills/job-babysitter"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15383,7 +9979,7 @@
         "ref": "main",
         "path": "jtbd"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15399,7 +9995,7 @@
         "ref": "main",
         "path": "lab-retro"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15415,7 +10011,7 @@
         "ref": "main",
         "path": "learning-vault"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15431,7 +10027,7 @@
         "ref": "main",
         "path": "skills/library-sync"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15447,7 +10043,7 @@
         "ref": "main",
         "path": "linear"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15463,7 +10059,7 @@
         "ref": "main",
         "path": "llm-cli"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15479,7 +10075,7 @@
         "ref": "main",
         "path": "meeting-prep"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15495,7 +10091,7 @@
         "ref": "main",
         "path": "meeting-processor"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15511,7 +10107,7 @@
         "ref": "main",
         "path": "meta"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15527,7 +10123,7 @@
         "ref": "main",
         "path": "name-audition"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15543,7 +10139,7 @@
         "ref": "main",
         "path": "nano-banana"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15559,7 +10155,7 @@
         "ref": "main",
         "path": "pdf-generation"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15575,7 +10171,7 @@
         "ref": "main",
         "path": "peer-agent-collaboration"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15591,7 +10187,7 @@
         "ref": "main",
         "path": "present"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15607,7 +10203,7 @@
         "ref": "main",
         "path": "presentation-generator"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15623,7 +10219,7 @@
         "ref": "main",
         "path": "publish-skill"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15639,7 +10235,7 @@
         "ref": "main",
         "path": "qmd-search"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15655,7 +10251,7 @@
         "ref": "main",
         "path": "rag-eval"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15671,7 +10267,7 @@
         "ref": "main",
         "path": "recording"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15687,7 +10283,7 @@
         "ref": "main",
         "path": "confide/skills/red"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15703,7 +10299,7 @@
         "ref": "main",
         "path": "confide/skills/rehydrate"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15719,7 +10315,7 @@
         "ref": "main",
         "path": "skills/release"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15735,7 +10331,7 @@
         "ref": "main",
         "path": "retrospective"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15751,7 +10347,7 @@
         "ref": "main",
         "path": "rigorous-experiments"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15767,7 +10363,7 @@
         "ref": "main",
         "path": "session-anonymizer"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15783,7 +10379,7 @@
         "ref": "main",
         "path": "session-finder"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15799,7 +10395,7 @@
         "ref": "main",
         "path": "session-search"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15815,7 +10411,7 @@
         "ref": "main",
         "path": "confide/skills/setup"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15831,7 +10427,7 @@
         "ref": "main",
         "path": "site-diagnosis"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15847,7 +10443,7 @@
         "ref": "main",
         "path": "sketch"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15863,7 +10459,7 @@
         "ref": "main",
         "path": "skill-studio"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15879,7 +10475,7 @@
         "ref": "main",
         "path": "sorted"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15895,7 +10491,7 @@
         "ref": "main",
         "path": "synthetic-session-generator"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15911,7 +10507,7 @@
         "ref": "main",
         "path": "tdd"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15927,7 +10523,7 @@
         "ref": "main",
         "path": "telegram"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15943,7 +10539,7 @@
         "ref": "main",
         "path": "telegram-post"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15959,7 +10555,7 @@
         "ref": "main",
         "path": "telegram-telethon"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15975,7 +10571,7 @@
         "ref": "main",
         "path": "temple-generator"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -15991,7 +10587,7 @@
         "ref": "main",
         "path": "tg-responder"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16007,7 +10603,7 @@
         "ref": "main",
         "path": "thinking-patterns"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16023,7 +10619,7 @@
         "ref": "main",
         "path": "timebuzzer-led"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16039,7 +10635,7 @@
         "ref": "main",
         "path": "transcript-analyzer"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16055,7 +10651,7 @@
         "ref": "main",
         "path": "tufte-report"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16071,7 +10667,7 @@
         "ref": "main",
         "path": "confide/skills/vault"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16087,7 +10683,7 @@
         "ref": "main",
         "path": "confide/skills/view"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16103,7 +10699,7 @@
         "ref": "main",
         "path": "vision-bench"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16119,7 +10715,7 @@
         "ref": "main",
         "path": "weekly-digest"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16135,7 +10731,7 @@
         "ref": "main",
         "path": "wispr-analytics"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16151,7 +10747,7 @@
         "ref": "main",
         "path": "wispr-fix"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16167,7 +10763,7 @@
         "ref": "main",
         "path": "wow-digest"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16183,7 +10779,7 @@
         "ref": "main",
         "path": "youtube-transcript"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16199,7 +10795,7 @@
         "ref": "main",
         "path": "zoom"
       },
-      "stars": 248,
+      "stars": 249,
       "updatedAt": "2026-06-07T11:41:14Z",
       "provenance": "curated",
       "sourceId": "glebis-claude-skills"
@@ -16215,7 +10811,7 @@
         "ref": "main",
         "path": "skills/productivity/caveman"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16231,7 +10827,7 @@
         "ref": "main",
         "path": "skills/deprecated/design-an-interface"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16247,7 +10843,7 @@
         "ref": "main",
         "path": "skills/engineering/diagnose"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16263,7 +10859,7 @@
         "ref": "main",
         "path": "skills/personal/edit-article"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16279,7 +10875,7 @@
         "ref": "main",
         "path": "skills/misc/git-guardrails-claude-code"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16295,7 +10891,7 @@
         "ref": "main",
         "path": "skills/productivity/grill-me"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16311,7 +10907,7 @@
         "ref": "main",
         "path": "skills/engineering/grill-with-docs"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16327,7 +10923,7 @@
         "ref": "main",
         "path": "skills/productivity/handoff"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16343,7 +10939,7 @@
         "ref": "main",
         "path": "skills/engineering/improve-codebase-architecture"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16359,7 +10955,7 @@
         "ref": "main",
         "path": "skills/misc/migrate-to-shoehorn"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16375,7 +10971,7 @@
         "ref": "main",
         "path": "skills/personal/obsidian-vault"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16391,7 +10987,7 @@
         "ref": "main",
         "path": "skills/engineering/prototype"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16407,7 +11003,7 @@
         "ref": "main",
         "path": "skills/deprecated/qa"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16423,7 +11019,7 @@
         "ref": "main",
         "path": "skills/deprecated/request-refactor-plan"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16439,7 +11035,7 @@
         "ref": "main",
         "path": "skills/in-progress/review"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16455,7 +11051,7 @@
         "ref": "main",
         "path": "skills/misc/scaffold-exercises"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16471,7 +11067,7 @@
         "ref": "main",
         "path": "skills/engineering/setup-matt-pocock-skills"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16487,7 +11083,7 @@
         "ref": "main",
         "path": "skills/misc/setup-pre-commit"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16503,7 +11099,7 @@
         "ref": "main",
         "path": "skills/engineering/tdd"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16519,7 +11115,7 @@
         "ref": "main",
         "path": "skills/in-progress/teach"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16535,7 +11131,7 @@
         "ref": "main",
         "path": "skills/engineering/to-issues"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16551,7 +11147,7 @@
         "ref": "main",
         "path": "skills/engineering/to-prd"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16567,7 +11163,7 @@
         "ref": "main",
         "path": "skills/engineering/triage"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16583,7 +11179,7 @@
         "ref": "main",
         "path": "skills/deprecated/ubiquitous-language"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16599,7 +11195,7 @@
         "ref": "main",
         "path": "skills/productivity/write-a-skill"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16615,7 +11211,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-beats"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16631,7 +11227,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-fragments"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16647,7 +11243,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-shape"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16663,7 +11259,7 @@
         "ref": "main",
         "path": "skills/engineering/zoom-out"
       },
-      "stars": 120299,
+      "stars": 120303,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -16679,7 +11275,7 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16695,7 +11291,7 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16711,7 +11307,7 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16727,7 +11323,7 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16743,7 +11339,7 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16759,7 +11355,7 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16775,7 +11371,7 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16791,7 +11387,7 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16807,7 +11403,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16823,7 +11419,7 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16839,7 +11435,7 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16855,7 +11451,7 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16871,7 +11467,7 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -16887,7 +11483,7 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 220326,
+      "stars": 220330,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -124,9 +124,22 @@ async function main() {
       console.error(`${src.repo}: ${err.message}`)
     }
   }
+  // The same skill can appear at two paths in a repo (e.g. a second copy whose
+  // SKILL.md has empty frontmatter), and since the id is repo+name it collides.
+  // Keep one entry per id — prefer the one that actually carries a description —
+  // so the catalog has no duplicate ids (which otherwise break list rendering).
+  const byId = new Map()
+  for (const s of skills) {
+    const prev = byId.get(s.id)
+    if (!prev || (!prev.description && s.description)) byId.set(s.id, s)
+  }
+  const deduped = [...byId.values()]
+  if (deduped.length !== skills.length) {
+    console.log(`Deduped ${skills.length - deduped.length} duplicate id(s)`)
+  }
   // Stable order so the committed index has minimal diffs.
-  skills.sort((a, b) => a.id.localeCompare(b.id))
-  const index = { generatedAt: new Date().toISOString(), skills }
+  deduped.sort((a, b) => a.id.localeCompare(b.id))
+  const index = { generatedAt: new Date().toISOString(), skills: deduped }
   await writeFile(INDEX_PATH, `${JSON.stringify(index, null, 2)}\n`)
   console.log(`Wrote ${skills.length} skill(s) to ${INDEX_PATH}`)
 }

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -374,11 +374,6 @@ function SkillRow({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5">
           <span className="text-[12.5px] font-mono text-primary truncate">{entry.name}</span>
-          {installed && (
-            <span className="shrink-0 text-[9px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400">
-              Installed
-            </span>
-          )}
           {typeof entry.stars === 'number' && entry.stars > 0 && (
             <span className="shrink-0 text-[10px] text-muted tabular-nums">
               {entry.stars > 999 ? `${Math.round(entry.stars / 1000)}k` : entry.stars}★

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -28,6 +28,7 @@ import {
   Check,
   CircleNotch,
   CaretDown,
+  LinkSimple,
 } from '@phosphor-icons/react'
 import { BACKDROP, CARD_SURFACE } from '../ui/Modal'
 import { useUIStore } from '../stores/uiStore'
@@ -48,6 +49,17 @@ function matches(entry: SkillEntry, terms: string[]): boolean {
   if (terms.length === 0) return true
   const hay = `${entry.name} ${entry.description}`.toLowerCase()
   return terms.every((t) => hay.includes(t))
+}
+
+// GitHub URL for a skill's source folder, or null for stubs with no source
+// (e.g. a locally installed skill we know nothing else about).
+function sourceUrl(entry: SkillEntry): string | null {
+  const { repo, ref, path } = entry.source
+  if (!repo) return null
+  const branch = ref || 'main'
+  return path
+    ? `https://github.com/${repo}/tree/${branch}/${path}`
+    : `https://github.com/${repo}/tree/${branch}`
 }
 
 function savedToEntry(s: SavedSkill): SkillEntry {
@@ -315,6 +327,19 @@ function SkillRow({
   const installRef = useRef<HTMLButtonElement>(null)
   const [menuAnchor, setMenuAnchor] = useState<{ top: number; left: number } | null>(null)
   const [saveBusy, setSaveBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const link = sourceUrl(entry)
+
+  const copyLink = async () => {
+    if (!link) return
+    try {
+      await navigator.clipboard.writeText(link)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1200)
+    } catch {
+      /* clipboard blocked — ignore */
+    }
+  }
 
   const openMenu = () => {
     const r = installRef.current?.getBoundingClientRect()
@@ -374,6 +399,16 @@ function SkillRow({
         </div>
         {entry.description && <div className="text-[11px] text-muted truncate">{entry.description}</div>}
       </div>
+
+      {link && (
+        <button
+          onClick={() => void copyLink()}
+          title={copied ? 'Copied!' : 'Copy link to skill'}
+          className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-muted hover:text-secondary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+        >
+          {copied ? <Check size={14} className="text-emerald-400" /> : <LinkSimple size={14} />}
+        </button>
+      )}
 
       <button
         ref={installRef}

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -28,7 +28,7 @@ import {
   Check,
   CircleNotch,
   CaretDown,
-  LinkSimple,
+  ArrowSquareOut,
 } from '@phosphor-icons/react'
 import { BACKDROP, CARD_SURFACE } from '../ui/Modal'
 import { useUIStore } from '../stores/uiStore'
@@ -327,19 +327,7 @@ function SkillRow({
   const installRef = useRef<HTMLButtonElement>(null)
   const [menuAnchor, setMenuAnchor] = useState<{ top: number; left: number } | null>(null)
   const [saveBusy, setSaveBusy] = useState(false)
-  const [copied, setCopied] = useState(false)
   const link = sourceUrl(entry)
-
-  const copyLink = async () => {
-    if (!link) return
-    try {
-      await navigator.clipboard.writeText(link)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1200)
-    } catch {
-      /* clipboard blocked — ignore */
-    }
-  }
 
   const openMenu = () => {
     const r = installRef.current?.getBoundingClientRect()
@@ -402,11 +390,11 @@ function SkillRow({
 
       {link && (
         <button
-          onClick={() => void copyLink()}
-          title={copied ? 'Copied!' : 'Copy link to skill'}
+          onClick={() => window.electronAPI?.openExternalUrl(link)}
+          title="Open skill on GitHub"
           className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-muted hover:text-secondary opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
         >
-          {copied ? <Check size={14} className="text-emerald-400" /> : <LinkSimple size={14} />}
+          <ArrowSquareOut size={14} />
         </button>
       )}
 

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -194,9 +194,13 @@ export function SkillsDialog() {
 
   const empty = installedRows.length === 0 && savedRows.length === 0 && browseRows.length === 0
 
+  // Key on id + path, not id alone: a repo can expose the same skill name at two
+  // paths, which collide to one id. Duplicate React keys break list diffing, so
+  // stale rows stay mounted when the query filters the list down — making search
+  // look like it ignores the query. id + path uniquely locates a SKILL.md.
   const renderRow = (entry: SkillEntry, installedRow: boolean) => (
     <SkillRow
-      key={entry.id}
+      key={`${entry.id}#${entry.source.path}`}
       entry={entry}
       installed={installedRow}
       saved={savedIds.has(entry.id)}


### PR DESCRIPTION
## Problem
Typing in the skills search still showed the full, unrelated list (or stale rows) and ignored the query — the count label updated but the rows didn't.

## Cause
The crawl derives `id` from repo + skill name. A repo that exposes the same skill at two paths (one copy with empty frontmatter) collides to one `id` but stays two entries. The dialog keys rows on `entry.id`, so duplicate ids = duplicate React keys, and list reconciliation breaks: filtering the list down leaves stale rows mounted. `alirezarezvani/claude-skills` alone doubled every skill (1035 entries for 700 skills).

## Fix (two layers)
1. **Pipeline** — dedup by `id` in `build-skills-index.mjs`, preferring the entry with a description. Index 1035 -> 700, 0 dup ids. This fixes the already-shipped app once merged, since it fetches this index from main at runtime (no rebuild needed).
2. **Renderer** — key rows on `id + path` instead of `id`. Robust regardless of data, and covers user-added repos whose paths collide. Ships in the next build.

After this, a query with no matches shows the empty state instead of the full list.