### PR TITLE
chore(skills): trim catalog to curated sources, require descriptions

### DIFF
--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-07T21:34:15.002Z",
+  "generatedAt": "2026-06-07T21:40:32.251Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
@@ -12,7 +12,7 @@
         "ref": "main",
         "path": "academic-paper"
       },
-      "stars": 28512,
+      "stars": 28514,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -28,7 +28,7 @@
         "ref": "main",
         "path": "academic-paper-reviewer"
       },
-      "stars": 28512,
+      "stars": 28514,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -44,7 +44,7 @@
         "ref": "main",
         "path": "academic-pipeline"
       },
-      "stars": 28512,
+      "stars": 28514,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -60,7 +60,7 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 28512,
+      "stars": 28514,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -76,7 +76,7 @@
         "ref": "main",
         "path": "skills/api-and-interface-design"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -92,7 +92,7 @@
         "ref": "main",
         "path": "skills/browser-testing-with-devtools"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -108,7 +108,7 @@
         "ref": "main",
         "path": "skills/ci-cd-and-automation"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -124,7 +124,7 @@
         "ref": "main",
         "path": "skills/code-review-and-quality"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -140,7 +140,7 @@
         "ref": "main",
         "path": "skills/code-simplification"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -156,7 +156,7 @@
         "ref": "main",
         "path": "skills/context-engineering"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -172,7 +172,7 @@
         "ref": "main",
         "path": "skills/debugging-and-error-recovery"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -188,7 +188,7 @@
         "ref": "main",
         "path": "skills/deprecation-and-migration"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -204,7 +204,7 @@
         "ref": "main",
         "path": "skills/documentation-and-adrs"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -220,7 +220,7 @@
         "ref": "main",
         "path": "skills/doubt-driven-development"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -236,7 +236,7 @@
         "ref": "main",
         "path": "skills/frontend-ui-engineering"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -252,7 +252,7 @@
         "ref": "main",
         "path": "skills/git-workflow-and-versioning"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -268,7 +268,7 @@
         "ref": "main",
         "path": "skills/idea-refine"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -284,7 +284,7 @@
         "ref": "main",
         "path": "skills/incremental-implementation"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -300,7 +300,7 @@
         "ref": "main",
         "path": "skills/interview-me"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -316,7 +316,7 @@
         "ref": "main",
         "path": "skills/performance-optimization"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -332,7 +332,7 @@
         "ref": "main",
         "path": "skills/planning-and-task-breakdown"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -348,7 +348,7 @@
         "ref": "main",
         "path": "skills/security-and-hardening"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -364,7 +364,7 @@
         "ref": "main",
         "path": "skills/shipping-and-launch"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -380,7 +380,7 @@
         "ref": "main",
         "path": "skills/source-driven-development"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -396,7 +396,7 @@
         "ref": "main",
         "path": "skills/spec-driven-development"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -412,7 +412,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -428,7 +428,7 @@
         "ref": "main",
         "path": "skills/using-agent-skills"
       },
-      "stars": 48925,
+      "stars": 48926,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -444,7 +444,7 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -460,7 +460,7 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -476,7 +476,7 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -492,7 +492,7 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -508,7 +508,7 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -524,7 +524,7 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -540,7 +540,7 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -556,7 +556,7 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -572,7 +572,7 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -588,7 +588,7 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -604,7 +604,7 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -620,7 +620,7 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -636,7 +636,7 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -652,7 +652,7 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -668,7 +668,7 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -684,7 +684,7 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -700,7 +700,7 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -716,10 +716,42 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147555,
+      "stars": 147556,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
+    },
+    {
+      "id": "career-ops/career-ops",
+      "name": "career-ops",
+      "description": "AI job search command center -- evaluate offers, generate CVs, scan portals, track applications",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "santifer/career-ops",
+        "ref": "main",
+        "path": ".agents/skills/career-ops"
+      },
+      "stars": 49798,
+      "updatedAt": "2026-06-07T17:25:27Z",
+      "provenance": "curated",
+      "sourceId": "career-ops"
+    },
+    {
+      "id": "caveman/cavecrew",
+      "name": "cavecrew",
+      "description": ">",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "JuliusBrussee/caveman",
+        "ref": "main",
+        "path": ".agents/skills/cavecrew"
+      },
+      "stars": 69753,
+      "updatedAt": "2026-05-20T10:44:54Z",
+      "provenance": "curated",
+      "sourceId": "caveman"
     },
     {
       "id": "coreyhaines-marketing-skills/ab-testing",
@@ -1410,20 +1442,20 @@
       "sourceId": "coreyhaines-marketing-skills"
     },
     {
-      "id": "dev-browser/dev-browser",
-      "name": "dev-browser",
-      "description": "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include \"go to [url]\", \"click on\", \"fill out the form\", \"take a screenshot\", \"scrape\", \"automate\", \"test the website\", \"log into\", or any browser interaction request.",
+      "id": "humanizer/humanizer",
+      "name": "humanizer",
+      "description": "|",
       "tags": [],
       "format": "skill-md",
       "source": {
-        "repo": "SawyerHood/dev-browser",
+        "repo": "blader/humanizer",
         "ref": "main",
-        "path": "skills/dev-browser"
+        "path": ""
       },
-      "stars": 6223,
-      "updatedAt": "2026-06-05T18:37:05Z",
+      "stars": 22786,
+      "updatedAt": "2026-05-27T02:55:25Z",
       "provenance": "curated",
-      "sourceId": "dev-browser"
+      "sourceId": "humanizer"
     },
     {
       "id": "last30days/last30days",
@@ -1436,7 +1468,7 @@
         "ref": "main",
         "path": "skills/last30days"
       },
-      "stars": 30619,
+      "stars": 30629,
       "updatedAt": "2026-06-06T16:58:08Z",
       "provenance": "curated",
       "sourceId": "last30days"
@@ -1452,7 +1484,7 @@
         "ref": "main",
         "path": "skills/productivity/caveman"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1468,7 +1500,7 @@
         "ref": "main",
         "path": "skills/deprecated/design-an-interface"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1484,7 +1516,7 @@
         "ref": "main",
         "path": "skills/engineering/diagnose"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1500,7 +1532,7 @@
         "ref": "main",
         "path": "skills/personal/edit-article"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1516,7 +1548,7 @@
         "ref": "main",
         "path": "skills/misc/git-guardrails-claude-code"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1532,7 +1564,7 @@
         "ref": "main",
         "path": "skills/productivity/grill-me"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1548,7 +1580,7 @@
         "ref": "main",
         "path": "skills/engineering/grill-with-docs"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1564,7 +1596,7 @@
         "ref": "main",
         "path": "skills/productivity/handoff"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1580,7 +1612,7 @@
         "ref": "main",
         "path": "skills/engineering/improve-codebase-architecture"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1596,7 +1628,7 @@
         "ref": "main",
         "path": "skills/misc/migrate-to-shoehorn"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1612,7 +1644,7 @@
         "ref": "main",
         "path": "skills/personal/obsidian-vault"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1628,7 +1660,7 @@
         "ref": "main",
         "path": "skills/engineering/prototype"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1644,7 +1676,7 @@
         "ref": "main",
         "path": "skills/deprecated/qa"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1660,7 +1692,7 @@
         "ref": "main",
         "path": "skills/deprecated/request-refactor-plan"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1676,7 +1708,7 @@
         "ref": "main",
         "path": "skills/in-progress/review"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1692,7 +1724,7 @@
         "ref": "main",
         "path": "skills/misc/scaffold-exercises"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1708,7 +1740,7 @@
         "ref": "main",
         "path": "skills/engineering/setup-matt-pocock-skills"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1724,7 +1756,7 @@
         "ref": "main",
         "path": "skills/misc/setup-pre-commit"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1740,7 +1772,7 @@
         "ref": "main",
         "path": "skills/engineering/tdd"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1756,7 +1788,7 @@
         "ref": "main",
         "path": "skills/in-progress/teach"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1772,7 +1804,7 @@
         "ref": "main",
         "path": "skills/engineering/to-issues"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1788,7 +1820,7 @@
         "ref": "main",
         "path": "skills/engineering/to-prd"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1804,7 +1836,7 @@
         "ref": "main",
         "path": "skills/engineering/triage"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1820,7 +1852,7 @@
         "ref": "main",
         "path": "skills/deprecated/ubiquitous-language"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1836,7 +1868,7 @@
         "ref": "main",
         "path": "skills/productivity/write-a-skill"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1852,7 +1884,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-beats"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1868,7 +1900,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-fragments"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1884,7 +1916,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-shape"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1900,10 +1932,26 @@
         "ref": "main",
         "path": "skills/engineering/zoom-out"
       },
-      "stars": 120320,
+      "stars": 120321,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
+    },
+    {
+      "id": "notebooklm/notebooklm",
+      "name": "notebooklm",
+      "description": "Complete API for Google NotebookLM - full programmatic access including features not in the web UI. Create notebooks, add sources, generate all artifact types, download in multiple formats. Activates on explicit /notebooklm or intent like \"create a podcast about X",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "teng-lin/notebooklm-py",
+        "ref": "main",
+        "path": ""
+      },
+      "stars": 16067,
+      "updatedAt": "2026-06-07T18:12:36Z",
+      "provenance": "curated",
+      "sourceId": "notebooklm"
     },
     {
       "id": "obsidian-skills/defuddle",
@@ -1986,86 +2034,6 @@
       "sourceId": "obsidian-skills"
     },
     {
-      "id": "second-brain-skills/brand-voice-generator",
-      "name": "brand-voice-generator",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "coleam00/second-brain-skills",
-        "ref": "main",
-        "path": ".claude/skills/brand-voice-generator"
-      },
-      "stars": 759,
-      "updatedAt": "2026-01-24T15:50:47Z",
-      "provenance": "curated",
-      "sourceId": "second-brain-skills"
-    },
-    {
-      "id": "second-brain-skills/mcp-client",
-      "name": "mcp-client",
-      "description": "Universal MCP client for connecting to any MCP server with progressive disclosure. Wraps MCP servers as skills to avoid context window bloat from tool definitions. Use when interacting with external MCP servers (Zapier, Sequential Thinking, GitHub, filesystem, etc.), listing available tools, or executing MCP tool calls. Triggers on requests like \"connect to Zapier\", \"use MCP server\", \"list MCP tools\", \"call Zapier action\", \"use sequential thinking\", or any MCP server interaction.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "coleam00/second-brain-skills",
-        "ref": "main",
-        "path": ".claude/skills/mcp-client"
-      },
-      "stars": 759,
-      "updatedAt": "2026-01-24T15:50:47Z",
-      "provenance": "curated",
-      "sourceId": "second-brain-skills"
-    },
-    {
-      "id": "second-brain-skills/pptx-generator",
-      "name": "pptx-generator",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "coleam00/second-brain-skills",
-        "ref": "main",
-        "path": ".claude/skills/pptx-generator"
-      },
-      "stars": 759,
-      "updatedAt": "2026-01-24T15:50:47Z",
-      "provenance": "curated",
-      "sourceId": "second-brain-skills"
-    },
-    {
-      "id": "second-brain-skills/skill-creator",
-      "name": "skill-creator",
-      "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "coleam00/second-brain-skills",
-        "ref": "main",
-        "path": ".claude/skills/skill-creator"
-      },
-      "stars": 759,
-      "updatedAt": "2026-01-24T15:50:47Z",
-      "provenance": "curated",
-      "sourceId": "second-brain-skills"
-    },
-    {
-      "id": "second-brain-skills/sop-creator",
-      "name": "sop-creator",
-      "description": "Create runbooks, playbooks, and technical documentation for engineering teams. Use when the user wants to document a process, create a runbook, build operational docs, or formalize any repeatable technical procedure. Triggers on requests like \"create a runbook for...\", \"document this process\", \"write a playbook\", or any technical documentation request.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "coleam00/second-brain-skills",
-        "ref": "main",
-        "path": ".claude/skills/sop-creator"
-      },
-      "stars": 759,
-      "updatedAt": "2026-01-24T15:50:47Z",
-      "provenance": "curated",
-      "sourceId": "second-brain-skills"
-    },
-    {
       "id": "superpowers/brainstorming",
       "name": "brainstorming",
       "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.",
@@ -2076,7 +2044,7 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2092,7 +2060,7 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2108,7 +2076,7 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2124,7 +2092,7 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2140,7 +2108,7 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2156,7 +2124,7 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2172,7 +2140,7 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2188,7 +2156,7 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2204,7 +2172,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2220,7 +2188,7 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2236,7 +2204,7 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2252,7 +2220,7 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2268,7 +2236,7 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2284,10 +2252,330 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 220343,
+      "stars": 220345,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
+    },
+    {
+      "id": "taste-skill/brandkit",
+      "name": "brandkit",
+      "description": "Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/brandkit"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/design-taste-frontend",
+      "name": "design-taste-frontend",
+      "description": "Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/taste-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/design-taste-frontend-v1",
+      "name": "design-taste-frontend-v1",
+      "description": "The original v1 taste-skill, preserved for projects depending on its exact behavior. The current default is `design-taste-frontend` (v2 experimental), which is a substantial rewrite. Use this v1 install name only if you need exact backward compatibility.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/taste-skill-v1"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/full-output-enforcement",
+      "name": "full-output-enforcement",
+      "description": "Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/output-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/gpt-taste",
+      "name": "gpt-taste",
+      "description": "Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/gpt-tasteskill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/high-end-visual-design",
+      "name": "high-end-visual-design",
+      "description": "Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/soft-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/image-to-code",
+      "name": "image-to-code",
+      "description": "Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/image-to-code-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/imagegen-frontend-mobile",
+      "name": "imagegen-frontend-mobile",
+      "description": "Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/imagegen-frontend-mobile"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/imagegen-frontend-web",
+      "name": "imagegen-frontend-web",
+      "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/imagegen-frontend-web"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/industrial-brutalist-ui",
+      "name": "industrial-brutalist-ui",
+      "description": "Raw mechanical interfaces fusing Swiss typographic print with military terminal aesthetics. Rigid grids, extreme type scale contrast, utilitarian color, analog degradation effects. For data-heavy dashboards, portfolios, or editorial sites that need to feel like declassified blueprints.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/brutalist-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/minimalist-ui",
+      "name": "minimalist-ui",
+      "description": "Clean editorial-style interfaces. Warm monochrome palette, typographic contrast, flat bento grids, muted pastels. No gradients, no heavy shadows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/minimalist-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/redesign-existing-projects",
+      "name": "redesign-existing-projects",
+      "description": "Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/redesign-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "taste-skill/stitch-design-taste",
+      "name": "stitch-design-taste",
+      "description": "Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "Leonxlnx/taste-skill",
+        "ref": "main",
+        "path": "skills/stitch-skill"
+      },
+      "stars": 36458,
+      "updatedAt": "2026-05-26T19:31:39Z",
+      "provenance": "curated",
+      "sourceId": "taste-skill"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-banner-design",
+      "name": "ckm:banner-design",
+      "description": "Design banners for social media, ads, website heroes, creative assets, and print. Multiple art direction options with AI-generated visuals. Actions: design, create, generate banner. Platforms: Facebook, Twitter/X, LinkedIn, YouTube, Instagram, Google Display, website hero, print. Styles: minimalist, gradient, bold typography, photo-based, illustrated, geometric, retro, glassmorphism, 3D, neon, duotone, editorial, collage. Uses ui-ux-pro-max, frontend-design, ai-artist, ai-multimodal skills.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/banner-design"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-brand",
+      "name": "ckm:brand",
+      "description": "Brand voice, visual identity, messaging frameworks, asset management, brand consistency. Activate for branded content, tone of voice, marketing assets, brand compliance, style guides.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/brand"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-design",
+      "name": "ckm:design",
+      "description": "Comprehensive design skill: brand identity, design tokens, UI styling, logo generation (55 styles, Gemini AI), corporate identity program (50 deliverables, CIP mockups), HTML presentations (Chart.js), banner design (22 styles, social/ads/web/print), icon design (15 styles, SVG, Gemini 3.1 Pro), social photos (HTML→screenshot, multi-platform). Actions: design logo, create CIP, generate mockups, build slides, design banner, generate icon, create social photos, social media images, brand identity, design system. Platforms: Facebook, Twitter, LinkedIn, YouTube, Instagram, Pinterest, TikTok, Threads, Google Ads.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/design"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-design-system",
+      "name": "ckm:design-system",
+      "description": "Token architecture, component specifications, and slide generation. Three-layer tokens (primitive→semantic→component), CSS variables, spacing/typography scales, component specs, strategic slide creation. Use for design tokens, systematic design, brand-compliant presentations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/design-system"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-slides",
+      "name": "ckm:slides",
+      "description": "Create strategic HTML presentations with Chart.js, design tokens, responsive layouts, copywriting formulas, and contextual slide strategies.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/slides"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ckm-ui-styling",
+      "name": "ckm:ui-styling",
+      "description": "Create beautiful, accessible user interfaces with shadcn/ui components (built on Radix UI + Tailwind), Tailwind CSS utility-first styling, and canvas-based visual designs. Use when building user interfaces, implementing design systems, creating responsive layouts, adding accessible components (dialogs, dropdowns, forms, tables), customizing themes and colors, implementing dark mode, generating visual designs and posters, or establishing consistent styling patterns across applications.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/ui-styling"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
+    },
+    {
+      "id": "ui-ux-pro-max/ui-ux-pro-max",
+      "name": "ui-ux-pro-max",
+      "description": "UI/UX design intelligence for web and mobile. Includes 50+ styles, 161 color palettes, 57 font pairings, 161 product types, 99 UX guidelines, and 25 chart types across 10 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui, and HTML/CSS). Actions: plan, build, create, design, implement, review, fix, improve, optimize, enhance, refactor, and check UI/UX code. Projects: website, landing page, dashboard, admin panel, e-commerce, SaaS, portfolio, blog, and mobile app. Elements: button, modal, navbar, sidebar, card, table, form, and chart. Styles: glassmorphism, claymorphism, minimalism, brutalism, neumorphism, bento grid, dark mode, responsive, skeuomorphism, and flat design. Topics: color systems, accessibility, animation, layout, typography, font pairing, spacing, interaction states, shadow, and gradient. Integrations: shadcn/ui MCP for component search and examples.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+        "ref": "main",
+        "path": ".claude/skills/ui-ux-pro-max"
+      },
+      "stars": 88489,
+      "updatedAt": "2026-04-03T05:08:19Z",
+      "provenance": "curated",
+      "sourceId": "ui-ux-pro-max"
     },
     {
       "id": "vercel-agent-skills/deploy-to-vercel",
@@ -2400,22 +2688,6 @@
       "updatedAt": "2026-06-03T17:03:05Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
-    },
-    {
-      "id": "webgpu-threejs/webgpu-threejs-tsl",
-      "name": "webgpu-threejs-tsl",
-      "description": "Comprehensive guide for developing WebGPU-enabled Three.js applications using TSL (Three.js Shading Language). Covers WebGPU renderer setup, TSL syntax and node materials, compute shaders, post-processing effects, and WGSL integration. Use this skill when working with Three.js WebGPU, TSL shaders, node materials, or GPU compute in Three.js.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "dgreenheck/webgpu-claude-skill",
-        "ref": "main",
-        "path": "skills/webgpu-threejs-tsl"
-      },
-      "stars": 981,
-      "updatedAt": "2026-04-10T14:28:23Z",
-      "provenance": "curated",
-      "sourceId": "webgpu-threejs"
     }
   ]
 }

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-07T21:40:32.251Z",
+  "generatedAt": "2026-06-07T21:43:06.866Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
@@ -444,7 +444,7 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -460,7 +460,7 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -476,7 +476,7 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -484,7 +484,7 @@
     {
       "id": "anthropic-skills/claude-api",
       "name": "claude-api",
-      "description": "|-",
+      "description": "Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration. TRIGGER — read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens). SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -492,7 +492,7 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -508,7 +508,7 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -524,7 +524,7 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -540,7 +540,7 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -556,7 +556,7 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -572,7 +572,7 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -588,7 +588,7 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -604,7 +604,7 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -620,7 +620,7 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -636,7 +636,7 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -652,7 +652,7 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -668,7 +668,7 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -684,7 +684,7 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -700,7 +700,7 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -716,7 +716,7 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147556,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -740,7 +740,7 @@
     {
       "id": "caveman/cavecrew",
       "name": "cavecrew",
-      "description": ">",
+      "description": "Decision guide for delegating to caveman-style subagents. Tells the main thread WHEN to spawn `cavecrew-investigator` (locate code), `cavecrew-builder` (1-2 file edit), or `cavecrew-reviewer` (diff review) instead of doing the work inline or using vanilla `Explore`. Subagent output is caveman-compressed so the tool-result injected back into main context is ~60% smaller — main context lasts longer across long sessions. Trigger: \"delegate to subagent\", \"use cavecrew\", \"spawn investigator/builder/reviewer\", \"save context\", \"compressed agent output\".",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -1444,7 +1444,7 @@
     {
       "id": "humanizer/humanizer",
       "name": "humanizer",
-      "description": "|",
+      "description": "Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and human-written. Based on Wikipedia's comprehensive \"Signs of AI writing\" guide. Detects and fixes patterns including: inflated symbolism, promotional language, superficial -ing analyses, vague attributions, em dash overuse, rule of three, AI vocabulary words, passive voice, negative parallelisms, and filler phrases.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -1468,7 +1468,7 @@
         "ref": "main",
         "path": "skills/last30days"
       },
-      "stars": 30629,
+      "stars": 30634,
       "updatedAt": "2026-06-06T16:58:08Z",
       "provenance": "curated",
       "sourceId": "last30days"
@@ -1476,7 +1476,7 @@
     {
       "id": "mattpocock-skills/caveman",
       "name": "caveman",
-      "description": ">",
+      "description": "Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler, articles, and pleasantries while keeping full technical accuracy. Use when user says \"caveman mode\", \"talk like caveman\", \"use caveman\", \"less tokens\", \"be brief\", or invokes /caveman.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -2044,7 +2044,7 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2060,7 +2060,7 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2076,7 +2076,7 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2092,7 +2092,7 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2108,7 +2108,7 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2124,7 +2124,7 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2140,7 +2140,7 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2156,7 +2156,7 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2172,7 +2172,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2188,7 +2188,7 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2204,7 +2204,7 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2220,7 +2220,7 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2236,7 +2236,7 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2252,7 +2252,7 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 220345,
+      "stars": 220346,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2268,7 +2268,7 @@
         "ref": "main",
         "path": "skills/brandkit"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2284,7 +2284,7 @@
         "ref": "main",
         "path": "skills/taste-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2300,7 +2300,7 @@
         "ref": "main",
         "path": "skills/taste-skill-v1"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2316,7 +2316,7 @@
         "ref": "main",
         "path": "skills/output-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2332,7 +2332,7 @@
         "ref": "main",
         "path": "skills/gpt-tasteskill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2348,7 +2348,7 @@
         "ref": "main",
         "path": "skills/soft-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2364,7 +2364,7 @@
         "ref": "main",
         "path": "skills/image-to-code-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2380,7 +2380,7 @@
         "ref": "main",
         "path": "skills/imagegen-frontend-mobile"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2396,7 +2396,7 @@
         "ref": "main",
         "path": "skills/imagegen-frontend-web"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2412,7 +2412,7 @@
         "ref": "main",
         "path": "skills/brutalist-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2428,7 +2428,7 @@
         "ref": "main",
         "path": "skills/minimalist-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2444,7 +2444,7 @@
         "ref": "main",
         "path": "skills/redesign-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
@@ -2460,7 +2460,7 @@
         "ref": "main",
         "path": "skills/stitch-skill"
       },
-      "stars": 36458,
+      "stars": 36459,
       "updatedAt": "2026-05-26T19:31:39Z",
       "provenance": "curated",
       "sourceId": "taste-skill"

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-07T20:50:31.126Z",
+  "generatedAt": "2026-06-07T21:21:45.238Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
@@ -12,7 +12,7 @@
         "ref": "main",
         "path": "academic-paper"
       },
-      "stars": 28504,
+      "stars": 28509,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -28,7 +28,7 @@
         "ref": "main",
         "path": "academic-paper-reviewer"
       },
-      "stars": 28504,
+      "stars": 28509,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -44,7 +44,7 @@
         "ref": "main",
         "path": "academic-pipeline"
       },
-      "stars": 28504,
+      "stars": 28509,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -60,7 +60,7 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 28504,
+      "stars": 28509,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -76,7 +76,7 @@
         "ref": "main",
         "path": "skills/api-and-interface-design"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -92,7 +92,7 @@
         "ref": "main",
         "path": "skills/browser-testing-with-devtools"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -108,7 +108,7 @@
         "ref": "main",
         "path": "skills/ci-cd-and-automation"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -124,7 +124,7 @@
         "ref": "main",
         "path": "skills/code-review-and-quality"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -140,7 +140,7 @@
         "ref": "main",
         "path": "skills/code-simplification"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -156,7 +156,7 @@
         "ref": "main",
         "path": "skills/context-engineering"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -172,7 +172,7 @@
         "ref": "main",
         "path": "skills/debugging-and-error-recovery"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -188,7 +188,7 @@
         "ref": "main",
         "path": "skills/deprecation-and-migration"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -204,7 +204,7 @@
         "ref": "main",
         "path": "skills/documentation-and-adrs"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -220,7 +220,7 @@
         "ref": "main",
         "path": "skills/doubt-driven-development"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -236,7 +236,7 @@
         "ref": "main",
         "path": "skills/frontend-ui-engineering"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -252,7 +252,7 @@
         "ref": "main",
         "path": "skills/git-workflow-and-versioning"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -268,7 +268,7 @@
         "ref": "main",
         "path": "skills/idea-refine"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -284,7 +284,7 @@
         "ref": "main",
         "path": "skills/incremental-implementation"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -300,7 +300,7 @@
         "ref": "main",
         "path": "skills/interview-me"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -316,7 +316,7 @@
         "ref": "main",
         "path": "skills/performance-optimization"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -332,7 +332,7 @@
         "ref": "main",
         "path": "skills/planning-and-task-breakdown"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -348,7 +348,7 @@
         "ref": "main",
         "path": "skills/security-and-hardening"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -364,7 +364,7 @@
         "ref": "main",
         "path": "skills/shipping-and-launch"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -380,7 +380,7 @@
         "ref": "main",
         "path": "skills/source-driven-development"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -396,7 +396,7 @@
         "ref": "main",
         "path": "skills/spec-driven-development"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -412,7 +412,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -428,7049 +428,10 @@
         "ref": "main",
         "path": "skills/using-agent-skills"
       },
