### PR TITLE
Command palette: fix keyboard nav, unify action path, mirror overview panel source

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -11,7 +11,7 @@ import { listPanelWindows, getWindow, getWindowType, getActiveMainWindow, getWin
 /** Panel-creation actions. These add a panel to the workspace's canvas, so they
  *  have nowhere to go in a detached dock/panel window (no canvas there) —
  *  `dispatch` re-routes them to the main window. */
-const PANEL_CREATE_ACTIONS = new Set<MenuActionId>(['newTerminal', 'newEditor', 'newBrowser', 'newFile'])
+const PANEL_CREATE_ACTIONS = new Set<MenuActionId>(['newTerminal', 'newEditor', 'newBrowser', 'newFile', 'newAgent', 'newCanvas'])
 
 /** Dispatch a renderer-side menu action to the focused window. Items in the
  *  template use this as their click handler — the renderer's useShortcuts hook
@@ -146,6 +146,8 @@ export function buildApplicationMenu(): void {
         { label: 'New Editor', accelerator: 'CmdOrCtrl+Shift+E', click: dispatch('newEditor') },
         { label: 'New Terminal', accelerator: 'CmdOrCtrl+T', click: dispatch('newTerminal') },
         { label: 'New Browser', accelerator: 'CmdOrCtrl+Shift+B', click: dispatch('newBrowser') },
+        { label: 'New Cate Agent', accelerator: 'CmdOrCtrl+Shift+A', click: dispatch('newAgent') },
+        { label: 'New Canvas', accelerator: 'CmdOrCtrl+Shift+C', click: dispatch('newCanvas') },
         { type: 'separator' },
         { label: 'Open Folder...', accelerator: 'CmdOrCtrl+O', click: dispatch('openFolder') },
         { label: 'Reload Workspace from Disk', click: dispatch('reloadWorkspace') },

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -11,15 +11,17 @@ import {
   getActiveCanvasOps,
   getActiveCanvasPanelId,
   getWorkspaceCanvasStore,
-  placementForActivePanel,
 } from '../stores/appStore'
-import { useUIStore, getSidebarLayout } from '../stores/uiStore'
-import { useSearchStore } from '../stores/searchStore'
+import { useUIStore } from '../stores/uiStore'
 import { getActivePanelId, setActivePanel } from '../lib/activePanel'
 import { resolvePanelById } from '../lib/workspace/panelReveal'
 import { getNodeActivePanelId } from '../panels/nodeDockRegistry'
-import type { MenuActionId, ShortcutAction } from '../../shared/types'
-import { confirmClosePanels } from '../lib/confirmClosePanels'
+import type { ShortcutAction } from '../../shared/types'
+import { runAction } from '../lib/runAction'
+
+// ensureWorkspaceFolder lives in lib/runAction now; re-exported here for the
+// panels/pages that still import it from this module.
+export { ensureWorkspaceFolder } from '../lib/runAction'
 
 // Cmd+Arrow panel navigation — moves the selection cursor between nodes.
 const NAVIGATE_ACTIONS = new Set<ShortcutAction>([
@@ -30,22 +32,6 @@ const NAVIGATE_ACTIONS = new Set<ShortcutAction>([
 const PAN_ACTIONS = new Set<ShortcutAction>([
   'panUp', 'panDown', 'panLeft', 'panRight',
 ])
-
-/**
- * Ensures the workspace has a rootPath before proceeding.
- * If no rootPath is set, opens the folder dialog first.
- * Returns the workspaceId if ready, or null if the user cancelled.
- */
-export async function ensureWorkspaceFolder(workspaceId: string): Promise<string | null> {
-  const ws = useAppStore.getState().getWorkspace(workspaceId)
-  if (ws?.rootPath) return workspaceId
-
-  const folderPath = await window.electronAPI.openFolderDialog()
-  if (!folderPath) return null
-
-  useAppStore.getState().setWorkspaceRootPath(workspaceId, folderPath)
-  return workspaceId
-}
 
 /**
  * Whether a terminal panel currently holds input focus, derived from the
@@ -113,178 +99,10 @@ export function useShortcuts(): void {
     const canvasStore = () => (getActiveCanvasOps()?.storeApi ?? canvasStoreApi).getState()
     const appStore = useAppStore.getState
 
-    /**
-     * Run a shortcut/menu action. Shared between the keyboard handler and the
-     * native menu IPC listener, so the two code paths can never drift.
-     * Re-reads store state at call time so it's safe to invoke at any moment.
-     */
-    async function runAction(action: MenuActionId): Promise<void> {
-      const selectedWorkspaceId = appStore().selectedWorkspaceId
-
-      // Menu-only actions first
-      if (action === 'openFolder') {
-        const folder = await window.electronAPI.openFolderDialog()
-        if (folder) {
-          useAppStore.getState().setWorkspaceRootPath(selectedWorkspaceId, folder)
-        }
-        return
-      }
-      if (action === 'reloadWorkspace') {
-        const { reloadActiveWorkspaceFromDisk } = await import('../lib/workspace/session')
-        await reloadActiveWorkspaceFromDisk()
-        return
-      }
-      if (action === 'manageLayouts') {
-        useUIStore.getState().setShowLayoutsDialog(true)
-        return
-      }
-
-      switch (action as ShortcutAction) {
-        case 'newTerminal': {
-          const placement = placementForActivePanel()
-          const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
-          if (wsId) appStore().createTerminal(wsId, undefined, undefined, placement)
-          break
-        }
-        case 'newBrowser': {
-          const placement = placementForActivePanel()
-          const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
-          if (wsId) appStore().createBrowser(wsId, undefined, undefined, placement)
-          break
-        }
-        case 'newEditor':
-        case 'newFile': {
-          const placement = placementForActivePanel()
-          const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
-          if (wsId) appStore().createEditor(wsId, undefined, undefined, placement)
-          break
-        }
-        case 'closePanel': {
-          const focusedNodeId = canvasStore().focusedNodeId
-          if (focusedNodeId) {
-            const node = canvasStore().nodes[focusedNodeId]
-            if (node && (await confirmClosePanels(selectedWorkspaceId, [node.panelId]))) {
-              appStore().closePanel(selectedWorkspaceId, node.panelId)
-            }
-          }
-          break
-        }
-        case 'toggleSidebar':
-          useUIStore.getState().toggleSidebar()
-          break
-        case 'toggleFileExplorer': {
-          const ui = useUIStore.getState()
-          const side = getSidebarLayout().left.includes('explorer') ? 'left' : 'right'
-          if (side === 'left') {
-            ui.setActiveLeftSidebarView(ui.activeLeftSidebarView === 'explorer' ? null : 'explorer')
-          } else {
-            ui.setActiveRightSidebarView(ui.activeRightSidebarView === 'explorer' ? null : 'explorer')
-          }
-          break
-        }
-        case 'toggleSearch': {
-          const ui = useUIStore.getState()
-          const side = getSidebarLayout().left.includes('search') ? 'left' : 'right'
-          const active = side === 'left' ? ui.activeLeftSidebarView : ui.activeRightSidebarView
-          const next = active === 'search' ? null : 'search'
-          if (side === 'left') ui.setActiveLeftSidebarView(next)
-          else ui.setActiveRightSidebarView(next)
-          if (next === 'search') useSearchStore.getState().requestFocus()
-          break
-        }
-        case 'toggleMinimap':
-          useUIStore.getState().toggleMinimapOpen()
-          break
-        case 'nodeSwitcher':
-          useUIStore.getState().setShowNodeSwitcher(true)
-          break
-        case 'commandPalette':
-          useUIStore.getState().setShowCommandPalette(true)
-          break
-        case 'zoomIn':
-          canvasStore().animateZoomTo(canvasStore().zoomLevel + 0.1)
-          break
-        case 'zoomOut':
-          canvasStore().animateZoomTo(canvasStore().zoomLevel - 0.1)
-          break
-        case 'zoomReset':
-          canvasStore().animateZoomTo(1.0)
-          break
-        case 'focusNext': {
-          const next = canvasStore().nextNode()
-          if (next) canvasStore().focusNode(next)
-          break
-        }
-        case 'focusPrevious': {
-          const prev = canvasStore().previousNode()
-          if (prev) canvasStore().focusNode(prev)
-          break
-        }
-        case 'saveFile':
-          window.dispatchEvent(new CustomEvent('save-file'))
-          break
-        case 'zoomToFit':
-          canvasStore().zoomToFit()
-          break
-        case 'zoomToSelection':
-          canvasStore().zoomToSelection()
-          break
-        case 'toolSelect':
-          useUIStore.getState().setActiveTool('select')
-          break
-        case 'toolHand':
-          useUIStore.getState().setActiveTool('hand')
-          break
-        case 'navigateUp':
-          canvasStore().navigateSelect('up')
-          break
-        case 'navigateDown':
-          canvasStore().navigateSelect('down')
-          break
-        case 'navigateLeft':
-          canvasStore().navigateSelect('left')
-          break
-        case 'navigateRight':
-          canvasStore().navigateSelect('right')
-          break
-        case 'panUp':
-          canvasStore().panViewport('up')
-          break
-        case 'panDown':
-          canvasStore().panViewport('down')
-          break
-        case 'panLeft':
-          canvasStore().panViewport('left')
-          break
-        case 'panRight':
-          canvasStore().panViewport('right')
-          break
-        case 'autoLayout':
-          canvasStore().autoLayout()
-          break
-        case 'undo':
-          canvasStore().undo()
-          break
-        case 'redo':
-          canvasStore().redo()
-          break
-        case 'deleteNode': {
-          const focusedId = canvasStore().focusedNodeId
-          if (focusedId && canvasStore().nodes[focusedId]) {
-            const node = canvasStore().nodes[focusedId]
-            if (await confirmClosePanels(selectedWorkspaceId, [node.panelId])) {
-              appStore().closePanel(selectedWorkspaceId, node.panelId)
-            }
-          }
-          break
-        }
-      }
-    }
-
     // Subscribe to native-menu dispatches. The menu fires this on every File /
     // View / Terminal / etc. item that maps to a runnable action.
     const unsubscribeMenu = window.electronAPI.onMenuTriggerAction((action) => {
-      runAction(action).catch(() => { /* noop — menu actions are best-effort */ })
+      runAction(action, canvasStoreApi).catch(() => { /* noop — menu actions are best-effort */ })
     })
 
     // A panel-creation shortcut fired while a detached dock/panel window was
@@ -294,7 +112,7 @@ export function useShortcuts(): void {
       if (workspaceId && appStore().getWorkspace(workspaceId) && appStore().selectedWorkspaceId !== workspaceId) {
         void appStore().selectWorkspace(workspaceId)
       }
-      runAction(action).catch(() => { /* noop */ })
+      runAction(action, canvasStoreApi).catch(() => { /* noop */ })
     })
 
     // Native "Layouts" menu → load a saved layout into the active canvas.