-      "stars": 48917,
+      "stars": 48922,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/a11y-audit",
-      "name": "a11y-audit",
-      "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/a11y-audit/skills/a11y-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ab-test-setup",
-      "name": "ab-test-setup",
-      "description": "When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions \"A/B test,\" \"split test,\" \"experiment,\" \"test this change,\" \"variant copy,\" \"multivariate test,\" \"hypothesis,\" \"conversion experiment,\" \"statistical significance,\" or \"test this.\" For tracking implementation, see analytics-tracking.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/ab-test-setup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ad-creative",
-      "name": "ad-creative",
-      "description": "When the user needs to generate, iterate, or scale ad creative for paid advertising. Use when they say 'write ad copy,' 'generate headlines,' 'create ad variations,' 'bulk creative,' 'iterate on ads,' 'ad copy validation,' 'RSA headlines,' 'Meta ad copy,' 'LinkedIn ad,' or 'creative testing.' This is pure creative production — distinct from paid-ads (campaign strategy). Use ad-creative when you need the copy, not the campaign plan.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/ad-creative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/adversarial-reviewer",
-      "name": "adversarial-reviewer",
-      "description": "Adversarial code review that breaks the self-review monoculture. Use when you want a genuinely critical review of recent changes, before merging a PR, or when you suspect Claude is being too agreeable about code quality. Forces perspective shifts through hostile reviewer personas that catch blind spots the author's mental model shares with the reviewer.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/adversarial-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aeo",
-      "name": "aeo",
-      "description": "Answer Engine Optimization (AEO) skill — optimize content to be cited by AI language models (ChatGPT, Perplexity, Claude, Gemini, Mistral) as authoritative sources. Distinct from SEO — AEO optimizes for citation in LLM-generated responses, not search rankings. Use when planning content for AI-first search audiences, auditing existing content for E-E-A-T signals, tracking which pages get cited by which LLMs, or building a citation-friendly content strategy. Triggers — 'AEO audit', 'optimize for ChatGPT', 'get cited by Perplexity', 'LLM citation strategy', 'answer engine optimization', 'content for AI search', 'E-E-A-T audit'. Output is a markdown audit report (default) or JSON for pipeline integration. Stdlib-only Python tools.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/aeo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-designer",
-      "name": "agent-designer",
-      "description": "Use when the user asks to design multi-agent systems, create agent architectures, define agent communication patterns, or build autonomous agent workflows.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/agent-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-protocol",
-      "name": "agent-protocol",
-      "description": "Inter-agent communication protocol for C-suite agent teams. Defines invocation syntax, loop prevention, isolation rules, and response formats. Use when C-suite agents need to query each other, coordinate cross-functional analysis, or run board meetings with multiple agent roles.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/agent-protocol"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agent-workflow-designer",
-      "name": "agent-workflow-designer",
-      "description": "Design production-grade multi-agent workflows with clear pattern choice (sequential, parallel, hierarchical), handoff contracts, failure handling, and cost/context controls. Use when architecting a multi-step agent pipeline, choosing between single-agent vs multi-agent approaches, or refactoring an LLM workflow that suffers from context bloat or unreliable handoffs.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/agent-workflow-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agenthub",
-      "name": "agenthub",
-      "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/agenthub"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/agile-product-owner",
-      "name": "agile-product-owner",
-      "description": "Agile product ownership for backlog management and sprint execution. Covers user story writing, acceptance criteria, sprint planning, and velocity tracking. Use for writing user stories, creating acceptance criteria, planning sprints, estimating story points, breaking down epics, or prioritizing backlog.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/agile-product-owner/skills/agile-product-owner"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-act-readiness",
-      "name": "ai-act-readiness",
-      "description": "/cs:ai-act-readiness <system> — EU AI Act 6-question forcing interrogation. Use during AI-system intake, before EU deployment, or during annual compliance refresh as Article 113 obligations phase in (2025-02-02 / 2025-08-02 / 2026-08-02 / 2027-08-02).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/ai-act-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-security",
-      "name": "ai-security",
-      "description": "Use when assessing AI/ML systems for prompt injection, jailbreak vulnerabilities, model inversion risk, data poisoning exposure, or agent tool abuse. Covers MITRE ATLAS technique mapping, injection signature detection, and adversarial robustness scoring.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/ai-security"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ai-seo",
-      "name": "ai-seo",
-      "description": "Optimize content to get cited by AI search engines — ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, Copilot. Use when you want your content to appear in AI-generated answers, not just ranked in blue links. Triggers: 'optimize for AI search', 'get cited by ChatGPT', 'AI Overviews', 'Perplexity citations', 'AI SEO', 'generative search', 'LLM visibility', 'GEO' (generative engine optimization). NOT for traditional SEO ranking (use seo-audit). NOT for content creation (use content-production).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/ai-seo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aims-audit",
-      "name": "aims-audit",
-      "description": "/cs:aims-audit <scope> — ISO/IEC 42001 AIMS internal-audit 6-question forcing interrogation. Use before certification stage 1, before annual internal audit cycles, or when onboarding a new AI system into an existing AIMS.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/aims-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/analytics-tracking",
-      "name": "analytics-tracking",
-      "description": "Set up, audit, and debug analytics tracking implementation — GA4, Google Tag Manager, event taxonomy, conversion tracking, and data quality. Use when building a tracking plan from scratch, auditing existing analytics for gaps or errors, debugging missing events, or setting up GTM. Trigger keywords: GA4 setup, Google Tag Manager, GTM, event tracking, analytics implementation, conversion tracking, tracking plan, event taxonomy, custom dimensions, UTM tracking, analytics audit, missing events, tracking broken. NOT for analyzing marketing campaign data — use campaign-analytics for that. NOT for BI dashboards — use product-analytics for in-product event analysis.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/analytics-tracking"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/andreessen",
-      "name": "andreessen",
-      "description": "Marc Andreessen-mode decision and productivity skill. A blunt, market-first operator that pressure-tests ideas, ventures, features, and career bets through Andreessen's actual frameworks — market dominates team and product; the only milestone that matters is product/market fit; bias to build over deliberate. Use when the user says 'andreessen', 'pmarca mode', 'should I build this', 'is there a market', 'are we at product/market fit', 'pmf check', 'pressure-test this idea', 'be brutal about this venture', 'market-first take', or wants a no-disclaimers, no-hedging, confidence-leveled verdict on whether something is worth pursuing. Also provides the 3x5-card + Anti-Todo personal productivity routine. Runs on a fixed anti-sycophancy operating prompt: leads with the strongest counterargument, never validates premises, uses explicit confidence levels, never apologizes for disagreeing. Not for polite brainstorming — this skill exists to tell you the market is dead when it is.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/andreessen/skills/andreessen"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/api-design-reviewer",
-      "name": "api-design-reviewer",
-      "description": "Comprehensive REST API design review with automated linting, breaking-change detection, and design scorecards. Catches inconsistent conventions, missing versioning, and design smells before APIs ship. Use when reviewing a PR that adds or changes API endpoints, auditing an existing API for v2 migration, or establishing API standards for a team.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/api-design-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/api-test-suite-builder",
-      "name": "api-test-suite-builder",
-      "description": "Use when the user asks to generate API tests, create integration test suites, test REST endpoints, or build contract tests.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/api-test-suite-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/app-store-optimization",
-      "name": "app-store-optimization",
-      "description": "App Store Optimization (ASO) toolkit for researching keywords, analyzing competitor rankings, generating metadata suggestions, and improving app visibility on Apple App Store and Google Play Store. Use when the user asks about ASO, app store rankings, app metadata, app titles and descriptions, app store listings, app visibility, or mobile app marketing on iOS or Android. Supports keyword research and scoring, competitor keyword analysis, metadata optimization, A/B test planning, launch checklists, and tracking ranking changes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/app-store-optimization"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/apple-hig-expert",
-      "name": "apple-hig-expert",
-      "description": "Expert guidance on Apple Human Interface Guidelines (HIG). Covers iOS, macOS, and visionOS with 2026 Liquid Glass aesthetics and accessibility-first design.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/apple-hig-expert/skills/apple-hig-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/atlassian-admin",
-      "name": "atlassian-admin",
-      "description": "Atlassian Administrator for managing and organizing Atlassian products (Jira, Confluence, Bitbucket, Trello), users, permissions, security, integrations, system configuration, and org-wide governance. Use when asked to add users to Jira, change Confluence permissions, configure access control, update admin settings, manage Atlassian groups, set up SSO, install marketplace apps, review security policies, or handle any org-wide Atlassian administration task.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/atlassian-admin"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/atlassian-templates",
-      "name": "atlassian-templates",
-      "description": "Atlassian Template and Files Creator/Modifier expert for creating, modifying, and managing Jira and Confluence templates, blueprints, custom layouts, reusable components, and standardized content structures. Use when building org-wide templates, custom blueprints, page layouts, and automated content generation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/atlassian-templates"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/autoresearch-agent",
-      "name": "autoresearch-agent",
-      "description": "Autonomous experiment loop that optimizes any file by a measurable metric. Inspired by Karpathy's autoresearch. The agent edits a target file, runs a fixed evaluation, keeps improvements (git commit), discards failures (git reset), and loops indefinitely. Use when: user wants to optimize code speed, reduce bundle/image size, improve test pass rate, optimize prompts, improve content quality (headlines, copy, CTR), or run any measurable improvement loop. Requires: a target file, an evaluation command that outputs a metric, and a git repo.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/autoresearch-agent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/aws-solution-architect",
-      "name": "aws-solution-architect",
-      "description": "Design AWS architectures for startups using serverless patterns and IaC templates. Use when asked to design serverless architecture, create CloudFormation templates, optimize AWS costs, set up CI/CD pipelines, or migrate to AWS. Covers Lambda, API Gateway, DynamoDB, ECS, Aurora, and cost optimization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/aws-solution-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/azure-cloud-architect",
-      "name": "azure-cloud-architect",
-      "description": "Design Azure architectures for startups and enterprises. Use when asked to design Azure infrastructure, create Bicep/ARM templates, optimize Azure costs, set up Azure DevOps pipelines, or migrate to Azure. Covers AKS, App Service, Azure Functions, Cosmos DB, and cost optimization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/azure-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/behuman",
-      "name": "behuman",
-      "description": "Use when the user wants more human-like AI responses — less robotic, less listy, more authentic. Triggers: 'behuman', 'be real', 'like a human', 'more human', 'less AI', 'talk like a person', 'mirror mode', 'stop being so AI', or when conversations are emotionally charged (grief, job loss, relationship advice, fear). NOT for technical questions, code generation, or factual lookups.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/behuman/skills/behuman"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board",
-      "name": "board",
-      "description": "Read, write, and browse the AgentHub message board for agent coordination.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/board"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-deck-builder",
-      "name": "board-deck-builder",
-      "description": "Assembles comprehensive board and investor update decks by pulling perspectives from all C-suite roles. Use when preparing board meetings, investor updates, quarterly business reviews, or fundraising narratives. Covers structure, narrative framework, bad news delivery, and common mistakes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/board-deck-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-meeting",
-      "name": "board-meeting",
-      "description": "Multi-agent board meeting protocol for strategic decisions. Runs a structured 6-phase deliberation: context loading, independent C-suite contributions (isolated, no cross-pollination), critic analysis, synthesis, founder review, and decision extraction. Use when the user invokes /cs:board, calls a board meeting, or wants structured multi-perspective executive deliberation on a strategic question.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/board-meeting"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/board-prep",
-      "name": "board-prep",
-      "description": "Board meeting preparation for the adversarial scenario, not the friendly one. Forces numbers-cold mastery, anticipates hard questions, builds a narrative that acknowledges weakness without losing the room. Use when preparing for a board meeting, an investor update, fundraising presentation, or any high-stakes adversarial review where every number must live in your head not just on a slide.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/board-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/boardroom",
-      "name": "boardroom",
-      "description": "/cs:boardroom <brief> — 6-phase multi-role deliberation across the C-suite with Phase 2 isolation, critic pre-screen, and synthesis. Outputs a board memo.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/boardroom"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/brand-guidelines",
-      "name": "brand-guidelines",
-      "description": "When the user wants to apply, document, or enforce brand guidelines for any product or company. Also use when the user mentions 'brand guidelines,' 'brand colors,' 'typography,' 'logo usage,' 'brand voice,' 'visual identity,' 'tone of voice,' 'brand standards,' 'style guide,' 'brand consistency,' or 'company design standards.' Covers color systems, typography, logo rules, imagery guidelines, and tone matrix for any brand — including Anthropic's official identity.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/brand-guidelines"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/brief",
-      "name": "brief",
-      "description": "/cs:brief <topic> — Generate a one-page strategy brief from an office-hours intake. First step in the strategic sprint pipeline.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/brief"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/browser-automation",
-      "name": "browser-automation",
-      "description": "Use when the user asks to automate browser tasks, scrape websites, fill forms, capture screenshots, extract structured data from web pages, or build web automation workflows. NOT for testing — use playwright-pro for that.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/browser-automation"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/browserstack",
-      "name": "browserstack",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/browserstack"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-growth-skills",
-      "name": "business-growth-skills",
-      "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-growth/skills/business-growth-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-investment-advisor",
-      "name": "business-investment-advisor",
-      "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "finance/business-investment-advisor/skills/business-investment-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/business-operations-skills",
-      "name": "business-operations-skills",
-      "description": "Use when running, diagnosing, or designing internal business operations — process documentation, vendor SLAs, capacity planning, internal comms, SOP/runbook authoring, procurement spend. Triggers on \"BizOps review\", \"where's the bottleneck\", \"vendor health\", \"internal SOP\", \"all-hands deck\", \"spend categorization\", \"capacity for Q3\", \"process mapping\". Forks context to route to one of six BizOps sub-skills (process-mapper, vendor-management, capacity-planner, internal-comms, knowledge-ops, procurement-optimizer) and returns a digest. Distinct from business-growth (external sales motion) and c-level-advisor (strategic, not operational).",
-      "tags": [
-        "bizops",
-        "operations",
-        "process",
-        "vendor",
-        "capacity",
-        "sop",
-        "procurement",
-        "coo",
-        "orchestrator"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/business-operations-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/c-level-advisor",
-      "name": "c-level-advisor",
-      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/c-level-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/c-level-agents",
-      "name": "c-level-agents",
-      "description": "Founder-mode executive team. 8 cs-* C-suite agents (CFO, CMO, CRO, CPO, COO, CHRO, CISO, Chief of Staff) and 17 /cs:* slash commands for forcing-question office hours, multi-role boardroom deliberation, strategic sprint pipeline, and meta routing. Use when the founder needs a virtual executive team, when invoking /cs:* commands, or when orchestrating multi-role decisions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/c-level-agents"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/c-level-skills",
-      "name": "c-level-skills",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/c-level-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/caio-review",
-      "name": "caio-review",
-      "description": "/cs:caio-review <plan> — Eval-demanding Chief AI Officer interrogation of any plan that involves AI: model selection, risk classification, cost economics, or AI hiring.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/caio-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/campaign-analytics",
-      "name": "campaign-analytics",
-      "description": "Analyzes campaign performance with multi-touch attribution, funnel conversion analysis, and ROI calculation for marketing optimization. Use when analyzing marketing campaigns, ad performance, attribution models, conversion rates, or calculating marketing ROI, ROAS, CPA, and campaign metrics across channels.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/campaign-analytics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capa-officer",
-      "name": "capa-officer",
-      "description": "CAPA system management for medical device QMS. Covers root cause analysis, corrective action planning, effectiveness verification, and CAPA metrics. Use for CAPA investigations, 5-Why analysis, fishbone diagrams, root cause determination, corrective action tracking, effectiveness verification, or CAPA program optimization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/capa-officer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capacity-planner",
-      "name": "capacity-planner",
-      "description": "Use when an ops leader (Director of CX, Head of Support, VP Ops, Head of BizOps, Head of IT ops, Head of Finance ops) is sizing ops capacity, building a headcount plan, modeling utilization risk, planning Q3 capacity or annual support capacity, or designing CS coverage — and needs Erlang-C queueing math, P90 demand sizing, shrinkage-adjusted FTE, manager-trigger thresholds, and a quarterly hiring sequence with ramp + attrition. Apply when sustained team utilization is above 80% or when the team is growing >50% in 12 months. Run before committing the headcount budget. This is NOT engineering capacity (see vpe-advisor for DORA + cycle time) and NOT strategic 3-year workforce planning (see chro-advisor).",
-      "tags": [
-        "bizops",
-        "capacity",
-        "headcount",
-        "utilization",
-        "queueing-theory",
-        "ops-planning",
-        "little-law",
-        "workforce"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/capacity-planner"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/capture",
-      "name": "capture",
-      "description": "Captures and organizes chaotic brain dumps into a structured, actionable system with zero information loss. Use this skill whenever the user says 'capture this', 'brain dump', 'let me dump some ideas', 'I've got a bunch of thoughts', 'here's everything on my mind', 'idea dump', 'let me get this out of my head', 'I need to organize my thoughts', 'here's what I'm thinking', or any variation where someone is unloading a messy stream of ideas, tasks, thoughts, and plans wanting them turned into something coherent. Also trigger when the user pastes or dictates a long, unstructured block of mixed ideas — even without the exact phrase — the intent is the same. Fast-to-action by design: no upfront intake. Output is four sections (Projects/Ideas, Tasks, Connections, How I Can Help) ending with a directive question. Asks at most one mid-organization clarifying question when a single item is genuinely ambiguous between task and project.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/capture/skills/capture"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/caveman",
-      "name": "caveman",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/caveman/skills/caveman"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cco-review",
-      "name": "cco-review",
-      "description": "/cs:cco-review <plan> — Retention-obsessed Chief Customer Officer interrogation of any plan that touches customer retention, segmentation, CS team sizing, or CS team hiring.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cco-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cdo-review",
-      "name": "cdo-review",
-      "description": "/cs:cdo-review <plan> — Decision-driven Chief Data Officer interrogation of any plan that touches training data, data architecture, data productization, or data team hiring.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cdo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ceo-advisor",
-      "name": "ceo-advisor",
-      "description": "Executive leadership guidance for strategic decision-making, organizational development, and stakeholder management. Use when planning strategy, preparing board presentations, managing investors, developing organizational culture, making executive decisions, fundraising, or when user mentions CEO, strategic planning, board meetings, investor updates, organizational leadership, or executive strategy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/ceo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cfo-advisor",
-      "name": "cfo-advisor",
-      "description": "Financial leadership for startups and scaling companies. Financial modeling, unit economics, fundraising strategy, cash management, and board financial packages. Use when building financial models, analyzing unit economics, planning fundraising, managing cash runway, preparing board materials, or when user mentions CFO, burn rate, runway, fundraising, unit economics, LTV, CAC, term sheets, or financial strategy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cfo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cfo-review",
-      "name": "cfo-review",
-      "description": "/cs:cfo-review <plan> — Numerate-skeptic interrogation of any plan that touches money. Unit economics, runway, dilution, capital allocation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cfo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/challenge",
-      "name": "challenge",
-      "description": "Pre-mortem plan analysis. Imagine the plan failed 12 months from now and work backwards to find the weaknesses. Surfaces assumptions, dependencies, and execution risks before committing resources. Use when before significant resource commitment, before presenting to a board or investors, when feedback has been one-sidedly positive, or when there is pressure to move fast and figure it out later.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/challenge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/change-management",
-      "name": "change-management",
-      "description": "Framework for rolling out organizational changes without chaos. Covers the ADKAR model adapted for startups, communication templates, resistance patterns, and change fatigue management. Handles process changes, org restructures, strategy pivots, and culture changes. Use when announcing a reorg, switching tools, pivoting strategy, killing a product, changing leadership, or when user mentions change management, change rollout, managing resistance, org change, reorg, or pivot communication.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/change-management"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/changelog",
-      "name": "changelog",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/changelog"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/changelog-generator",
-      "name": "changelog-generator",
-      "description": "Produce consistent, auditable release notes from Conventional Commits. Separates commit parsing, semantic-bump logic, and changelog rendering for automated releases with editorial control. Use when cutting a release, generating CHANGELOG.md from git history, or automating release notes in CI.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/changelog-generator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/channel-economics",
-      "name": "channel-economics",
-      "description": "Use when reviewing or rebalancing direct vs. partner-led channel economics — computing fully-loaded cost-to-serve per channel, channel ROI with cash / LTV / marginal lenses, and optimal channel mix subject to constraints. For Head of Commercial, RevOps, and VP Sales doing quarterly channel review when pipeline is mixed (e.g., 60% direct + 40% partner-led) and nobody actually knows which channel makes money after CAC, support load, partner discount, deal-velocity differences, retention differential, and overhead allocation are all loaded in. Outputs cost to serve, channel ROI verdicts (DOUBLE-DOWN / MAINTAIN / DEFUND / EXIT), a sensitivity-tested channel-mix recommendation, and the diminishing-returns inflection. Not channel structure (that's partnerships-architect — tiers, joint GTM, revshare). Not RevOps process (that's business-growth/revenue-operations — lead routing, SDR motion). Not strategic CRO judgment (that's c-level-advisor/cro-advisor — comp plans, when-to-hire-a-VP-Sales). Not historical close-and-report (that's finance/financial-analysis). This skill answers: direct vs partner profitability, channel profitability, channel mix, channel economics.",
-      "tags": [
-        "commercial",
-        "channel-economics",
-        "cost-to-serve",
-        "channel-mix",
-        "channel-roi",
-        "direct-vs-partner",
-        "unit-economics"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/channel-economics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chaos-engineering",
-      "name": "chaos-engineering",
-      "description": "Use when planning, running, or learning from chaos engineering experiments. Triggers on \"chaos experiment\", \"fault injection\", \"gameday\", \"resilience test\", \"blast radius\", \"steady state\", \"abort criteria\", \"Chaos Toolkit\", \"Chaos Mesh\", \"Litmus\", \"Gremlin\", \"AWS FIS\", or any deliberate failure-injection question. Ships experiment designer, blast-radius calculator, and postmortem generator (all stdlib Python), 4 references on chaos principles + experiment design + attack taxonomy + tooling landscape, and a /chaos-experiment slash command. Composes with feature-flags-architect (kill switches as abort triggers) and kubernetes-operator (common chaos targets).",
-      "tags": [
-        "chaos-engineering",
-        "resilience",
-        "fault-injection",
-        "gameday",
-        "sre",
-        "reliability",
-        "chaos-toolkit",
-        "chaos-mesh",
-        "litmus",
-        "gremlin",
-        "aws-fis"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/chaos-engineering/skills/chaos-engineering"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chaos-experiment",
-      "name": "chaos-experiment",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/chaos-experiment"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-ai-officer-advisor",
-      "name": "chief-ai-officer-advisor",
-      "description": "Chief AI Officer advisory for startups: model build-vs-buy decisions (API vs fine-tune vs in-house), AI risk classification under EU AI Act + US state patchwork, AI cost economics (API-to-self-hosted breakeven), and AI team org evolution. Use when deciding whether to call an API or fine-tune, classifying AI use cases for regulatory risk, calculating when self-hosting pays off, sequencing AI hires, or when user mentions CAIO, AI strategy, model selection, foundation model, fine-tuning, EU AI Act, NIST AI RMF, AI governance, model risk, or AI economics. Strategic only — does not duplicate engineering AI/ML skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/chief-ai-officer-advisor/skills/chief-ai-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-customer-officer-advisor",
-      "name": "chief-customer-officer-advisor",
-      "description": "Chief Customer Officer advisory for startups: retention decomposition (gross retention vs NRR honesty, churn root-cause taxonomy), customer segmentation strategy (differential investment across tiers + ICP fit scoring), CS team coverage model (pooled vs named CSM thresholds + ratio math), and CS team org evolution (CS vs Support vs AM distinctions). Use when designing retention strategy, segmenting customers for differential investment, sizing CS team, or sequencing CS hires. Strategic only — does not duplicate engineering/business-growth tactical skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/chief-customer-officer-advisor/skills/chief-customer-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-data-officer-advisor",
-      "name": "chief-data-officer-advisor",
-      "description": "Chief Data Officer advisory for startups: AI training data rights and consent provenance, data product strategy (warehouse vs lakehouse vs mesh, build-vs-buy), B2B customer-data-as-asset valuation and M&A readiness, data team org evolution. Use when deciding whether to train models on customer data, choosing data architecture, valuing data for fundraising or M&A, sequencing data hires, or when user mentions CDO, chief data officer, data strategy, data mesh, lakehouse, training data, data product, data monetization, or customer data asset. NOT a tactical data engineering skill — strategic decisions only.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/chief-data-officer-advisor/skills/chief-data-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chief-of-staff",
-      "name": "chief-of-staff",
-      "description": "C-suite orchestration layer. Routes founder questions to the right advisor role(s), triggers multi-role board meetings for complex decisions, synthesizes outputs, and tracks decisions. Every C-suite interaction starts here. Loads company context automatically.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/chief-of-staff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/chro-advisor",
-      "name": "chro-advisor",
-      "description": "People leadership for scaling companies. Hiring strategy, compensation design, org structure, culture, and retention. Use when building hiring plans, designing comp frameworks, restructuring teams, managing performance, building culture, or when user mentions CHRO, HR, people strategy, talent, headcount, compensation, org design, retention, or performance management.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/chro-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/churn-prevention",
-      "name": "churn-prevention",
-      "description": "Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save offers, setting up dunning emails, or reducing failed-payment churn. Trigger keywords: cancel flow, churn reduction, save offers, dunning, exit survey, payment recovery, win-back, involuntary churn, failed payments, cancel page. NOT for customer health scoring or expansion revenue — use customer-success-manager for that.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/churn-prevention"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ci-cd-pipeline-builder",
-      "name": "ci-cd-pipeline-builder",
-      "description": "Generate pragmatic CI/CD pipelines from detected project stack signals — fast baseline generation, repeatable checks, environment-aware deployment stages. Use when setting up CI for a new project, refactoring existing pipelines, or standardizing deployment workflows across multiple repos.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/ci-cd-pipeline-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ciso-advisor",
-      "name": "ciso-advisor",
-      "description": "Security leadership for growth-stage companies. Risk quantification in dollars, compliance roadmap (SOC 2/ISO 27001/HIPAA/GDPR), security architecture strategy, incident response leadership, and board-level security reporting. Use when building security programs, justifying security budget, selecting compliance frameworks, managing incidents, assessing vendor risk, or when user mentions CISO, security strategy, compliance roadmap, zero trust, or board security reporting.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/ciso-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ciso-review",
-      "name": "ciso-review",
-      "description": "/cs:ciso-review <plan> — Risk-paranoid interrogation of any plan that touches data, compliance, or production access.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/ciso-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/claude-coach",
-      "name": "claude-coach",
-      "description": "Personal coach that teaches users to become Claude power users. Use this skill the FIRST time a user asks to \"learn Claude\", \"be a power user\", \"coach me\", \"teach me Claude tricks\", \"what can Claude do\", \"make me better at prompting\", or any variation. After activation, also use it on EVERY subsequent turn to detect missed optimization opportunities (vague prompts, ignored capabilities, manual work Claude could automate) and surface a single power-user tip. Trigger generously — most users do not know what they do not know, so err on the side of coaching.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/claude-coach/skills/claude-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/clinical-research",
-      "name": "clinical-research",
-      "description": "Use when designing a prospective clinical study before submission — selecting and classifying endpoints (primary / key-secondary / exploratory, with surrogate-endpoint flagging), estimating sample size and power for two-arm designs (means / proportions / survival), or scoring a study plan for feasibility and a GO / GO-WITH-CONDITIONS / REDESIGN / NO-GO phase-gate decision. Every output is an ESTIMATE plus a named human owner (clinician / biostatistician / regulatory owner) — never clinical fact, never a finished protocol. Distinct from ra-qm-team, which handles the regulatory/QM submission (ISO 13485, EU MDR, FDA 510(k)/PMA/QSR), not the study design.",
-      "tags": [
-        "research-ops",
-        "clinical-research",
-        "study-design",
-        "endpoint",
-        "sample-size",
-        "power",
-        "phase-gate",
-        "biostatistics"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research-ops/skills/clinical-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cloud-security",
-      "name": "cloud-security",
-      "description": "Use when assessing cloud infrastructure for security misconfigurations, IAM privilege escalation paths, S3 public exposure, open security group rules, or IaC security gaps. Covers AWS, Azure, and GCP posture assessment with MITRE ATT&CK mapping.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/cloud-security"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmd-a11y-audit",
-      "name": "cmd-a11y-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmd-a11y-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmd-code-to-prd",
-      "name": "cmd-code-to-prd",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmd-code-to-prd"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmd-cs-aeo",
-      "name": "cmd-cs-aeo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmd-cs-aeo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmd-focused-fix",
-      "name": "cmd-focused-fix",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cmd-focused-fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmo-advisor",
-      "name": "cmo-advisor",
-      "description": "Marketing leadership for scaling companies. Brand positioning, growth model design, marketing budget allocation, and marketing org design. Use when designing brand strategy, selecting growth models (PLG vs sales-led vs community-led), allocating marketing budgets, building marketing teams, or when user mentions CMO, brand strategy, growth model, CAC, LTV, channel mix, or marketing ROI.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cmo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cmo-review",
-      "name": "cmo-review",
-      "description": "/cs:cmo-review <plan> — Narrative-first interrogation of positioning, ICP, message house, and channel mix.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cmo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-reviewer",
-      "name": "code-reviewer",
-      "description": "Code review automation for TypeScript, JavaScript, Python, Go, Swift, Kotlin, C#, .NET, Java, C, C++, Rust, Ruby, PHP, and Dart/Flutter. Analyzes PRs for complexity and risk, checks code quality for SOLID violations and code smells, generates review reports. Use when reviewing pull requests, analyzing code quality, identifying issues, generating review checklists.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/code-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-to-prd",
-      "name": "code-to-prd",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/code-to-prd/skills/code-to-prd"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/code-tour",
-      "name": "code-tour",
-      "description": "Use when the user asks to create a CodeTour .tour file — persona-targeted, step-by-step walkthroughs that link to real files and line numbers. Trigger for: create a tour, onboarding tour, architecture tour, PR review tour, explain how X works, vibe check, RCA tour, contributor guide, or any structured code walkthrough request.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/code-tour/skills/code-tour"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/codebase-onboarding",
-      "name": "codebase-onboarding",
-      "description": "Analyze a codebase and generate onboarding documentation for engineers, tech leads, and contractors. Fast fact-gathering and repeatable onboarding outputs. Use when onboarding a new engineer, writing architecture-overview docs for a new project, or producing tech-lead briefings for unfamiliar repos.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/codebase-onboarding"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cold-email",
-      "name": "cold-email",
-      "description": "When the user wants to write, improve, or build a sequence of B2B cold outreach emails to prospects who haven't asked to hear from them. Use when the user mentions 'cold email,' 'cold outreach,' 'prospecting emails,' 'SDR emails,' 'sales emails,' 'first touch email,' 'follow-up sequence,' or 'email prospecting.' Also use when they share an email draft that sounds too sales-y and needs to be humanized. Distinct from email-sequence (lifecycle/nurture to opted-in subscribers) — this is unsolicited outreach to new prospects. NOT for lifecycle emails, newsletters, or drip campaigns (use email-sequence).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/cold-email"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/command-guide",
-      "name": "command-guide",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/command-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-forecaster",
-      "name": "commercial-forecaster",
-      "description": "Use when building a quarterly bookings forecast, ARR projection, pipeline forecast, NRR projection, or commit/best-case/pipe-only board number — especially when the CRO needs to walk the board through funnel math + cohort ARR + per-stage conversion assumptions without the theatre of a single undefended number. Decomposes pipeline into commit, best-case, and pipe-only tiers; projects cohort-level NRR/GRR to surface leaky cohorts before they show up in the consolidated number; scores per-stage funnel confidence so soft-floor stages get treated differently from high-confidence ones. Every output explicitly names the conversion rate used, the data window, and the weighting choice. For Head of Commercial, RevOps, VP Sales, and CRO at quarterly forecast or board prep. NOT financial close (see finance/financial-analysis). NOT strategic CRO hiring/territory (see c-level-advisor/cro-advisor). NOT pricing (see sibling pricing-strategist).",
-      "tags": [
-        "commercial",
-        "forecasting",
-        "bookings",
-        "arr",
-        "nrr",
-        "grr",
-        "cohort",
-        "funnel",
-        "pipeline-math"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/commercial-forecaster"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-policy",
-      "name": "commercial-policy",
-      "description": "Use when designing or revising a company's commercial policy — the rules of engagement governing discounts off list price, approver thresholds, exception flows, and the deal framework that Deal Desk and AEs operate under. Covers discount matrix design (ARR band x term length x payment terms x strategic value), commercial policy design, exception policy, discount governance, approval thresholds, deal framework structure, and policy linting (contradictions, gaps, cliff edges, gaming surfaces). For Head of Commercial, Head of Deal Desk, VP Sales, or RevOps at the policy-design moment — NOT per-deal application (that is deal-desk) and NOT pricing model selection (that is pricing-strategist).",
-      "tags": [
-        "commercial",
-        "discount-policy",
-        "discount-matrix",
-        "exception-flow",
-        "governance",
-        "deal-framework",
-        "commercial-discipline"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/commercial-policy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/commercial-skills",
-      "name": "commercial-skills",
-      "description": "Use when reviewing, approving, or designing commercial motion — pricing models, deal review, discount approval, partnership economics, channel mix, commercial policy, RFP/RFI response, bookings forecast. Triggers on \"review this deal\", \"should we discount\", \"pricing model\", \"partner economics\", \"RFP response\", \"bookings forecast\", \"channel mix\". Forks context to route to one of seven Commercial sub-skills (pricing-strategist, deal-desk, partnerships-architect, channel-economics, commercial-policy, rfp-responder, commercial-forecaster) and returns a digest. Distinct from business-growth (sales execution) and c-level-advisor/cro-advisor (strategic CRO judgment).",
-      "tags": [
-        "commercial",
-        "pricing",
-        "deal-desk",
-        "partnerships",
-        "channel",
-        "rfp",
-        "forecast",
-        "cro",
-        "orchestrator"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/commercial-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/company-os",
-      "name": "company-os",
-      "description": "The meta-framework for how a company runs — the connective tissue between all C-suite roles. Covers operating system selection (EOS, Scaling Up, OKR-native, hybrid), accountability charts, scorecards, meeting pulse, issue resolution, and 90-day rocks. Use when setting up company operations, selecting a management framework, designing meeting rhythms, building accountability systems, implementing OKRs, or when user mentions EOS, Scaling Up, operating system, L10 meetings, rocks, scorecard, accountability chart, or quarterly planning.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/company-os"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitive-intel",
-      "name": "competitive-intel",
-      "description": "Systematic competitor tracking that feeds CMO positioning, CRO battlecards, and CPO roadmap decisions. Use when analyzing competitors, building sales battlecards, tracking market moves, positioning against alternatives, or when user mentions competitive intelligence, competitive analysis, competitor research, battlecards, win/loss, or market positioning.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/competitive-intel"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitive-matrix",
-      "name": "competitive-matrix",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/competitive-matrix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitive-teardown",
-      "name": "competitive-teardown",
-      "description": "Analyzes competitor products and companies by synthesizing data from pricing pages, app store reviews, job postings, SEO signals, and social media into structured competitive intelligence. Produces feature comparison matrices scored across 12 dimensions, SWOT analyses, positioning maps, UX audits, pricing model breakdowns, action item roadmaps, and stakeholder presentation templates. Use when conducting competitor analysis, comparing products against competitors, researching the competitive landscape, building battle cards for sales, preparing for a product strategy or roadmap session, responding to a competitor's new feature or pricing change, or performing a quarterly competitive review.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/competitive-teardown"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/competitor-alternatives",
-      "name": "competitor-alternatives",
-      "description": "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'switch from competitor,' or 'comparison content.' Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. Emphasizes deep research, modular content architecture, and varied section types beyond feature tables.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/competitor-alternatives"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/compliance-os",
-      "name": "compliance-os",
-      "description": "Compliance OS — meta-orchestrator that lets compliance teams CONFIGURE which frameworks apply, COMPUTE cross-framework control overlap, SIMULATE internal audits, and CONSOLIDATE evidence across multiple frameworks. Four decisions: (1) Given a company profile, which of the 12 supported frameworks apply (ISO 27001/13485/42001/14971, EU AI Act, MDR 745, GDPR, SOC 2, FDA QSR, NIST CSF 2.0, NIS2, HIPAA)? (2) Across selected frameworks, which controls overlap and how much evidence reuses? (3) For a given framework + scope, what does a realistic mock audit produce — drawing from the 205-scenario library? (4) Across selected frameworks, what's the unified evidence checklist with reuse map? Use when standing up a multi-framework program, planning the annual audit calendar, or preparing for certification stage 1. Does NOT replace per-framework skills (it orchestrates them).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/compliance-os"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/compliance-os-bundle",
-      "name": "compliance-os-bundle",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/compliance-os-bundle"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/compliance-readiness",
-      "name": "compliance-readiness",
-      "description": "/cs:compliance-readiness <program> — Multi-framework compliance officer 6-question forcing interrogation of any compliance program. Use before starting a new framework, planning the annual audit calendar, or preparing for certification stage 1.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/compliance-readiness"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/confluence-expert",
-      "name": "confluence-expert",
-      "description": "Atlassian Confluence expert for creating and managing spaces, knowledge bases, and documentation. Configures space permissions and hierarchies, creates page templates with macros, sets up documentation taxonomies, designs page layouts, and manages content governance. Use when users need to build or restructure a Confluence space, design page hierarchies with permission structures, author or standardise documentation templates, embed Jira reports in pages, run knowledge base audits, or establish documentation standards and collaborative workflows.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/confluence-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-creator",
-      "name": "content-creator",
-      "description": "Deprecated redirect skill that routes legacy 'content creator' requests to the correct specialist. Use when a user invokes 'content creator', asks to write a blog post, article, guide, or brand voice analysis (routes to content-production), or asks to plan content, build a topic cluster, or create a content calendar (routes to content-strategy). Does not handle requests directly — identifies user intent and redirects to content-production for writing/SEO/brand-voice tasks or content-strategy for planning tasks.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/content-creator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-humanizer",
-      "name": "content-humanizer",
-      "description": "Makes AI-generated content sound genuinely human — not just cleaned up, but alive. Use when content feels robotic, uses too many AI clichés, lacks personality, or reads like it was written by committee. Triggers: 'this sounds like AI', 'make it more human', 'add personality', 'it feels generic', 'sounds robotic', 'fix AI writing', 'inject our voice'. NOT for initial content creation (use content-production). NOT for SEO optimization (use content-production Mode 3).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/content-humanizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-production",
-      "name": "content-production",
-      "description": "Full content production pipeline — takes a topic from blank page to published-ready piece. Use when you need to execute content: write a blog post, article, or guide end-to-end. Triggers: 'write a post about', 'draft an article', 'create content for', 'help me write', 'I need a blog post'. NOT for content strategy or calendar planning (use content-strategy). NOT for repurposing existing content (use content-repurposing). NOT for social captions only.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/content-production"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-strategist",
-      "name": "content-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/content-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/content-strategy",
-      "name": "content-strategy",
-      "description": "When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions \\\"content strategy,\\\" \\\"what should I write about,\\\" \\\"content ideas,\\\" \\\"blog strategy,\\\" \\\"topic clusters,\\\" or \\\"content planning.\\\" For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/content-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/context-engine",
-      "name": "context-engine",
-      "description": "Loads and manages company context for all C-suite advisor skills. Reads ~/.claude/company-context.md, detects stale context (>90 days), enriches context during conversations, and enforces privacy/anonymization rules before external API calls.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/context-engine"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/contract-and-proposal-writer",
-      "name": "contract-and-proposal-writer",
-      "description": "Generate professional, jurisdiction-aware business documents: freelance contracts, project proposals, SOWs, NDAs, and MSAs. Structured Markdown output with docx conversion instructions. Covers US (Delaware), EU (GDPR), UK, and DACH (German law) jurisdictions. Not a substitute for legal counsel — use as strong starting points. Use when drafting a freelance contract, preparing a client proposal, writing an SOW for a new engagement, or producing an NDA before sharing sensitive material.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-growth/skills/contract-and-proposal-writer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/coo-advisor",
-      "name": "coo-advisor",
-      "description": "Operations leadership for scaling companies. Process design, OKR execution, operational cadence, and scaling playbooks. Use when designing operations, setting up OKRs, building processes, scaling teams, analyzing bottlenecks, planning operational cadence, or when user mentions COO, operations, process improvement, OKRs, scaling, operational efficiency, or execution.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/coo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/copy-editing",
-      "name": "copy-editing",
-      "description": "When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish this,' 'make this better,' or 'copy sweep.' This skill provides a systematic approach to editing marketing copy through multiple focused passes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/copy-editing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/copywriting",
-      "name": "copywriting",
-      "description": "When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says \\\"write copy for,\\\" \\\"improve this copy,\\\" \\\"rewrite this page,\\\" \\\"marketing copy,\\\" \\\"headline help,\\\" or \\\"CTA copy.\\\" For email copy, see email-sequence. For popup copy, see popup-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/copywriting"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/coverage",
-      "name": "coverage",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/coverage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cpo-advisor",
-      "name": "cpo-advisor",
-      "description": "Product leadership for scaling companies. Product vision, portfolio strategy, product-market fit, and product org design. Use when setting product vision, managing a product portfolio, measuring PMF, designing product teams, prioritizing at the portfolio level, reporting to the board on product, or when user mentions CPO, product strategy, product-market fit, product organization, portfolio prioritization, or roadmap strategy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cpo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cpo-review",
-      "name": "cpo-review",
-      "description": "/cs:cpo-review <plan> — JTBD-driven interrogation of product roadmap, PMF signal, and portfolio focus.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cpo-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cro-advisor",
-      "name": "cro-advisor",
-      "description": "Revenue leadership for B2B SaaS companies. Revenue forecasting, sales model design, pricing strategy, net revenue retention, and sales team scaling. Use when designing the revenue engine, setting quotas, modeling NRR, evaluating pricing, building board forecasts, or when user mentions CRO, chief revenue officer, revenue strategy, sales model, ARR growth, NRR, expansion revenue, churn, pricing strategy, or sales capacity.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cro-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cro-review",
-      "name": "cro-review",
-      "description": "/cs:cro-review <plan> — Pipeline-paranoid interrogation of revenue, win rate, NRR, and ramp time.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cro-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cross-eval",
-      "name": "cross-eval",
-      "description": "/cs:cross-eval <memo> — Multi-model consensus on a board memo or strategy brief. Claude + Codex + Gemini cross-review with graceful degradation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cross-eval"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-aeo",
-      "name": "cs-aeo",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-aeo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-agile-product-owner",
-      "name": "cs-agile-product-owner",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-agile-product-owner"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-backend-engineer",
-      "name": "cs-backend-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-backend-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-backend-review",
-      "name": "cs-backend-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-backend-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-ceo-advisor",
-      "name": "cs-ceo-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-ceo-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-content-creator",
-      "name": "cs-content-creator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-content-creator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-cto-advisor",
-      "name": "cs-cto-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-cto-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-demand-gen-specialist",
-      "name": "cs-demand-gen-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-demand-gen-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-engineer-grill",
-      "name": "cs-engineer-grill",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-engineer-grill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-engineering-lead",
-      "name": "cs-engineering-lead",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-engineering-lead"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-financial-analyst",
-      "name": "cs-financial-analyst",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-financial-analyst"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-frontend-engineer",
-      "name": "cs-frontend-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-frontend-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-frontend-review",
-      "name": "cs-frontend-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-frontend-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-fullstack-engineer",
-      "name": "cs-fullstack-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-fullstack-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-fullstack-review",
-      "name": "cs-fullstack-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-fullstack-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-growth-strategist",
-      "name": "cs-growth-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-growth-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-karpathy-reviewer",
-      "name": "cs-karpathy-reviewer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-karpathy-reviewer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-onboard",
-      "name": "cs-onboard",
-      "description": "Founder onboarding interview that captures company context across 7 dimensions. Invoke with /cs:setup for initial interview or /cs:update for quarterly refresh. Generates ~/.claude/company-context.md used by all C-suite advisor skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cs-onboard"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-product-analyst",
-      "name": "cs-product-analyst",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-product-analyst"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-product-manager",
-      "name": "cs-product-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-product-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-product-strategist",
-      "name": "cs-product-strategist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-product-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-project-manager",
-      "name": "cs-project-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-project-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-quality-regulatory",
-      "name": "cs-quality-regulatory",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-quality-regulatory"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-senior-engineer",
-      "name": "cs-senior-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-senior-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-ux-researcher",
-      "name": "cs-ux-researcher",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-ux-researcher"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-wiki-ingestor",
-      "name": "cs-wiki-ingestor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-wiki-ingestor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-wiki-librarian",
-      "name": "cs-wiki-librarian",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-wiki-librarian"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-wiki-linter",
-      "name": "cs-wiki-linter",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-wiki-linter"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cs-workspace-admin",
-      "name": "cs-workspace-admin",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/cs-workspace-admin"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cto-advisor",
-      "name": "cto-advisor",
-      "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/cto-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/cto-review",
-      "name": "cto-review",
-      "description": "/cs:cto-review <plan> — Architecture and scaling interrogation. Tech debt, scaling cliffs, team scaling, build-vs-buy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/cto-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/culture-architect",
-      "name": "culture-architect",
-      "description": "Build, measure, and evolve company culture as operational behavior — not wall posters. Covers mission/vision/values workshops, values-to-behaviors translation, culture code creation, culture health assessment, and cultural rituals by stage. Use when building company values, assessing culture health, designing cultural rituals, creating culture codes, handling culture clashes, or when user mentions culture, values, culture debt, founder culture, or culture code.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/culture-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/customer-success-manager",
-      "name": "customer-success-manager",
-      "description": "Monitors customer health, predicts churn risk, and identifies expansion opportunities using weighted scoring models for SaaS customer success. Use when analyzing customer accounts, reviewing retention metrics, scoring at-risk customers, or when the user mentions churn, customer health scores, upsell opportunities, expansion revenue, retention analysis, or customer analytics. Runs three Python CLI tools to produce deterministic health scores, churn risk tiers, and prioritized expansion recommendations across Enterprise, Mid-Market, and SMB segments.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-growth/skills/customer-success-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/data-quality-auditor",
-      "name": "data-quality-auditor",
-      "description": "Audit datasets for completeness, consistency, accuracy, and validity. Profile data distributions, detect anomalies and outliers, surface structural issues, and produce an actionable remediation plan.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/data-quality-auditor/skills/data-quality-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/database-designer",
-      "name": "database-designer",
-      "description": "Use when the user asks to design database schemas, plan data migrations, optimize queries, choose between SQL and NoSQL, or model data relationships.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/database-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/database-schema-designer",
-      "name": "database-schema-designer",
-      "description": "Use when the user asks to create ERD diagrams, normalize database schemas, design table relationships, or plan schema migrations.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/database-schema-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/deal-desk",
-      "name": "deal-desk",
-      "description": "Use when reviewing a specific inbound deal before close — when sales has asked for a discount that exceeds AE authority, when the customer has redlined the MSA, when per-deal economics (margin after discount, multi-year payment shape, indemnity exposure) need to be quantified, or when discount approval needs to be routed to a named human approver (Sales Director, VP Sales, CFO, CRO, General Counsel). Covers deal review, discount approval routing, per-deal margin scoring, deal exception handling, MSA redline triage, contract landmine detection (uncapped indemnity, MFN, perpetual license-back, missing DPA), and named-approver chain assembly. NEVER auto-approves — every output is a numeric scorecard plus a routing recommendation to a named human.",
-      "tags": [
-        "commercial",
-        "deal-desk",
-        "discount",
-        "margin",
-        "approval",
-        "redline",
-        "msa",
-        "terms"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/deal-desk"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/decide",
-      "name": "decide",
-      "description": "/cs:decide <memo> — Log a decision to two-layer memory via decision-logger. Approved memo becomes durable; raw transcripts kept for reference.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/decide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/decision-logger",
-      "name": "decision-logger",
-      "description": "Two-layer memory architecture for board meeting decisions. Manages raw transcripts (Layer 1) and approved decisions (Layer 2). Use when logging decisions after a board meeting, reviewing past decisions with /cs:decisions, or checking overdue action items with /cs:review. Invoked automatically by the board-meeting skill after Phase 5 founder approval.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/decision-logger"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/demo-video",
-      "name": "demo-video",
-      "description": "Use when the user asks to create a demo video, product walkthrough, feature showcase, animated presentation, marketing video, or GIF from screenshots or scene descriptions. Orchestrates playwright, ffmpeg, and edge-tts MCPs to produce polished video content.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/demo-video/skills/demo-video"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/dependency-auditor",
-      "name": "dependency-auditor",
-      "description": "Audit and manage dependencies across multi-language projects. Identifies vulnerabilities, license conflicts, transitive dependency risks, and safe-upgrade paths. Use when auditing third-party packages before release, investigating a CVE, planning a major version bump, or running a license-compliance review.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/dependency-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/design-system",
-      "name": "design-system",
-      "description": "Captures the user's brand identity once via a 10-question onboarding wizard (primary/accent HEX + heading + body Google Fonts + design style editorial/technical/minimal/playful + default output directory + syntax theme + TOC behavior + optional logo/company), validates body-text and link contrast against WCAG 2.2 AA, derives 12 CSS custom properties in HSL space, and stores the result for every markdown-html converter to consume. Use before any markdown-html conversion. Triggers on first-run onboarding (\"set up the brand\", \"configure markdown-html\", \"run onboarding\"), on explicit reset (\"reset the design system\", \"re-onboard\"), and is checked by every converter via config_loader.py before rendering. Refuses to save if body-text contrast fails AA 4.5:1 or the output dir isn't writable. Precedence: project (./.markdown-html/) > global (~/.config/markdown-html/) > built-in defaults; MARKDOWN_HTML_NO_CONFIG=1 bypasses.",
-      "tags": [
-        "design-system",
-        "brand-palette",
-        "wcag",
-        "onboarding",
-        "customization",
-        "markdown-html",
-        "css-variables",
-        "typography"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "markdown-html/skills/design-system"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/devops-engineer",
-      "name": "devops-engineer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/devops-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/docker-development",
-      "name": "docker-development",
-      "description": "Docker and container development agent skill and plugin for Dockerfile optimization, docker-compose orchestration, multi-stage builds, and container security hardening. Use when: user wants to optimize a Dockerfile, create or improve docker-compose configurations, implement multi-stage builds, audit container security, reduce image size, or follow container best practices. Covers build performance, layer caching, secret management, and production-ready container patterns.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/docker-development/skills/docker-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/dossier",
-      "name": "dossier",
-      "description": "Decision-grade entity research skill — produces a hypothesis-tested dossier on a specific company, person, nonprofit, or government org, not a generic profile. Forcing intake makes the user state their hypothesis upfront (what they already believe and want to verify or disprove) so the dossier tests it rather than confirms it. Output is an editable Word document (.docx) with verdict on the hypothesis, identity facts, 12-month activity timeline, network signals, reputation signals, red flags, 3-5 conversation hooks tied to specific findings, and source-provenance audit log. Uses WebSearch + WebFetch + free APIs (SEC EDGAR, GitHub, ProPublica Nonprofit Explorer) as workhorses; optional BYOK MCPs (LinkedIn, Crunchbase, Apollo, Pitchbook, SimilarWeb) enhance coverage. Triggers: 'research [company]', 'dossier on [person/company]', 'background check on [entity]', 'prep me for a meeting with [person/company]', 'due diligence on [company]', 'what should I know about [entity]', 'research [person] before I [meet/hire/invest]', 'competitor research on [company]', 'investor diligence [company]', 'interview prep for [company]'. Honors sensitivity exclusions for journalism + personal-vetting contexts.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/dossier/skills/dossier"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/email-sequence",
-      "name": "email-sequence",
-      "description": "When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions \"email sequence,\" \"drip campaign,\" \"nurture sequence,\" \"onboarding emails,\" \"welcome sequence,\" \"re-engagement emails,\" \"email automation,\" or \"lifecycle emails.\" For in-app onboarding, see onboarding-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/email-sequence"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/email-template-builder",
-      "name": "email-template-builder",
-      "description": "Build complete transactional email systems: React Email templates, provider integration (Resend, Postmark, SendGrid, AWS SES), preview server, i18n support, dark mode, spam optimization, analytics tracking. Use when adding transactional email to a new product, migrating between email providers, refactoring legacy email templates for accessibility, or adding internationalization to existing templates.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/email-template-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/engineering-advanced-skills",
-      "name": "engineering-advanced-skills",
-      "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/engineering-advanced-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/engineering-skills",
-      "name": "engineering-skills",
-      "description": "23 engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more tools. Architecture, frontend, backend, QA, DevOps, security, AI/ML, data engineering, Playwright, Stripe, AWS, MS365. 30+ Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/engineering-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/env-secrets-manager",
-      "name": "env-secrets-manager",
-      "description": "Manage environment-variable hygiene and secrets safety across local development and production. Practical auditing, drift awareness, rotation readiness. Use when auditing .env files for committed secrets, planning a credential rotation, debugging missing-env-var production incidents, or hardening a new project against secrets leakage.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/env-secrets-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/epic-design",
-      "name": "epic-design",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/epic-design"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/eu-ai-act-specialist",
-      "name": "eu-ai-act-specialist",
-      "description": "EU AI Act (Regulation (EU) 2024/1689) operational compliance for compliance teams. Three Article-level decisions: (1) What's the risk tier of this AI system — prohibited (Art. 5), high-risk (Art. 6 + Annex III), limited-risk (Art. 50), or minimal-risk? (2) For high-risk systems, what's the Article 43 conformity assessment route (Module A internal control vs Module H full QMS + notified body) and what goes in the Annex IV technical documentation? (3) Per organizational role (provider / deployer / importer / distributor / authorized representative), what are the active obligations and deadlines? Use during AI system intake review, when planning conformity assessment, or when scoping deployer obligations. Cites Articles + Annexes for every output. NOT executive AI strategy (see chief-ai-officer-advisor). NOT a legal substitute.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/compliance-team-eu-ai-act/skills/eu-ai-act-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/eval",
-      "name": "eval",
-      "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/eval"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/execute",
-      "name": "execute",
-      "description": "/cs:execute <decision> — Generate a 90-day execution plan with weekly milestones, DRIs, and check-in cadence from an approved decision.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/execute"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/executive-mentor",
-      "name": "executive-mentor",
-      "description": "Adversarial thinking partner for founders and executives. Stress-tests plans, prepares for brutal board meetings, dissects decisions with no good options, and forces honest post-mortems. Use when you need someone to find the holes before the board does, make a decision you've been avoiding, or understand what actually went wrong.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/executive-mentor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/experiment-designer",
-      "name": "experiment-designer",
-      "description": "Use when planning product experiments, writing testable hypotheses, estimating sample size, prioritizing tests, or interpreting A/B outcomes with practical statistical rigor.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/experiment-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/extract",
-      "name": "extract",
-      "description": "Turn a proven pattern or debugging solution into a standalone reusable skill with SKILL.md, reference docs, and examples.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/extract"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fda-consultant-specialist",
-      "name": "fda-consultant-specialist",
-      "description": "FDA regulatory consultant for medical device companies. Provides 510(k)/PMA/De Novo pathway guidance, QSR (21 CFR 820) compliance, HIPAA assessments, and device cybersecurity. Use when user mentions FDA submission, 510(k), PMA, De Novo, QSR, premarket, predicate device, substantial equivalence, HIPAA medical device, or FDA cybersecurity.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/fda-consultant-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fda-qsr-audit-prep",
-      "name": "fda-qsr-audit-prep",
-      "description": "/cs:fda-qsr-audit-prep <scope> — FDA 21 CFR 820 (QSR / QMSR) audit 6-question forcing interrogation. Post-Feb 2026 substantially harmonized with ISO 13485. Use before annual internal QSR audit, pre-FDA-inspection readiness, or Form 483 response.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/fda-qsr-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/feature-flags-architect",
-      "name": "feature-flags-architect",
-      "description": "Use when adding, retiring, or auditing feature flags. Triggers on \"add a flag\", \"ship behind a flag\", \"rollout plan\", \"kill switch\", \"stale flags\", \"flag debt\", \"LaunchDarkly\", \"GrowthBook\", \"Statsig\", \"Unleash\", \"Flipt\", or any progressive-delivery question. Ships flag debt scanner, rollout planner, and kill-switch auditor (all stdlib Python), 4 references on flag taxonomy + provider trade-offs + rollout strategies + lifecycle, plus a /flag-cleanup slash command.",
-      "tags": [
-        "feature-flags",
-        "progressive-delivery",
-        "rollout",
-        "kill-switch",
-        "launchdarkly",
-        "growthbook",
-        "statsig",
-        "unleash",
-        "flipt",
-        "release-engineering"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/feature-flags-architect/skills/feature-flags-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/finance-lead",
-      "name": "finance-lead",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/finance-lead"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/finance-skills",
-      "name": "finance-skills",
-      "description": "Financial analyst agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Ratio analysis, DCF valuation, budget variance, rolling forecasts. 4 Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "finance/skills/finance-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/financial-analyst",
-      "name": "financial-analyst",
-      "description": "Performs financial ratio analysis, DCF valuation, budget variance analysis, and rolling forecast construction for strategic decision-making. Use when analyzing financial statements, building valuation models, assessing budget variances, or constructing financial projections and forecasts. Also applicable when users mention financial modeling, cash flow analysis, company valuation, financial projections, or spreadsheet analysis.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "finance/skills/financial-analyst"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/financial-health",
-      "name": "financial-health",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/financial-health"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/fix",
-      "name": "fix",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/flag-cleanup",
-      "name": "flag-cleanup",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/flag-cleanup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/focused-fix",
-      "name": "focused-fix",
-      "description": "Use when the user asks to fix, debug, or make a specific feature/module/area work end-to-end. Triggers: 'make X work', 'fix the Y feature', 'the Z module is broken', 'focus on [area]'. Not for quick single-bug fixes — this is for systematic deep-dive repair across all files and dependencies.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/focused-fix"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/form-cro",
-      "name": "form-cro",
-      "description": "When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions \"form optimization,\" \"lead form conversions,\" \"form friction,\" \"form fields,\" \"form completion rate,\" or \"contact form.\" For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/form-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/founder-coach",
-      "name": "founder-coach",
-      "description": "Personal leadership development for founders and first-time CEOs. Covers founder archetype identification, delegation frameworks, energy management, CEO calendar audits, leadership style evolution, blind spot identification, imposter syndrome, founder mental health, and succession planning. Use when a founder feels like the bottleneck, struggles to delegate, is burning out, transitioning from IC to executive, managing a board, or when user mentions founder mode, CEO growth, leadership development, delegation, burnout, or imposter syndrome.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/founder-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/founder-mode",
-      "name": "founder-mode",
-      "description": "/cs:founder-mode <question> — Auto-routes any founder question to the right C-role advisor or to /cs:boardroom for multi-role topics. The single-command entry point.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/founder-mode"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/free-tool-strategy",
-      "name": "free-tool-strategy",
-      "description": "When the user wants to build a free tool for marketing — lead generation, SEO value, or brand awareness. Use when they mention 'engineering as marketing,' 'free tool,' 'calculator,' 'generator,' 'checker,' 'grader,' 'marketing tool,' 'lead gen tool,' 'build something for traffic,' 'interactive tool,' or 'free resource.' Covers idea evaluation, tool design, and launch strategy. For pure SEO content strategy (no tool), use seo-audit or content-strategy instead.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/free-tool-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/freeze",
-      "name": "freeze",
-      "description": "/cs:freeze <decision> <days> — Lock a strategic decision for a cooldown period to prevent impulse reversal. Mirrors gstack's safety primitives for the business layer.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/freeze"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/full-page-screenshot",
-      "name": "full-page-screenshot",
-      "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/full-page-screenshot"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gc-review",
-      "name": "gc-review",
-      "description": "/cs:gc-review <plan> — General Counsel interrogation of contracts, IP, regulatory, term sheets, and employment-law surface.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/gc-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gcp-cloud-architect",
-      "name": "gcp-cloud-architect",
-      "description": "Design GCP architectures for startups and enterprises. Use when asked to design Google Cloud infrastructure, deploy to GKE or Cloud Run, configure BigQuery pipelines, optimize GCP costs, or migrate to GCP. Covers Cloud Run, GKE, Cloud Functions, Cloud SQL, BigQuery, and cost optimization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/gcp-cloud-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gdpr-audit-prep",
-      "name": "gdpr-audit-prep",
-      "description": "/cs:gdpr-audit-prep <scope> — GDPR audit 6-question Article-cited forcing interrogation. Use before annual internal GDPR review, post-breach internal audit, DPA investigation readiness, or acquisition due diligence.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/gdpr-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/gdpr-dsgvo-expert",
-      "name": "gdpr-dsgvo-expert",
-      "description": "GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance assessments, privacy audits, data protection planning, DPIA generation, and data subject rights management.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/gdpr-dsgvo-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/general-counsel-advisor",
-      "name": "general-counsel-advisor",
-      "description": "General Counsel advisory for startups: contract review (MSA, SaaS, NDA, DPA, employment), IP strategy, term sheet decoding, and regulatory landscape mapping. Use when reviewing any contract or term sheet, deciding when to engage outside counsel, defining IP strategy, evaluating regulatory exposure (HIPAA, GDPR, FDA, fintech), or when user mentions general counsel, GC, legal review, contract risk, term sheet, IP assignment, or regulatory exposure. NOT a substitute for licensed counsel — surfaces questions to bring to qualified attorneys.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/general-counsel-advisor/skills/general-counsel-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/generate",
-      "name": "generate",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/generate"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/git-worktree-manager",
-      "name": "git-worktree-manager",
-      "description": "Run parallel feature work safely with Git worktrees. Standardizes branch isolation, port allocation, environment sync, and cleanup so each worktree behaves like an independent local app. Optimized for multi-agent workflows where each agent or terminal session owns one worktree. Use when running multiple feature branches simultaneously, isolating experimental work, or coordinating multi-agent development across the same repo.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/git-worktree-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/google-workspace",
-      "name": "google-workspace",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/google-workspace"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/google-workspace-cli",
-      "name": "google-workspace-cli",
-      "description": "Google Workspace administration via the gws CLI. Install, authenticate, and automate Gmail, Drive, Sheets, Calendar, Docs, Chat, and Tasks. Run security audits, execute 43 built-in recipes, and use 10 persona bundles. Use for Google Workspace admin, gws CLI setup, Gmail automation, Drive management, or Calendar scheduling.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/google-workspace-cli/skills/google-workspace-cli"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grants",
-      "name": "grants",
-      "description": "NIH grant research skill for clinical researchers. Grill-me intake (research idea + career stage + preliminary data + environment + submission posture + known institute targets) locks down the funding strategy before any search runs. Runs a 5-facet Consensus positioning analysis (with draft Significance/Innovation language), maps the research to the right NIH institutes and study sections via RePORTER, finds NOSIs and funded overlap, and produces an editable Word document (.docx) with budget/scope-aware mechanism recommendations, submission timelines, and a mandatory program officer recommendation. Triggers: 'grants for [topic]', 'find grants for my research idea', 'what grants match my research', 'help me find NIH funding', 'grant opportunities for my research', or any grant-related request. NIH-only scope — non-NIH funders (PCORI, DOD CDMRP, VA, foundations) are out of scope and flagged at intake.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/grants/skills/grants"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grill-me",
-      "name": "grill-me",
-      "description": "Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions \"grill me\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/grill-me/skills/grill-me"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/grill-with-docs",
-      "name": "grill-with-docs",
-      "description": "Docs-anchored grilling session — challenges a plan against the project's existing language (CONTEXT.md) and recorded decisions (docs/adr/), and updates those files inline as terminology and decisions crystallise. Use when user wants to stress-test a plan against documented domain language, or mentions \"grill with docs\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/grill-with-docs/skills/grill-with-docs"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/growth-marketer",
-      "name": "growth-marketer",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/growth-marketer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/handoff",
-      "name": "handoff",
-      "description": "Compact the current conversation into a handoff document for another agent to pick up. References existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path or URL instead of duplicating them. Use when user wants to hand off the conversation to a fresh agent or starts a new session that picks up prior work.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/handoff/skills/handoff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/hard-call",
-      "name": "hard-call",
-      "description": "/em -hard-call — Framework for Decisions With No Good Options",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/hard-call"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/helm-chart-builder",
-      "name": "helm-chart-builder",
-      "description": "Helm chart development agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw — chart scaffolding, values design, template patterns, dependency management, security hardening, and chart testing. Use when: user wants to create or improve Helm charts, design values.yaml files, implement template helpers, audit chart security (RBAC, network policies, pod security), manage subcharts, or run helm lint/test.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/helm-chart-builder/skills/helm-chart-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/inbox-setup",
-      "name": "inbox-setup",
-      "description": "One-time setup skill that builds a personalized inbox triage knowledge base via interactive interview. Interviews the user about their email patterns, business context, reply style, and priorities using grill-me discipline (one question at a time, forcing format where possible, dependency-ordered, each question explains why I'm asking), then generates the knowledge base files that power the companion 'inbox-triage' skill. Run this once before using inbox-triage for the first time. Re-run when business, pricing, or priorities change significantly. Triggers: 'set up my inbox', 'configure inbox triage', 'set up my email system', 'configure email triage', 'build my email knowledge base', 'initialize email management', 'set up inbox triage', 'onboard email triage', or any variation where someone wants to get the email triage system running for the first time.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/email/skills/inbox-setup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/inbox-triage",
-      "name": "inbox-triage",
-      "description": "Runs a full inbox triage using the knowledge base created by the 'inbox-setup' skill. Light-intake by design (most invocations skip questions and run with KB-default preferences); asks at most 2 grill-me override questions when invocation is outside normal cadence or includes category-skip intent. Searches recent emails, classifies them via the user's taxonomy, researches new senders, generates recommendations, drafts replies (NEVER sends), delivers a report in the user's preferred format, and updates the knowledge base with learnings. Designed to run on a recurring schedule (1-3x daily) or on demand. Triggers: 'triage my inbox', 'inbox triage', 'check my email', 'run email triage', 'process my inbox', 'what's new in my email', 'handle my email', 'email triage', or any variation where the user wants their inbox processed. Requires the inbox-setup skill to have been run first.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/email/skills/inbox-triage"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/incident-commander",
-      "name": "incident-commander",
-      "description": "Comprehensive incident response framework from detection through resolution and post-incident review. Battle-tested SRE/DevOps practices: severity classification, timeline reconstruction, structured post-incident analysis. Use when declaring an incident, coordinating multi-team response during an outage, leading a post-mortem, or setting up on-call practices for a new service.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/incident-commander"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/incident-response",
-      "name": "incident-response",
-      "description": "Use when a security incident has been detected or declared and needs classification, triage, escalation path determination, and forensic evidence collection. Covers SEV1-SEV4 classification, false positive filtering, incident taxonomy, and NIST SP 800-61 lifecycle.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/incident-response"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/information-security-manager-iso27001",
-      "name": "information-security-manager-iso27001",
-      "description": "ISO 27001 ISMS implementation and cybersecurity governance for HealthTech and MedTech companies. Use for ISMS design, security risk assessment, control implementation, ISO 27001 certification, security audits, incident response, and compliance verification. Covers ISO 27001, ISO 27002, healthcare security, and medical device cybersecurity.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/information-security-manager-iso27001"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/init",
-      "name": "init",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/internal-comms",
-      "name": "internal-comms",
-      "description": "Use when a Head of People Ops, BizOps lead, or Internal Communications owner needs to draft and sequence an internal-only change-management communication — a re-org announcement, a tool rollout, a policy change, a benefit change, a leadership transition, a layoff, an acquisition close, or an internal product launch — and the audience is employees (not customers). Triggers on \"all-hands announcement\", \"town-hall script\", \"change comms\", \"internal newsletter\", \"rollout comms\", \"policy change announcement\", \"re-org announcement\", \"internal FAQ\", \"manager talking points\", \"Prosci ADKAR\", \"Kotter 8-step\", \"layoff comms\", \"RIF comms\", \"internal memo\". Pairs Prosci ADKAR (Awareness / Desire / Knowledge / Ability / Reinforcement) and Kotter's 8-step change model with deterministic stdlib-only Python tools to produce a sequenced touchpoint calendar, a Kotter-compliant primary announcement, an audience-segmented FAQ, and manager cascade talking points. Industry-tuned via --profile {tech-startup, scaleup, enterprise, public-company, non-profit}. Distinct from marketing-skill/* (external/customer-facing), c-level-advisor/internal-narrative (strategic framing, not tactical drafts), and c-level-advisor/change-management (executive change strategy, not the comms package itself).",
-      "tags": [
-        "bizops",
-        "internal-comms",
-        "change-management",
-        "adkar",
-        "kotter",
-        "all-hands",
-        "town-hall",
-        "prosci"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/internal-comms"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/internal-narrative",
-      "name": "internal-narrative",
-      "description": "Build and maintain one coherent company story across all audiences — employees, investors, customers, candidates, and partners. Detects narrative contradictions and ensures the same truth is framed for each audience's needs. Use when preparing investor updates, all-hands presentations, board communications, recruiting narratives, crisis communications, or when user mentions company narrative, messaging consistency, storytelling, all-hands, investor update, or crisis communication.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/internal-narrative"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/interview-system-designer",
-      "name": "interview-system-designer",
-      "description": "This skill should be used when the user asks to \"design interview processes\", \"create hiring pipelines\", \"calibrate interview loops\", \"generate interview questions\", \"design competency matrices\", \"analyze interviewer bias\", \"create scoring rubrics\", \"build question banks\", or \"optimize hiring systems\". Use for designing role-specific interview loops, competency assessments, and hiring calibration systems.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/interview-system-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/intl-expansion",
-      "name": "intl-expansion",
-      "description": "International market expansion strategy. Market selection, entry modes, localization, regulatory compliance, and go-to-market by region. Use when expanding to new countries, evaluating international markets, planning localization, or building regional teams.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/intl-expansion"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/isms-audit-expert",
-      "name": "isms-audit-expert",
-      "description": "Information Security Management System (ISMS) audit expert for ISO 27001 compliance verification, security control assessment, and certification support. Use when the user mentions ISO 27001, ISMS audit, Annex A controls, Statement of Applicability (SOA), gap analysis, nonconformity management, internal audit, surveillance audit, or security certification preparation. Helps review control implementation evidence, document audit findings, classify nonconformities, generate risk-based audit plans, map controls to Annex A requirements, prepare Stage 1 and Stage 2 audit documentation, and support corrective action workflows.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/isms-audit-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso13485-audit-prep",
-      "name": "iso13485-audit-prep",
-      "description": "/cs:iso13485-audit-prep <scope> — ISO 13485 QMS audit 6-question forcing interrogation. Design controls + CAPA + post-market focused. Use before Clause 8.2.4 internal audit, MDR / FDA QSR alignment review, or product-launch DHF closure audit.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/iso13485-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso27001-audit-prep",
-      "name": "iso27001-audit-prep",
-      "description": "/cs:iso27001-audit-prep <scope> — ISO 27001 ISMS audit readiness 6-question forcing interrogation. Use before annual Clause 9.2 internal audit, surveillance audit prep, or stage 1 certification readiness.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/iso27001-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/iso42001-specialist",
-      "name": "iso42001-specialist",
-      "description": "ISO/IEC 42001:2023 AI Management System (AIMS) specialist for compliance teams running internal audits. Three decisions: (1) Where are the gaps against Clauses 4-10 and what do we close first? (2) What goes in the AI risk register and which Annex A controls treat each risk? (3) What's the 12-month internal audit plan that satisfies Clause 9.2? Use when preparing for certification, scoping internal audit cycles, or onboarding AI systems into an existing ISMS (27001) / QMS (13485) program. NOT an executive AI strategy skill (see chief-ai-officer-advisor). NOT EU AI Act compliance (see compliance-team-eu-ai-act).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/compliance-team-iso42001/skills/iso42001-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/jira-expert",
-      "name": "jira-expert",
-      "description": "Atlassian Jira expert for creating and managing projects, planning, product discovery, JQL queries, workflows, custom fields, automation, reporting, and all Jira features. Use for Jira project setup, configuration, advanced search, dashboard creation, workflow design, and technical Jira operations.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/jira-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/karpathy-check",
-      "name": "karpathy-check",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/karpathy-check"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/karpathy-coder",
-      "name": "karpathy-coder",
-      "description": "Use when writing, reviewing, or committing code to enforce Karpathy's 4 coding principles — surface assumptions before coding, keep it simple, make surgical changes, define verifiable goals. Triggers on \"review my diff\", \"check complexity\", \"am I overcomplicating this\", \"karpathy check\", \"before I commit\", or any code quality concern where the LLM might be overcoding.",
-      "tags": [
-        "code-quality",
-        "discipline",
-        "karpathy",
-        "simplicity",
-        "surgical-changes",
-        "anti-patterns",
-        "review"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/karpathy-coder/skills/karpathy-coder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/knowledge-ops",
-      "name": "knowledge-ops",
-      "description": "Use when a Head of Ops, Knowledge Manager, or TPM-Internal needs to author, validate, or clean up company SOPs and internal runbooks (procurement intake, vendor offboarding, incident-comms cascade, employee onboarding, expense reimbursement, system-access provisioning, customer-escalation playbook) — including 5W2H completeness checks (Who-What-When-Where-Why-How-HowMuch), cross-link and orphan-page validation across a sprawling Notion/Confluence/Obsidian wiki, KB ingestion + hygiene reporting, ops onboarding doc generation, and runbook step verification (named owner, expected duration, observable success signal, rollback path, escalation contact). Pairs Kaoru Ishikawa's 5W2H method, Atul Gawande's *The Checklist Manifesto*, ISO 9001, ITIL v4 Service Operation, FDA 21 CFR Part 211, and Google SRE Workbook runbook discipline with deterministic stdlib-only Python tools that score completeness, detect anti-patterns, and emit prioritized cleanup lists. Distinct from `engineering/llm-wiki` (Karpathy-style personal PKM second brain), `engineering-team/runbook-generator` (system-ops production debugging runbook), `project-management/*` (Jira/Confluence delivery + ticket tracking), and sibling `business-operations/process-mapper` (BPMN process *design*, while knowledge-ops is process *documentation*).",
-      "tags": [
-        "bizops",
-        "sop",
-        "runbook",
-        "knowledge-management",
-        "kb",
-        "5w2h",
-        "wiki",
-        "ops-documentation"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/knowledge-ops"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/kubernetes-operator",
-      "name": "kubernetes-operator",
-      "description": "Use when building a Kubernetes Operator — custom controllers that reconcile CRD state. Triggers on \"build an operator\", \"CRD design\", \"reconcile loop\", \"controller-runtime\", \"kubebuilder\", \"operator-sdk\", \"metacontroller\", \"KOPF\", \"operator capability levels\", or \"custom resource\". Ships CRD validator, reconcile-loop linter, and OperatorHub capability auditor (all stdlib Python), 4 references on the operator pattern + CRD design + reconcile patterns + tooling landscape, and a /operator-audit slash command. NOT a generic k8s skill — specifically the Operator pattern.",
-      "tags": [
-        "kubernetes",
-        "operator",
-        "crd",
-        "controller-runtime",
-        "kubebuilder",
-        "operator-sdk",
-        "metacontroller",
-        "kopf",
-        "reconcile",
-        "devops"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/kubernetes-operator/skills/kubernetes-operator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/landing",
-      "name": "landing",
-      "description": "Generates a premium single-page HTML landing page with 3D CSS animations, GSAP scroll effects, and mouse-parallax depth. Forcing intake (product + elevator pitch, audience register, brand overrides, tone) locks down positioning before any copy or markup is written, so the page reflects the actual product rather than generic boilerplate. Use whenever the user says 'landing for X', 'create a landing page', 'build a landing page', 'make a landing page for X', 'I need a web page for Y', or provides product/service details and wants a polished website. Also triggers on 'promotional page', 'product page', 'one-pager', 'web presence', 'sales page'. Outputs a single self-contained HTML file (Claude Code) or HTML artifact (Claude.ai). Supports configurable brand colors via CSS custom property overrides.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing/landing/skills/landing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/landing-page-generator",
-      "name": "landing-page-generator",
-      "description": "Generates high-converting landing pages as complete Next.js/React (TSX) components with Tailwind CSS. Creates hero sections, feature grids, pricing tables, FAQ accordions, testimonial blocks, and CTA sections using proven copy frameworks (PAS, AIDA, BAB). Outputs SEO meta tags, structured data, and performance-optimised code targeting Core Web Vitals (LCP < 1s, CLS < 0.1). Use when the user asks to create a landing page, marketing page, homepage, single-page site, lead capture page, campaign page, promo page, or conversion-optimised web page — or when they want to A/B test landing page variants or replace a static page with one designed to convert.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/landing-page-generator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/launch-strategy",
-      "name": "launch-strategy",
-      "description": "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'GTM plan,' 'launch checklist,' or 'launch momentum.' This skill covers phased launches, channel strategy, and ongoing launch momentum.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/launch-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/litreview",
-      "name": "litreview",
-      "description": "Academic literature orientation skill that searches papers via Consensus, builds a strategic search plan using PICO (default) or SPIDER / Decomposition / hybrid as fallbacks, and synthesizes findings into a professionally formatted Word document (.docx) research guide. Grill-me intake (research question specificity + framework hint + tentative depth) before the recon search; a second forcing checkpoint after Phase 2 confirms framework + sub-areas + depth before searches consume budget. Configurable depth (5/10/20 queries) controls coverage vs. speed. Output is a 'launching pad' — not a finished review, but an orientation guide that lets a researcher dive in confidently. Triggers: 'litreview on [topic]', 'literature review on [topic]', 'I'm starting a literature review on X', 'I'm writing a paper on X', 'help me research X', 'I'm doing research on X', 'can you help me research X'. Do NOT trigger for single one-off paper searches where the user just wants a quick list — that's a plain Consensus search.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/litreview/skills/litreview"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/llm-cost-optimizer",
-      "name": "llm-cost-optimizer",
-      "description": "Use proactively whenever LLM API costs come up -- or should. Triggers include: 'my AI costs are too high', 'optimize token usage', 'which model should I use', 'LLM spend is out of control', 'implement prompt caching', 'we're about to launch an AI feature', 'build me an AI endpoint'. Don't wait for an explicit cost complaint -- if someone is building an AI feature, designing an LLM endpoint, or choosing between models, cost architecture belongs in the conversation. Apply immediately when any of these are true: a system prompt appears that exceeds a few hundred tokens, all requests are hitting the same model, max_tokens is not set, or no per-feature cost logging exists. NOT for RAG pipeline design (use rag-architect). NOT for improving prompt quality or effectiveness (use senior-prompt-engineer).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/llm-cost-optimizer/skills/llm-cost-optimizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/llm-wiki",
-      "name": "llm-wiki",
-      "description": "Use when building or maintaining a persistent personal knowledge base (second brain) in Obsidian where an LLM incrementally ingests sources, updates entity/concept pages, maintains cross-references, and keeps a synthesis current. Triggers include \"second brain\", \"Obsidian wiki\", \"personal knowledge management\", \"ingest this paper/article/book\", \"build a research wiki\", \"compound knowledge\", \"Memex\", or whenever the user wants knowledge to accumulate across sessions instead of being re-derived by RAG on every query.",
-      "tags": [
-        "knowledge-management",
-        "obsidian",
-        "second-brain",
-        "pkm",
-        "rag-alternative",
-        "wiki",
-        "karpathy",
-        "memex"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/llm-wiki/skills/llm-wiki"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/loop",
-      "name": "loop",
-      "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/loop"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ma-playbook",
-      "name": "ma-playbook",
-      "description": "M&A strategy for acquiring companies or being acquired. Due diligence, valuation, integration, and deal structure. Use when evaluating acquisitions, preparing for acquisition, M&A due diligence, integration planning, or deal negotiation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/ma-playbook"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/markdown-html-orchestrator",
-      "name": "markdown-html-orchestrator",
-      "description": "Use when a user wants to convert any markdown file in their Claude project into a single-file, lightly-interactive HTML — long-form documents (specs, plans, RFCs, reports, explainers), code reviews with diffs and severity-tagged annotations, or slide decks. Triggers on \"convert this markdown to HTML\", \"make this an HTML file\", \"turn this into an interactive document\", \"render this report as HTML\", \"PR writeup as HTML\", \"slides from this markdown\". Forks context to route to one of three converter sub-skills (md-document, md-review, md-slides) based on a deterministic doctype classifier, after the user has run the design-system onboarding once. Refuses if input is under 100 lines (per Shihipar — markdown still wins below the threshold) or design-system isn't onboarded. Distinct from Anthropic's official Playground plugin (which is interactive prompt-tuning controls with sliders/knobs/prompt-copy-back) and from marketing/landing/ (which is a landing-page generator).",
-      "tags": [
-        "markdown",
-        "html",
-        "converter",
-        "orchestrator",
-        "documentation",
-        "code-review",
-        "slides",
-        "design-system"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "markdown-html/skills/markdown-html-orchestrator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/market-research",
-      "name": "market-research",
-      "description": "Use when doing upstream market-research methodology — sizing a market as TAM/SAM/SOM computed BOTH top-down and bottoms-up (never a single unsourced number), planning a survey sample size with finite-population correction and per-segment minimums, or scoring candidate market segments against Kotler's measurable/substantial/accessible/differentiable/actionable criteria. Outputs always show the method and the assumptions. For market-research analysts and product-marketing at the sizing/survey/segmentation moment. Distinct from marketing-skill (campaign analytics, attribution, demand-gen) — this is the evidence-building methodology, not live-campaign optimization.",
-      "tags": [
-        "research-ops",
-        "market-research",
-        "tam-sam-som",
-        "market-sizing",
-        "survey",
-        "sampling",
-        "segmentation",
-        "competitive-intelligence"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research-ops/skills/market-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-context",
-      "name": "marketing-context",
-      "description": "Create and maintain the marketing context document that all marketing skills read before starting. Use when the user mentions 'marketing context,' 'brand voice,' 'set up context,' 'target audience,' 'ICP,' 'style guide,' 'who is my customer,' 'positioning,' or wants to avoid repeating foundational information across marketing tasks. Run this at the start of any new project before using other marketing skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-context"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-demand-acquisition",
-      "name": "marketing-demand-acquisition",
-      "description": "Creates demand generation campaigns, optimizes paid ad spend across LinkedIn, Google, and Meta, develops SEO strategies, and structures partnership programs for Series A+ startups scaling internationally. Use when planning marketing strategy, growth marketing, advertising campaigns, PPC optimization, lead generation, pipeline generation, or startup marketing budgets. Covers multi-channel acquisition (Google Ads, LinkedIn Ads, Meta Ads), CAC analysis, MQL/SQL workflows, attribution modeling, technical SEO, and co-marketing partnerships for hybrid PLG/Sales-Led motions in EU/US/Canada markets.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-demand-acquisition"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-ideas",
-      "name": "marketing-ideas",
-      "description": "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' or 'ideas to grow.' This skill provides 139 proven marketing approaches organized by category.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-ideas"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-ops",
-      "name": "marketing-ops",
-      "description": "Central router for the marketing skill ecosystem. Use when unsure which marketing skill to use, when orchestrating a multi-skill campaign, or when coordinating across content, SEO, CRO, channels, and analytics. Also use when the user mentions 'marketing help,' 'campaign plan,' 'what should I do next,' 'marketing priorities,' or 'coordinate marketing.'",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-ops"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-psychology",
-      "name": "marketing-psychology",
-      "description": "When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,' 'cognitive bias,' 'persuasion,' 'behavioral science,' 'why people buy,' 'decision-making,' or 'consumer behavior.' This skill provides 70+ mental models organized for marketing application.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-psychology"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-skills",
-      "name": "marketing-skills",
-      "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/marketing-strategy-pmm",
-      "name": "marketing-strategy-pmm",
-      "description": "Product marketing skill for positioning, GTM strategy, competitive intelligence, and product launches. Use when the user asks about product positioning, go-to-market planning, competitive analysis, target audience definition, ICP definition, market research, launch plans, or sales enablement. Covers April Dunford positioning, ICP definition, competitive battlecards, launch playbooks, and international market entry. Produces deliverables including positioning statements, battlecard documents, launch plans, and go-to-market strategies.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/marketing-strategy-pmm"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/mcp-server-builder",
-      "name": "mcp-server-builder",
-      "description": "Design and ship production-ready MCP (Model Context Protocol) servers from OpenAPI contracts instead of hand-written tool wrappers. Python and TypeScript support, schema validation, safe evolution. Use when exposing an existing API as an MCP server, building tool integrations for Claude or Codex or Cursor, or scaffolding an MCP project from scratch.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/mcp-server-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/md-document",
-      "name": "md-document",
-      "description": "Converts long-form markdown (specs, RFCs, reports, plans, explainers) into a single-file, lightly-interactive HTML document with sticky TOC, scrollspy, search filter, code-copy buttons, and design-system-driven brand tokens. Triggers when the markdown-html-orchestrator classifies an input as DOCUMENT, or when invoked directly via /cs:md-document. Reads the design-system config via config_loader.py and inlines the user's 12 derived CSS custom properties; refuses to render if onboarding hasn't run. Single-file output — Google Fonts + Prism.js CDN are the only externals; no framework runtime, no build step. Use after orchestrator routing or after design-system onboarding is confirmed.",
-      "tags": [
-        "markdown",
-        "html",
-        "documentation",
-        "single-file",
-        "toc",
-        "scrollspy",
-        "search",
-        "code-copy",
-        "design-system"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "markdown-html/skills/md-document"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/md-review",
-      "name": "md-review",
-      "description": "Converts a markdown PR writeup or code review (one with ```diff fenced blocks and severity-tagged > [!BLOCKER]/[!MAJOR]/[!MINOR]/[!NIT] callouts) into a single-file 2-column HTML review — unified-diff on the left, severity-tagged annotation cards on the right, top jump-nav listing every finding, mandatory named reviewer footer. Triggers when the markdown-html-orchestrator classifies an input as REVIEW, or when invoked directly via /cs:md-review. Refuses without explicit --reviewer (a code review must name a human), refuses if no diff hunks present (route to md-document instead), and refuses to encode severity in color only (every badge ships color + icon + aria-label per WCAG 1.4.1). Use after orchestrator routing.",
-      "tags": [
-        "markdown",
-        "html",
-        "code-review",
-        "diff",
-        "severity",
-        "annotations",
-        "single-file",
-        "design-system",
-        "wcag-1.4.1"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "markdown-html/skills/md-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/md-slides",
-      "name": "md-slides",
-      "description": "Converts a markdown deck (slides separated by `---` HR boundaries or by `# ` H1 headings, with optional `<!-- notes: ... -->` presenter notes blocks) into a single-file HTML presentation with arrow-key / space / PgDn / PgUp / Home / End / P / Esc keyboard navigation, presenter mode (split view with current slide + speaker notes + clock + next-slide preview), URL-hash deep linking, and `@media print` page-per-slide for PDF export. Triggers when the markdown-html-orchestrator classifies an input as SLIDES, or when invoked directly via /cs:md-slides. Reuses md-document's markdown parser for slide-body rendering and reads design-system tokens via config_loader.py. Refuses if input has no clear slide boundaries, produces a 1-slide deck, or `--strict-notes` is on with < 50% notes coverage. Use after orchestrator routing.",
-      "tags": [
-        "markdown",
-        "html",
-        "slides",
-        "deck",
-        "presenter-mode",
-        "keyboard-nav",
-        "print-to-pdf",
-        "single-file",
-        "design-system"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "markdown-html/skills/md-slides"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/mdr-745-specialist",
-      "name": "mdr-745-specialist",
-      "description": "EU MDR 2017/745 compliance specialist for medical device classification, technical documentation, clinical evidence, and post-market surveillance. Covers Annex VIII classification rules, Annex II/III technical files, Annex XIV clinical evaluation, and EUDAMED integration.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/mdr-745-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/meeting-analyzer",
-      "name": "meeting-analyzer",
-      "description": "Analyzes meeting transcripts and recordings to surface behavioral patterns, communication anti-patterns, and actionable coaching feedback. Use this skill whenever the user uploads or points to meeting transcripts (.txt, .md, .vtt, .srt, .docx), asks about their communication habits, wants feedback on how they run meetings, requests speaking ratio analysis, mentions filler words or conflict avoidance, or wants to compare their communication across time periods. Also trigger when users mention tools like Granola, Otter, Fireflies, or Zoom transcripts. Even if the user just says \"look at my meetings\" or \"how do I come across in meetings\" — use this skill.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/meeting-analyzer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/merge",
-      "name": "merge",
-      "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/merge"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/migrate",
-      "name": "migrate",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/migrate"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/migration-architect",
-      "name": "migration-architect",
-      "description": "Zero-downtime migration planning, compatibility validation, and rollback strategy generation. Tools for system, database, and infrastructure migrations with minimal business impact. Use when planning a database migration, infrastructure cutover, system replacement, or any high-risk transition that needs explicit rollback paths.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/migration-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/monorepo-navigator",
-      "name": "monorepo-navigator",
-      "description": "Navigate, manage, and optimize monorepos. Covers Turborepo, Nx, pnpm workspaces, and Lerna. Cross-package impact analysis, selective builds/tests on affected packages, remote caching, dependency graph visualization, and structured multi-repo to monorepo migrations. Use when setting up a new monorepo, optimizing CI for a large workspace, debugging cross-package dependency issues, or planning a multi-repo consolidation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/monorepo-navigator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ms365-tenant-manager",
-      "name": "ms365-tenant-manager",
-      "description": "Microsoft 365 tenant administration for Global Administrators. Automate M365 tenant setup, Office 365 admin tasks, Azure AD user management, Exchange Online configuration, Teams administration, and security policies. Generate PowerShell scripts for bulk operations, Conditional Access policies, license management, and compliance reporting. Use for M365 tenant manager, Office 365 admin, Azure AD users, Global Administrator, tenant configuration, or Microsoft 365 automation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/ms365-tenant-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/notebooklm",
-      "name": "notebooklm",
-      "description": "Browser automation skill for controlling Google's NotebookLM. Handles reading and querying notebooks, adding sources (URLs, text, files, YouTube links, synthesized content), generating Studio outputs (Audio Overview, infographics, slide decks, study guides, briefing docs, mind maps, timelines, FAQs), and creating new notebooks. Triggers on any phrase involving NotebookLM — 'open NotebookLM', 'check my [name] notebook', 'pull info from NotebookLM', 'ask my notebook about X', 'add [source] to NotebookLM', 'create an infographic in NotebookLM', 'use NotebookLM Studio', 'generate a slide deck from my notebook', or any variation where the goal involves NotebookLM. Requires browser automation environment — fails gracefully when unavailable.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/notebooklm/skills/notebooklm"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/observability-designer",
-      "name": "observability-designer",
-      "description": "Design production-ready observability strategies combining metrics, logs, and traces. Includes SLI/SLO design, golden-signals monitoring, alert optimization. Use when adding observability to a new service, refactoring alerting that is too noisy, or designing an SLO program before scaling production load.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/observability-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/office-hours",
-      "name": "office-hours",
-      "description": "/cs:office-hours <topic> — YC-style 6-question founder interrogation before any advice. Forces clarity on problem, customer, distribution, defensibility, capital, and founder fit.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/office-hours"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/okr",
-      "name": "okr",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/okr"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/onboard",
-      "name": "onboard",
-      "description": "/cs:onboard — Founder interview that populates ~/.claude/company-context.md. The first command to run when starting with c-level-agents.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/onboard"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/onboarding-cro",
-      "name": "onboarding-cro",
-      "description": "When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions \"onboarding flow,\" \"activation rate,\" \"user activation,\" \"first-run experience,\" \"empty states,\" \"onboarding checklist,\" \"aha moment,\" or \"new user experience.\" For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/onboarding-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/operator-audit",
-      "name": "operator-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/operator-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/org-health-diagnostic",
-      "name": "org-health-diagnostic",
-      "description": "Cross-functional organizational health check combining signals from all C-suite roles. Scores 8 dimensions on a traffic-light scale with drill-down recommendations. Use when assessing overall company health, preparing for board reviews, identifying at-risk functions, or when user mentions org health, health check, or health dashboard.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/org-health-diagnostic"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/page-cro",
-      "name": "page-cro",
-      "description": "When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says \"CRO,\" \"conversion rate optimization,\" \"this page isn't converting,\" \"improve conversions,\" or \"why isn't this page working.\" For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/page-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/paid-ads",
-      "name": "paid-ads",
-      "description": "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ad copy,' 'ad creative,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' or 'audience targeting.' This skill covers campaign strategy, ad creation, audience targeting, and optimization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/paid-ads"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/partnerships-architect",
-      "name": "partnerships-architect",
-      "description": "Use when a startup is approached by a prospective partner and someone has to decide should we sign this partner, at what partner tier (referral / reseller / OEM / SI-consulting / strategic alliance), with what joint GTM commitment, and at what revshare. Classifies partner tier from independent-demand evidence vs. preferential-terms hunting, designs a 90-day joint GTM plan, models revshare against direct-sale margin, and surfaces kill criteria for unwinding under-performing partnerships. For Head of Partnerships, Head of BD, and Founder-CEOs doing reseller agreement, OEM deal, or strategic alliance review — not technical sale enablement, not channel cost economics, not M&A.",
-      "tags": [
-        "commercial",
-        "partnerships",
-        "channel-partners",
-        "joint-gtm",
-        "revshare",
-        "oem",
-        "reseller",
-        "strategic-alliance"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/partnerships-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/patent",
-      "name": "patent",
-      "description": "Patent prior-art and landscape intelligence skill — not generic patent help. Commits to one of five sub-use-cases via forcing intake (novelty search / freedom-to-operate / competitive landscape / acquisition diligence / litigation prior-art) before any search runs. Searches Google Patents, Espacenet, USPTO, and optionally Lens.org for citation-graph signals. Output is an editable Word document (.docx) with verdict, ranked closest art (claim-text extracted), CPC-class-aware landscape, family-resolved hits, geographic coverage, FTO flags where applicable, strategy recommendations, and full audit log. Triggers: 'prior art search for [invention]', 'patent search on [topic]', 'freedom to operate analysis', 'FTO for [product]', 'patent landscape for [field]', 'is [invention] novel', 'patents on [topic]', 'competitive patent analysis', 'prior art for litigation', 'patent diligence on [company]'. Produces search signal, not legal advice — always recommends consulting a patent attorney before filing or licensing decisions. Trademark, copyright, and trade-secret questions are out of scope.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/patent/skills/patent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/paywall-upgrade-cro",
-      "name": "paywall-upgrade-cro",
-      "description": "When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions \"paywall,\" \"upgrade screen,\" \"upgrade modal,\" \"upsell,\" \"feature gate,\" \"convert free to paid,\" \"freemium conversion,\" \"trial expiration screen,\" \"limit reached screen,\" \"plan upgrade prompt,\" or \"in-app pricing.\" Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/paywall-upgrade-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/performance-profiler",
-      "name": "performance-profiler",
-      "description": "Systematic performance profiling for Node.js, Python, and Go applications. Identifies CPU, memory, and I/O bottlenecks, generates flamegraphs, analyzes bundle sizes, optimizes database queries, runs load tests with k6 and Artillery. Always measures before and after. Use when investigating a slow endpoint, planning a performance budget, or hunting a memory leak in production.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/performance-profiler"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/persona",
-      "name": "persona",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/persona"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pipeline",
-      "name": "pipeline",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pipeline"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/playwright-pro",
-      "name": "playwright-pro",
-      "description": "Production-grade Playwright testing toolkit. Use when the user mentions Playwright tests, end-to-end testing, browser automation, fixing flaky tests, test migration, CI/CD testing, or test suites. Generate tests, fix flaky failures, migrate from Cypress/Selenium, sync with TestRail, run on BrowserStack. 55 templates, 3 agents, smart reporting.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/pw"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/plugin-audit",
-      "name": "plugin-audit",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/plugin-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pm-skills",
-      "name": "pm-skills",
-      "description": "6 project management agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Senior PM, scrum master, Jira expert (JQL), Confluence expert, Atlassian admin, template creator. MCP integration for live Jira/Confluence automation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/pm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/popup-cro",
-      "name": "popup-cro",
-      "description": "When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions \"exit intent,\" \"popup conversions,\" \"modal optimization,\" \"lead capture popup,\" \"email popup,\" \"announcement banner,\" or \"overlay.\" For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/popup-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/post-mortem",
-      "name": "post-mortem",
-      "description": "/cs:post-mortem <decision> — Honest retrospective on an executed decision, scored against original assumptions and dissent. Closes the strategic sprint loop.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/post-mortem"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/postmortem",
-      "name": "postmortem",
-      "description": "/em -postmortem — Honest Analysis of What Went Wrong",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/postmortem"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pr-review-expert",
-      "name": "pr-review-expert",
-      "description": "Use when the user asks to review pull requests, analyze code changes, check for security issues in PRs, or assess code quality of diffs.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/pr-review-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/prd",
-      "name": "prd",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/prd"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pricing-strategist",
-      "name": "pricing-strategist",
-      "description": "Use when designing or revisiting product pricing — selecting a pricing model (subscription seat-based, usage-based, value-based, freemium, or hybrid), running Van Westendorp Price Sensitivity Meter analysis on WTP survey data, or designing Good/Better/Best packaging tiers. Recommends a model and a price range with trade-offs, never a single number. For Commercial leads, Product Marketing, and CMOs at the pricing-design moment — not deal-by-deal discounting, not brand positioning.",
-      "tags": [
-        "commercial",
-        "pricing",
-        "packaging",
-        "wtp",
-        "van-westendorp",
-        "value-based-pricing",
-        "saas-pricing"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/pricing-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pricing-strategy",
-      "name": "pricing-strategy",
-      "description": "Design, optimize, and communicate SaaS pricing — tier structure, value metrics, pricing pages, and price increase strategy. Use when building a pricing model from scratch, redesigning existing pricing, planning a price increase, or improving a pricing page. Trigger keywords: pricing tiers, pricing page, price increase, packaging, value metric, per seat pricing, usage-based pricing, freemium, good-better-best, pricing strategy, monetization, pricing page conversion, Van Westendorp. NOT for broader product strategy — use product-strategist for that. NOT for customer success or renewals — use customer-success-manager for expansion revenue.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/pricing-strategy"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/process-mapper",
-      "name": "process-mapper",
-      "description": "Use when a BizOps lead, COO, or process-improvement owner needs to document an end-to-end business process (procurement, employee onboarding, incident handoff, customer-onboarding, claims adjudication) in BPMN-style notation, measure cycle times by stage, surface where work spends most of its time waiting vs. being worked, and quantify the gap between processing time and total elapsed time. Pairs Lean / Six Sigma / Theory-of-Constraints canon with deterministic stdlib-only Python tools to produce a process map, a ranked bottleneck list (with severity + root-cause hypothesis), and a cycle-time analysis (P50, P90, value-add ratio, Little's-Law throughput). Distinct from sales-pipeline, system-reliability (SLO), and strategic-OKR work — this is tactical process documentation for internal operations.",
-      "tags": [
-        "bizops",
-        "process",
-        "bpmn",
-        "bottleneck",
-        "cycle-time",
-        "lean",
-        "six-sigma",
-        "value-stream"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/process-mapper"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/procurement-optimizer",
-      "name": "procurement-optimizer",
-      "description": "Use when running an annual SaaS audit, doing category-level spend review, or rationalizing the supplier base — when the user needs to do a spend audit, spend categorization (UNSPSC-aligned), purchasing-cycle analysis, or risk-balanced supplier consolidation. Triggers on \"spend audit\", \"SaaS audit\", \"spend categorization\", \"supplier rationalization\", \"supplier consolidation\", \"purchasing cycle\", \"procurement review\", \"category strategy\", \"duplicate SaaS\", \"renewal cluster\". Ships 3 stdlib-only Python tools (UNSPSC-aligned spend categorizer with Pareto breakdown and industry profiles, purchasing-cycle analyzer that surfaces bottleneck categories per Goldratt's Theory of Constraints, supplier-consolidation planner that refuses single-source recommendations for tier-1 categories without a documented break-glass plan), 3 reference docs each citing 7+ authoritative sources (A.T. Kearney / Hackett / Spend Matters / UNSPSC / Productiv / Vendr / Tropic / IACCM / ISM / BCG), and a 20-minute spend-intake template. Distinct from sibling vendor-management (performance scoring of vendors you keep paying), finance/financial-analysis (close + report, not category strategy), and c-level-advisor/general-counsel-advisor (contract law, not category rationalization).",
-      "tags": [
-        "bizops",
-        "procurement",
-        "spend-categorization",
-        "supplier-consolidation",
-        "unspsc",
-        "saas-audit",
-        "purchasing-cycle"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/procurement-optimizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-analytics",
-      "name": "product-analytics",
-      "description": "Use when defining product KPIs, building metric dashboards, running cohort or retention analysis, or interpreting feature adoption trends across product stages.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/product-analytics"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-discovery",
-      "name": "product-discovery",
-      "description": "Use when validating product opportunities, mapping assumptions, planning discovery sprints, or testing problem-solution fit before committing delivery resources.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/product-discovery"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-manager",
-      "name": "product-manager",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/product-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-manager-toolkit",
-      "name": "product-manager-toolkit",
-      "description": "Comprehensive toolkit for product managers including RICE prioritization, customer interview analysis, PRD templates, discovery frameworks, and go-to-market strategies. Use for feature prioritization, user research synthesis, requirement documentation, and product strategy development.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/product-manager-toolkit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-research",
-      "name": "product-research",
-      "description": "Use when planning and synthesizing product/user research as a method-and-repository discipline — selecting the right method for the goal (generative interviews vs usability test vs concept test vs validation), computing method-based saturation/sample size with an explicit confidence level, or synthesizing coded observations into insights while flagging single-source anecdotes. Never fabricates user insight; an insight requires recurrence across independent participants. Distinct from product-team/ux-researcher-designer (persona/journey artifacts), product-discovery (discovery-sprint planning), and experiment-designer (live A/B) — this is the research-ops method + insight-repository layer.",
-      "tags": [
-        "research-ops",
-        "product-research",
-        "ux-research",
-        "jtbd",
-        "usability",
-        "saturation",
-        "insight-synthesis",
-        "research-repository"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research-ops/skills/product-research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-skills",
-      "name": "product-skills",
-      "description": "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/product-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/product-strategist",
-      "name": "product-strategist",
-      "description": "Strategic product leadership toolkit for Head of Product covering OKR cascade generation, quarterly planning, competitive landscape analysis, product vision documents, and team scaling proposals. Use when creating quarterly OKR documents, defining product goals or KPIs, building product roadmaps, running competitive analysis, drafting team structure or hiring plans, aligning product strategy across engineering and design, or generating cascaded goal hierarchies from company to team level.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/product-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/programmatic-seo",
-      "name": "programmatic-seo",
-      "description": "When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions \"programmatic SEO,\" \"template pages,\" \"pages at scale,\" \"directory pages,\" \"location pages,\" \"[keyword] + [city] pages,\" \"comparison pages,\" \"integration pages,\" or \"building many pages for SEO.\" For auditing existing SEO issues, see seo-audit.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/programmatic-seo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/project-health",
-      "name": "project-health",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/project-health"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/promote",
-      "name": "promote",
-      "description": "Graduate a proven pattern from auto-memory (MEMORY.md) to CLAUDE.md or .claude/rules/ for permanent enforcement.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/promote"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/prompt-engineer-toolkit",
-      "name": "prompt-engineer-toolkit",
-      "description": "Analyzes and rewrites prompts for better AI output, creates reusable prompt templates for marketing use cases (ad copy, email campaigns, social media), and structures end-to-end AI content workflows. Use when the user wants to improve prompts for AI-assisted marketing, build prompt templates, or optimize AI content workflows. Also use when the user mentions 'prompt engineering,' 'improve my prompts,' 'AI writing quality,' 'prompt templates,' or 'AI content workflow.'",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/prompt-engineer-toolkit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/prompt-governance",
-      "name": "prompt-governance",
-      "description": "Use when managing prompts in production at scale: versioning prompts, running A/B tests on prompts, building prompt registries, preventing prompt regressions, or creating eval pipelines for production AI features. Triggers: 'manage prompts in production', 'prompt versioning', 'prompt regression', 'prompt A/B test', 'prompt registry', 'eval pipeline'. NOT for writing or improving individual prompts (use senior-prompt-engineer). NOT for RAG pipeline design (use rag-architect). NOT for LLM cost reduction (use llm-cost-optimizer).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/prompt-governance/skills/prompt-governance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pulse",
-      "name": "pulse",
-      "description": "Multi-source recency research skill that takes the pulse of any topic across Reddit, Hacker News, the open web, and optionally X/Twitter within a configurable recent window (default 30 days). Forcing intake clarifies topic specificity, angle (trend/sentiment/problems/opportunities/comparison), time window, and platform scope before searching. Returns a synthesized briefing with citations, engagement metrics, and cross-platform pattern analysis. Triggers: 'pulse on [topic]', 'what's happening with [topic]', 'what are people saying about [topic]', 'current conversation about [topic]', 'take the pulse of [topic]', 'trending: [topic]', 'find me info on [topic]', or any variation requesting multi-source recency intelligence on a topic. Also use for competitor research, trend discovery, tool comparisons, and audience sentiment analysis.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/pulse/skills/pulse"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/pw",
-      "name": "pw",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/pw"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/qms-audit-expert",
-      "name": "qms-audit-expert",
-      "description": "ISO 13485 internal audit expertise for medical device QMS. Covers audit planning, execution, nonconformity classification, and CAPA verification. Use for internal audit planning, audit execution, finding classification, external audit preparation, or audit program management.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/qms-audit-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-documentation-manager",
-      "name": "quality-documentation-manager",
-      "description": "Document control system management for medical device QMS. Covers document numbering, version control, change management, and 21 CFR Part 11 compliance. Use for document control procedures, change control workflow, document numbering, version management, electronic signature compliance, or regulatory documentation review.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/quality-documentation-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-manager-qmr",
-      "name": "quality-manager-qmr",
-      "description": "Senior Quality Manager Responsible Person (QMR) for HealthTech and MedTech companies. Provides quality system governance, management review leadership, regulatory compliance oversight, and quality performance monitoring per ISO 13485 Clause 5.5.2.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/quality-manager-qmr"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/quality-manager-qms-iso13485",
-      "name": "quality-manager-qms-iso13485",
-      "description": "ISO 13485 Quality Management System implementation and maintenance for medical device organizations. Provides QMS design, documentation control, internal auditing, CAPA management, and certification support. Use when working with medical device quality systems, preparing for ISO 13485 audits, managing regulatory compliance documentation, setting up corrective actions, or building audit preparation programs. Useful for quality management, audit preparation, regulatory compliance, medical device documentation, and corrective action workflows.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/quality-manager-qms-iso13485"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ra-qm-skills",
-      "name": "ra-qm-skills",
-      "description": "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/ra-qm-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/rag-architect",
-      "name": "rag-architect",
-      "description": "Use when the user asks to design RAG pipelines, optimize retrieval strategies, choose embedding models, implement vector search, or build knowledge retrieval systems.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/rag-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/readme",
-      "name": "README",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/README"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/red-team",
-      "name": "red-team",
-      "description": "Use when planning or executing authorized red team engagements, attack path analysis, or offensive security simulations. Covers MITRE ATT&CK kill-chain planning, technique scoring, choke point identification, OPSEC risk assessment, and crown jewel targeting.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/red-team"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/referral-program",
-      "name": "referral-program",
-      "description": "When the user wants to design, launch, or optimize a referral or affiliate program. Use when they mention 'referral program,' 'affiliate program,' 'word of mouth,' 'refer a friend,' 'incentive program,' 'customer referrals,' 'brand ambassador,' 'partner program,' 'referral link,' or 'growth through referrals.' Covers program mechanics, incentive design, and optimization — not just the idea of referrals but the actual system.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/referral-program"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/reflect",
-      "name": "reflect",
-      "description": "Mid-conversation reflection skill that pauses execution and zooms out from detail-mode to honestly reassess direction, assumptions, and bias. Use when the user says 'reflect', 'take a step back', 'step back', 'zoom out', 'are we missing something', 'bigger picture', 'sanity check this', 'are we on track', 'are we overthinking this', 'forest for the trees', or any variation signaling intent to break out of detail-mode and reassess. Also trigger when the conversation has gone deep on implementation details without strategic check-in, or when the user shows signs of being stuck — that's often a signal the framing needs a reset, not more detail work. Intentionally low-intake: runs the 5-dimension analysis immediately when prior context is rich enough; asks one forcing clarifier only when invocation context is too thin to reassess from.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "productivity/reflect/skills/reflect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/regulatory-affairs-head",
-      "name": "regulatory-affairs-head",
-      "description": "Senior Regulatory Affairs Manager for HealthTech and MedTech companies. Prepares FDA 510(k), De Novo, and PMA submission packages; analyzes regulatory pathways for new medical devices; drafts responses to FDA deficiency letters and Notified Body queries; develops CE marking technical documentation under EU MDR 2017/745; coordinates multi-market approval strategies across FDA, EU, Health Canada, PMDA, and NMPA; and maintains regulatory intelligence on evolving standards. Use when users need to plan or execute FDA submissions, navigate 510(k) or PMA approval processes, achieve CE marking, prepare pre-submission meeting materials, write regulatory strategy documents, respond to agency queries, or manage compliance documentation for medical device market access.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/regulatory-affairs-head"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/release-manager",
-      "name": "release-manager",
-      "description": "Use when the user asks to plan releases, manage changelogs, coordinate deployments, create release branches, or automate versioning.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/release-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/remember",
-      "name": "remember",
-      "description": "Explicitly save important knowledge to auto-memory with timestamp and context. Use when a discovery is too important to rely on auto-capture.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/remember"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/report",
-      "name": "report",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/report"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research",
-      "name": "research",
-      "description": "Default entry point for any research request — a hybrid router that classifies the question deterministically and either delegates to a specialist research skill (pulse for trends/sentiment, grants for NIH funding, litreview for academic literature, syllabus for course reading, patent for prior-art + IP landscape, dossier for entity research) or runs its own plan-decompose-multi-source-search-synthesize-cite fallback workflow when no specialist matches. Always surfaces the routing decision so users can override. Triggers — \"research [topic]\", \"look into [topic]\", \"what do we know about [topic]\", \"investigate [topic]\", \"find me information on [topic]\", \"do some research on [topic]\", \"I need to understand [topic]\", or any research request that doesn't obviously match a more-specific specialist skill. Output is a markdown briefing (default) or .docx document (on request) with full citations and an audit log.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/research/skills/research"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-bundle",
-      "name": "research-bundle",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/research-bundle"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-finance",
-      "name": "research-finance",
-      "description": "Use when managing the money for an internal R&D program or portfolio — building a multi-period program budget with the F&A (indirect) split, tracking burn rate and runway against value-inflection milestones, or routing R&D cost items to a capitalize-vs-expense determination. Every budget output surfaces its assumptions block; capitalize-vs-expense is decision-support only and routes to a named finance owner — it never books an entry or decides accounting treatment. Distinct from finance/financial-analysis (corporate DCF, close, valuation) and research/grants (funding discovery — this manages money already won).",
-      "tags": [
-        "research-ops",
-        "research-finance",
-        "rd-budget",
-        "burn-rate",
-        "runway",
-        "fa-rate",
-        "capitalize-vs-expense",
-        "portfolio"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research-ops/skills/research-finance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-ops-skills",
-      "name": "research-ops-skills",
-      "description": "Use when planning, funding, scoping, or synthesizing enterprise research across workstreams — clinical study design, R&D program finance, market sizing/surveys, or product/user research. Triggers on \"design this clinical study\", \"what sample size\", \"R&D budget\", \"burn rate\", \"capitalize or expense\", \"TAM SAM SOM\", \"market sizing\", \"survey design\", \"segment the market\", \"plan user interviews\", \"usability test\", \"synthesize research insights\". Forks context to route to one of four Research-Operations sub-skills (clinical-research, research-finance, market-research, product-research) and returns a digest. Distinct from ra-qm-team (regulatory submission), finance (corporate close/valuation), research/grants (funding discovery), product-team (persona/journey/live experiments), and marketing-skill (campaign analytics).",
-      "tags": [
-        "research-ops",
-        "clinical-research",
-        "research-finance",
-        "market-research",
-        "product-research",
-        "rd",
-        "orchestrator"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research-ops/skills/research-ops-skills"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/research-summarizer",
-      "name": "research-summarizer",
-      "description": "Structured research summarization agent skill for non-dev users. Handles academic papers, web articles, reports, and documentation. Extracts key findings, generates comparative analyses, and produces properly formatted citations. Use when: user wants to summarize a research paper, compare multiple sources, extract citations from documents, or create structured research briefs. Plugin for Claude Code, Codex, Gemini CLI, and OpenClaw.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/research-summarizer/skills/research-summarizer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/resume",
-      "name": "resume",
-      "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/resume"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/retro",
-      "name": "retro",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/retro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/revenue-operations",
-      "name": "revenue-operations",
-      "description": "Analyzes sales pipeline health, revenue forecasting accuracy, and go-to-market efficiency metrics for SaaS revenue optimization. Use when analyzing sales pipeline coverage, forecasting revenue, evaluating go-to-market performance, reviewing sales metrics, assessing pipeline analysis, tracking forecast accuracy with MAPE, calculating GTM efficiency, or measuring sales efficiency and unit economics for SaaS teams.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-growth/skills/revenue-operations"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/review",
-      "name": "review",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/rfp-responder",
-      "name": "rfp-responder",
-      "description": "Use when an RFP, RFI, RFQ, security questionnaire, vendor questionnaire, or proposal request arrives and the team needs a structured response — parsing multi-section buyer-dictated requirements (MANDATORY vs WEIGHTED vs NICE-TO-HAVE), building a Shipley-method proof-point matrix mapping each requirement to a verifiable proof point, articulating 3-5 win-themes that ladder up across requirements, and producing a Shipley-derived winrate estimate that informs a bid / no-bid / partner-bid recommendation. For Bid Managers, Proposal Leads, Directors of Sales, and Sales Engineers at the response-strategy moment. Surfaces GAP requirements explicitly — never invents claims. NOT free-form proposal narrative authoring, NOT contract redline, NOT marketing collateral.",
-      "tags": [
-        "commercial",
-        "rfp",
-        "rfi",
-        "rfq",
-        "shipley",
-        "win-theme",
-        "proof-points",
-        "structured-response",
-        "bid-management"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "commercial/skills/rfp-responder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/rice",
-      "name": "rice",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/rice"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/risk-management-specialist",
-      "name": "risk-management-specialist",
-      "description": "Medical device risk management specialist implementing ISO 14971 throughout product lifecycle. Provides risk analysis, risk evaluation, risk control, and post-production information analysis. Use when user mentions risk management, ISO 14971, risk analysis, FMEA, fault tree analysis, hazard identification, risk control, risk matrix, benefit-risk analysis, residual risk, risk acceptability, or post-market risk.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/risk-management-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/roadmap-communicator",
-      "name": "roadmap-communicator",
-      "description": "Use when preparing roadmap narratives, release notes, changelogs, or stakeholder updates tailored for executives, engineering teams, and customers.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/roadmap-communicator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/run",
-      "name": "run",
-      "description": "One-shot lifecycle command that chains init → baseline → spawn → eval → merge in a single invocation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/run"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/runbook-generator",
-      "name": "runbook-generator",
-      "description": "Generate operational runbooks from a service name — deployment, incident response, maintenance, and rollback workflows. Templated structure customizable per environment. Use when documenting on-call procedures for a new service, standardizing incident response across teams, or producing runbooks before launching to production.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/runbook-generator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/saas-health",
-      "name": "saas-health",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/saas-health"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/saas-metrics-coach",
-      "name": "saas-metrics-coach",
-      "description": "SaaS financial health advisor. Use when a user shares revenue or customer numbers, or mentions ARR, MRR, churn, LTV, CAC, NRR, or asks how their SaaS business is doing.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "finance/skills/saas-metrics-coach"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/saas-scaffolder",
-      "name": "saas-scaffolder",
-      "description": "Generates complete, production-ready SaaS project boilerplate including authentication, database schemas, billing integration, API routes, and a working dashboard using Next.js 14+ App Router, TypeScript, Tailwind CSS, shadcn/ui, Drizzle ORM, and Stripe. Use when the user wants to create a new SaaS app, start a subscription-based web project, scaffold a Next.js application, or mentions terms like starter template, boilerplate, new project, or wiring up auth and payments.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/saas-scaffolder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sales-engineer",
-      "name": "sales-engineer",
-      "description": "Analyzes RFP/RFI responses for coverage gaps, builds competitive feature comparison matrices, and plans proof-of-concept (POC) engagements for pre-sales engineering. Use when responding to RFPs, bids, or proposal requests; comparing product features against competitors; planning or scoring a customer POC or sales demo; preparing a technical proposal; or performing win/loss competitor analysis. Handles tasks described as 'RFP response', 'bid response', 'proposal response', 'competitor comparison', 'feature matrix', 'POC planning', 'sales demo prep', or 'pre-sales engineering'.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-growth/skills/sales-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sample-skill",
-      "name": "sample-skill",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/sample-skill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/scenario-war-room",
-      "name": "scenario-war-room",
-      "description": "Cross-functional what-if modeling for cascading multi-variable scenarios. Unlike single-assumption stress testing, this models compound adversity across all business functions simultaneously. Use when facing complex risk scenarios, strategic decisions with major downside, or when the user asks 'what if X AND Y both happen?'",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/scenario-war-room"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/schema-markup",
-      "name": "schema-markup",
-      "description": "When the user wants to implement, audit, or validate structured data (schema markup) on their website. Use when the user mentions 'structured data,' 'schema.org,' 'JSON-LD,' 'rich results,' 'rich snippets,' 'schema markup,' 'FAQ schema,' 'Product schema,' 'HowTo schema,' or 'structured data errors in Search Console.' Also use when someone asks why their content isn't showing rich results or wants to improve AI search visibility. NOT for general SEO audits (use seo-audit) or technical SEO crawl issues (use site-architecture).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/schema-markup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/scrum-master",
-      "name": "scrum-master",
-      "description": "Advanced Scrum Master skill for data-driven agile team analysis and coaching. Use when the user asks about sprint planning, velocity tracking, retrospectives, standup facilitation, backlog grooming, story points, burndown charts, blocker resolution, or agile team health. Runs Python scripts to analyse sprint JSON exports from Jira or similar tools: velocity_analyzer.py for Monte Carlo sprint forecasting, sprint_health_scorer.py for multi-dimension health scoring, and retrospective_analyzer.py for action-item and theme tracking. Produces confidence-interval forecasts, health grade reports, and improvement-velocity trends for high-performing Scrum teams.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/scrum-master"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/secrets-vault-manager",
-      "name": "secrets-vault-manager",
-      "description": "Use when the user asks to set up secret management infrastructure, integrate HashiCorp Vault, configure cloud secret stores (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager), implement secret rotation, or audit secret access patterns.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/secrets-vault-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/security-guidance",
-      "name": "security-guidance",
-      "description": "PreToolUse security-anti-pattern hook for Claude Code. Catches 12 common security risks (command injection, XSS, SQL injection, unsafe deserialization, GitHub Actions workflow injection, eval/new Function code injection) BEFORE the Edit/Write/MultiEdit operation completes. Session-state caching prevents duplicate warnings on the same file+rule combo. Stdlib only — no dependencies. Use when you want a safety net during Claude Code sessions that touch security-sensitive code (auth, payments, user input handling, IaC). Disable with ENABLE_SECURITY_REMINDER=0 if you need to perform a verified-safe operation that would otherwise trip a pattern. Triggers — \"add security hook\", \"block unsafe code\", \"detect command injection before write\", \"prevent SQL injection patterns\", \"security warning hook\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/security-guidance/skills/security-guidance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/security-pen-testing",
-      "name": "security-pen-testing",
-      "description": "Use when the user asks to perform security audits, penetration testing, vulnerability scanning, OWASP Top 10 checks, or offensive security assessments. Covers static analysis, dependency scanning, secret detection, API security testing, and pen test report generation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/security-pen-testing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/self-eval",
-      "name": "self-eval",
-      "description": "Honestly evaluate AI work quality using a two-axis scoring system. Use after completing a task, code review, or work session to get an unbiased assessment. Detects score inflation, forces devil's advocate reasoning, and persists scores across sessions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/self-eval"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/self-improving-agent",
-      "name": "self-improving-agent",
-      "description": "Curate Claude Code's auto-memory into durable project knowledge. Analyze MEMORY.md for patterns, promote proven learnings to CLAUDE.md and .claude/rules/, extract recurring solutions into reusable skills. Use when: (1) reviewing what Claude has learned about your project, (2) graduating a pattern from notes to enforced rules, (3) turning a debugging solution into a skill, (4) checking memory health and capacity.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/self-improving-agent"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-architect",
-      "name": "senior-architect",
-      "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\", \"choose a database\", \"plan for scalability\", \"make technical decisions\", or \"review system design\". Use for architecture decision records (ADRs), tech stack evaluation, system design reviews, dependency analysis, and generating architecture diagrams in Mermaid, PlantUML, or ASCII format.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-backend",
-      "name": "senior-backend",
-      "description": "Designs and implements backend systems including REST APIs, microservices, database architectures, authentication flows, and security hardening. Use when the user asks to \"design REST APIs\", \"optimize database queries\", \"implement authentication\", \"build microservices\", \"review backend code\", \"set up GraphQL\", \"handle database migrations\", or \"load test APIs\". Covers Node.js/Express/Fastify development, PostgreSQL optimization, API security, and backend architecture patterns.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-backend"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-computer-vision",
-      "name": "senior-computer-vision",
-      "description": "Computer vision engineering skill for object detection, image segmentation, and visual AI systems. Covers CNN and Vision Transformer architectures, YOLO/Faster R-CNN/DETR detection, Mask R-CNN/SAM segmentation, and production deployment with ONNX/TensorRT. Includes PyTorch, torchvision, Ultralytics, Detectron2, and MMDetection frameworks. Use when building detection pipelines, training custom models, optimizing inference, or deploying vision systems.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-computer-vision"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-data-engineer",
-      "name": "senior-data-engineer",
-      "description": "Data engineering skill for building scalable data pipelines, ETL/ELT systems, and data infrastructure. Expertise in Python, SQL, Spark, Airflow, dbt, Kafka, and modern data stack. Includes data modeling, pipeline orchestration, data quality, and DataOps. Use when designing data architectures, building data pipelines, optimizing data workflows, implementing data governance, or troubleshooting data issues.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-data-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-data-scientist",
-      "name": "senior-data-scientist",
-      "description": "World-class senior data scientist skill specialising in statistical modeling, experiment design, causal inference, and predictive analytics. Covers A/B testing (sample sizing, two-proportion z-tests, Bonferroni correction), difference-in-differences, feature engineering pipelines (Scikit-learn, XGBoost), cross-validated model evaluation (AUC-ROC, AUC-PR, SHAP), and MLflow experiment tracking — using Python (NumPy, Pandas, Scikit-learn), R, and SQL. Use when designing or analysing controlled experiments, building and evaluating classification or regression models, performing causal analysis on observational data, engineering features for structured tabular datasets, or translating statistical findings into data-driven business decisions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-data-scientist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-devops",
-      "name": "senior-devops",
-      "description": "Comprehensive DevOps skill for CI/CD, infrastructure automation, containerization, and cloud platforms (AWS, GCP, Azure). Includes pipeline setup, infrastructure as code, deployment automation, and monitoring. Use when setting up pipelines, deploying applications, managing infrastructure, implementing monitoring, or optimizing deployment processes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-devops"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-frontend",
-      "name": "senior-frontend",
-      "description": "Frontend development skill for React, Next.js, TypeScript, and Tailwind CSS applications. Use when building React components, optimizing Next.js performance, analyzing bundle sizes, scaffolding frontend projects, implementing accessibility, or reviewing frontend code quality.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-frontend"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-fullstack",
-      "name": "senior-fullstack",
-      "description": "Fullstack development toolkit with project scaffolding for Next.js, FastAPI, MERN, and Django stacks, code quality analysis with security and complexity scoring, and stack selection guidance. Use when the user asks to \"scaffold a new project\", \"create a Next.js app\", \"set up FastAPI with React\", \"analyze code quality\", \"audit my codebase\", \"what stack should I use\", \"generate project boilerplate\", or mentions fullstack development, project setup, or tech stack comparison.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-fullstack"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-ml-engineer",
-      "name": "senior-ml-engineer",
-      "description": "ML engineering skill for productionizing models, building MLOps pipelines, and integrating LLMs. Covers model deployment, feature stores, drift monitoring, RAG systems, and cost optimization. Use when the user asks about deploying ML models to production, setting up MLOps infrastructure (MLflow, Kubeflow, Kubernetes, Docker), monitoring model performance or drift, building RAG pipelines, or integrating LLM APIs with retry logic and cost controls. Focused on production and operational concerns rather than model research or initial training.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-ml-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-pm",
-      "name": "senior-pm",
-      "description": "Senior Project Manager for enterprise software, SaaS, and digital transformation projects. Specializes in portfolio management, quantitative risk analysis, resource optimization, stakeholder alignment, and executive reporting. Uses advanced methodologies including EMV analysis, Monte Carlo simulation, WSJF prioritization, and multi-dimensional health scoring. Use when a user needs help with project plans, project status reports, risk assessments, resource allocation, project roadmaps, milestone tracking, team capacity planning, portfolio health reviews, program management, or executive-level project reporting — especially for enterprise-scale initiatives with multiple workstreams, complex dependencies, or multi-million dollar budgets.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/senior-pm"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-prompt-engineer",
-      "name": "senior-prompt-engineer",
-      "description": "This skill should be used when the user asks to \"optimize prompts\", \"design prompt templates\", \"evaluate LLM outputs\", \"build agentic systems\", \"implement RAG\", \"create few-shot examples\", \"analyze token usage\", or \"design AI workflows\". Use for prompt engineering patterns, LLM evaluation frameworks, agent architectures, and structured output design.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-prompt-engineer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-qa",
-      "name": "senior-qa",
-      "description": "Generates unit tests, integration tests, and E2E tests for React/Next.js applications. Scans components to create Jest + React Testing Library test stubs, analyzes Istanbul/LCOV coverage reports to surface gaps, scaffolds Playwright test files from Next.js routes, mocks API calls with MSW, creates test fixtures, and configures test runners. Use when the user asks to \"generate tests\", \"write unit tests\", \"analyze test coverage\", \"scaffold E2E tests\", \"set up Playwright\", \"configure Jest\", \"implement testing patterns\", or \"improve test quality\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-qa"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-secops",
-      "name": "senior-secops",
-      "description": "Senior SecOps engineer skill for application security, vulnerability management, compliance verification, and secure development practices. Runs SAST/DAST scans, generates CVE remediation plans, checks dependency vulnerabilities, creates security policies, enforces secure coding patterns, and automates compliance checks against SOC2, PCI-DSS, HIPAA, and GDPR. Use when conducting a security review or audit, responding to a CVE or security incident, hardening infrastructure, implementing authentication or secrets management, running penetration test prep, checking OWASP Top 10 exposure, or enforcing security controls in CI/CD pipelines.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-secops"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/senior-security",
-      "name": "senior-security",
-      "description": "Security engineering toolkit for threat modeling, vulnerability analysis, secure architecture, and penetration testing. Includes STRIDE analysis, OWASP guidance, cryptography patterns, and security scanning tools. Use when the user asks about security reviews, threat analysis, vulnerability assessments, secure coding practices, security audits, attack surface analysis, CVE remediation, or security best practices.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/senior-security"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/seo-audit",
-      "name": "seo-audit",
-      "description": "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" or \"SEO health check.\" For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/seo-audit"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/seo-auditor",
-      "name": "seo-auditor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/seo-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/setup",
-      "name": "setup",
-      "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/autoresearch-agent/skills/setup"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ship-gate",
-      "name": "ship-gate",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/ship-gate"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/signup-flow-cro",
-      "name": "signup-flow-cro",
-      "description": "When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions \"signup conversions,\" \"registration friction,\" \"signup form optimization,\" \"free trial signup,\" \"reduce signup dropoff,\" or \"account creation flow.\" For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/signup-flow-cro"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/site-architecture",
-      "name": "site-architecture",
-      "description": "When the user wants to audit, redesign, or plan their website's structure, URL hierarchy, navigation design, or internal linking strategy. Use when the user mentions 'site architecture,' 'URL structure,' 'internal links,' 'site navigation,' 'breadcrumbs,' 'topic clusters,' 'hub pages,' 'orphan pages,' 'silo structure,' 'information architecture,' or 'website reorganization.' Also use when someone has SEO problems and the root cause is structural (not content or schema). NOT for content strategy decisions about what to write (use content-strategy) or for schema markup (use schema-markup).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/site-architecture"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skill-security-auditor",
-      "name": "skill-security-auditor",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/skill-security-auditor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skill-tester",
-      "name": "skill-tester",
-      "description": "Validate, test, and score the quality of skills within the claude-skills ecosystem. Comprehensive meta-skill: structure validation, Python script testing (syntax + imports + runtime + output format), multi-dimensional quality scoring with letter grades and tier classification (BASIC/STANDARD/POWERFUL). Use when authoring a new skill, auditing existing skills for tier promotion, setting up pre-commit hooks for skill quality, or integrating skill QA into CI.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/skill-tester"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-chaos-engineering",
-      "name": "skills-chaos-engineering",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-chaos-engineering"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-chief-ai-officer-advisor",
-      "name": "skills-chief-ai-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-chief-ai-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-chief-customer-officer-advisor",
-      "name": "skills-chief-customer-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-chief-customer-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-chief-data-officer-advisor",
-      "name": "skills-chief-data-officer-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-chief-data-officer-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-eu-ai-act-specialist",
-      "name": "skills-eu-ai-act-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-eu-ai-act-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-feature-flags-architect",
-      "name": "skills-feature-flags-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-feature-flags-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-general-counsel-advisor",
-      "name": "skills-general-counsel-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-general-counsel-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-handoff",
-      "name": "skills-handoff",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-handoff"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-init",
-      "name": "skills-init",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-iso42001-specialist",
-      "name": "skills-iso42001-specialist",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-iso42001-specialist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-kubernetes-operator",
-      "name": "skills-kubernetes-operator",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-kubernetes-operator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-review",
-      "name": "skills-review",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-run",
-      "name": "skills-run",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-run"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-slo-architect",
-      "name": "skills-slo-architect",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-slo-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-status",
-      "name": "skills-status",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-status-2",
-      "name": "skills-status-2",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-status-2"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/skills-vpe-advisor",
-      "name": "skills-vpe-advisor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/skills-vpe-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/slo-architect",
-      "name": "slo-architect",
-      "description": "Use when defining, reviewing, or operating SLOs/SLIs/error budgets. Triggers on \"define an SLO\", \"what should our SLO be\", \"error budget\", \"burn rate\", \"SLI\", \"service level objective\", \"Google SRE workbook\", \"multi-window burn-rate alert\", or any reliability-target question. Ships SLO designer, error-budget calculator with multi-window burn-rate thresholds, and SLO reviewer that catches the common bugs (target too aggressive, window too short, conflicting SLOs, no SLI definition). 4 references on SLO principles + SLI design + error budget math + composition with feature-flags-architect/chaos-engineering/kubernetes-operator. NOT a generic observability skill — specifically the SLO discipline.",
-      "tags": [
-        "slo",
-        "sli",
-        "sla",
-        "error-budget",
-        "burn-rate",
-        "sre",
-        "reliability",
-        "google-sre-workbook",
-        "observability"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/slo-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/slo-design",
-      "name": "slo-design",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/slo-design"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/snowflake-development",
-      "name": "snowflake-development",
-      "description": "Use when writing Snowflake SQL, building data pipelines with Dynamic Tables or Streams/Tasks, using Cortex AI functions, creating Cortex Agents, writing Snowpark Python, configuring dbt for Snowflake, or troubleshooting Snowflake errors.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/snowflake-development/skills/snowflake-development"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/soc2-audit-prep",
-      "name": "soc2-audit-prep",
-      "description": "/cs:soc2-audit-prep <scope> — SOC 2 Type II readiness 6-question forcing interrogation. Observation-period focused. Use before Type II observation begins, mid-period checkpoint, or pre-field-test month-10 readiness.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "compliance-os/skills/soc2-audit-prep"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/soc2-compliance",
-      "name": "soc2-compliance",
-      "description": "Use when the user asks to prepare for SOC 2 audits, map Trust Service Criteria, build control matrices, collect audit evidence, perform gap analysis, or assess SOC 2 Type I vs Type II readiness.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "ra-qm-team/skills/soc2-compliance"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-content",
-      "name": "social-content",
-      "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' or 'viral content.' This skill covers content creation, repurposing, and platform-specific strategies.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/social-content"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-media-analyzer",
-      "name": "social-media-analyzer",
-      "description": "Social media campaign analysis and performance tracking. Calculates engagement rates, ROI, and benchmarks across platforms. Use for analyzing social media performance, calculating engagement rate, measuring campaign ROI, comparing platform metrics, or benchmarking against industry standards.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/social-media-analyzer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/social-media-manager",
-      "name": "social-media-manager",
-      "description": "When the user wants to develop social media strategy, plan content calendars, manage community engagement, or grow their social presence across platforms. Also use when the user mentions 'social media strategy,' 'social calendar,' 'community management,' 'social media plan,' 'grow followers,' 'engagement rate,' 'social media audit,' or 'which platforms should I use.' For writing individual social posts, see social-content. For analyzing social performance data, see social-media-analyzer.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/social-media-manager"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/solo-founder",
-      "name": "solo-founder",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/solo-founder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spawn",
-      "name": "spawn",
-      "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/agenthub/skills/spawn"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spec-driven-workflow",
-      "name": "spec-driven-workflow",
-      "description": "Use when the user asks to write specs before code, define acceptance criteria, plan features before implementation, generate tests from specifications, or follow spec-first development practices.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/spec-driven-workflow"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/spec-to-repo",
-      "name": "spec-to-repo",
-      "description": "Use when the user says 'build me an app', 'create a project from this spec', 'scaffold a new repo', 'generate a starter', 'turn this idea into code', 'bootstrap a project', 'I have requirements and need a codebase', or provides a natural-language project specification and expects a complete, runnable repository. Stack-agnostic: Next.js, FastAPI, Rails, Go, Rust, Flutter, and more.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/spec-to-repo"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sprint-health",
-      "name": "sprint-health",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/sprint-health"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sprint-plan",
-      "name": "sprint-plan",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/sprint-plan"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/sql-database-assistant",
-      "name": "sql-database-assistant",
-      "description": "Use when the user asks to write SQL queries, optimize database performance, generate migrations, explore database schemas, or work with ORMs like Prisma, Drizzle, TypeORM, or SQLAlchemy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/sql-database-assistant"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/startup-cto",
-      "name": "startup-cto",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/startup-cto"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/statistical-analyst",
-      "name": "statistical-analyst",
-      "description": "Run hypothesis tests, analyze A/B experiment results, calculate sample sizes, and interpret statistical significance with effect sizes. Use when you need to validate whether observed differences are real, size an experiment correctly before launch, or interpret test results with confidence.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/statistical-analyst/skills/statistical-analyst"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/status",
-      "name": "status",
-      "description": "Memory health dashboard showing line counts, topic files, capacity, stale entries, and recommendations.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/self-improving-agent/skills/status"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/strategic-alignment",
-      "name": "strategic-alignment",
-      "description": "Cascades strategy from boardroom to individual contributor. Detects and fixes misalignment between company goals and team execution. Covers strategy articulation, cascade mapping, orphan goal detection, silo identification, communication gap analysis, and realignment protocols. Use when teams are pulling in different directions, OKRs don't connect, departments optimize locally at company expense, or when user mentions alignment, strategy cascade, silo, conflicting OKRs, or strategy communication.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/strategic-alignment"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/stress-test",
-      "name": "stress-test",
-      "description": "/em -stress-test — Business Assumption Stress Testing",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/executive-mentor/skills/stress-test"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/stripe-integration-expert",
-      "name": "stripe-integration-expert",
-      "description": "Production-grade Stripe integrations: subscriptions with trials and proration, one-time payments, usage-based billing, checkout sessions, idempotent webhook handlers, customer portal, and invoicing. Covers Next.js, Express, and Django patterns. Use when integrating Stripe for the first time, debugging webhook reliability issues, migrating from a different payment provider, or adding usage-based billing to an existing subscription product.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/stripe-integration-expert"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/syllabus",
-      "name": "syllabus",
-      "description": "Generates a curated supplementary reading list from any course syllabus using Consensus academic search. Grill-me intake (syllabus input format + course audience + year range) plus a grouping forcing-options checkpoint before any search runs — so the reading list matches the course's level and recency need. Parses the syllabus to extract topics and learning outcomes, searches Consensus for recent peer-reviewed papers per topic, and produces a professionally formatted .docx with clickable Consensus links, plain-language summaries calibrated to audience level, and Bloom-higher-order discussion questions tied to course learning goals. Triggers whenever a user uploads a syllabus, course outline, or curriculum document and wants supplementary readings. Also triggers on: 'syllabus reading list', 'find papers for my course', 'create a reading list from this syllabus', 'recent research for my class', 'supplementary readings', 'find journal articles for these topics', 'what recent papers cover this material', 'any new research on these course topics', 'update my syllabus with recent papers'. Even casual mentions when a syllabus is attached should trigger this skill.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "research/syllabus/skills/syllabus"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tc",
-      "name": "tc",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tc"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tc-tracker",
-      "name": "tc-tracker",
-      "description": "Use when the user asks to track technical changes, create change records, manage TC lifecycles, or hand off work between AI sessions. Covers init/create/update/status/resume/close/export workflows for structured code change documentation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/tc-tracker"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tdd",
-      "name": "tdd",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tdd"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tdd-guide",
-      "name": "tdd-guide",
-      "description": "Test-driven development skill for writing unit tests, generating test fixtures and mocks, analyzing coverage gaps, and guiding red-green-refactor workflows across Jest, Pytest, JUnit, Vitest, and Mocha. Use when the user asks to write tests, improve test coverage, practice TDD, generate mocks or stubs, or mentions testing frameworks like Jest, pytest, or JUnit.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/tdd-guide"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/team-communications",
-      "name": "team-communications",
-      "description": "Write internal company communications — 3P updates (Progress/Plans/Problems), company-wide newsletters, FAQ roundups, incident reports, leadership updates, status reports, project updates, and general internal comms. Use this skill any time the user asks to draft, edit, or format something meant for internal audiences. Trigger on keywords like \"3P\", \"weekly update\", \"newsletter\", \"FAQ\", \"internal comms\", \"status report\", \"company update\", \"team update\", \"incident report\", or any request to summarize work for leadership, teammates, or the broader company. Even casual requests like \"write my update\" or \"summarize what my team did this week\" should trigger this skill.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "project-management/skills/team-communications"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tech-debt",
-      "name": "tech-debt",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/tech-debt"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tech-debt-tracker",
-      "name": "tech-debt-tracker",
-      "description": "Scan codebases for technical debt, score severity, track trends, and generate prioritized remediation plans. Use when users mention tech debt, code quality, refactoring priority, debt scoring, cleanup sprints, or code health assessment. Also use for legacy code modernization planning and maintenance cost estimation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/skills/tech-debt-tracker"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/tech-stack-evaluator",
-      "name": "tech-stack-evaluator",
-      "description": "Technology stack evaluation and comparison with TCO analysis, security assessment, and ecosystem health scoring. Use when comparing frameworks, evaluating technology stacks, calculating total cost of ownership, assessing migration paths, or analyzing ecosystem viability.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/tech-stack-evaluator"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/template",
-      "name": "TEMPLATE",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/TEMPLATE"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/terraform-patterns",
-      "name": "terraform-patterns",
-      "description": "Terraform infrastructure-as-code agent skill and plugin for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Covers module design patterns, state management strategies, provider configuration, security hardening, policy-as-code with Sentinel/OPA, and CI/CD plan/apply workflows. Use when: user wants to design Terraform modules, manage state backends, review Terraform security, implement multi-region deployments, or follow IaC best practices.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/terraform-patterns/skills/terraform-patterns"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/testrail",
-      "name": "testrail",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/playwright-pro/skills/testrail"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/threat-detection",
-      "name": "threat-detection",
-      "description": "Use when hunting for threats in an environment, analyzing IOCs, or detecting behavioral anomalies in telemetry. Covers hypothesis-driven threat hunting, IOC sweep generation, z-score anomaly detection, and MITRE ATT&CK-mapped signal prioritization.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering-team/skills/threat-detection"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ui-design-system",
-      "name": "ui-design-system",
-      "description": "UI design system toolkit for Senior UI Designer including design token generation, component documentation, responsive design calculations, and developer handoff tools. Use for creating design systems, maintaining visual consistency, and facilitating design-dev collaboration.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/ui-design-system"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/universal-scraping-architect",
-      "name": "universal-scraping-architect",
-      "description": "Use for web scraping, crawling, document extraction, API parsing, or building validation-heavy data pipelines using Firecrawl or local Python scripts.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/universal-scraping-architect"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/user-story",
-      "name": "user-story",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/user-story"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/ux-researcher-designer",
-      "name": "ux-researcher-designer",
-      "description": "UX research and design toolkit for Senior UX Designer/Researcher including data-driven persona generation, journey mapping, usability testing frameworks, and research synthesis. Use for user research, persona creation, journey mapping, and design validation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "product-team/skills/ux-researcher-designer"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vendor-management",
-      "name": "vendor-management",
-      "description": "Use when reviewing, scoring, or auditing third-party SaaS / vendor relationships — running a vendor scorecard, tracking SLA compliance, classifying third-party risk, preparing a tier-1 vendor review, or auditing the SaaS portfolio. Triggers on \"vendor SLA\", \"vendor scorecard\", \"third-party risk\", \"TPRM\", \"vendor review\", \"SaaS audit\", \"supplier performance\", \"vendor health check\", \"renewal review\". Forks context so large vendor catalogs (50-500 line items) and SLA logs don't pollute the parent thread. Ships 3 stdlib-only Python tools (vendor scorer with industry tuning, SLA compliance tracker with credit-claim flags, vendor risk classifier across 4 risk vectors), 3 reference docs each citing 7+ authoritative sources (Gartner / Shared Assessments / NIST / ISO 27036 / breach post-mortems), and a 5-vendor catalog template. Distinct from c-level-advisor/general-counsel-advisor (contract law, not operational management), business-growth/contract-and-proposal-writer (outbound proposals, not inbound vendor scoring), and sibling procurement-optimizer (spend categorization, not vendor performance).",
-      "tags": [
-        "bizops",
-        "vendor",
-        "sla",
-        "third-party-risk",
-        "vendor-management",
-        "saas-management",
-        "tprm"
-      ],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "business-operations/skills/vendor-management"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/video-content-strategist",
-      "name": "video-content-strategist",
-      "description": "Use when planning video content strategy, writing video scripts, optimizing YouTube channels, building short-form video pipelines (Reels, TikTok, Shorts), or repurposing long-form content into video. Triggers: 'start a YouTube channel', 'video content strategy', 'write a video script', 'repurpose into video', 'YouTube SEO', 'short-form video'. NOT for written blog content (use content-production). NOT for social captions without video (use social-media-manager).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/video-content-strategist/skills/video-content-strategist"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vpe-advisor",
-      "name": "vpe-advisor",
-      "description": "VP of Engineering advisory for startups: delivery throughput (DORA 4 metrics + bottleneck identification), engineering hiring funnel (sourcing → screen → onsite → offer conversion + time-to-fill + pipeline gap), engineering team structure (squad/tribe/chapter design + tech-lead manager-trigger thresholds), and production discipline (on-call, deployment cadence, postmortem culture). Use when sprint velocity is dropping, eng hiring is broken, team structure is unclear, or deciding when to add a tech-lead manager. NOT a CTO skill (which owns architecture) — VPE owns delivery operations and how the team ships.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/skills/vpe-advisor"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/vpe-review",
-      "name": "vpe-review",
-      "description": "/cs:vpe-review <plan> — Throughput-first VP of Engineering interrogation of any plan that touches delivery, eng hiring, team structure, or production discipline.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "c-level-advisor/c-level-agents/skills/vpe-review"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/webinar-marketing",
-      "name": "webinar-marketing",
-      "description": "When the user wants to plan, promote, run, or improve a webinar or virtual event to generate and convert demand. Use when the user mentions 'webinar,' 'virtual event,' 'online event,' 'live demo,' 'virtual summit,' 'workshop,' 'masterclass,' 'fireside chat,' 'roundtable,' 'registration funnel,' 'show-up rate,' 'attendance rate,' 'webinar promotion,' 'webinar follow-up,' or 'on-demand webinar.' Also use when they have a webinar that isn't converting — low registrations, low show-up, or attendees who don't buy — and want to diagnose and fix it. Covers the full funnel: registration, promotion, show-up, live engagement, live-to-close, and post-event nurture. Distinct from launch-strategy (full product launches) and email-sequence (lifecycle nurture) — this is the end-to-end webinar/event motion. NOT for in-person field events logistics, and NOT for generic lifecycle email (use email-sequence).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/webinar-marketing"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/wiki-ingest",
-      "name": "wiki-ingest",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/wiki-ingest"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/wiki-init",
-      "name": "wiki-init",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/wiki-init"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/wiki-lint",
-      "name": "wiki-lint",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/wiki-lint"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/wiki-log",
-      "name": "wiki-log",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/wiki-log"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/wiki-query",
-      "name": "wiki-query",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": ".gemini/skills/wiki-query"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/workflow-builder",
-      "name": "workflow-builder",
-      "description": "Design and write deterministic multi-agent workflow scripts (.js files in .claude/workflows/) for Claude Code's Workflow tool. Use when a user wants to build, create, author, scaffold, or run a custom Claude Code workflow, orchestrate sub-agents (fan-out, pipeline, loop, judge-panel), or automate a repeatable multi-step task across fresh-context agents.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/workflow-builder/skills/workflow-builder"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/write-a-skill",
-      "name": "write-a-skill",
-      "description": "Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, build, or author a new skill.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "engineering/write-a-skill/skills/write-a-skill"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/x-twitter-growth",
-      "name": "x-twitter-growth",
-      "description": "X/Twitter growth engine for building audience, crafting viral content, and analyzing engagement. Use when the user wants to grow on X/Twitter, write tweets or threads, analyze their X profile, research competitors on X, plan a posting strategy, or optimize engagement. Complements social-content (generic multi-platform) with X-specific depth: algorithm mechanics, thread engineering, reply strategy, profile optimization, and competitive intelligence via web search.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/x-twitter-growth"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
-    },
-    {
-      "id": "alirezarezvani-claude-skills/youtube-full",
-      "name": "youtube-full",
-      "description": "Use when the user needs YouTube transcripts, video search, channel browsing, playlist extraction, or content monitoring. Trigger phrases: 'get the transcript for', 'search YouTube for', 'what are the latest videos on', 'list this playlist', 'monitor this channel', or any request involving a YouTube URL, video ID, or @handle. Do NOT use for downloading video or audio files, YouTube engagement data (likes, comments), or private/age-restricted videos.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "alirezarezvani/claude-skills",
-        "ref": "main",
-        "path": "marketing-skill/skills/youtube-full"
-      },
-      "stars": 17408,
-      "updatedAt": "2026-06-07T04:15:18Z",
-      "provenance": "curated",
-      "sourceId": "alirezarezvani-claude-skills"
     },
     {
       "id": "anthropic-skills/algorithmic-art",
@@ -7483,7 +444,7 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7499,7 +460,7 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7515,7 +476,7 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7531,7 +492,7 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7547,7 +508,7 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7563,7 +524,7 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7579,7 +540,7 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7595,7 +556,7 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7611,7 +572,7 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7627,7 +588,7 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7643,7 +604,7 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7659,7 +620,7 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7675,7 +636,7 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7691,7 +652,7 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7707,7 +668,7 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7723,7 +684,7 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7739,7 +700,7 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7755,7 +716,7 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147552,
+      "stars": 147554,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -7771,7 +732,7 @@
         "ref": "main",
         "path": "skills/ab-testing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7787,7 +748,7 @@
         "ref": "main",
         "path": "skills/ad-creative"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7803,7 +764,7 @@
         "ref": "main",
         "path": "skills/ads"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7819,7 +780,7 @@
         "ref": "main",
         "path": "skills/ai-seo"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7835,7 +796,7 @@
         "ref": "main",
         "path": "skills/analytics"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7851,7 +812,7 @@
         "ref": "main",
         "path": "skills/aso"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7867,7 +828,7 @@
         "ref": "main",
         "path": "skills/churn-prevention"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7883,7 +844,7 @@
         "ref": "main",
         "path": "skills/co-marketing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7899,7 +860,7 @@
         "ref": "main",
         "path": "skills/cold-email"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7915,7 +876,7 @@
         "ref": "main",
         "path": "skills/community-marketing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7931,7 +892,7 @@
         "ref": "main",
         "path": "skills/competitor-profiling"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7947,7 +908,7 @@
         "ref": "main",
         "path": "skills/competitors"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7963,7 +924,7 @@
         "ref": "main",
         "path": "skills/content-strategy"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7979,7 +940,7 @@
         "ref": "main",
         "path": "skills/copy-editing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -7995,7 +956,7 @@
         "ref": "main",
         "path": "skills/copywriting"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8011,7 +972,7 @@
         "ref": "main",
         "path": "skills/cro"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8027,7 +988,7 @@
         "ref": "main",
         "path": "skills/customer-research"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8043,7 +1004,7 @@
         "ref": "main",
         "path": "skills/directory-submissions"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8059,7 +1020,7 @@
         "ref": "main",
         "path": "skills/emails"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8075,7 +1036,7 @@
         "ref": "main",
         "path": "skills/free-tools"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8091,7 +1052,7 @@
         "ref": "main",
         "path": "skills/image"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8107,7 +1068,7 @@
         "ref": "main",
         "path": "skills/launch"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8123,7 +1084,7 @@
         "ref": "main",
         "path": "skills/lead-magnets"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8139,7 +1100,7 @@
         "ref": "main",
         "path": "skills/marketing-ideas"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8155,7 +1116,7 @@
         "ref": "main",
         "path": "skills/marketing-plan"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8171,7 +1132,7 @@
         "ref": "main",
         "path": "skills/marketing-psychology"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8187,7 +1148,7 @@
         "ref": "main",
         "path": "skills/onboarding"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8203,7 +1164,7 @@
         "ref": "main",
         "path": "skills/paywalls"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8219,7 +1180,7 @@
         "ref": "main",
         "path": "skills/popups"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8235,7 +1196,7 @@
         "ref": "main",
         "path": "skills/pricing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8251,7 +1212,7 @@
         "ref": "main",
         "path": "skills/product-marketing"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8267,7 +1228,7 @@
         "ref": "main",
         "path": "skills/programmatic-seo"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8283,7 +1244,7 @@
         "ref": "main",
         "path": "skills/prospecting"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8299,7 +1260,7 @@
         "ref": "main",
         "path": "skills/referrals"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8315,7 +1276,7 @@
         "ref": "main",
         "path": "skills/revops"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8331,7 +1292,7 @@
         "ref": "main",
         "path": "skills/sales-enablement"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8347,7 +1308,7 @@
         "ref": "main",
         "path": "skills/schema"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8363,7 +1324,7 @@
         "ref": "main",
         "path": "skills/seo-audit"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8379,7 +1340,7 @@
         "ref": "main",
         "path": "skills/signup"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8395,7 +1356,7 @@
         "ref": "main",
         "path": "skills/site-architecture"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8411,7 +1372,7 @@
         "ref": "main",
         "path": "skills/sms"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8427,7 +1388,7 @@
         "ref": "main",
         "path": "skills/social"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -8443,2362 +1404,10 @@
         "ref": "main",
         "path": "skills/video"
       },
-      "stars": 32325,
+      "stars": 32329,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/asr-transcribe-to-text",
-      "name": "asr-transcribe-to-text",
-      "description": "Transcribes audio and video files to text using Qwen3-ASR. Supports two modes — local MLX inference on macOS Apple Silicon (no API key, 15-27x realtime) and remote API via vLLM/OpenAI-compatible endpoints. Auto-detects platform and recommends the best path. Triggers when the user wants to transcribe recordings, convert audio/video to text, do speech-to-text, or mentions ASR, Qwen ASR, 转录, 语音转文字, 录音转文字. Also triggers for meeting recordings, lectures, interviews, podcasts, screen recordings, or any audio/video file the user wants converted to text.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-audio/asr-transcribe-to-text"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/auto-repo-setup",
-      "name": "auto-repo-setup",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "auto-repo-setup"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/benchmark-due-diligence",
-      "name": "benchmark-due-diligence",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "benchmark-due-diligence"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/bigdata-skill",
-      "name": "bigdata-skill",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "bigdata-skill"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/capture-screen",
-      "name": "capture-screen",
-      "description": "Programmatic screenshot capture on macOS. Find window IDs with Swift CGWindowListCopyWindowInfo, control application windows via AppleScript (zoom, scroll, select), and capture with screencapture. Use when automating screenshots, capturing application windows for documentation, or building multi-shot visual workflows.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "capture-screen"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/claude-code-history-files-finder",
-      "name": "claude-code-history-files-finder",
-      "description": "Finds and recovers content from Claude Code session history files. This skill should be used when searching for deleted files, tracking changes across sessions, analyzing conversation history, or recovering code from previous Claude interactions. Triggers include mentions of \"session history\", \"recover deleted\", \"find in history\", \"previous conversation\", or \".claude/projects\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/claude-code-history-files-finder"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/claude-md-progressive-disclosurer",
-      "name": "claude-md-progressive-disclosurer",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/claude-md-progressive-disclosurer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/claude-skills-troubleshooting",
-      "name": "claude-skills-troubleshooting",
-      "description": "Diagnose and resolve Claude Code plugin and skill issues. This skill should be used when plugins are installed but not showing in available skills list, skills are not activating as expected, or when troubleshooting enabledPlugins configuration in settings.json. Triggers include \"plugin not working\", \"skill not showing\", \"installed but disabled\", or \"enabledPlugins\" issues.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/claude-skills-troubleshooting"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/cli-demo-generator",
-      "name": "cli-demo-generator",
-      "description": "Generates professional animated CLI demos as GIFs using VHS terminal recordings. Handles tape file creation, self-bootstrapping demos with hidden setup, output noise filtering, post-processing speed-up, and frame-level verification. Use when users want to create terminal demos, record CLI workflows as GIFs, generate animated documentation, build demo tapes for README files, or need to showcase any command-line tool visually. Also triggers on \"record terminal\", \"VHS tape\", \"demo GIF\", \"animate my CLI\", or any request to visually demonstrate shell commands.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "cli-demo-generator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/cloudflare-troubleshooting",
-      "name": "cloudflare-troubleshooting",
-      "description": "Investigate and resolve Cloudflare configuration issues using API-driven evidence gathering. Use when troubleshooting ERR_TOO_MANY_REDIRECTS, SSL errors, DNS issues, or any Cloudflare-related problems. Focus on systematic investigation using Cloudflare API to examine actual configuration rather than making assumptions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "cloudflare-troubleshooting"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/competitors-analysis",
-      "name": "competitors-analysis",
-      "description": "Analyze competitor repositories with evidence-based approach. Use when tracking competitors, creating competitor profiles, or generating competitive analysis. CRITICAL - all analysis must be based on actual cloned code, never assumptions. Triggers include \"analyze competitor\", \"add competitor\", \"competitive analysis\", or \"竞品分析\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "competitors-analysis"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/continue-claude-work",
-      "name": "continue-claude-work",
-      "description": "Recover actionable context from local `.claude` session artifacts and continue interrupted work without running `claude --resume`. This skill should be used when the user provides a Claude session ID, asks to continue prior work from local history, or wants to inspect `.claude` files before resuming implementation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/continue-claude-work"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/debugging-network-issues",
-      "name": "debugging-network-issues",
-      "description": "Evidence-driven investigation for network, streaming, and protocol-layer bugs where symptoms don't match the obvious cause. Use when debugging connection resets (ECONNRESET, HTTP/2 RST_STREAM, INTERNAL_ERROR), SSE or long-polling stalls, fixed-time connection drops, CDN/proxy/CGNAT idle timeouts, or symptoms like \"socket closed unexpectedly\", \"stream interrupted\", \"fails after N seconds\", \"works sometimes but not always\", \"upstream silent for X seconds\". Applies falsification-first layered isolation to pin down the responsible network layer instead of stacking assumptions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "debugging-network-issues"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/deep-research",
-      "name": "deep-research",
-      "description": "|",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "deep-research"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/developing-ios-apps",
-      "name": "developing-ios-apps",
-      "description": "Develops iOS/macOS apps with XcodeGen, SwiftUI, and SPM, including Apple Developer signing, notarization, and CI/CD pipelines. Use when building iOS/macOS apps, fixing Xcode build failures, deploying to real devices, or configuring CI/CD signing. Triggers on XcodeGen project.yml, SPM dependency issues, code signing errors (Error -25294, keychain mismatch, adhoc fallback, EMFILE, notarization credential conflict), \"Library not loaded @rpath\", Electron @electron/osx-sign / @electron/notarize, notarytool, or certificate/provisioning problems.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "iOS-APP-developer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/doc-to-markdown",
-      "name": "doc-to-markdown",
-      "description": "Converts DOCX/PDF/PPTX to high-quality Markdown with automatic post-processing. Fixes pandoc grid tables, simple tables, image paths, CJK bold spacing, attribute noise, and code blocks. Benchmarked best-in-class (7.6/10) against Docling, MarkItDown, Pandoc raw, and Mammoth. Trigger on \"convert document\", \"docx to markdown\", \"parse word\", \"doc to markdown\", \"解析word\", \"转换文档\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/doc-to-markdown"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/docs-cleaner",
-      "name": "docs-cleaner",
-      "description": "Consolidates redundant documentation while preserving all valuable content. This skill should be used when users want to clean up documentation bloat, merge redundant docs, reduce documentation sprawl, or consolidate multiple files covering the same topic. Triggers include \"clean up docs\", \"consolidate documentation\", \"too many doc files\", \"merge these docs\", or when documentation exceeds 500 lines across multiple files covering similar topics.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/docs-cleaner"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/douban-skill",
-      "name": "douban-skill",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "douban-skill"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/excel-automation",
-      "name": "excel-automation",
-      "description": "Create, parse, and control Excel files on macOS. Professional formatting with openpyxl, complex xlsm parsing with stdlib zipfile+xml for investment bank financial models, and Excel window control via AppleScript. Use when creating formatted Excel reports, parsing financial models that openpyxl cannot handle, or automating Excel on macOS.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "excel-automation"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/fact-checker",
-      "name": "fact-checker",
-      "description": "Verifies factual claims in documents using web search and official sources, then proposes corrections with user confirmation. Use when the user asks to fact-check, verify information, validate claims, check accuracy, or update outdated information in documents. Supports AI model specs, technical documentation, statistics, and general factual statements.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "fact-checker"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/feishu-doc-scraper",
-      "name": "feishu-doc-scraper",
-      "description": "Extract Feishu (Lark) Docs, Wiki pages/collections, spreadsheets, and Minutes (妙记) transcripts into faithful local Markdown via the lark-cli API (no LLM rewriting of the body; browser-DOM fallback when lark-cli can't reach the content). Use whenever the source is a Feishu/Lark URL and fidelity matters — 导出飞书文档/合集/妙记转写, 把飞书 wiki/知识库转 markdown, archiving a Feishu collection, exporting a 妙记 transcript, or saving a Feishu page — even if the user only says clipping, archiving, converting, or \"save this\". Also covers the owner-exported .docx → faithful Markdown path.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "feishu-doc-scraper"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/financial-data-collector",
-      "name": "financial-data-collector",
-      "description": "Collect real financial data for any US publicly traded company from free public sources (yfinance). Output structured JSON consumable by downstream financial skills (DCF modeling, comps analysis, earnings review). Handles market data (price, shares, beta), historical financials (income statement, cash flow, balance sheet), WACC inputs, and analyst estimates. Use when users request collect data for ticker, get financials for company, pull market data, gather DCF inputs, or any task requiring structured financial data before analysis. Also triggers on financial data, company data, stock data.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "financial-data-collector"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/fixing-claude-export-conversations",
-      "name": "fixing-claude-export-conversations",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/claude-export-txt-better"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/gangtise-copilot",
-      "name": "gangtise-copilot",
-      "description": "Gangtise (岗底斯投研) OpenAPI skill suite installer and diagnostic tool. One-click install 19 official skills (data, research, utility), configure accessKey/secretAccessKey, run health diagnostics. Trigger when user mentions Gangtise, 岗底斯, any gangtise-* skill, credential setup, or reports errors like 'token is invalid' / '接口地址错误'.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "gangtise-copilot"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/github-contributor",
-      "name": "github-contributor",
-      "description": "End-to-end playbook for shipping high-quality pull requests to open-source projects you don't maintain — discovery, CONTRIBUTING compliance, PR-size check, minimal-diff implementation, PR description with AI-assisted disclosure, conflict resolution, and post-submission maintainer interaction. Use whenever creating, editing, or pushing a PR to a third-party GitHub repo — \"submit a PR\", \"open a PR\", \"fix this upstream\", \"rebase against main\", \"respond to the bot review\", an `owner/repo` target, or 提 PR / 上游 PR / 贡献代码 / rebase 冲突 / 回应维护者.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "github-contributor"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/github-ops",
-      "name": "github-ops",
-      "description": "Provides comprehensive GitHub operations using gh CLI and GitHub API. Activates when working with pull requests, issues, repositories, workflows, or GitHub API operations including creating/viewing/merging PRs, managing issues, querying API endpoints, and handling GitHub workflows in enterprise or public GitHub environments.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "github-ops"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/i18n-expert",
-      "name": "i18n-expert",
-      "description": "This skill should be used when setting up, auditing, or enforcing internationalization/localization in UI codebases (React/TS, i18next or similar, JSON locales), including installing/configuring the i18n framework, replacing hard-coded strings, ensuring en-US/zh-CN coverage, mapping error codes to localized messages, and validating key parity, pluralization, and formatting.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "i18n-expert"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/ima-copilot",
-      "name": "ima-copilot",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "ima-copilot"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/llm-icon-finder",
-      "name": "llm-icon-finder",
-      "description": "Finding and accessing AI/LLM model brand icons from lobe-icons library. Use when users need icon URLs, want to download brand logos for AI models/providers/applications (Claude, GPT, Gemini, etc.), or request icons in SVG/PNG/WEBP formats.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "llm-icon-finder"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/llm-wiki-setup",
-      "name": "llm-wiki-setup",
-      "description": "Co-create a personal investment-research LLM Wiki (Andrej Karpathy's pattern) where the user's OWN analysis framework becomes a living CLAUDE.md — by interviewing them, NOT by handing them a template. Use whenever the user wants to build a compounding research knowledge base, 投研第二大脑, 投研知识库, or 个人投研 wiki; instantiate Karpathy's LLM Wiki gist for finance/investing; turn their stock-picking, analyst-tracking, or earnings-watching workflow into a structured markdown vault; or build a wiki tracking companies / industries / macro / analysts over time. Pure markdown + wikilinks, NO RAG / vector DB (Karpathy's core idea — do not over-engineer). Also triggers for ingesting research reports / earnings calls / expert notes into an existing wiki, and for post-earnings prediction→fulfillment reviews. Core value = extracting the user's personal investment preferences into THEIR OWN schema, never imposing a standard one.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "llm-wiki-setup"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/macos-cleaner",
-      "name": "macos-cleaner",
-      "description": "Analyze and reclaim macOS disk space through intelligent cleanup recommendations. This skill should be used when users report disk space issues, need to clean up their Mac, or want to understand what's consuming storage. Focus on safe, interactive analysis with user confirmation before any deletions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "macos-cleaner"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/marketplace-dev",
-      "name": "marketplace-dev",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/marketplace-dev"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/meeting-minutes-taker",
-      "name": "meeting-minutes-taker",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-audio/meeting-minutes-taker"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/mermaid-tools",
-      "name": "mermaid-tools",
-      "description": "Extracts Mermaid diagrams from markdown files and generates high-quality PNG images using bundled scripts. Activates when working with Mermaid diagrams, converting diagrams to PNG, extracting diagrams from markdown, or processing markdown files with embedded Mermaid code.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/mermaid-tools"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/pdf-creator",
-      "name": "pdf-creator",
-      "description": "Convert markdown files to professional PDF documents with proper Chinese font support, theme system, and visual self-check. Use whenever the user asks to create PDFs, convert markdown to PDF, generate printable documents, or needs documents formatted for print or mobile reading. This skill MUST be used instead of manual pandoc/Chrome invocations — it handles CJK typography, Chrome header/footer suppression, and mandatory visual verification that manual approaches miss. **Scope — markdown → PDF only.** For Word (.docx) output use `minimax-docx`; this skill does not produce docx and the two pipelines are intentionally orthogonal.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/pdf-creator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/pdf-to-html",
-      "name": "pdf-to-html",
-      "description": "Converts a PDF into one self-contained, readable HTML file that preserves images, tables, charts and reading order — optionally translating it into another language while keeping every figure. Uses structured extraction (PyMuPDF), font-size-driven layout, compressed base64-inlined images (a single portable file), and mandatory headless-Chrome visual verification. Use whenever someone wants to READ a PDF as a web page or clean document, turn a PDF into HTML, or translate a PDF into another language while keeping its images/tables/charts intact — e.g. \"PDF 转 HTML\", \"把这个 PDF 转成中文网页版\", \"make this report readable\", \"translate this PDF but don't lose the charts\", \"I just want to read this PDF on my phone\". Distinct from doc-to-markdown (plain Markdown text) and pdf-creator (Markdown→PDF) — this one produces a styled, image-faithful HTML reading experience.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/pdf-to-html"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/ppt-creator",
-      "name": "ppt-creator",
-      "description": "Create professional slide decks from topics or documents. Generates structured content with data-driven charts, speaker notes, and complete PPTX files. Applies persuasive storytelling principles (Pyramid Principle, assertion-evidence). Supports multiple formats (Marp, PowerPoint). Use for presentations, pitches, slide decks, or keynotes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-docs/ppt-creator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/product-analysis",
-      "name": "product-analysis",
-      "description": "Multi-path parallel product analysis with cross-model test-time compute scaling. Spawns parallel agents (Claude Code agent teams + Codex CLI) to explore product from multiple perspectives, then synthesizes findings into actionable optimization plans. Can invoke competitors-analysis for competitive benchmarking. Use when \"product audit\", \"self-review\", \"发布前审查\", \"产品分析\", \"analyze our product\", \"UX audit\", or \"信息架构审计\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "product-analysis"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/prompt-optimizer",
-      "name": "prompt-optimizer",
-      "description": "Transform vague prompts into precise, well-structured specifications using EARS (Easy Approach to Requirements Syntax) methodology. This skill should be used when users provide loose requirements, ambiguous feature descriptions, or need to enhance prompts for AI-generated code, products, or documents. Triggers include requests to \"optimize my prompt\", \"improve this requirement\", \"make this more specific\", or when raw requirements lack detail and structure.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "prompt-optimizer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/promptfoo-evaluation",
-      "name": "promptfoo-evaluation",
-      "description": "Configures and runs LLM evaluation using Promptfoo framework. Use when setting up prompt testing, creating evaluation configs (promptfooconfig.yaml), writing Python custom assertions, implementing llm-rubric for LLM-as-judge, or managing few-shot examples in prompts. Triggers on keywords like \"promptfoo\", \"eval\", \"LLM evaluation\", \"prompt testing\", or \"model comparison\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "promptfoo-evaluation"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/qa-expert",
-      "name": "qa-expert",
-      "description": "This skill should be used when establishing comprehensive QA testing processes for any software project. Use when creating test strategies, writing test cases following Google Testing Standards, executing test plans, tracking bugs with P0-P4 classification, calculating quality metrics, or generating progress reports. Includes autonomous execution capability via master prompts and complete documentation templates for third-party QA team handoffs. Implements OWASP security testing and achieves 90% coverage targets.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "qa-expert"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/repomix-safe-mixer",
-      "name": "repomix-safe-mixer",
-      "description": "Safely package codebases with repomix by automatically detecting and removing hardcoded credentials before packing. Use when packaging code for distribution, creating reference packages, or when the user mentions security concerns about sharing code with repomix.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "repomix-safe-mixer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/repomix-unmixer",
-      "name": "repomix-unmixer",
-      "description": "Extracts files from repomix-packed repositories, restoring original directory structures from XML/Markdown/JSON formats. Activates when users need to unmix repomix files, extract packed repositories, restore file structures from repomix output, or reverse the repomix packing process.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "repomix-unmixer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/scrapling-skill",
-      "name": "scrapling-skill",
-      "description": "Install, troubleshoot, and use Scrapling CLI to extract HTML, Markdown, or text from webpages. Use this skill whenever the user mentions Scrapling, `uv tool install scrapling`, `scrapling extract`, WeChat/mp.weixin articles, browser-backed page fetching, or needs help deciding between static and dynamic extraction.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "scrapling-skill"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/skill-creator",
-      "name": "skill-creator",
-      "description": "Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-skill/skill-creator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/skill-reviewer",
-      "name": "skill-reviewer",
-      "description": "Reviews and improves Claude Code skills against official best practices. Supports three modes - self-review (validate your own skills), external review (evaluate others' skills), and auto-PR (fork, improve, submit). Use when checking skill quality, reviewing skill repositories, or contributing improvements to open-source skills.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-skill/skill-reviewer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/skills-search",
-      "name": "skills-search",
-      "description": "This skill should be used when users want to search, discover, install, or manage Claude Code skills from the CCPM registry. Triggers include requests like \"find skills for PDF\", \"search for code review skills\", \"install cloudflare-troubleshooting\", \"list my installed skills\", \"what does skill-creator do\", or any mention of finding/installing/managing Claude Code skills or plugins.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-skill/skills-search"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/slides-creator",
-      "name": "slides-creator",
-      "description": "Narrative-first slide deck creation. Guides users through structured narrative design (ABCDEFG model), then delegates visual generation to baoyu-slide-deck. Triggers on \"create slides\", \"make a presentation\", \"generate deck\", \"slide deck\", \"PPT\", or when user needs to turn content into visual slides.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "slides-creator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/statusline-generator",
-      "name": "statusline-generator",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/statusline-generator"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/stepfun-asr",
-      "name": "stepfun-asr",
-      "description": "Transcribe audio with StepFun's stepaudio-2.5-asr — an SSE endpoint (NOT /v1/audio/transcriptions) with 32K context, ~85-101x RTF on long audio, and a single-call ceiling around 30 minutes (no client-side chunking). Use when transcribing Chinese / English audio with StepFun, when long-form recordings (5-30 min) need to land in one request, when migrating from step-asr / step-asr-1.1, or when hitting the misleading `model stepaudio-2.5-asr not supported` error (which actually means wrong endpoint). Triggers on 阶跃 ASR, StepFun ASR, stepaudio-2.5-asr, 转录, 语音识别, 长音频转写, 语音转文字. For TTS with the sibling stepaudio-2.5-tts model, use the stepfun-tts skill instead.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-audio/stepfun-asr"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/stepfun-tts",
-      "name": "stepfun-tts",
-      "description": "Generate Chinese / Japanese speech with StepFun's stepaudio-2.5-tts — Contextual TTS that replaces step-tts-2's `voice_label` with natural-language `instruction` (≤200 chars) plus inline `()` parentheses for句内 prosody. Use when the user wants emotional / prosody control over voice synthesis (whisper, pause, stress, mood pivot mid-sentence), batch-generates game / app voice lines, migrates from `step-tts-2` (the `voice_label → instruction` breaking change), or hits StepFun's stricter 2.5-era censorship (死/消失/political terms). Triggers on 阶跃 TTS, StepAudio 合成, 语音合成, 配音, 文本转语音, TTS 升级, 迁移 step-tts-2. For transcription with the sibling stepaudio-2.5-asr model, use the stepfun-asr skill instead.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-audio/stepfun-tts"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/teams-channel-post-writer",
-      "name": "teams-channel-post-writer",
-      "description": "Creates educational Teams channel posts for internal knowledge sharing about Claude Code features, tools, and best practices. Applies when writing posts, announcements, or documentation to teach colleagues effective Claude Code usage, announce new features, share productivity tips, or document lessons learned. Provides templates, writing guidelines, and structured approaches emphasizing concrete examples, underlying principles, and connections to best practices like context engineering. Activates for content involving Teams posts, channel announcements, feature documentation, or tip sharing.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "teams-channel-post-writer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/terminal-screenshot",
-      "name": "terminal-screenshot",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-claude-code/terminal-screenshot"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/terraform-skill",
-      "name": "terraform-skill",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "terraform-skill"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/transcript-fixer",
-      "name": "transcript-fixer",
-      "description": "Corrects speech-to-text transcription errors using dictionary rules and AI-powered analysis. Builds personalized correction databases that learn from each fix. Triggers when working with ASR/STT output containing recognition errors, homophones, garbled technical terms, or Chinese/English mixed content. Also triggers on requests to clean up meeting notes, lecture transcripts, interview recordings, or any text produced by speech recognition. Use this skill even when the user just says \"fix this transcript\" or \"clean up these meeting notes\" without mentioning ASR specifically.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "daymade-audio/transcript-fixer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/tunnel-doctor",
-      "name": "tunnel-doctor",
-      "description": ">",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "tunnel-doctor"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/twitter-reader",
-      "name": "twitter-reader",
-      "description": "Fetch Twitter/X post content including long-form Articles with full images and metadata. Use when Claude needs to retrieve tweet/article content, author info, engagement metrics, and embedded media. Supports individual posts and X Articles (long-form content). Automatically downloads all images to local attachments folder and generates complete Markdown with proper image references. Preferred over Jina for X Articles with images.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "twitter-reader"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/ui-designer",
-      "name": "ui-designer",
-      "description": "Extract design systems from reference UI images and generate implementation-ready UI design prompts. Use when users provide UI screenshots/mockups and want to create consistent designs, generate design systems, or build MVP UIs matching reference aesthetics.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "ui-designer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/video-comparer",
-      "name": "video-comparer",
-      "description": "This skill should be used when comparing two videos to analyze compression results or quality differences. Generates interactive HTML reports with quality metrics (PSNR, SSIM) and frame-by-frame visual comparisons. Triggers when users mention \"compare videos\", \"video quality\", \"compression analysis\", \"before/after compression\", or request quality assessment of compressed videos.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "video-comparer"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/windows-remote-desktop-connection-doctor",
-      "name": "windows-remote-desktop-connection-doctor",
-      "description": "Diagnose Windows App (Microsoft Remote Desktop / Azure Virtual Desktop / W365) connection quality issues on macOS. Analyze transport protocol selection (UDP Shortpath vs WebSocket), detect VPN/proxy interference with STUN/TURN negotiation, and parse Windows App logs for Shortpath failures. This skill should be used when VDI connections are slow, when transport shows WebSocket instead of UDP, when RDP Shortpath fails to establish, or when RTT is unexpectedly high.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "windows-remote-desktop-connection-doctor"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "daymade-claude-code-skills/youtube-downloader",
-      "name": "youtube-downloader",
-      "description": "Download YouTube videos and HLS streams (m3u8) from platforms like Mux, Vimeo, etc. using yt-dlp and ffmpeg. Use this skill when users request downloading videos, extracting audio, handling protected streams with authentication headers, or troubleshooting download issues like nsig extraction failures, 403 errors, or cookie extraction problems.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "daymade/claude-code-skills",
-        "ref": "main",
-        "path": "youtube-downloader"
-      },
-      "stars": 1157,
-      "updatedAt": "2026-06-06T19:54:25Z",
-      "provenance": "curated",
-      "sourceId": "daymade-claude-code-skills"
-    },
-    {
-      "id": "glebis-claude-skills/agency-docs-updater",
-      "name": "agency-docs-updater",
-      "description": "End-to-end pipeline for publishing Claude Code lab meetings. Accepts optional args: date (YYYYMMDD, \"yesterday\", \"today\") and lab number (e.g. \"04\"). Examples: \"yesterday 04\", \"20260420 05\", \"04\" (today, lab 04), \"\" (today, auto-detect lab).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "agency-docs-updater"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/agency-meetup-publish",
-      "name": "agency-meetup-publish",
-      "description": "End-to-end pipeline for publishing AGENCY Community meetup recordings to YouTube. Downloads Zoom recording, adds intro/outro, generates thumbnail, creates description with timecodes, uploads to YouTube, sets thumbnail, and adds to the AGENCY Community playlist. Use this skill when the user wants to publish a meetup, says \"upload the meetup\", \"publish the recording\", \"process the Zoom recording for YouTube\", or mentions uploading an AGENCY Community session. Also triggers on requests to add intro/outro to a meeting recording and upload it.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "agency-meetup-publish"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/agency-socials",
-      "name": "agency-socials",
-      "description": "Generate social media covers and assets for AGENCY Community events, meetups, and YouTube recordings. Use when creating event covers, YouTube thumbnails, or social posts for the AGENCY Community.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "agency-socials"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/agent-cli",
-      "name": "agent-cli",
-      "description": "Add agent-friendly --json NDJSON output to Python CLI scripts, or scaffold a complete cli_utils package for a project. Use this skill when the user wants to make scripts machine-readable for AI agents, add --json flags, convert print statements to structured JSON, build a CLI helper library, create an open-source CLI-for-agents package, add structured logging, or make CLI output machine-readable. Also use when the user mentions NDJSON, structured CLI output, agent-friendly CLI, non-interactive scripts, or JSON I/O for automation.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "agent-cli"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/annotate",
-      "name": "annotate",
-      "description": "Build and verify a PII gold set with HUMAN annotators (first-class). Launch the browser annotator, label spans per the codebook, export per-annotator label files, then compute inter-annotator agreement (Cohen's/Fleiss' kappa) and draft an adjudicated gold. Use when the user says \"annotate PII\", \"label this transcript\", \"build a gold set\", \"inter-annotator agreement\", \"review annotations\", \"adjudicate labels\", or wants to measure/defend a de-identification gold standard. Local-only: synthetic or consented data only; annotators' names and transcript text stay on the machine — only labels/stats are collected, nothing PII is re-shared.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/annotate"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/anon",
-      "name": "anon",
-      "description": "De-identify a session transcript (file or folder) by redacting PII LOCALLY before any sharing or cloud use. Produces a redacted GREEN copy with unique reserved-sentinel placeholders ([CONFIDE_PERSON_0001], [CONFIDE_EMAIL_0001], [CONFIDE_DATE_0002]...) plus a counts-only stats summary, and a local secret <name>.map.json (0600, gitignored) that enables confide:rehydrate to restore real values after a cloud analysis. Use when the user says \"anonymize this transcript\", \"redact PII\", \"de-identify session\", \"make safe to share\", \"strip personal data\", \"anonymize notes before sending to an LLM\", or points at a transcript/folder that should be scrubbed. Local-only by default — raw text never leaves the machine; the map is the only artifact with originals and stays local; nothing printed is PII; human review is still required before sharing.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/anon"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/audit",
-      "name": "audit",
-      "description": "Run a corpus-scale, STATS-ONLY PII audit over a folder of session transcripts LOCALLY and produce an aggregate report — counts by type and by layer, the per-session redaction-rate distribution, document lengths, and a coarse residual proxy. Use when the user says \"audit my sessions\", \"scan folder for PII\", \"how much PII across these transcripts\", \"PII stats for my corpus\", \"is my redaction holding at scale\", or points at a directory of transcripts and asks how much personal data it contains. Fully local — raw text never leaves the machine; the report carries ZERO PII values, transcript substrings, or filenames (only anonymized own-NN ids and counts), so the aggregates are safe to surface. Run it on a RED (raw) corpus to size the PII, or on a GREEN (already-redacted) corpus to check residual leakage.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/audit"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/balanced",
-      "name": "balanced",
-      "description": "Constructive, evidence-based dialogue mode that avoids sycophancy. This skill should be used when the user wants balanced multi-perspective analysis, critical feedback, or rigorous challenge of their ideas. Triggers on \"/balanced\" or requests for honest/critical/balanced feedback. Supports passive, interactive, tldr, steelman, and decision modes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "balanced"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/brand-agency",
-      "name": "brand-agency",
-      "description": "Applies Agency brand colors and typography to artifacts including presentations, SVG graphics, documents, and web interfaces. This skill should be used when brand colors, visual formatting, neobrutalism style, or Agency design standards apply. Keywords - branding, corporate identity, visual identity, styling, brand colors, typography, visual formatting, visual design, neobrutalism.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "brand-agency"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/browser-mate",
-      "name": "browser-mate",
-      "description": "Use when automating a real, logged-in Chrome WITHOUT disturbing the user's open tabs — e.g. authenticated sessions like ChatGPT, LinkedIn, or any site needing a persistent login. Launches or reuses a dedicated debug Chrome instance per named profile that coexists with the user's main browser; it never quits or kills any browser (unlike real-browser, which closes Chrome Beta's tabs). Trigger on \"automate this site without closing my tabs\", \"use my logged-in session\", \"open ChatGPT/LinkedIn in automation\", or when a browser task must preserve the user's existing windows. macOS, requires the agent-browser CLI.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "browser-mate"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/browsing-history",
-      "name": "browsing-history",
-      "description": "Query browsing history from all synced devices (iPhone, Mac, iPad, desktop). Supports natural language queries for filtering by date, device, domain, and keywords. Uses LLM classification for content categories. Can output to stdout or save as markdown/JSON to Obsidian vault.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "browsing-history"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/chrome-history",
-      "name": "chrome-history",
-      "description": "Query Chrome browsing history with natural language. Filter by date range, article type, keywords, and specific sites.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "chrome-history"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/coaching-session-summarizer",
-      "name": "coaching-session-summarizer",
-      "description": "This skill should be used to summarize coaching or therapy session transcripts after a Fathom/Granola sync. The agent analyzes the transcript itself (no API key, runs on the subscription) and appends key insights, decisions, action items, and trail connections. Supports quick extraction or deep analysis with cross-session pattern detection.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "coaching-session-summarizer"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/codex",
-      "name": "codex",
-      "description": "Use when the user asks to run Codex CLI (codex exec, codex resume) or references OpenAI Codex for code analysis, refactoring, or automated editing",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "codex"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/context-builder",
-      "name": "context-builder",
-      "description": "Generate interactive AI transformation context-builder prompts for consulting clients. Use when creating structured discovery session prompts that guide a company through context gathering about their business, pain points, tech stack, and AI opportunities. Produces a resumable, multi-section prompt with Express/Deep Dive modes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "context-builder"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/cull",
-      "name": "cull",
-      "description": "Use when the user wants to view, review, rate, organize, search, or export images / AI-art generations with the Cull app (https://cull.company/ · https://github.com/glebis/cull). Trigger on \"show me these images\", \"review this batch\", \"open these in Cull\", \"rate / shortlist / collect these\", \"find similar images\", \"make a smart collection\", \"run a quality pass\", \"export the keepers\", \"publish this collection\". Works via the `cull` CLI by default (no MCP required); the `mcp__cull__*` tools are optional for richer interactive control.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "cull"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/daydream",
-      "name": "daydream",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "daydream"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/decision-toolkit",
-      "name": "decision-toolkit",
-      "description": "Generate structured decision-making tools — step-by-step guides, bias checkers, scenario explorers, and interactive dashboards. Use when facing significant choices requiring systematic analysis. Supports multiple cognitive styles and output formats.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "decision-toolkit"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/deep-research",
-      "name": "deep-research",
-      "description": "This skill should be used when conducting comprehensive research on any topic using the OpenAI Deep Research API. It automates prompt enhancement through interactive clarifying questions, saves research parameters, and executes deep research with web search capabilities. Use when the user asks for in-depth analysis, investigation, research summaries, or topic exploration.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "deep-research"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/disk-cleanup",
-      "name": "disk-cleanup",
-      "description": "Scan and clean macOS system caches, package manager caches, and app data to reclaim disk space. Surveys ~/Library/Caches, ~/.cache, Docker, npm/pip/uv/pnpm, Homebrew, browser caches, app updater caches, Claude Desktop, Xcode DerivedData, Playwright browsers, system logs, and ML model caches. Presents a size-sorted inventory table, offers four preset cleanup levels (safe / safe+docker / full / pick-individually), executes cleanup using `trash` (never rm), and reports before/after disk usage. IMPORTANT — you MUST use this skill whenever the user's request involves any of these scenarios on macOS: freeing disk space, cleaning or clearing caches, investigating what's consuming storage, running low on disk, \"disk is full\", \"clean up my Mac\", \"free up space\", \"clear caches\", \"storage cleanup\", \"what's eating my disk\", \"where did my space go\", checking disk usage of caches, \"disk almost full\" warnings, needing space for Xcode or other large installs, or any complaint about low available storage on their Mac. This skill covers the ENTIRE workflow from survey through cleanup — do not attempt to handle these requests without it.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "skills/disk-cleanup"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/doctorg",
-      "name": "doctorg",
-      "description": "Evidence-based health research using tiered trusted sources with GRADE-inspired evidence ratings. Integrates Apple Health data for personalized context. Use when user asks health, nutrition, exercise, sleep, or wellness questions.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "doctorg"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/ecosystem",
-      "name": "ecosystem",
-      "description": "Audit the Claude Code ecosystem — skill health and staleness, project activity pulse, CLAUDE.md instruction drift, Mac Mini service status. Use this skill whenever the user asks about ecosystem health, stale skills, abandoned projects, system status, infrastructure check, \"what's broken\", \"what's stale\", \"how's my setup\", or any request to review the state of their Claude Code environment. Also triggers on \"/ecosystem\", \"audit my ecosystem\", \"ecosystem health\", \"ecosystem audit\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "ecosystem"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/elevenlabs-tts",
-      "name": "elevenlabs-tts",
-      "description": "This skill converts text to high-quality audio files using ElevenLabs API. Use this skill when users request text-to-speech generation, audio narration, or voice synthesis with customizable voice parameters (stability, similarity boost) and voice presets (rachel, adam, bella, elli, josh, arnold, ava).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "elevenlabs-tts"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/fathom",
-      "name": "fathom",
-      "description": "Fetch meetings, transcripts, summaries, and action items from Fathom API. Use when user asks to get Fathom recordings, sync meeting transcripts, or fetch recent calls.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "fathom"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/firecrawl-research",
-      "name": "firecrawl-research",
-      "description": "This skill should be used when the user requests to research topics using FireCrawl, enrich notes with web sources, search and scrape information, or write scientific/academic papers. It extracts research topics from markdown files, creates research documents with scraped sources, generates BibTeX bibliographies from research results, and provides Pandoc/MyST templates for academic writing with citation management.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "firecrawl-research"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/github-gist",
-      "name": "github-gist",
-      "description": "Publish files or Obsidian notes as GitHub Gists. Use when user wants to share code/notes publicly, create quick shareable snippets, or publish markdown to GitHub. Triggers include \"publish as gist\", \"create gist\", \"share on github\", \"make a gist from this\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "github-gist"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/gmail",
-      "name": "gmail",
-      "description": "This skill should be used when searching, fetching, or downloading emails from Gmail. Use for queries like \"search Gmail for...\", \"find emails from John\", \"show unread emails\", \"emails about project X\", or \"download attachment from email\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "gmail"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/google-image-search",
-      "name": "google-image-search",
-      "description": "Search and download images via Google Custom Search API with LLM-powered selection. This skill should be used when finding images for articles, presentations, research documents, or enriching Obsidian notes with relevant visuals. Supports simple queries, batch processing from JSON config, automatic config generation from terms, and full note enrichment with automatic image insertion below headings.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "google-image-search"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/gpt-image-2",
-      "name": "gpt-image-2",
-      "description": "Generate and edit images using OpenAI's GPT Image 2 API. Interactive skill that guides users through image creation with style presets, cost-aware draft/final workflow, thinking mode, carousels, and photo editing. This skill should be used when the user requests image generation via OpenAI/GPT Image 2, wants to create social media carousels, edit photos into artistic styles, or needs images with readable text (infographics, diagrams, posters).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "gpt-image-2"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/granola",
-      "name": "granola",
-      "description": "This skill should be used when importing, listing, or exporting Granola meeting recordings and transcripts. Queries Granola's Personal API to list meetings, extract transcripts, and export to Obsidian notes in Fathom-compatible format.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "granola"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/gws",
-      "name": "gws",
-      "description": "This skill should be used when interacting with Google Workspace services via the gws CLI — Gmail (search, triage, send, labels, filters, drafts), Calendar (agenda, events, Meet conferencing), Drive (upload, list, share, download), Sheets (read, append), Docs, Tasks, Chat (send), People/Contacts, and cross-service workflows (standup, meeting prep, weekly digest, email-to-task). Triggers on queries like \"check my email\", \"search Gmail\", \"send email\", \"calendar agenda\", \"create calendar event\", \"upload to Drive\", \"read spreadsheet\", \"create a task\", \"triage inbox\", \"find contact\", \"post to Chat\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "gws"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/health-data",
-      "name": "health-data",
-      "description": "Query Apple Health SQLite database for vitals, activity, sleep, and workouts. Supports Markdown, JSON, and FHIR R4 output formats. This skill should be used when analyzing health metrics, generating health reports, answering questions about fitness or sleep patterns, or exporting health data in standard formats.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "health-data"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/insight-extractor",
-      "name": "insight-extractor",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "insight-extractor"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/job-babysitter",
-      "name": "job-babysitter",
-      "description": "This skill should be used to watch a long-running background job (ffmpeg/media encode, qmd or other embedding/vector-DB run, batch agent/LLM pipeline, or a real-browser/agent-browser daemon) until it finishes or wedges, then deliver a verdict (done, needs-attention, or blocked) plus the exact next command, without burning dozens of manual poll commands. Triggers on \"babysit this job\", \"watch this until it's done\", \"ping me when the encode/embed/batch finishes\", \"is this background process stuck\", \"monitor this ffmpeg/qmd run\", or any request to wait on a long-running process and be told when it's complete or hung.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "skills/job-babysitter"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/jtbd",
-      "name": "jtbd",
-      "description": "Terminal-first JTBD engine for founders and product people. Interview fast, kill jargon, capture real switching forces (Push/Pull/Habit/Anxiety), score opportunities, and export structured artifacts (JSON + one-pager + messaging angles + GTM brief). Use when the user says \"help me figure out what to build\", \"analyze these customer reviews\", \"what are people actually hiring this for\", \"I need messaging for my product\", \"turn this interview into insights\", \"what should I prioritize\", or any variation of articulating what a project does, why it matters, who it's for, or converting interview/review/transcript signal into a decision-grade brief. Also triggers on \"describe my project\", \"JTBD\", \"jobs to be done\", \"switching forces\", or \"mine these reviews\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "jtbd"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/lab-retro",
-      "name": "lab-retro",
-      "description": "Final retrospective and self-assessment for participants of Claude Code Lab. Runs four sequential interactive parts — progress audit, best prompt, monthly plan, and feedback — using AskUserQuestion. Triggers on \"/lab-retro\", \"lab retrospective\", \"claude code lab final\", or after completing the 6-week Claude Code Lab cohort.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "lab-retro"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/learning-vault",
-      "name": "learning-vault",
-      "description": "Generate a dedicated Obsidian learning vault for any certification, course, or study goal. Creates structured notes with domains, concepts, lessons, scenarios, MoCs, dataview queries, action items, and multiple navigation paths. Inspired by the genome vault pattern. Use when the user wants to create a study vault, learning vault, certification prep vault, or structured knowledge base for a learning goal.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "learning-vault"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/library-sync",
-      "name": "library-sync",
-      "description": "Sync and manage bilingual (EN/RU) library content for agency-docs. Use when adding, updating, or reviewing library articles. Handles translation, sync checks, and Russian stylistic review.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "skills/library-sync"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/linear",
-      "name": "linear",
-      "description": "Manage Linear issues, projects, and workflows via CLI. This skill should be used when the user wants to create, list, update, or search Linear issues, manage projects or milestones, or interact with their Linear workspace. Triggers on \"create a task\", \"add a Linear issue\", \"list my issues\", \"update GLE-123\", \"what's in my backlog\", or any Linear-related request.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "linear"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/llm-cli",
-      "name": "llm-cli",
-      "description": "Process textual and multimedia files with various LLM providers using the llm CLI. Supports both non-interactive and interactive modes with model selection, config persistence, and file input handling.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "llm-cli"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/meeting-prep",
-      "name": "meeting-prep",
-      "description": "Prepare for upcoming meetings — pulls Cal.com bookings, researches participants, audits previous sessions from Obsidian vault, and creates prep notes. Also links prep notes to post-meeting session notes.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "meeting-prep"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/meeting-processor",
-      "name": "meeting-processor",
-      "description": "This skill should be used when processing meeting transcripts to auto-detect meeting type (leadgen, partnership, coaching, internal) and extract type-specific structured analysis. Triggers on \"process meeting\", \"analyze meeting\", \"meeting summary\", or after syncing new Fathom/Granola transcripts.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "meeting-processor"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/meta",
-      "name": "meta",
-      "description": "Execute Claude Code commands in the telegram_agent project directory. Use when the user wants to work on the telegram agent itself, fix bugs, add features, or modify the bot code. This is a COMMAND HANDLER, not a script executor.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "meta"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/name-audition",
-      "name": "name-audition",
-      "description": "Run candidate product, brand, company, or benchmark names through an audition — authoritative domain-availability checks, collision research across SaaS/GitHub/packages/the target adjacent domain, a light trademark and ownability read, a ranked callback list, and an interactive casting report of finalists with optional draft branding. Use when the user is naming a product, app, company, feature, or benchmark; asks \"is this name taken\", \"check these domains\", \"help me pick a name\", \"is X available\", \"name my product\", \"brand name research\", \"audition names\"; or wants to compare and pressure-test a shortlist of candidate names before committing.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "name-audition"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/nano-banana",
-      "name": "nano-banana",
-      "description": "Generate and edit images using Google's Gemini image generation models (Nano Banana family). Supports style presets, platform-specific sizing (YouTube/slides/blog), variants, image editing via inlineData, reference images for style transfer, and organized output with metadata. Default model is Nano Banana 2 (gemini-3.1-flash-image-preview). Key is auto-decrypted via SOPS.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "nano-banana"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/pdf-generation",
-      "name": "pdf-generation",
-      "description": "Professional PDF generation from markdown using Pandoc with Eisvogel template and EB Garamond fonts. Use when converting markdown to PDF, creating white papers, research documents, marketing materials, or technical documentation. Supports both English and Russian documents with professional typography and color-coded themes. Mobile-optimized layout (6x9) by default for Telegram bot context, desktop/print layout (A4) for other contexts.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "pdf-generation"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/peer-agent-collaboration",
-      "name": "peer-agent-collaboration",
-      "description": "Use when the user wants Claude Code, Codex, or other AI coding/business agents to work together as peers. This skill should be used whenever the user mentions coordinating Claude Code and Codex, agent handoffs, multi-agent workflows, parity, respect, pushback between agents, deciding which agent should lead, or turning a business/code workflow into a two-agent operating model.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "peer-agent-collaboration"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/present",
-      "name": "present",
-      "description": "Generate interactive HTML presentations with professional ElevenLabs voiceover narration synced to slides. Supports dual article/slides mode, scroll-reveal animations, GPT Image 2 illustrations, and configurable detail levels. Use this skill when the user wants to create a presentation, slide deck, narrated briefing, research report with voiceover, or any content that should be presentable as both a readable article and a navigable slide deck. Also triggers on \"make a presentation\", \"create slides\", \"present this\", \"narrated deck\", \"voiceover slides\", \"briefing with audio\", or requests to turn research/notes into a shareable presentation. Works with any content — research findings, meeting summaries, proposals, educational material.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "present"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/presentation-generator",
-      "name": "presentation-generator",
-      "description": "Generate interactive HTML presentations with neobrutalism styling, ASCII art decorations, and Agency brand colors. Outputs HTML (interactive with navigation), PNG (individual slides via Playwright), and PDF. References brand-agency skill for colors and typography. Use when creating presentations, slide decks, pitch materials, or visual summaries.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "presentation-generator"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/publish-skill",
-      "name": "publish-skill",
-      "description": "This skill should be used when publishing a new or updated skill to the claude-skills-site Astro website. Use this skill for both adding new skills AND updating existing ones on the site. Triggers on \"/publish-skill skillname\", \"add skill to site\", \"publish skillname to skills site\", \"update skill on site\", \"edit skill on site\", \"sync skill to site\", \"republish skill\". Reads SKILL.md from the skills repo, generates MDX frontmatter and body, picks the right bundle, updates bundle skills array, and commits/pushes both repos. For existing skills, pass --update to preserve apothecary_name, hero_image, and activity data while regenerating the rest. A hero image is generated by default (pass --no-image to skip).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "publish-skill"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/qmd-search",
-      "name": "qmd-search",
-      "description": "This skill should be used to search the local Obsidian vault / markdown knowledge base by meaning, not just keywords, using the on-device qmd engine (BM25 + vector + LLM rerank). Trigger when the user asks to \"search my vault/notes\", \"find notes about X\", \"what do my notes say about Y\", \"do I have anything on Z\", \"semantic search my knowledge base\", or wants concept/cross-lingual retrieval over markdown. Fully local — nothing leaves the machine.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "qmd-search"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/rag-eval",
-      "name": "rag-eval",
-      "description": "Iterate on RAG systems with structured evals instead of eyeballing. This skill should be used when the user is tuning a RAG pipeline — changing retrieval prompts, swapping models, adjusting chunking, or debugging poor answers — and wants a cheap, ranked set of experiments with cost tracking and structured feedback on the stack. Also use when the user asks \"how do I know if my RAG is working?\", \"this RAG eval is burning money\", or \"what should I try next on retrieval?\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "rag-eval"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/recording",
-      "name": "recording",
-      "description": "Demo/recording mode that redacts personally identifiable and sensitive information from Claude Code's outputs. Use when the user invokes /recording or says they are about to record, screen-share, or demo their Claude Code session and want PII scrubbed in real time.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "recording"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/red",
-      "name": "red",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/red"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/rehydrate",
-      "name": "rehydrate",
-      "description": "Put the real values back into an analysis that was produced from GREEN (placeholder) text — LOCALLY, using the user's own reversible map. Completes the confide round-trip (redact -> cloud-analyze the green -> rehydrate locally). Use when the user says \"rehydrate\", \"restore real names\", \"unmask the analysis\", \"put the names back\", \"de-redact this output\", \"reverse the placeholders\", or hands you an analysis full of [CONFIDE_PERSON_0001]/[CONFIDE_DATE_0002] plus a *.map.json. Runs only on the user's own map; the map never leaves the machine; nothing fetched or transmitted. Prints counts only — never echoes restored PII. Warns on placeholders not in the map (possible LLM hallucination).",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/rehydrate"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/release",
-      "name": "release",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "skills/release"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/retrospective",
-      "name": "retrospective",
-      "description": "Interactive post-session retrospective that captures learnings, updates skills, and saves memories. Use when the user says \"/retrospective\", \"let's do a retro\", \"what did we learn\", \"session review\", \"retro\", or \"wrap up\". Also use at the end of long productive sessions when significant patterns or corrections emerged. Supports multi-session mode — by default processes all of today's sessions across projects.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "retrospective"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/rigorous-experiments",
-      "name": "rigorous-experiments",
-      "description": "This skill should be used when designing, running, validating, or auditing statistical experiments on personal or observational time-series data (health metrics, speech/text corpora, behavioral logs, diaries, n-of-1 self-tracking). It enforces pre-registration, exact permutation tests, FDR discipline, data-validation gates, adversarial code review, and cross-validation with external models. Triggers on \"design an experiment\", \"test this hypothesis on my data\", \"is this correlation real\", \"audit these findings\", \"pre-register\", \"validate this dataset\", or any n-of-1 / quantified-self analysis request.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "rigorous-experiments"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/session-anonymizer",
-      "name": "session-anonymizer",
-      "description": "Three-layer PII anonymization for session transcripts (therapy, coaching, consulting, mentoring). Runs Natasha (Russian NER), OpenAI Privacy Filter, and local LLM (Ollama) in sequence for maximum coverage. Fully local by default. This skill should be used when anonymizing session transcripts, notes, or any text containing client PII before AI analysis. Triggers on \"anonymize\", \"redact PII\", \"anonymize session\", \"protect client data\", \"strip personal data\", \"anonymize transcript\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "session-anonymizer"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/session-finder",
-      "name": "session-finder",
-      "description": "Index and search Claude Code sessions using semantic embeddings (Gemini). Find past sessions by topic, relaunch the best match. Triggers on \"find session\", \"which session did I\", \"relaunch the session where\", \"session about X\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "session-finder"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/session-search",
-      "name": "session-search",
-      "description": "This skill should be used when searching Claude Code session transcripts with semantic understanding. Triggers on queries like \"find sessions about X\", \"when did I work on Y\", \"search previous conversations\". Supports natural language queries with synonym matching.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "session-search"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/setup",
-      "name": "setup",
-      "description": "Set up, install, and configure CONFIDE local de-identification — installs Python deps (natasha, scrubadub, phonenumbers, pymorphy2), ensures Ollama + pulls the default qwen2.5:3b model, detects optional llama.cpp, and writes the optimal-default config so confide:anon and confide:red work with zero further config. Everything is local-first; raw text never leaves the machine. Use when the user says \"set up confide\", \"install confide\", \"configure confide de-id\", \"confide setup\", or \"get confide ready\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/setup"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/site-diagnosis",
-      "name": "site-diagnosis",
-      "description": "Pre-consultation diagnostic questionnaire for clients building websites with AI tools (Claude, Codex, Cursor, Bolt, v0, etc.) who have concerns about quality, design, or maintainability. Collects structured answers about their project, tools, pain points, and goals, then generates a consultation brief. Use when preparing for a website review consultation, when a client asks for a site audit, or when someone says their AI-built site has problems. Supports Russian and English — asks the client to choose language first.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "site-diagnosis"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/sketch",
-      "name": "sketch",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "sketch"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/skill-studio",
-      "name": "skill-studio",
-      "description": "Interview-driven automation design tool. This skill should be used when the user wants to design a new skill, agent, automation, shortcut, or any other automatable workflow. Runs a coverage-driven JTBD interview (text or voice), then exports a one-page markdown spec plus an SVG design map. Can also analyze Claude Code sessions (current or by ID) to extract workflows, subagent patterns, and skill usage, then propose new skills based on observed patterns. Use this skill whenever the user mentions analyzing a session, extracting workflows, proposing skills from past work, reviewing what tools or agents were used, or turning a session into a skill. Triggers on \"analyze this session\", \"what skills could I build from this\", \"propose skills from session\", \"what workflows did I use\", \"what did I do in this session\", \"extract patterns\", \"turn this into a skill\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "skill-studio"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/sorted",
-      "name": "sorted",
-      "description": "Automate getSorted.de (Sorted) for freelancer invoicing, expense tracking, and German tax submissions (VAT, ZM, annual returns). Uses real-browser automation via Chrome Beta + agent-browser. Triggers on \"create invoice\", \"sorted invoice\", \"download invoice\", \"submit VAT\", \"tax report\", \"sorted expenses\", \"/sorted\", or any getSorted.de interaction.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "sorted"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/synthetic-session-generator",
-      "name": "synthetic-session-generator",
-      "description": "This skill should be used to generate realistic, persona-consistent synthetic coaching and therapy session transcripts for evals, demos, and training data. It produces fictional but believable coach/client (or therapist/client) dialogue grounded in a chosen modality (ICF/GROW coaching, CBT, IFS parts work, ACT/motivational interviewing) and exports to Fathom/Granola transcript style, plain dialogue, structured JSON, or Obsidian markdown. Triggers on requests like \"generate a synthetic coaching session\", \"make fake therapy transcripts for evals\", \"create demo session transcripts\", \"synthetic CBT dialogue\", \"persona-consistent coaching transcript\", \"test data for my session summarizer\", or \"mock coaching call\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "synthetic-session-generator"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/tdd",
-      "name": "tdd",
-      "description": "This skill should be used when the user wants to implement features or fix bugs using test-driven development. Enforces the RED-GREEN-REFACTOR cycle with vertical slicing, context isolation between test writing and implementation, human checkpoints, and auto-test feedback loops. Uses multi-agent orchestration with the Task tool for architecturally enforced context isolation. Supports Jest, Vitest, pytest, Go test, cargo test, PHPUnit, and RSpec.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "tdd"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/telegram",
-      "name": "telegram",
-      "description": "This skill should be used when fetching, searching, downloading, sending, editing, or publishing messages on Telegram. Use for queries like \"show my Telegram messages\", \"search Telegram for...\", \"get unread messages\", \"send a message to...\", \"edit that message\", \"publish this draft to klodkot\", or \"add Telegram messages to my notes\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "telegram"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/telegram-post",
-      "name": "telegram-post",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "telegram-post"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/telegram-telethon",
-      "name": "telegram-telethon",
-      "description": "This skill should be used for comprehensive Telegram automation via Telethon API. Use for sending/receiving messages, monitoring chats, running a background daemon that triggers Claude Code sessions, managing channels/groups, and downloading media. Triggers on \"telegram daemon\", \"monitor telegram\", \"telegram bot\", \"spawn Claude from telegram\", or any Telethon-related request. IMPORTANT: Use `draft` command for \"драфт/draft\", use `send` for \"отправь/send\"; if ambiguous, ASK before sending.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "telegram-telethon"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/temple-generator",
-      "name": "temple-generator",
-      "description": "Generate a 3D interactive knowledge map (Inner Temple) from any Obsidian vault or document set. Supports multi-scale abstraction layers and dual-graph common maps between two vaults.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "temple-generator"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/tg-responder",
-      "name": "tg-responder",
-      "description": "Review and send Telegram response drafts, manage follow-ups for unanswered outbound messages. Use when the user says \"/tg-responder review\", \"/tg-responder status\", \"/tg-responder follow-ups\", \"check telegram drafts\", \"review pending messages\", \"telegram inbox\", \"who hasn't replied\", or \"follow up\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "tg-responder"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/thinking-patterns",
-      "name": "thinking-patterns",
-      "description": "",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "thinking-patterns"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/timebuzzer-led",
-      "name": "timebuzzer-led",
-      "description": "Control timeBuzzer hardware LED via MIDI — set color, effects (pulse, strobe, rainbow, fade), and semantic status signals. Use when the user asks to change the buzzer LED color, signal status through the buzzer, or sync the buzzer with other lighting.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "timebuzzer-led"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/transcript-analyzer",
-      "name": "transcript-analyzer",
-      "description": "This skill analyzes meeting transcripts to extract decisions, action items, opinions, questions, and terminology using Cerebras AI (llama-3.3-70b). Use this skill when the user asks to analyze a transcript, extract action items from meetings, find decisions in conversations, build glossaries from discussions, or summarize key points from recorded meetings.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "transcript-analyzer"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/tufte-report",
-      "name": "tufte-report",
-      "description": "Create Tufte-inspired data reports and infographic dashboards as standalone HTML files. Uses EB Garamond for text, Monaspace Argon for numbers, Chart.js for interactive charts, and inline SVG sparklines. Produces publication-quality reports with 2-column narrative+data layouts, status dashboards, scroll animations, and responsive mobile support. Use this skill whenever the user wants to create a data report, activity dashboard, infographic, personal analytics page, health tracker visualization, or any document that combines narrative text with interactive charts and tables. Also triggers for \"make a report like Tufte\", \"create an infographic\", \"build a dashboard\", \"visualize my data\", or requests for beautiful data-driven documents.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "tufte-report"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/vault",
-      "name": "vault",
-      "description": ">-",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/vault"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/view",
-      "name": "view",
-      "description": "Build a self-contained interactive HTML that lets you SEE de-identification and restoration — original ↔ redacted ↔ rehydrated, with color-coded PII spans and All/None/Selected toggles. Use when the user says \"show me what was redacted\", \"visualize the de-id\", \"compare original and redacted\", \"highlight the PII\", \"view redaction diff\", \"see what rehydrate restored\", or wants to inspect exactly which spans each type/layer removes. LOCAL only — the HTML embeds REAL values (like a vault artifact): written locally, gitignored, banner-marked private, never shipped or committed.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "confide/skills/view"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/vision-bench",
-      "name": "vision-bench",
-      "description": "Score and compare images using vision LLMs as judges. YAML-defined criteria presets for 11 use cases (text-to-image, photorealism, document OCR, charts, UI, portrait, product, scientific, invoice, alt-text, artistic style). Supports OpenAI, Anthropic, Gemini, Mistral, and OpenRouter as judge providers. Keys auto-decrypted via SOPS + age.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "vision-bench"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/weekly-digest",
-      "name": "weekly-digest",
-      "description": "Research, score, and publish a weekly industry digest on any topic. Casts a wide net via web search (20+ candidates), verifies sources for AI-generated slop, scores each item on five parameters (Novelty, Relevance, Slopiness, Technical depth, Feasibility), selects the top items, and generates both markdown files and a Tufte-style HTML report. Use this skill whenever the user says \"/weekly-digest\", \"run the weekly digest\", \"industry digest\", \"what's new in [topic]\", \"weekly roundup\", \"news digest on [topic]\", \"research what happened this week in [topic]\", or any request to create a curated, scored summary of recent developments in a field. Also use when the user wants to monitor a topic area with quality filtering — the slopiness scoring is the key differentiator from a simple news search.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "weekly-digest"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/wispr-analytics",
-      "name": "wispr-analytics",
-      "description": "This skill should be used when analyzing Wispr Flow voice dictation history for self-reflection, work patterns, mental health insights, or productivity analytics AND when managing the Wispr Flow dictionary (adding terms, fixing mishears, exporting/importing, suggesting improvements). Triggered by requests like \"/wispr-analytics\", \"analyze my dictations\", \"what did I dictate today\", \"wispr reflection\", \"add to wispr dictionary\", \"improve dictation\", \"wispr suggest\", \"export wispr dictionary\", or any request to review voice dictation patterns or manage dictation quality.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "wispr-analytics"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/wispr-fix",
-      "name": "wispr-fix",
-      "description": "Queue and batch-apply Wispr Flow dictation corrections. Use when the user invokes /wispr-fix or writes \"wispr fix: X -> Y\" to correct a speech-to-text mishear.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "wispr-fix"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/wow-digest",
-      "name": "wow-digest",
-      "description": "Daily digest of 3-7 genuinely surprising items from newsletters and Telegram channels. Scores content for epistemic friction, not just relevance. Appends to daily note. Use when the user says \"/wow-digest\", \"run the wow digest\", \"what's surprising today\", \"morning reading\", or \"digest my newsletters\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "wow-digest"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/youtube-transcript",
-      "name": "youtube-transcript",
-      "description": "Extract YouTube video transcripts with metadata and save as Markdown to Obsidian vault. Use this skill when the user requests downloading YouTube transcripts, converting YouTube videos to text, or extracting video subtitles. Does not download video/audio files, only metadata and subtitles.",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "youtube-transcript"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
-    },
-    {
-      "id": "glebis-claude-skills/zoom",
-      "name": "zoom",
-      "description": "Create and manage Zoom meetings and access cloud recordings via the Zoom API. Use for queries like \"create a Zoom meeting\", \"list my Zoom meetings\", \"show my Zoom recordings\", or \"schedule a meeting for tomorrow\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "glebis/claude-skills",
-        "ref": "main",
-        "path": "zoom"
-      },
-      "stars": 249,
-      "updatedAt": "2026-06-07T11:41:14Z",
-      "provenance": "curated",
-      "sourceId": "glebis-claude-skills"
     },
     {
       "id": "mattpocock-skills/caveman",
@@ -10811,7 +1420,7 @@
         "ref": "main",
         "path": "skills/productivity/caveman"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10827,7 +1436,7 @@
         "ref": "main",
         "path": "skills/deprecated/design-an-interface"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10843,7 +1452,7 @@
         "ref": "main",
         "path": "skills/engineering/diagnose"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10859,7 +1468,7 @@
         "ref": "main",
         "path": "skills/personal/edit-article"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10875,7 +1484,7 @@
         "ref": "main",
         "path": "skills/misc/git-guardrails-claude-code"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10891,7 +1500,7 @@
         "ref": "main",
         "path": "skills/productivity/grill-me"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10907,7 +1516,7 @@
         "ref": "main",
         "path": "skills/engineering/grill-with-docs"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10923,7 +1532,7 @@
         "ref": "main",
         "path": "skills/productivity/handoff"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10939,7 +1548,7 @@
         "ref": "main",
         "path": "skills/engineering/improve-codebase-architecture"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10955,7 +1564,7 @@
         "ref": "main",
         "path": "skills/misc/migrate-to-shoehorn"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10971,7 +1580,7 @@
         "ref": "main",
         "path": "skills/personal/obsidian-vault"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -10987,7 +1596,7 @@
         "ref": "main",
         "path": "skills/engineering/prototype"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11003,7 +1612,7 @@
         "ref": "main",
         "path": "skills/deprecated/qa"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11019,7 +1628,7 @@
         "ref": "main",
         "path": "skills/deprecated/request-refactor-plan"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11035,7 +1644,7 @@
         "ref": "main",
         "path": "skills/in-progress/review"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11051,7 +1660,7 @@
         "ref": "main",
         "path": "skills/misc/scaffold-exercises"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11067,7 +1676,7 @@
         "ref": "main",
         "path": "skills/engineering/setup-matt-pocock-skills"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11083,7 +1692,7 @@
         "ref": "main",
         "path": "skills/misc/setup-pre-commit"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11099,7 +1708,7 @@
         "ref": "main",
         "path": "skills/engineering/tdd"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11115,7 +1724,7 @@
         "ref": "main",
         "path": "skills/in-progress/teach"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11131,7 +1740,7 @@
         "ref": "main",
         "path": "skills/engineering/to-issues"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11147,7 +1756,7 @@
         "ref": "main",
         "path": "skills/engineering/to-prd"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11163,7 +1772,7 @@
         "ref": "main",
         "path": "skills/engineering/triage"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11179,7 +1788,7 @@
         "ref": "main",
         "path": "skills/deprecated/ubiquitous-language"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11195,7 +1804,7 @@
         "ref": "main",
         "path": "skills/productivity/write-a-skill"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11211,7 +1820,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-beats"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11227,7 +1836,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-fragments"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11243,7 +1852,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-shape"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11259,7 +1868,7 @@
         "ref": "main",
         "path": "skills/engineering/zoom-out"
       },
-      "stars": 120303,
+      "stars": 120313,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -11275,7 +1884,7 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11291,7 +1900,7 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11307,7 +1916,7 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11323,7 +1932,7 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11339,7 +1948,7 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11355,7 +1964,7 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11371,7 +1980,7 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11387,7 +1996,7 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11403,7 +2012,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11419,7 +2028,7 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11435,7 +2044,7 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11451,7 +2060,7 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11467,7 +2076,7 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -11483,7 +2092,7 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 220330,
+      "stars": 220337,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-07T21:21:45.238Z",
+  "generatedAt": "2026-06-07T21:34:15.002Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
@@ -12,7 +12,7 @@
         "ref": "main",
         "path": "academic-paper"
       },
-      "stars": 28509,
+      "stars": 28512,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -28,7 +28,7 @@
         "ref": "main",
         "path": "academic-paper-reviewer"
       },
-      "stars": 28509,
+      "stars": 28512,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -44,7 +44,7 @@
         "ref": "main",
         "path": "academic-pipeline"
       },
-      "stars": 28509,
+      "stars": 28512,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -60,7 +60,7 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 28509,
+      "stars": 28512,
       "updatedAt": "2026-06-07T16:16:50Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
@@ -76,7 +76,7 @@
         "ref": "main",
         "path": "skills/api-and-interface-design"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -92,7 +92,7 @@
         "ref": "main",
         "path": "skills/browser-testing-with-devtools"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -108,7 +108,7 @@
         "ref": "main",
         "path": "skills/ci-cd-and-automation"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -124,7 +124,7 @@
         "ref": "main",
         "path": "skills/code-review-and-quality"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -140,7 +140,7 @@
         "ref": "main",
         "path": "skills/code-simplification"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -156,7 +156,7 @@
         "ref": "main",
         "path": "skills/context-engineering"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -172,7 +172,7 @@
         "ref": "main",
         "path": "skills/debugging-and-error-recovery"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -188,7 +188,7 @@
         "ref": "main",
         "path": "skills/deprecation-and-migration"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -204,7 +204,7 @@
         "ref": "main",
         "path": "skills/documentation-and-adrs"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -220,7 +220,7 @@
         "ref": "main",
         "path": "skills/doubt-driven-development"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -236,7 +236,7 @@
         "ref": "main",
         "path": "skills/frontend-ui-engineering"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -252,7 +252,7 @@
         "ref": "main",
         "path": "skills/git-workflow-and-versioning"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -268,7 +268,7 @@
         "ref": "main",
         "path": "skills/idea-refine"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -284,7 +284,7 @@
         "ref": "main",
         "path": "skills/incremental-implementation"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -300,7 +300,7 @@
         "ref": "main",
         "path": "skills/interview-me"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -316,7 +316,7 @@
         "ref": "main",
         "path": "skills/performance-optimization"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -332,7 +332,7 @@
         "ref": "main",
         "path": "skills/planning-and-task-breakdown"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -348,7 +348,7 @@
         "ref": "main",
         "path": "skills/security-and-hardening"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -364,7 +364,7 @@
         "ref": "main",
         "path": "skills/shipping-and-launch"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -380,7 +380,7 @@
         "ref": "main",
         "path": "skills/source-driven-development"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -396,7 +396,7 @@
         "ref": "main",
         "path": "skills/spec-driven-development"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -412,7 +412,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -428,7 +428,7 @@
         "ref": "main",
         "path": "skills/using-agent-skills"
       },
-      "stars": 48922,
+      "stars": 48925,
       "updatedAt": "2026-06-07T18:36:32Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
@@ -444,7 +444,7 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -460,7 +460,7 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -476,7 +476,7 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -492,7 +492,7 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -508,7 +508,7 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -524,7 +524,7 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -540,7 +540,7 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -556,7 +556,7 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -572,7 +572,7 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -588,7 +588,7 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -604,7 +604,7 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -620,7 +620,7 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -636,7 +636,7 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -652,7 +652,7 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -668,7 +668,7 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -684,7 +684,7 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -700,7 +700,7 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -716,7 +716,7 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147554,
+      "stars": 147555,
       "updatedAt": "2026-06-07T20:21:35Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
@@ -732,7 +732,7 @@
         "ref": "main",
         "path": "skills/ab-testing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -748,7 +748,7 @@
         "ref": "main",
         "path": "skills/ad-creative"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -764,7 +764,7 @@
         "ref": "main",
         "path": "skills/ads"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -780,7 +780,7 @@
         "ref": "main",
         "path": "skills/ai-seo"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -796,7 +796,7 @@
         "ref": "main",
         "path": "skills/analytics"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -812,7 +812,7 @@
         "ref": "main",
         "path": "skills/aso"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -828,7 +828,7 @@
         "ref": "main",
         "path": "skills/churn-prevention"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -844,7 +844,7 @@
         "ref": "main",
         "path": "skills/co-marketing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -860,7 +860,7 @@
         "ref": "main",
         "path": "skills/cold-email"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -876,7 +876,7 @@
         "ref": "main",
         "path": "skills/community-marketing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -892,7 +892,7 @@
         "ref": "main",
         "path": "skills/competitor-profiling"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -908,7 +908,7 @@
         "ref": "main",
         "path": "skills/competitors"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -924,7 +924,7 @@
         "ref": "main",
         "path": "skills/content-strategy"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -940,7 +940,7 @@
         "ref": "main",
         "path": "skills/copy-editing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -956,7 +956,7 @@
         "ref": "main",
         "path": "skills/copywriting"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -972,7 +972,7 @@
         "ref": "main",
         "path": "skills/cro"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -988,7 +988,7 @@
         "ref": "main",
         "path": "skills/customer-research"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1004,7 +1004,7 @@
         "ref": "main",
         "path": "skills/directory-submissions"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1020,7 +1020,7 @@
         "ref": "main",
         "path": "skills/emails"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1036,7 +1036,7 @@
         "ref": "main",
         "path": "skills/free-tools"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1052,7 +1052,7 @@
         "ref": "main",
         "path": "skills/image"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1068,7 +1068,7 @@
         "ref": "main",
         "path": "skills/launch"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1084,7 +1084,7 @@
         "ref": "main",
         "path": "skills/lead-magnets"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1100,7 +1100,7 @@
         "ref": "main",
         "path": "skills/marketing-ideas"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1116,7 +1116,7 @@
         "ref": "main",
         "path": "skills/marketing-plan"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1132,7 +1132,7 @@
         "ref": "main",
         "path": "skills/marketing-psychology"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1148,7 +1148,7 @@
         "ref": "main",
         "path": "skills/onboarding"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1164,7 +1164,7 @@
         "ref": "main",
         "path": "skills/paywalls"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1180,7 +1180,7 @@
         "ref": "main",
         "path": "skills/popups"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1196,7 +1196,7 @@
         "ref": "main",
         "path": "skills/pricing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1212,7 +1212,7 @@
         "ref": "main",
         "path": "skills/product-marketing"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1228,7 +1228,7 @@
         "ref": "main",
         "path": "skills/programmatic-seo"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1244,7 +1244,7 @@
         "ref": "main",
         "path": "skills/prospecting"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1260,7 +1260,7 @@
         "ref": "main",
         "path": "skills/referrals"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1276,7 +1276,7 @@
         "ref": "main",
         "path": "skills/revops"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1292,7 +1292,7 @@
         "ref": "main",
         "path": "skills/sales-enablement"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1308,7 +1308,7 @@
         "ref": "main",
         "path": "skills/schema"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1324,7 +1324,7 @@
         "ref": "main",
         "path": "skills/seo-audit"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1340,7 +1340,7 @@
         "ref": "main",
         "path": "skills/signup"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1356,7 +1356,7 @@
         "ref": "main",
         "path": "skills/site-architecture"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1372,7 +1372,7 @@
         "ref": "main",
         "path": "skills/sms"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1388,7 +1388,7 @@
         "ref": "main",
         "path": "skills/social"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
@@ -1404,10 +1404,42 @@
         "ref": "main",
         "path": "skills/video"
       },
-      "stars": 32329,
+      "stars": 32330,
       "updatedAt": "2026-06-05T22:53:41Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
+    },
+    {
+      "id": "dev-browser/dev-browser",
+      "name": "dev-browser",
+      "description": "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include \"go to [url]\", \"click on\", \"fill out the form\", \"take a screenshot\", \"scrape\", \"automate\", \"test the website\", \"log into\", or any browser interaction request.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "SawyerHood/dev-browser",
+        "ref": "main",
+        "path": "skills/dev-browser"
+      },
+      "stars": 6223,
+      "updatedAt": "2026-06-05T18:37:05Z",
+      "provenance": "curated",
+      "sourceId": "dev-browser"
+    },
+    {
+      "id": "last30days/last30days",
+      "name": "last30days",
+      "description": "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "mvanhorn/last30days-skill",
+        "ref": "main",
+        "path": "skills/last30days"
+      },
+      "stars": 30619,
+      "updatedAt": "2026-06-06T16:58:08Z",
+      "provenance": "curated",
+      "sourceId": "last30days"
     },
     {
       "id": "mattpocock-skills/caveman",
@@ -1420,7 +1452,7 @@
         "ref": "main",
         "path": "skills/productivity/caveman"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1436,7 +1468,7 @@
         "ref": "main",
         "path": "skills/deprecated/design-an-interface"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1452,7 +1484,7 @@
         "ref": "main",
         "path": "skills/engineering/diagnose"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1468,7 +1500,7 @@
         "ref": "main",
         "path": "skills/personal/edit-article"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1484,7 +1516,7 @@
         "ref": "main",
         "path": "skills/misc/git-guardrails-claude-code"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1500,7 +1532,7 @@
         "ref": "main",
         "path": "skills/productivity/grill-me"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1516,7 +1548,7 @@
         "ref": "main",
         "path": "skills/engineering/grill-with-docs"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1532,7 +1564,7 @@
         "ref": "main",
         "path": "skills/productivity/handoff"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1548,7 +1580,7 @@
         "ref": "main",
         "path": "skills/engineering/improve-codebase-architecture"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1564,7 +1596,7 @@
         "ref": "main",
         "path": "skills/misc/migrate-to-shoehorn"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1580,7 +1612,7 @@
         "ref": "main",
         "path": "skills/personal/obsidian-vault"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1596,7 +1628,7 @@
         "ref": "main",
         "path": "skills/engineering/prototype"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1612,7 +1644,7 @@
         "ref": "main",
         "path": "skills/deprecated/qa"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1628,7 +1660,7 @@
         "ref": "main",
         "path": "skills/deprecated/request-refactor-plan"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1644,7 +1676,7 @@
         "ref": "main",
         "path": "skills/in-progress/review"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1660,7 +1692,7 @@
         "ref": "main",
         "path": "skills/misc/scaffold-exercises"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1676,7 +1708,7 @@
         "ref": "main",
         "path": "skills/engineering/setup-matt-pocock-skills"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1692,7 +1724,7 @@
         "ref": "main",
         "path": "skills/misc/setup-pre-commit"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1708,7 +1740,7 @@
         "ref": "main",
         "path": "skills/engineering/tdd"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1724,7 +1756,7 @@
         "ref": "main",
         "path": "skills/in-progress/teach"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1740,7 +1772,7 @@
         "ref": "main",
         "path": "skills/engineering/to-issues"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1756,7 +1788,7 @@
         "ref": "main",
         "path": "skills/engineering/to-prd"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1772,7 +1804,7 @@
         "ref": "main",
         "path": "skills/engineering/triage"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1788,7 +1820,7 @@
         "ref": "main",
         "path": "skills/deprecated/ubiquitous-language"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1804,7 +1836,7 @@
         "ref": "main",
         "path": "skills/productivity/write-a-skill"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1820,7 +1852,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-beats"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1836,7 +1868,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-fragments"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1852,7 +1884,7 @@
         "ref": "main",
         "path": "skills/in-progress/writing-shape"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
@@ -1868,10 +1900,170 @@
         "ref": "main",
         "path": "skills/engineering/zoom-out"
       },
-      "stars": 120313,
+      "stars": 120320,
       "updatedAt": "2026-06-07T17:44:50Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
+    },
+    {
+      "id": "obsidian-skills/defuddle",
+      "name": "defuddle",
+      "description": "Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "kepano/obsidian-skills",
+        "ref": "main",
+        "path": "skills/defuddle"
+      },
+      "stars": 34819,
+      "updatedAt": "2026-06-06T18:14:46Z",
+      "provenance": "curated",
+      "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "obsidian-skills/json-canvas",
+      "name": "json-canvas",
+      "description": "Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "kepano/obsidian-skills",
+        "ref": "main",
+        "path": "skills/json-canvas"
+      },
+      "stars": 34819,
+      "updatedAt": "2026-06-06T18:14:46Z",
+      "provenance": "curated",
+      "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "obsidian-skills/obsidian-bases",
+      "name": "obsidian-bases",
+      "description": "Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card views, filters, or formulas in Obsidian.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "kepano/obsidian-skills",
+        "ref": "main",
+        "path": "skills/obsidian-bases"
+      },
+      "stars": 34819,
+      "updatedAt": "2026-06-06T18:14:46Z",
+      "provenance": "curated",
+      "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "obsidian-skills/obsidian-cli",
+      "name": "obsidian-cli",
+      "description": "Interact with Obsidian vaults using the Obsidian CLI to read, create, search, and manage notes, tasks, properties, and more. Also supports plugin and theme development with commands to reload plugins, run JavaScript, capture errors, take screenshots, and inspect the DOM. Use when the user asks to interact with their Obsidian vault, manage notes, search vault content, perform vault operations from the command line, or develop and debug Obsidian plugins and themes.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "kepano/obsidian-skills",
+        "ref": "main",
+        "path": "skills/obsidian-cli"
+      },
+      "stars": 34819,
+      "updatedAt": "2026-06-06T18:14:46Z",
+      "provenance": "curated",
+      "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "obsidian-skills/obsidian-markdown",
+      "name": "obsidian-markdown",
+      "description": "Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "kepano/obsidian-skills",
+        "ref": "main",
+        "path": "skills/obsidian-markdown"
+      },
+      "stars": 34819,
+      "updatedAt": "2026-06-06T18:14:46Z",
+      "provenance": "curated",
+      "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "second-brain-skills/brand-voice-generator",
+      "name": "brand-voice-generator",
+      "description": "|",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coleam00/second-brain-skills",
+        "ref": "main",
+        "path": ".claude/skills/brand-voice-generator"
+      },
+      "stars": 759,
+      "updatedAt": "2026-01-24T15:50:47Z",
+      "provenance": "curated",
+      "sourceId": "second-brain-skills"
+    },
+    {
+      "id": "second-brain-skills/mcp-client",
+      "name": "mcp-client",
+      "description": "Universal MCP client for connecting to any MCP server with progressive disclosure. Wraps MCP servers as skills to avoid context window bloat from tool definitions. Use when interacting with external MCP servers (Zapier, Sequential Thinking, GitHub, filesystem, etc.), listing available tools, or executing MCP tool calls. Triggers on requests like \"connect to Zapier\", \"use MCP server\", \"list MCP tools\", \"call Zapier action\", \"use sequential thinking\", or any MCP server interaction.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coleam00/second-brain-skills",
+        "ref": "main",
+        "path": ".claude/skills/mcp-client"
+      },
+      "stars": 759,
+      "updatedAt": "2026-01-24T15:50:47Z",
+      "provenance": "curated",
+      "sourceId": "second-brain-skills"
+    },
+    {
+      "id": "second-brain-skills/pptx-generator",
+      "name": "pptx-generator",
+      "description": "|",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coleam00/second-brain-skills",
+        "ref": "main",
+        "path": ".claude/skills/pptx-generator"
+      },
+      "stars": 759,
+      "updatedAt": "2026-01-24T15:50:47Z",
+      "provenance": "curated",
+      "sourceId": "second-brain-skills"
+    },
+    {
+      "id": "second-brain-skills/skill-creator",
+      "name": "skill-creator",
+      "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coleam00/second-brain-skills",
+        "ref": "main",
+        "path": ".claude/skills/skill-creator"
+      },
+      "stars": 759,
+      "updatedAt": "2026-01-24T15:50:47Z",
+      "provenance": "curated",
+      "sourceId": "second-brain-skills"
+    },
+    {
+      "id": "second-brain-skills/sop-creator",
+      "name": "sop-creator",
+      "description": "Create runbooks, playbooks, and technical documentation for engineering teams. Use when the user wants to document a process, create a runbook, build operational docs, or formalize any repeatable technical procedure. Triggers on requests like \"create a runbook for...\", \"document this process\", \"write a playbook\", or any technical documentation request.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coleam00/second-brain-skills",
+        "ref": "main",
+        "path": ".claude/skills/sop-creator"
+      },
+      "stars": 759,
+      "updatedAt": "2026-01-24T15:50:47Z",
+      "provenance": "curated",
+      "sourceId": "second-brain-skills"
     },
     {
       "id": "superpowers/brainstorming",
@@ -1884,7 +2076,7 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1900,7 +2092,7 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1916,7 +2108,7 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1932,7 +2124,7 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1948,7 +2140,7 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1964,7 +2156,7 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1980,7 +2172,7 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -1996,7 +2188,7 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2012,7 +2204,7 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2028,7 +2220,7 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2044,7 +2236,7 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2060,7 +2252,7 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2076,7 +2268,7 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
@@ -2092,10 +2284,138 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 220337,
+      "stars": 220343,
       "updatedAt": "2026-06-03T05:46:02Z",
       "provenance": "curated",
       "sourceId": "superpowers"
+    },
+    {
+      "id": "vercel-agent-skills/deploy-to-vercel",
+      "name": "deploy-to-vercel",
+      "description": "Deploy applications and websites to Vercel. Use when the user requests deployment actions like \"deploy my app\", \"deploy and give me the link\", \"push this live\", or \"create a preview deployment\".",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/deploy-to-vercel"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/vercel-cli-with-tokens",
+      "name": "vercel-cli-with-tokens",
+      "description": "Deploy and manage projects on Vercel using token-based authentication. Use when working with Vercel CLI using access tokens rather than interactive login — e.g. \"deploy to vercel\", \"set up vercel\", \"add environment variables to vercel\".",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/vercel-cli-with-tokens"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/vercel-optimize",
+      "name": "vercel-optimize",
+      "description": "Use for Vercel cost and performance optimization on deployed projects, especially Next.js, SvelteKit, Nuxt, and limited Astro apps. Collect Vercel metrics, usage, project config, and code scan results first; investigate only metric-backed candidates; produce ranked recommendations grounded in verified files and version-aware Vercel/framework docs. Trigger for Vercel bill reduction, slow or expensive routes, caching opportunities, Function Invocations, Build Minutes, Fast Data Transfer, Core Web Vitals, Bot Management, Fluid compute, or cost breakdown requests.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/vercel-optimize"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/vercel-react-best-practices",
+      "name": "vercel-react-best-practices",
+      "description": "React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/react-best-practices"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/vercel-react-view-transitions",
+      "name": "vercel-react-view-transitions",
+      "description": "Guide for implementing smooth, native-feeling animations using React's View Transition API (`<ViewTransition>` component, `addTransitionType`, and CSS view transition pseudo-elements). Use this skill whenever the user wants to add page transitions, animate route changes, create shared element animations, animate enter/exit of components, animate list reorder, implement directional (forward/back) navigation animations, or integrate view transitions in Next.js. Also use when the user mentions view transitions, `startViewTransition`, `ViewTransition`, transition types, or asks about animating between UI states in React without third-party animation libraries.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/react-view-transitions"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/web-design-guidelines",
+      "name": "web-design-guidelines",
+      "description": "Review UI code for Web Interface Guidelines compliance. Use when asked to \"review my UI\", \"check accessibility\", \"audit design\", \"review UX\", or \"check my site against best practices\".",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/web-design-guidelines"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "vercel-agent-skills/writing-guidelines",
+      "name": "writing-guidelines",
+      "description": "Review docs/prose for Writing Guidelines compliance. Use when asked to \"review my docs\", \"check writing style\", \"audit prose\", \"review docs voice and tone\", or \"check this page against the writing handbook\".",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "vercel-labs/agent-skills",
+        "ref": "main",
+        "path": "skills/writing-guidelines"
+      },
+      "stars": 27685,
+      "updatedAt": "2026-06-03T17:03:05Z",
+      "provenance": "curated",
+      "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "webgpu-threejs/webgpu-threejs-tsl",
+      "name": "webgpu-threejs-tsl",
+      "description": "Comprehensive guide for developing WebGPU-enabled Three.js applications using TSL (Three.js Shading Language). Covers WebGPU renderer setup, TSL syntax and node materials, compute shaders, post-processing effects, and WGSL integration. Use this skill when working with Three.js WebGPU, TSL shaders, node materials, or GPU compute in Three.js.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "dgreenheck/webgpu-claude-skill",
+        "ref": "main",
+        "path": "skills/webgpu-threejs-tsl"
+      },
+      "stars": 981,
+      "updatedAt": "2026-04-10T14:28:23Z",
+      "provenance": "curated",
+      "sourceId": "webgpu-threejs"
     }
   ]
 }

--- a/registry/sources.json
+++ b/registry/sources.json
@@ -6,6 +6,12 @@
     { "id": "mattpocock-skills", "repo": "mattpocock/skills", "path": "skills" },
     { "id": "addyosmani-agent-skills", "repo": "addyosmani/agent-skills", "path": "skills" },
     { "id": "coreyhaines-marketing-skills", "repo": "coreyhaines31/marketingskills", "path": "skills" },
-    { "id": "academic-research-skills", "repo": "Imbad0202/academic-research-skills", "path": "" }
+    { "id": "academic-research-skills", "repo": "Imbad0202/academic-research-skills", "path": "" },
+    { "id": "vercel-agent-skills", "repo": "vercel-labs/agent-skills", "path": "skills" },
+    { "id": "obsidian-skills", "repo": "kepano/obsidian-skills", "path": "skills" },
+    { "id": "dev-browser", "repo": "SawyerHood/dev-browser", "path": "skills" },
+    { "id": "webgpu-threejs", "repo": "dgreenheck/webgpu-claude-skill", "path": "skills" },
+    { "id": "last30days", "repo": "mvanhorn/last30days-skill", "path": "skills" },
+    { "id": "second-brain-skills", "repo": "coleam00/second-brain-skills", "path": ".claude/skills" }
   ]
 }