@@ -480,7 +298,7 @@ export function useShortcuts(): void {
       e.preventDefault()
       e.stopPropagation()
 
-      runAction(action).catch(() => { /* noop */ })
+      runAction(action, canvasStoreApi).catch(() => { /* noop */ })
     }
 
     function handleKeyUp(e: KeyboardEvent) {

--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -1,0 +1,226 @@
+// =============================================================================
+// runAction — the single source of truth for menu / shortcut / command-palette
+// actions. Both the global keyboard handler (useShortcuts) and the Cmd+K command
+// palette dispatch through here, so the two can never drift: a "New Terminal"
+// fired from ⌘T and from the palette take the exact same path — including the
+// context-aware placement (drop onto the focused canvas, or tab into the focused
+// dock stack) and the ensure-folder prompt.
+// =============================================================================
+
+import type { StoreApi } from 'zustand'
+import {
+  useAppStore,
+  getActiveCanvasOps,
+  placementForActivePanel,
+} from '../stores/appStore'
+import { useUIStore, getSidebarLayout } from '../stores/uiStore'
+import { useSearchStore } from '../stores/searchStore'
+import type { MenuActionId, ShortcutAction } from '../../shared/types'
+import type { CanvasStore } from '../stores/canvasStore'
+import { confirmClosePanels } from './confirmClosePanels'
+
+/**
+ * Ensures the workspace has a rootPath before proceeding.
+ * If no rootPath is set, opens the folder dialog first.
+ * Returns the workspaceId if ready, or null if the user cancelled.
+ */
+export async function ensureWorkspaceFolder(workspaceId: string): Promise<string | null> {
+  const ws = useAppStore.getState().getWorkspace(workspaceId)
+  if (ws?.rootPath) return workspaceId
+
+  const folderPath = await window.electronAPI.openFolderDialog()
+  if (!folderPath) return null
+
+  useAppStore.getState().setWorkspaceRootPath(workspaceId, folderPath)
+  return workspaceId
+}
+
+/**
+ * Run a shortcut/menu/command-palette action. Re-reads store state at call time
+ * so it's safe to invoke at any moment. `canvasStoreApi` is the fallback canvas
+ * store used when no active canvas can be resolved (single-canvas / detached
+ * windows) — pass the value from `useCanvasStoreApi()`.
+ */
+export async function runAction(
+  action: MenuActionId,
+  canvasStoreApi: StoreApi<CanvasStore>,
+): Promise<void> {
+  // Resolve the *active* canvas store at call time rather than binding to a
+  // store captured on mount. The visible canvas is a per-panel store;
+  // getActiveCanvasOps derives it from the canonical active panel, falling back
+  // to the passed store for single-canvas / detached windows.
+  const canvasStore = () => (getActiveCanvasOps()?.storeApi ?? canvasStoreApi).getState()
+  const appStore = useAppStore.getState
+  const selectedWorkspaceId = appStore().selectedWorkspaceId
+
+  // Menu-only actions first
+  if (action === 'openFolder') {
+    const folder = await window.electronAPI.openFolderDialog()
+    if (folder) {
+      useAppStore.getState().setWorkspaceRootPath(selectedWorkspaceId, folder)
+    }
+    return
+  }
+  if (action === 'reloadWorkspace') {
+    const { reloadActiveWorkspaceFromDisk } = await import('./workspace/session')
+    await reloadActiveWorkspaceFromDisk()
+    return
+  }
+  if (action === 'manageLayouts') {
+    useUIStore.getState().setShowLayoutsDialog(true)
+    return
+  }
+
+  switch (action as ShortcutAction) {
+    case 'newTerminal': {
+      const placement = placementForActivePanel()
+      const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
+      if (wsId) appStore().createTerminal(wsId, undefined, undefined, placement)
+      break
+    }
+    case 'newBrowser': {
+      const placement = placementForActivePanel()
+      const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
+      if (wsId) appStore().createBrowser(wsId, undefined, undefined, placement)
+      break
+    }
+    case 'newEditor':
+    case 'newFile': {
+      const placement = placementForActivePanel()
+      const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
+      if (wsId) appStore().createEditor(wsId, undefined, undefined, placement)
+      break
+    }
+    case 'newAgent': {
+      const placement = placementForActivePanel()
+      const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
+      if (wsId) appStore().createAgent(wsId, undefined, placement)
+      break
+    }
+    case 'newCanvas': {
+      const placement = placementForActivePanel()
+      const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
+      if (wsId) appStore().createCanvas(wsId, undefined, placement)
+      break
+    }
+    case 'closePanel': {
+      const focusedNodeId = canvasStore().focusedNodeId
+      if (focusedNodeId) {
+        const node = canvasStore().nodes[focusedNodeId]
+        if (node && (await confirmClosePanels(selectedWorkspaceId, [node.panelId]))) {
+          appStore().closePanel(selectedWorkspaceId, node.panelId)
+        }
+      }
+      break
+    }
+    case 'toggleSidebar':
+      useUIStore.getState().toggleSidebar()
+      break
+    case 'toggleFileExplorer': {
+      const ui = useUIStore.getState()
+      const side = getSidebarLayout().left.includes('explorer') ? 'left' : 'right'
+      if (side === 'left') {
+        ui.setActiveLeftSidebarView(ui.activeLeftSidebarView === 'explorer' ? null : 'explorer')
+      } else {
+        ui.setActiveRightSidebarView(ui.activeRightSidebarView === 'explorer' ? null : 'explorer')
+      }
+      break
+    }
+    case 'toggleSearch': {
+      const ui = useUIStore.getState()
+      const side = getSidebarLayout().left.includes('search') ? 'left' : 'right'
+      const active = side === 'left' ? ui.activeLeftSidebarView : ui.activeRightSidebarView
+      const next = active === 'search' ? null : 'search'
+      if (side === 'left') ui.setActiveLeftSidebarView(next)
+      else ui.setActiveRightSidebarView(next)
+      if (next === 'search') useSearchStore.getState().requestFocus()
+      break
+    }
+    case 'toggleMinimap':
+      useUIStore.getState().toggleMinimapOpen()
+      break
+    case 'nodeSwitcher':
+      useUIStore.getState().setShowNodeSwitcher(true)
+      break
+    case 'commandPalette':
+      useUIStore.getState().setShowCommandPalette(true)
+      break
+    case 'zoomIn':
+      canvasStore().animateZoomTo(canvasStore().zoomLevel + 0.1)
+      break
+    case 'zoomOut':
+      canvasStore().animateZoomTo(canvasStore().zoomLevel - 0.1)
+      break
+    case 'zoomReset':
+      canvasStore().animateZoomTo(1.0)
+      break
+    case 'focusNext': {
+      const next = canvasStore().nextNode()
+      if (next) canvasStore().focusNode(next)
+      break
+    }
+    case 'focusPrevious': {
+      const prev = canvasStore().previousNode()
+      if (prev) canvasStore().focusNode(prev)
+      break
+    }
+    case 'saveFile':
+      window.dispatchEvent(new CustomEvent('save-file'))
+      break
+    case 'zoomToFit':
+      canvasStore().zoomToFit()
+      break
+    case 'zoomToSelection':
+      canvasStore().zoomToSelection()
+      break
+    case 'toolSelect':
+      useUIStore.getState().setActiveTool('select')
+      break
+    case 'toolHand':
+      useUIStore.getState().setActiveTool('hand')
+      break
+    case 'navigateUp':
+      canvasStore().navigateSelect('up')
+      break
+    case 'navigateDown':
+      canvasStore().navigateSelect('down')
+      break
+    case 'navigateLeft':
+      canvasStore().navigateSelect('left')
+      break
+    case 'navigateRight':
+      canvasStore().navigateSelect('right')
+      break
+    case 'panUp':
+      canvasStore().panViewport('up')
+      break
+    case 'panDown':
+      canvasStore().panViewport('down')
+      break
+    case 'panLeft':
+      canvasStore().panViewport('left')
+      break
+    case 'panRight':
+      canvasStore().panViewport('right')
+      break
+    case 'autoLayout':
+      canvasStore().autoLayout()
+      break
+    case 'undo':
+      canvasStore().undo()
+      break
+    case 'redo':
+      canvasStore().redo()
+      break
+    case 'deleteNode': {
+      const focusedId = canvasStore().focusedNodeId
+      if (focusedId && canvasStore().nodes[focusedId]) {
+        const node = canvasStore().nodes[focusedId]
+        if (await confirmClosePanels(selectedWorkspaceId, [node.panelId])) {
+          appStore().closePanel(selectedWorkspaceId, node.panelId)
+        }
+      }
+      break
+    }
+  }
+}

--- a/src/renderer/lib/workspace/useWorkspacePanelTree.ts
+++ b/src/renderer/lib/workspace/useWorkspacePanelTree.ts
@@ -1,0 +1,164 @@
+// =============================================================================
+// useWorkspacePanelTree — the single source of truth for "what panels does this
+// workspace contain, and where do they live". Reads the workspace panel registry
+// (ws.panels) and joins it against EVERY canvas store's nodes plus the dock
+// store, so the result is multi-canvas- and dock-aware and excludes ghosts
+// (records placed nowhere) and panels detached into other windows.
+//
+// Both the sidebar workspace overview (WorkspaceTab) and the Cmd+K command
+// palette consume this, so the two can never disagree about which panels exist
+// or where they are.
+// =============================================================================
+
+import { useMemo, useState, useCallback, useEffect } from 'react'
+import { useShallow } from 'zustand/shallow'
+import type { PanelState, DockLayoutNode } from '../../../shared/types'
+import { useAppStore } from '../../stores/appStore'
+import { getOrCreateCanvasStoreForPanel } from '../../stores/canvasStore'
+import {
+  getCanvasSnapshotForPanel,
+  getNodeDockLayout,
+  getWorkspaceCanvasPanelIds,
+  getWorkspaceDockSnapshot,
+} from './canvasAccess'
+import { partitionWorkspacePanels, buildColdStartCanvasChildOwners } from '../../sidebar/partitionWorkspacePanels'
+
+const EMPTY_PANELS: Record<string, PanelState> = {}
+
+export interface WorkspacePanelTree {
+  /** The raw workspace panel registry (ws.panels). */
+  panels: Record<string, PanelState>
+  /** All panels, sorted by type then title. */
+  panelList: PanelState[]
+  /** Canvas-type panels (parents), in order. */
+  canvasPanels: PanelState[]
+  /** Children grouped by the canvas panel id that hosts them. */
+  childrenByCanvas: Record<string, PanelState[]>
+  /** Canvas children whose owning canvas is gone and no canvas remains. */
+  orphanCanvasChildren: PanelState[]
+  /** Docked panels that sit beside the canvases. */
+  freePanels: PanelState[]
+  /** Flat list in the overview's render order, ghosts/detached excluded. */
+  orderedPanels: PanelState[]
+}
+
+function collectPanelIdsFromDockLayout(
+  layout: DockLayoutNode | null | undefined,
+  out: Set<string>,
+): void {
+  if (!layout) return
+  if (layout.type === 'tabs') {
+    for (const id of layout.panelIds) out.add(id)
+    return
+  }
+  for (const child of layout.children) collectPanelIdsFromDockLayout(child, out)
+}
+
+// Subscribe to every canvas store in a workspace and return a map of
+// canvas-child panel id -> the canvas panel id that hosts it. A workspace can
+// host multiple canvas panels, and the legacy singleton `useCanvasStore` only
+// mirrors whichever canvas mounted first — so we scan ALL canvas panels in the
+// workspace. We record WHICH canvas owns each child (not merely THAT it lives
+// on some canvas), so each child nests under its own canvas instead of
+// collapsing them all under the first one.
+function useWorkspaceCanvasChildOwners(workspaceId: string): Map<string, string> {
+  const canvasPanelIds = useAppStore(useShallow((s) => {
+    const ws = s.workspaces.find((w) => w.id === workspaceId)
+    if (!ws) return [] as string[]
+    return Object.values(ws.panels)
+      .filter((p) => p.type === 'canvas')
+      .map((p) => p.id)
+  }))
+
+  const stores = useMemo(
+    () => canvasPanelIds.map((id) => getOrCreateCanvasStoreForPanel(id)),
+    [canvasPanelIds],
+  )
+
+  const compute = useCallback(() => {
+    const owners = new Map<string, string>()
+    for (let i = 0; i < stores.length; i++) {
+      const canvasPanelId = canvasPanelIds[i]
+      for (const node of Object.values(stores[i].getState().nodes)) {
+        // Each canvas node has its own mini-dock layout; a node may host several
+        // tabbed panels. `node.panelId` is only the seed — walk the full layout
+        // so additional tabs still classify as children of this canvas. Read the
+        // LIVE per-node DockStore (the runtime authority).
+        const ids = new Set<string>()
+        collectPanelIdsFromDockLayout(getNodeDockLayout(canvasPanelId, node.id), ids)
+        if (node.panelId) ids.add(node.panelId)
+        for (const id of ids) owners.set(id, canvasPanelId)
+      }
+    }
+    return owners
+  }, [stores, canvasPanelIds])
+
+  const [owners, setOwners] = useState<Map<string, string>>(compute)
+
+  useEffect(() => {
+    // Recompute immediately on store-set change so we don't render one frame of
+    // stale ids after switching workspaces.
+    setOwners(compute())
+    const unsubs = stores.map((s) => s.subscribe(() => setOwners(compute())))
+    return () => {
+      for (const fn of unsubs) fn()
+    }
+  }, [stores, compute])
+
+  return owners
+}
+
+export function useWorkspacePanelTree(workspaceId: string): WorkspacePanelTree {
+  const panels = useAppStore(useShallow((s) => {
+    const ws = s.workspaces.find((w) => w.id === workspaceId)
+    return ws?.panels ?? EMPTY_PANELS
+  }))
+
+  // Sorted panel list grouped by type (canvas, terminal, editor, browser, …).
+  const panelList = useMemo(() => {
+    const TYPE_ORDER: Record<string, number> = { canvas: 0, terminal: 1, editor: 2, browser: 3 }
+    return Object.values(panels).slice().sort((a, b) => {
+      const ta = TYPE_ORDER[a.type] ?? 99
+      const tb = TYPE_ORDER[b.type] ?? 99
+      if (ta !== tb) return ta - tb
+      return (a.title || '').localeCompare(b.title || '')
+    })
+  }, [panels])
+
+  // Set of panel ids living on this workspace's canvases. The reactive hook
+  // covers every live canvas store; the resolver fills the cold-start gap for a
+  // workspace whose canvas was never mounted (its persisted projection).
+  const liveCanvasChildOwners = useWorkspaceCanvasChildOwners(workspaceId)
+  const canvasChildOwners = useMemo(() => {
+    const owners = new Map<string, string>(liveCanvasChildOwners)
+    const coldOwners = buildColdStartCanvasChildOwners(
+      getWorkspaceCanvasPanelIds(workspaceId).map((canvasPanelId) => ({
+        canvasPanelId,
+        nodes: Object.values(getCanvasSnapshotForPanel(canvasPanelId)?.nodes ?? {}),
+      })),
+    )
+    for (const [id, owner] of coldOwners) if (!owners.has(id)) owners.set(id, owner)
+    return owners
+  }, [liveCanvasChildOwners, workspaceId])
+
+  // The dock-placed id set lets partitioning drop ghosts — panels still in
+  // ws.panels but referenced by no canvas or dock. Read live (snapshot
+  // resolver); null = unknown (cold start), in which case nothing is filtered so
+  // a real panel is never hidden. Read inline (not memoized) so a dock move that
+  // re-renders via the canvas-owners subscription re-reads the latest placement.
+  const dockSnapshot = getWorkspaceDockSnapshot(workspaceId)
+  const dockPlacedIds = dockSnapshot ? new Set(Object.keys(dockSnapshot.locations)) : null
+  const { canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels } =
+    partitionWorkspacePanels(panelList, canvasChildOwners, dockPlacedIds)
+
+  // Flatten to the overview's render order: each canvas followed by its
+  // children, then orphaned canvas children, then docked free panels.
+  const orderedPanels: PanelState[] = []
+  for (const cp of canvasPanels) {
+    orderedPanels.push(cp)
+    for (const child of childrenByCanvas[cp.id] ?? []) orderedPanels.push(child)
+  }
+  orderedPanels.push(...orphanCanvasChildren, ...freePanels)
+
+  return { panels, panelList, canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels, orderedPanels }
+}

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -1,18 +1,16 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { CaretRight, Terminal as TerminalIcon, Folder, FolderPlus, SquaresFour, DotsThree, type Icon as PhosphorIcon } from '@phosphor-icons/react'
-import type { WorkspaceState, PanelType, DockLayoutNode } from '../../shared/types'
+import type { WorkspaceState, PanelType, PanelState } from '../../shared/types'
 import { useStatusStore } from '../stores/statusStore'
 import { useAppStore, WORKSPACE_COLORS } from '../stores/appStore'
 import { ACCENT_COLOR_NAMES } from '../../shared/colors'
-import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
-import { getCanvasSnapshotForPanel, getNodeDockLayout, getWorkspaceCanvasPanelIds, getWorkspaceDockSnapshot } from '../lib/workspace/canvasAccess'
 import { revealPanel } from '../lib/workspace/panelReveal'
+import { useWorkspacePanelTree } from '../lib/workspace/useWorkspacePanelTree'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import type { AgentState } from '../../shared/types'
 import { terminalRegistry } from '../lib/terminal/terminalRegistry'
 import { closePanelWithConfirm } from '../lib/closePanelWithConfirm'
-import { partitionWorkspacePanels, buildColdStartCanvasChildOwners } from './partitionWorkspacePanels'
 import { worktreeTitleStyle } from '../lib/worktreeTitleStyle'
 import { isMiddleClick } from '../lib/mouse'
 import { PANEL_REGISTRY } from '../panels/registry'
@@ -65,75 +63,6 @@ function CompanionDot({ workspace }: { workspace: WorkspaceState }): JSX.Element
 
 async function focusWorkspacePanel(workspaceId: string, panelId: string): Promise<void> {
   await revealPanel(workspaceId, panelId, { retry: true })
-}
-
-// Subscribe to every canvas store in a workspace and return a map of
-// canvas-child panel id -> the canvas panel id that hosts it. A workspace can
-// host multiple canvas panels, and the legacy singleton `useCanvasStore` only
-// mirrors whichever canvas mounted first — so we scan ALL canvas panels in the
-// workspace. We record WHICH canvas owns each child (not merely THAT it lives
-// on some canvas), so the sidebar nests each child under its own canvas instead
-// of collapsing them all under the first one.
-function useWorkspaceCanvasChildOwners(workspaceId: string): Map<string, string> {
-  const canvasPanelIds = useAppStore(useShallow((s) => {
-    const ws = s.workspaces.find((w) => w.id === workspaceId)
-    if (!ws) return [] as string[]
-    return Object.values(ws.panels)
-      .filter((p) => p.type === 'canvas')
-      .map((p) => p.id)
-  }))
-
-  const stores = useMemo(
-    () => canvasPanelIds.map((id) => getOrCreateCanvasStoreForPanel(id)),
-    [canvasPanelIds],
-  )
-
-  const compute = useCallback(() => {
-    const owners = new Map<string, string>()
-    for (let i = 0; i < stores.length; i++) {
-      const canvasPanelId = canvasPanelIds[i]
-      for (const node of Object.values(stores[i].getState().nodes)) {
-        // Each canvas node has its own mini-dock layout; a node may host
-        // several tabbed panels. `node.panelId` is only the seed — walk the
-        // full layout so additional tabs (e.g. Terminal 2, Terminal 4
-        // dragged into the same canvas node) still classify as children of
-        // this canvas. Read the LIVE per-node DockStore (the runtime
-        // authority) so an open multi-tab node shows all its tabs immediately;
-        // node.dockLayout is only a save-time projection now.
-        const ids = new Set<string>()
-        collectPanelIdsFromDockLayout(getNodeDockLayout(canvasPanelId, node.id), ids)
-        if (node.panelId) ids.add(node.panelId)
-        for (const id of ids) owners.set(id, canvasPanelId)
-      }
-    }
-    return owners
-  }, [stores, canvasPanelIds])
-
-  const [owners, setOwners] = useState<Map<string, string>>(compute)
-
-  useEffect(() => {
-    // Recompute immediately on store-set change so we don't render one frame
-    // of stale ids after switching workspaces.
-    setOwners(compute())
-    const unsubs = stores.map((s) => s.subscribe(() => setOwners(compute())))
-    return () => {
-      for (const fn of unsubs) fn()
-    }
-  }, [stores, compute])
-
-  return owners
-}
-
-function collectPanelIdsFromDockLayout(
-  layout: DockLayoutNode | null | undefined,
-  out: Set<string>,
-): void {
-  if (!layout) return
-  if (layout.type === 'tabs') {
-    for (const id of layout.panelIds) out.add(id)
-    return
-  }
-  for (const child of layout.children) collectPanelIdsFromDockLayout(child, out)
 }
 
 export interface PanelRenameProps {
@@ -288,13 +217,12 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const agentInfoByPanel = useAgentInfoByPanel(workspace.id)
 
 
-  // useWorkspaceList's equality fn ignores `panels`, so subscribe to this
-  // workspace's panels separately to keep the tree in sync as panels are
-  // added/removed/renamed.
-  const panels = useAppStore(useShallow((s) => {
-    const ws = s.workspaces.find((w) => w.id === workspace.id)
-    return ws?.panels ?? workspace.panels
-  }))
+  // The shared panel tree: ws.panels joined against every canvas store + the
+  // dock store, multi-canvas/dock-aware and ghost-filtered. The Cmd+K palette
+  // reads the exact same source (see useWorkspacePanelTree), so the overview and
+  // the palette can never disagree about which panels exist or where they live.
+  const { panels, canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels } =
+    useWorkspacePanelTree(workspace.id)
 
   // worktrees ignored by useWorkspaceList's equality fn → workspace.worktrees
   // is stale. Subscribe directly so the per-row accent updates as worktrees
@@ -304,34 +232,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     return ws?.worktrees ?? workspace.worktrees ?? []
   }))
 