--- a/registry/sources.json
+++ b/registry/sources.json
@@ -9,9 +9,12 @@
     { "id": "academic-research-skills", "repo": "Imbad0202/academic-research-skills", "path": "" },
     { "id": "vercel-agent-skills", "repo": "vercel-labs/agent-skills", "path": "skills" },
     { "id": "obsidian-skills", "repo": "kepano/obsidian-skills", "path": "skills" },
-    { "id": "dev-browser", "repo": "SawyerHood/dev-browser", "path": "skills" },
-    { "id": "webgpu-threejs", "repo": "dgreenheck/webgpu-claude-skill", "path": "skills" },
     { "id": "last30days", "repo": "mvanhorn/last30days-skill", "path": "skills" },
-    { "id": "second-brain-skills", "repo": "coleam00/second-brain-skills", "path": ".claude/skills" }
+    { "id": "ui-ux-pro-max", "repo": "nextlevelbuilder/ui-ux-pro-max-skill", "path": ".claude/skills" },
+    { "id": "caveman", "repo": "JuliusBrussee/caveman", "path": ".agents/skills" },
+    { "id": "career-ops", "repo": "santifer/career-ops", "path": ".agents/skills" },
+    { "id": "taste-skill", "repo": "Leonxlnx/taste-skill", "path": "skills" },
+    { "id": "humanizer", "repo": "blader/humanizer", "path": "" },
+    { "id": "notebooklm", "repo": "teng-lin/notebooklm-py", "path": "" }
   ]
 }

--- a/registry/sources.json
+++ b/registry/sources.json
@@ -5,10 +5,7 @@
     { "id": "superpowers", "repo": "obra/superpowers", "path": "skills" },
     { "id": "mattpocock-skills", "repo": "mattpocock/skills", "path": "skills" },
     { "id": "addyosmani-agent-skills", "repo": "addyosmani/agent-skills", "path": "skills" },
-    { "id": "alirezarezvani-claude-skills", "repo": "alirezarezvani/claude-skills", "path": "" },
     { "id": "coreyhaines-marketing-skills", "repo": "coreyhaines31/marketingskills", "path": "skills" },
-    { "id": "academic-research-skills", "repo": "Imbad0202/academic-research-skills", "path": "" },
-    { "id": "daymade-claude-code-skills", "repo": "daymade/claude-code-skills", "path": "" },
-    { "id": "glebis-claude-skills", "repo": "glebis/claude-skills", "path": "" }
+    { "id": "academic-research-skills", "repo": "Imbad0202/academic-research-skills", "path": "" }
   ]
 }

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -37,13 +37,44 @@ function parseRepo(repo) {
   return { owner, name }
 }
 
+// Strip the least-indented prefix shared by all non-blank lines (YAML block
+// scalar indentation).
+function dedent(lines) {
+  const indents = lines.filter((l) => l.trim()).map((l) => l.match(/^[ \t]*/)[0].length)
+  const min = indents.length ? Math.min(...indents) : 0
+  return lines.map((l) => l.slice(min))
+}
+
 function parseFrontmatter(text) {
   const m = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text)
   const fm = {}
   if (m) {
-    for (const line of m[1].split('\n')) {
-      const mm = /^([a-zA-Z0-9_-]+):\s*(.*)$/.exec(line)
-      if (mm) fm[mm[1]] = mm[2].trim().replace(/^["']|["']$/g, '')
+    const lines = m[1].split('\n')
+    let i = 0
+    while (i < lines.length) {
+      const mm = /^([a-zA-Z0-9_-]+):\s*(.*)$/.exec(lines[i])
+      if (!mm) { i++; continue }
+      const key = mm[1]
+      const raw = mm[2].trim()
+      // Block scalar: `key: |` (literal) or `key: >` (folded), with optional
+      // chomping (+/-). Gather the following more-indented (or blank) lines.
+      if (/^[|>][+-]?$/.test(raw)) {
+        const fold = raw[0] === '>'
+        const block = []
+        i++
+        while (i < lines.length && (lines[i].trim() === '' || /^[ \t]/.test(lines[i]))) {
+          block.push(lines[i]); i++
+        }
+        while (block.length && !block[block.length - 1].trim()) block.pop()
+        const body = dedent(block)
+        // Folded: join lines within a paragraph by spaces, keep blank-line breaks.
+        fm[key] = fold
+          ? body.join('\n').split(/\n{2,}/).map((p) => p.split('\n').join(' ').trim()).join('\n').trim()
+          : body.join('\n').trim()
+      } else {
+        fm[key] = raw.replace(/^["']|["']$/g, '')
+        i++
+      }
     }
   }
   const tags = fm.tags ? fm.tags.replace(/[[\]]/g, '').split(',').map((s) => s.trim()).filter(Boolean) : []
@@ -91,7 +122,8 @@ async function crawlSource(src) {
     try {
       const { fm, tags: tg } = parseFrontmatter(await rawText(owner, name, ref, t.path))
       if (fm.name) skillName = fm.name
-      if (fm.description) description = fm.description
+      // Collapse block-scalar newlines so the catalog blurb is one clean line.
+      if (fm.description) description = fm.description.replace(/\s+/g, ' ').trim()
       tags = tg
     } catch {
       /* keep dir-derived name */

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -137,11 +137,17 @@ async function main() {
   if (deduped.length !== skills.length) {
     console.log(`Deduped ${skills.length - deduped.length} duplicate id(s)`)
   }
+  // Quality floor: drop entries with no frontmatter description. They carry no
+  // signal for search and read as broken rows, so keep the catalog selective.
+  const curated = deduped.filter((s) => s.description && s.description.trim())
+  if (curated.length !== deduped.length) {
+    console.log(`Dropped ${deduped.length - curated.length} entr(ies) with no description`)
+  }
   // Stable order so the committed index has minimal diffs.
-  deduped.sort((a, b) => a.id.localeCompare(b.id))
-  const index = { generatedAt: new Date().toISOString(), skills: deduped }
+  curated.sort((a, b) => a.id.localeCompare(b.id))
+  const index = { generatedAt: new Date().toISOString(), skills: curated }
   await writeFile(INDEX_PATH, `${JSON.stringify(index, null, 2)}\n`)
-  console.log(`Wrote ${skills.length} skill(s) to ${INDEX_PATH}`)
+  console.log(`Wrote ${curated.length} skill(s) to ${INDEX_PATH}`)
 }
 
 main().catch((err) => {

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -137,11 +137,17 @@ async function main() {
   if (deduped.length !== skills.length) {
     console.log(`Deduped ${skills.length - deduped.length} duplicate id(s)`)
   }
-  // Quality floor: drop entries with no frontmatter description. They carry no
-  // signal for search and read as broken rows, so keep the catalog selective.
-  const curated = deduped.filter((s) => s.description && s.description.trim())
-  if (curated.length !== deduped.length) {
-    console.log(`Dropped ${deduped.length - curated.length} entr(ies) with no description`)
+  // Quality floor: drop entries with no frontmatter description (no search
+  // signal, render as broken rows) and from repos under MIN_STARS. Keeps the
+  // catalog selective — only well-adopted, documented skills ship.
+  const MIN_STARS = 10_000
+  const described = deduped.filter((s) => s.description && s.description.trim())
+  if (described.length !== deduped.length) {
+    console.log(`Dropped ${deduped.length - described.length} entr(ies) with no description`)
+  }
+  const curated = described.filter((s) => (s.stars ?? 0) >= MIN_STARS)
+  if (curated.length !== described.length) {
+    console.log(`Dropped ${described.length - curated.length} entr(ies) under ${MIN_STARS} stars`)
   }
   // Stable order so the committed index has minimal diffs.
   curated.sort((a, b) => a.id.localeCompare(b.id))


### PR DESCRIPTION
Makes the skills index more selective.

## Sources removed (sources.json)
- alirezarezvani/claude-skills (was 422 entries, 60% of the catalog, the "17k★" flood)
- glebis/claude-skills (86)
- daymade/claude-code-skills (61)

## Build quality floor (build-skills-index.mjs)
Drop entries with no frontmatter description: no search signal and they render as broken rows.

## Result
700 -> 131 skills across 6 curated sources, 0 duplicates, 0 empty descriptions.