-  // Set of panel ids living on this workspace's canvases. The reactive hook
-  // covers every live canvas store (the active workspace + any other whose
-  // canvas mounted earlier this session — those stores stay alive in the
-  // registry after switching away). The resolver fills the cold-start gap for a
-  // workspace whose canvas was never mounted (returns its persisted projection).
-  // Used regardless of isSelected so active and non-active workspaces apply the
-  // same classification rule.
-  const liveCanvasChildOwners = useWorkspaceCanvasChildOwners(workspace.id)
-  const canvasChildOwners = useMemo(() => {
-    const owners = new Map<string, string>(liveCanvasChildOwners)
-    // Cold-start fallback: a workspace whose canvases were never mounted this
-    // session have no live store, so fill ownership from the per-canvas persisted
-    // projection. Iterate EVERY canvas panel (not just the primary) via
-    // getCanvasSnapshotForPanel so a never-mounted SECONDARY canvas's children
-    // are attributed to it, not lumped under the primary. The live owners (from
-    // any mounted canvas) take precedence — buildColdStartCanvasChildOwners only
-    // fills ids not already owned, and we seed it with the live map.
-    const coldOwners = buildColdStartCanvasChildOwners(
-      getWorkspaceCanvasPanelIds(workspace.id).map((canvasPanelId) => ({
-        canvasPanelId,
-        nodes: Object.values(getCanvasSnapshotForPanel(canvasPanelId)?.nodes ?? {}),
-      })),
-    )
-    for (const [id, owner] of coldOwners) if (!owners.has(id)) owners.set(id, owner)
-    return owners
-    // liveCanvasChildOwners changes whenever a live store mutates, which re-runs
-    // the resolver too; the cold-start projection is otherwise static.
-  }, [liveCanvasChildOwners, workspace.id])
 
   // Ports in the status store are keyed by ptyId, but panel rows are keyed by
   // panelId. Translate via terminalRegistry so the indicators on the workspace
@@ -489,17 +389,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
 
   const panelCount = Object.keys(panels).length
 
-  // Sorted panel list grouped by type
-  const panelList = useMemo(() => {
-    const TYPE_ORDER: Record<string, number> = { canvas: 0, terminal: 1, editor: 2, browser: 3 }
-    return Object.values(panels).slice().sort((a, b) => {
-      const ta = TYPE_ORDER[a.type] ?? 99
-      const tb = TYPE_ORDER[b.type] ?? 99
-      if (ta !== tb) return ta - tb
-      return (a.title || '').localeCompare(b.title || '')
-    })
-  }, [panels])
-
   const handlePanelClick = useCallback(async (e: React.MouseEvent, panelId: string) => {
     e.stopPropagation()
     await focusWorkspacePanel(workspace.id, panelId)
@@ -555,18 +444,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const hasColor = !!workspace.color
   const accent = workspace.color || ''
 
-  // Partition the tree (see partitionWorkspacePanels): canvas panels host their
-  // children (keyed by the canvas that actually owns each), docked panels render
-  // as free siblings. The dock-placed id set lets us drop ghosts — panels still
-  // in workspace.panels but referenced by no canvas or dock (e.g. left behind by
-  // an interrupted close, or a panel whose canvas went away). Read live (snapshot
-  // resolver), falling back to the persisted projection; null = unknown (cold
-  // start), in which case we don't filter so a real panel is never hidden.
-  const dockSnapshot = getWorkspaceDockSnapshot(workspace.id)
-  const dockPlacedIds = dockSnapshot ? new Set(Object.keys(dockSnapshot.locations)) : null
-  const { canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels } =
-    partitionWorkspacePanels(panelList, canvasChildOwners, dockPlacedIds)
-
   // Worktree color resolver: only meaningful when the workspace has 2+
   // worktrees (matches WorktreePill's visibility rule — single-branch
   // workspaces would just get noisy with monochrome dots).
@@ -580,7 +457,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     return wt?.color
   }
 
-  const renderPanelRow = (p: typeof panelList[number], indent = false) => {
+  const renderPanelRow = (p: PanelState, indent = false) => {
     const label = p.title || p.filePath?.split('/').pop() || p.url || p.type
     const isRenaming = renamingPanelId === p.id
     const rename: PanelRenameProps = {

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -8,7 +8,6 @@
 // =============================================================================
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useShallow } from 'zustand/shallow'
 import {
   Terminal,
   Globe,
@@ -25,14 +24,21 @@ import {
   Trash,
   GraduationCap,
   PuzzlePiece,
+  X,
+  MapTrifold,
+  Selection,
+  ArrowUUpLeft,
+  ArrowUUpRight,
 } from '@phosphor-icons/react'
-import type { PanelType } from '../../shared/types'
+import type { PanelType, MenuActionId } from '../../shared/types'
 import { CateLogo } from './CateLogo'
 import { BACKDROP, CARD_SURFACE } from './Modal'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
-import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { runAction } from '../lib/runAction'
+import { useWorkspacePanelTree } from '../lib/workspace/useWorkspacePanelTree'
 import { revealPanel } from '../lib/workspace/panelReveal'
 import { openFileAsPanel } from '../lib/fs/fileRouting'
 import { getRecentFiles } from '../lib/fs/recentFiles'
@@ -44,7 +50,6 @@ import { getRecentFiles } from '../lib/fs/recentFiles'
 interface CommandItem {
   id: string
   title: string
-  shortcutText: string
   icon: React.ReactNode
   action: () => void
 }
@@ -57,15 +62,21 @@ const FileTextIcon = () => <FileText size={ICON_SIZE} />
 const LayoutIcon = () => <SquaresFour size={ICON_SIZE} />
 const SidebarIcon = () => <Sidebar size={ICON_SIZE} />
 const FolderOpenIcon = () => <FolderOpen size={ICON_SIZE} />
+const SearchIcon = () => <MagnifyingGlass size={ICON_SIZE} />
 const LayersIcon = () => <Stack size={ICON_SIZE} />
 const ZoomResetIcon = () => <MagnifyingGlass size={ICON_SIZE} />
 const ZoomToFitIcon = () => <ArrowsOutSimple size={ICON_SIZE} />
+const ZoomSelectionIcon = () => <Selection size={ICON_SIZE} />
 const SaveIcon = () => <FloppyDisk size={ICON_SIZE} />
 const ReloadIcon = () => <ArrowsClockwise size={ICON_SIZE} />
 const DeleteCompanionIcon = () => <Trash size={ICON_SIZE} />
 const TutorialIcon = () => <GraduationCap size={ICON_SIZE} />
 const SkillsIcon = () => <PuzzlePiece size={ICON_SIZE} />
 const AgentIcon = () => <CateLogo size={ICON_SIZE} />
+const CloseIcon = () => <X size={ICON_SIZE} />
+const MinimapIcon = () => <MapTrifold size={ICON_SIZE} />
+const UndoIcon = () => <ArrowUUpLeft size={ICON_SIZE} />
+const RedoIcon = () => <ArrowUUpRight size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
 // Result types
@@ -82,8 +93,6 @@ interface PanelResult {
   title: string
   type: PanelType
   secondary: string
-  nodeId?: string
-  recency: number
 }
 
 // A single navigable entry in the flat list, used for keyboard selection.
@@ -102,17 +111,8 @@ const NAVIGABLE_PANEL_TYPES: PanelType[] = ['terminal', 'editor', 'browser', 'ag
 export const CommandPalette: React.FC = () => {
   const showCommandPalette = useUIStore((s) => s.showCommandPalette)
   const setShowCommandPalette = useUIStore((s) => s.setShowCommandPalette)
-  const setShowNodeSwitcher = useUIStore((s) => s.setShowNodeSwitcher)
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
-  const createTerminal = useAppStore((s) => s.createTerminal)
-  const createBrowser = useAppStore((s) => s.createBrowser)
-  const createEditor = useAppStore((s) => s.createEditor)
-  const createCanvas = useAppStore((s) => s.createCanvas)
-  const createAgent = useAppStore((s) => s.createAgent)
-  const toggleSidebar = useUIStore((s) => s.toggleSidebar)
-  const setActiveRightSidebarView = useUIStore((s) => s.setActiveRightSidebarView)
   const canvasApi = useCanvasStoreApi()
-  const setZoom = useCanvasStoreContext((s) => s.setZoom)
 
   // The reinstall command is only meaningful for a remote (ssh/wsl) workspace.
   const isRemoteWorkspace = useAppStore((s) => {
@@ -126,6 +126,7 @@ export const CommandPalette: React.FC = () => {
   const [fileResults, setFileResults] = useState<FileResult[]>([])
   const [searching, setSearching] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  const selectedRowRef = useRef<HTMLDivElement>(null)
 
   const close = useCallback(() => {
     setShowCommandPalette(false)
@@ -134,106 +135,46 @@ export const CommandPalette: React.FC = () => {
     setFileResults([])
   }, [setShowCommandPalette])
 
-  const dockCenter = { target: 'dock', zone: 'center' } as const
+  // Dispatch a menu/shortcut action through the SAME code path as the keyboard
+  // shortcut and native menu (lib/runAction) — so panel creation here is
+  // context-aware (drops onto the focused canvas or tabs into the focused dock
+  // stack) exactly like ⌘T / ⌘⇧B do, instead of the old dock-center default.
+  const run = useCallback(
+    (action: MenuActionId) => () => { void runAction(action, canvasApi) },
+    [canvasApi],
+  )
 
   // Build command items
   const allCommands: CommandItem[] = useMemo(
     () => [
-      {
-        id: 'newTerminal',
-        title: 'New Terminal',
-        shortcutText: '⌘T',
-        icon: <TerminalIcon />,
-        action: () => createTerminal(selectedWorkspaceId, undefined, undefined, dockCenter),
-      },
-      {
-        id: 'newBrowser',
-        title: 'New Browser',
-        shortcutText: '⌘⇧B',
-        icon: <GlobeIcon />,
-        action: () => createBrowser(selectedWorkspaceId, undefined, undefined, dockCenter),
-      },
-      {
-        id: 'newEditor',
-        title: 'New Editor',
-        shortcutText: '⌘⇧E',
-        icon: <FileTextIcon />,
-        action: () => createEditor(selectedWorkspaceId, undefined, undefined, dockCenter),
-      },
-      {
-        id: 'newAgent',
-        title: 'New Cate agent',
-        shortcutText: '',
-        icon: <AgentIcon />,
-        action: () => createAgent(selectedWorkspaceId, undefined, dockCenter),
-      },
-      {
-        id: 'newCanvas',
-        title: 'New Canvas',
-        shortcutText: '',
-        icon: <LayoutIcon />,
-        action: () => createCanvas(selectedWorkspaceId),
-      },
-      {
-        id: 'toggleSidebar',
-        title: 'Toggle Sidebar',
-        shortcutText: '⌘\\',
-        icon: <SidebarIcon />,
-        action: () => toggleSidebar(),
-      },
-      {
-        id: 'toggleFileExplorer',
-        title: 'Toggle File Explorer',
-        shortcutText: '⌘⇧X',
-        icon: <FolderOpenIcon />,
-        action: () => { setActiveRightSidebarView('explorer') },
-      },
-      {
-        id: 'nodeSwitcher',
-        title: 'Switch Panel',
-        shortcutText: '⌃Space',
-        icon: <LayersIcon />,
-        action: () => setShowNodeSwitcher(true),
-      },
-      {
-        id: 'zoomReset',
-        title: 'Reset Zoom',
-        shortcutText: '⌘0',
-        icon: <ZoomResetIcon />,
-        action: () => setZoom(1.0),
-      },
-      {
-        id: 'zoomToFit',
-        title: 'Zoom to Fit',
-        shortcutText: '⌘1',
-        icon: <ZoomToFitIcon />,
-        action: () => canvasApi.getState().zoomToFit(),
-      },
-      {
-        id: 'autoLayout',
-        title: 'Auto-Layout Canvas',
-        shortcutText: '⇧⌘L',
-        icon: <LayersIcon />,
-        action: () => canvasApi.getState().autoLayout(),
-      },
-      {
-        id: 'manageLayouts',
-        title: 'Saved Layouts…',
-        shortcutText: '',
-        icon: <SaveIcon />,
-        action: () => useUIStore.getState().setShowLayoutsDialog(true),
-      },
+      { id: 'newTerminal', title: 'New Terminal', icon: <TerminalIcon />, action: run('newTerminal') },
+      { id: 'newBrowser', title: 'New Browser', icon: <GlobeIcon />, action: run('newBrowser') },
+      { id: 'newEditor', title: 'New Editor', icon: <FileTextIcon />, action: run('newEditor') },
+      { id: 'newAgent', title: 'New Cate Agent', icon: <AgentIcon />, action: run('newAgent') },
+      { id: 'newCanvas', title: 'New Canvas', icon: <LayoutIcon />, action: run('newCanvas') },
+      { id: 'closePanel', title: 'Close Panel', icon: <CloseIcon />, action: run('closePanel') },
+      { id: 'saveFile', title: 'Save File', icon: <SaveIcon />, action: run('saveFile') },
+      { id: 'toggleSidebar', title: 'Toggle Sidebar', icon: <SidebarIcon />, action: run('toggleSidebar') },
+      { id: 'toggleFileExplorer', title: 'Toggle File Explorer', icon: <FolderOpenIcon />, action: run('toggleFileExplorer') },
+      { id: 'toggleSearch', title: 'Toggle Search', icon: <SearchIcon />, action: run('toggleSearch') },
+      { id: 'toggleMinimap', title: 'Toggle Minimap', icon: <MinimapIcon />, action: run('toggleMinimap') },
+      { id: 'nodeSwitcher', title: 'Switch Panel', icon: <LayersIcon />, action: run('nodeSwitcher') },
+      { id: 'zoomReset', title: 'Reset Zoom', icon: <ZoomResetIcon />, action: run('zoomReset') },
+      { id: 'zoomToFit', title: 'Zoom to Fit', icon: <ZoomToFitIcon />, action: run('zoomToFit') },
+      { id: 'zoomToSelection', title: 'Zoom to Selection', icon: <ZoomSelectionIcon />, action: run('zoomToSelection') },
+      { id: 'autoLayout', title: 'Auto-Layout Canvas', icon: <LayersIcon />, action: run('autoLayout') },
+      { id: 'undo', title: 'Undo', icon: <UndoIcon />, action: run('undo') },
+      { id: 'redo', title: 'Redo', icon: <RedoIcon />, action: run('redo') },
+      { id: 'manageLayouts', title: 'Saved Layouts…', icon: <SaveIcon />, action: run('manageLayouts') },
       {
         id: 'skills',
         title: 'Skills…',
-        shortcutText: '',
         icon: <SkillsIcon />,
         action: () => useUIStore.getState().setShowSkillsDialog(true),
       },
       {
         id: 'showTutorial',
         title: 'Show Tutorial',
-        shortcutText: '',
         icon: <TutorialIcon />,
         // Replays the first-run guided tour by clearing the completed flag.
         action: () => {
@@ -241,15 +182,7 @@ export const CommandPalette: React.FC = () => {
           try { window.electronAPI?.trackFeatureUsed?.('onboarding_replayed') } catch { /* noop */ }
         },
       },
-      {
-        id: 'reloadWorkspace',
-        title: 'Reload Workspace from Disk',
-        shortcutText: '',
-        icon: <ReloadIcon />,
-        action: () => {
-          void import('../lib/workspace/session').then((m) => m.reloadActiveWorkspaceFromDisk())
-        },
-      },
+      { id: 'reloadWorkspace', title: 'Reload Workspace from Disk', icon: <ReloadIcon />, action: run('reloadWorkspace') },
       // Remote-only: delete the daemon from the host. Main re-probes to the
       // 'missing' phase; the canvas lock then offers "Install Companion" for a
       // clean reinstall — the deliberate delete → install two-step.
@@ -257,34 +190,21 @@ export const CommandPalette: React.FC = () => {
         ? [{
             id: 'deleteCompanion',
             title: 'Delete Companion',
-            shortcutText: '',
             icon: <DeleteCompanionIcon />,
             action: () => { void deleteCompanion(selectedWorkspaceId) },
           }]
         : []),
     ],
-    [
-      selectedWorkspaceId,
-      createTerminal,
-      createBrowser,
-      createEditor,
-      createCanvas,
-      createAgent,
-      toggleSidebar,
-      setActiveRightSidebarView,
-      setShowNodeSwitcher,
-      setZoom,
-      isRemoteWorkspace,
-      deleteCompanion,
-    ],
+    [run, isRemoteWorkspace, deleteCompanion, selectedWorkspaceId],
   )
 
   // Open panels in the current workspace.
-  const openPanels = useAppStore(useShallow((s) => {
-    const ws = s.workspaces.find((w) => w.id === s.selectedWorkspaceId)
-    if (!ws) return []
-    return Object.values(ws.panels)
-  }))
+  // Panels come from the SAME source as the sidebar workspace overview
+  // (useWorkspacePanelTree): ws.panels joined against every canvas store + the
+  // dock store. So a panel docked or on a secondary canvas still appears, ghosts
+  // (placed nowhere) and panels detached into other windows don't, and the order
+  // mirrors the overview's tree.
+  const { panels, orderedPanels } = useWorkspacePanelTree(selectedWorkspaceId)
 
   const rootPath = useAppStore((s) => s.workspaces.find((w) => w.id === s.selectedWorkspaceId)?.rootPath)
 
@@ -296,31 +216,22 @@ export const CommandPalette: React.FC = () => {
     return allCommands.filter((cmd) => cmd.title.toLowerCase().includes(query))
   }, [allCommands, query])
 
-  // Panels matched by title only. Ranked most-recently-focused first.
+  // Navigable panels in overview order, matched by title.
   const filteredPanels = useMemo<PanelResult[]>(() => {
-    const cs = canvasApi.getState()
-    const focusedNodeId = cs.focusedNodeId
-    const nodeByPanelId = new Map<string, { id: string; creationIndex: number }>()
-    for (const n of Object.values(cs.nodes)) nodeByPanelId.set(n.panelId, { id: n.id, creationIndex: n.creationIndex })
-
     const results: PanelResult[] = []
-    for (const panel of openPanels) {
+    for (const panel of orderedPanels) {
       if (!NAVIGABLE_PANEL_TYPES.includes(panel.type)) continue
       const title = panel.title ?? panel.type
       if (query && !title.toLowerCase().includes(query)) continue
-      const n = nodeByPanelId.get(panel.id)
       results.push({
         panelId: panel.id,
         title,
         type: panel.type,
         secondary: panel.filePath ?? panel.url ?? panel.type,
-        nodeId: n?.id,
-        recency: n ? (focusedNodeId === n.id ? Number.MAX_SAFE_INTEGER : n.creationIndex) : 0,
       })
     }
-    results.sort((a, b) => b.recency - a.recency)
     return results
-  }, [openPanels, query, canvasApi])
+  }, [orderedPanels, query])
 
   // With a query, search workspace files by name (debounced). With an empty box,
   // skip the filesystem walk and show recently-opened files instead.
@@ -353,7 +264,7 @@ export const CommandPalette: React.FC = () => {
   // are already open (they appear under Panels), and resolve a display name/path.
   const recentFileResults = useMemo<FileResult[]>(() => {
     if (query) return []
-    const openPaths = new Set(openPanels.map((p) => p.filePath).filter(Boolean) as string[])
+    const openPaths = new Set(Object.values(panels).map((p) => p.filePath).filter(Boolean) as string[])
     return getRecentFiles(selectedWorkspaceId)
       .filter((p) => !openPaths.has(p))
       .map((p) => ({
@@ -361,7 +272,7 @@ export const CommandPalette: React.FC = () => {
         name: p.split('/').pop() ?? p,
         relativePath: rootPath && p.startsWith(rootPath) ? p.slice(rootPath.length).replace(/^\/+/, '') : p,
       }))
-  }, [query, openPanels, selectedWorkspaceId, rootPath])
+  }, [query, panels, selectedWorkspaceId, rootPath])
 
   const displayedFiles = query ? fileResults : recentFileResults
 
@@ -379,6 +290,12 @@ export const CommandPalette: React.FC = () => {
     setSelectedIndex((prev) => (prev >= totalItems ? Math.max(0, totalItems - 1) : prev))
   }, [totalItems])
 
+  // Keep the selected row in view as arrow-nav moves through items that have
+  // scrolled out of the (max-height, overflow-y-auto) results list.
+  useEffect(() => {
+    selectedRowRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
   // Focus input when shown.
   useEffect(() => {
     if (showCommandPalette) {
@@ -389,8 +306,11 @@ export const CommandPalette: React.FC = () => {
     }
   }, [showCommandPalette])
 
+  // Navigate to a panel the same way the sidebar overview does — revealPanel
+  // resolves the panel's real location (dock zone or any canvas) and brings it
+  // forward, so docked / secondary-canvas panels are reached correctly.
   const focusPanelById = useCallback(
-    (panelId: string) => { void revealPanel(selectedWorkspaceId, panelId) },
+    (panelId: string) => { void revealPanel(selectedWorkspaceId, panelId, { retry: true }) },
     [selectedWorkspaceId],
   )
 
@@ -420,45 +340,19 @@ export const CommandPalette: React.FC = () => {
       if (item.kind === 'command') {
         item.command.action()
       } else if (item.kind === 'panel') {
-        if (item.panel.nodeId) canvasApi.getState().focusAndCenter(item.panel.nodeId)
-        else focusPanelById(item.panel.panelId)
+        focusPanelById(item.panel.panelId)
       } else {
         openFile(item.file)
       }
     },
-    [close, canvasApi, focusPanelById, openFile],
+    [close, focusPanelById, openFile],
   )
 
-  // Keyboard navigation
-  useEffect(() => {
-    if (!showCommandPalette) return
-
-    function handleKey(e: KeyboardEvent) {
-      switch (e.key) {
-        case 'ArrowDown':
-          e.preventDefault()
-          setSelectedIndex((prev) => (totalItems === 0 ? 0 : (prev + 1) % totalItems))
-          break
-        case 'ArrowUp':
-          e.preventDefault()
-          setSelectedIndex((prev) => (totalItems === 0 ? 0 : (prev - 1 + totalItems) % totalItems))
-          break
-        case 'Enter': {
-          e.preventDefault()
-          const item = flatItems[selectedIndex]
-          if (item) activate(item)
-          break
-        }
-        case 'Escape':
-          e.preventDefault()
-          close()
-          break
-      }
-    }
-
-    document.addEventListener('keydown', handleKey, { capture: true })
-    return () => document.removeEventListener('keydown', handleKey, { capture: true })
-  }, [showCommandPalette, flatItems, selectedIndex, totalItems, activate, close])
+  // Arrow/Enter/Escape are handled on the search input's own onKeyDown (see the
+  // <input> below). The input is the element that actually holds focus while the
+  // palette is open, so binding there is reliable — a document-level listener
+  // would only fire if focus happened to stay on the host document, which it
+  // doesn't when the palette opens over a focused terminal/canvas surface.
 
   if (!showCommandPalette) return null
 
@@ -483,9 +377,32 @@ export const CommandPalette: React.FC = () => {
             <MagnifyingGlass size={15} className="text-muted shrink-0" />
             <input
               ref={inputRef}
+              autoFocus
               type="text"
               value={searchText}
               onChange={(e) => { setSearchText(e.target.value); setSelectedIndex(0) }}
+              onKeyDown={(e) => {
+                switch (e.key) {
+                  case 'ArrowDown':
+                    e.preventDefault()
+                    setSelectedIndex((prev) => (totalItems === 0 ? 0 : (prev + 1) % totalItems))
+                    break
+                  case 'ArrowUp':
+                    e.preventDefault()
+                    setSelectedIndex((prev) => (totalItems === 0 ? 0 : (prev - 1 + totalItems) % totalItems))
+                    break
+                  case 'Enter': {
+                    e.preventDefault()
+                    const item = flatItems[selectedIndex]
+                    if (item) activate(item)
+                    break
+                  }
+                  case 'Escape':
+                    e.preventDefault()
+                    close()
+                    break
+                }
+              }}
               placeholder="Search commands, panels and files by name"
               className="flex-1 bg-transparent text-primary text-[13px] outline-none placeholder:text-muted"
             />
@@ -509,13 +426,13 @@ export const CommandPalette: React.FC = () => {
                     return (
                       <Row
                         key={cmd.id}
+                        ref={isSelected ? selectedRowRef : undefined}
                         selected={isSelected}
                         onClick={() => activate({ kind: 'command', command: cmd })}
                         onMouseEnter={() => setSelectedIndex(i)}
                       >
                         <span className="shrink-0 text-secondary">{cmd.icon}</span>
                         <span className="text-[13px] text-primary flex-1 truncate">{cmd.title}</span>
-                        <Shortcut text={cmd.shortcutText} />
                       </Row>
                     )
                   })}
@@ -533,6 +450,7 @@ export const CommandPalette: React.FC = () => {
                     return (
                       <Row
                         key={panel.panelId}
+                        ref={isSelected ? selectedRowRef : undefined}
                         selected={isSelected}
                         onClick={() => activate({ kind: 'panel', panel })}
                         onMouseEnter={() => setSelectedIndex(itemIndex)}
@@ -557,6 +475,7 @@ export const CommandPalette: React.FC = () => {
                     return (
                       <Row
                         key={file.path}
+                        ref={isSelected ? selectedRowRef : undefined}
                         selected={isSelected}
                         onClick={() => activate({ kind: 'file', file })}
                         onMouseEnter={() => setSelectedIndex(itemIndex)}
@@ -583,22 +502,24 @@ export const CommandPalette: React.FC = () => {
 // Layout primitives — slim rows, section headers, separators, keycap shortcuts
 // -----------------------------------------------------------------------------
 
-const Row: React.FC<{
+const Row = React.forwardRef<HTMLDivElement, {
   selected: boolean
   onClick: () => void
   onMouseEnter: () => void
   children: React.ReactNode
-}> = ({ selected, onClick, onMouseEnter, children }) => (
+}>(({ selected, onClick, onMouseEnter, children }, ref) => (
   <div
+    ref={ref}
     className={`flex items-center gap-2.5 mx-1.5 px-2.5 py-1.5 cursor-pointer rounded-md ${
-      selected ? 'bg-[rgb(var(--agent-rgb))]/12' : ''
+      selected ? 'bg-[rgb(var(--agent-rgb))]/25 ring-1 ring-inset ring-[rgb(var(--agent-rgb))]/40' : ''
     }`}
     onClick={onClick}
     onMouseEnter={onMouseEnter}
   >
     {children}
   </div>
-)
+))
+Row.displayName = 'Row'
 
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="px-3.5 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted">
@@ -607,31 +528,6 @@ const SectionHeader: React.FC<{ children: React.ReactNode }> = ({ children }) =>
 )
 
 const Separator: React.FC = () => <div className="mx-3.5 my-1 border-t border-subtle" />
-
-// Render a shortcut string (e.g. "⌘⇧B", "⌃Space") as individual keycaps.
-const Shortcut: React.FC<{ text: string }> = ({ text }) => {
-  if (!text) return null
-  const mods = new Set(['⌘', '⌥', '⌃', '⇧'])
-  const keys: string[] = []
-  let rest = ''
-  for (const ch of text) {
-    if (mods.has(ch)) keys.push(ch)
-    else rest += ch
-  }
-  if (rest) keys.push(rest)
-  return (
-    <span className="flex items-center gap-1 shrink-0">
-      {keys.map((k, i) => (
-        <kbd
-          key={i}
-          className="min-w-[18px] h-[18px] px-1 rounded border border-strong bg-surface-4 text-secondary text-[10px] leading-none flex items-center justify-center"
-        >
-          {k}
-        </kbd>
-      ))}
-    </span>
-  )
-}
 
 // -----------------------------------------------------------------------------
 // Panel icon — type-aware glyph matching the canvas panel colors

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -550,6 +550,8 @@ export type ShortcutAction =
   | 'newTerminal'
   | 'newBrowser'
   | 'newEditor'
+  | 'newAgent'
+  | 'newCanvas'
   | 'newFile'
   | 'closePanel'
   | 'toggleSidebar'
@@ -603,6 +605,8 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
   'newTerminal',
   'newBrowser',
   'newEditor',
+  'newAgent',
+  'newCanvas',
   'newFile',
   'closePanel',
   'toggleSidebar',
@@ -639,6 +643,8 @@ export const SHORTCUT_DISPLAY_NAMES: Record<ShortcutAction, string> = {
   newTerminal: 'New Terminal',
   newBrowser: 'New Browser',
   newEditor: 'New Editor',
+  newAgent: 'New Cate Agent',
+  newCanvas: 'New Canvas',
   newFile: 'New File',
   closePanel: 'Close Panel',
   toggleSidebar: 'Toggle Sidebar',
@@ -675,6 +681,8 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, StoredShortcut> = {
   newTerminal: storedShortcut('t', { command: true }),
   newBrowser: storedShortcut('b', { command: true, shift: true }),
   newEditor: storedShortcut('e', { command: true, shift: true }),
+  newAgent: storedShortcut('a', { command: true, shift: true }),
+  newCanvas: storedShortcut('c', { command: true, shift: true }),
   newFile: storedShortcut('n', { command: true }),
   closePanel: storedShortcut('w', { command: true }),
   toggleSidebar: storedShortcut('b', { command: true }),


### PR DESCRIPTION
### What

Several related fixes to the Cmd+K command palette.

**Keyboard navigation**
- Arrow/Enter did nothing because nav lived on a `document` capture listener that lost the keys when the palette opened over a focused terminal/canvas. Moved handling to the search input's `onKeyDown` + `autoFocus` (same pattern as the working `SavedLayoutsDialog`).
- Made the selected-row highlight actually visible (was ~12% opacity) and added `scrollIntoView` so selection follows off-screen items instead of appearing to "jump back to the top".
- Removed the per-row keybind display.

**One action path**
- Extracted `runAction` into `lib/runAction` so the palette, keyboard shortcuts, and native menu all dispatch through it. Panel creation from the palette is now context-aware (drops onto the focused canvas or tabs into the focused dock stack, with the ensure-folder prompt) instead of the old hardcoded dock-center default.
- Added **New Cate Agent** (⌘⇧A) and **New Canvas** (⌘⇧C) as real shortcuts + menu items (they had no keybind). They show up automatically in the shortcuts settings.
- Added discrete actions missing from the palette: Close Panel, Save File, Toggle Search, Toggle Minimap, Zoom to Selection, Undo, Redo.

**One panel source**
- The palette used to read `ws.panels` cross-referenced against only the primary canvas, so docked / secondary-canvas panels were mis-ranked and ghosts/detached panels could leak. Extracted `useWorkspacePanelTree` (the join the sidebar overview already did: `ws.panels` against every canvas store + the dock store, ghost-filtered) and used it in both `WorkspaceTab` and the palette, so the two can't disagree.

### Note

The palette's panel order is now the overview's tree order rather than most-recently-focused-first. Easy to layer recency back on if preferred.

### Testing
- `tsc --noEmit` clean, eslint clean (pre-existing warnings only)
- 76 sidebar tests pass (incl. WorkspaceTab), useShortcuts tests pass
- production build succeeds