### PR TITLE
fix(remote): ssh2 parseKey crash blocking SSH connect

### DIFF
--- a/src/main/companion/sshKey.interop.test.ts
+++ b/src/main/companion/sshKey.interop.test.ts
@@ -1,0 +1,117 @@
+// =============================================================================
+// Interop regression guard for `assertSupportedPrivateKey` — issue #335.
+//
+// The bug: `sshKey.ts` reached ssh2's parser via `mod.utils.parseKey`. ssh2 is
+// CommonJS and `utils` is NOT a statically-detectable named export, so under
+// Node's native ESM↔CJS interop (the PACKAGED app) `mod.utils` is `undefined`
+// and every real key threw `Cannot read properties of undefined (reading
+// 'parseKey')`. The unit suite (sshKey.test.ts) stayed green because vitest's
+// own loader hoists `utils`, so it can NEVER reproduce this — no matter the file
+// name or environment knob.
+//
+// The only faithful reproduction is a real child `node` process importing the
+// compiled module through native interop. We transpile the REAL sshKey.ts with
+// esbuild, run it under plain Node, and assert a freshly generated key is
+// accepted. To prove the test actually exercises the regression path, we also
+// run a variant with the `mod.default?.utils` fallback neutered and assert it
+// still throws the original TypeError.
+// =============================================================================
+
+import { describe, it, expect } from 'vitest'
+import { transformSync } from 'esbuild'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '..', '..', '..')
+
+// Compile the real source to ESM. The `await import('ssh2')` is indirected
+// through a variable, so esbuild leaves it as a runtime import resolved against
+// the project's node_modules — i.e. the exact module ssh2 ships.
+const compiled = transformSync(readFileSync(join(here, 'sshKey.ts'), 'utf8'), {
+  loader: 'ts',
+  format: 'esm',
+}).code
+
+// The child generates a real key, calls the REAL validator, and reports the raw
+// interop shape so a failure tells us whether the env or the code regressed.
+const RUNNER = `
+import { assertSupportedPrivateKey } from './sshKey.mjs'
+import { generateKeyPairSync } from 'node:crypto'
+
+const mod = await import('ssh2')
+const raw = { utils: typeof mod.utils, defaultParseKey: typeof mod.default?.utils?.parseKey }
+
+const { privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+})
+
+let accepted = false
+await assertSupportedPrivateKey(Buffer.from(privateKey))
+accepted = true
+
+let formatErr = ''
+try {
+  await assertSupportedPrivateKey(Buffer.from('not a key at all'))
+} catch (e) {
+  formatErr = e.message
+}
+
+console.log(JSON.stringify({ raw, accepted, formatErr }))
+`
+
+/**
+ * Write `module` + runner into a throwaway dir UNDER the repo (so the child's
+ * `import('ssh2')` resolves against the project's node_modules) and run it in a
+ * real Node process. Returns the child's stdout, or throws with its stderr.
+ */
+function runInNode(moduleSource: string): string {
+  const cacheRoot = join(repoRoot, 'node_modules', '.cache')
+  mkdirSync(cacheRoot, { recursive: true })
+  const dir = mkdtempSync(join(cacheRoot, 'sshKey-interop-'))
+  try {
+    writeFileSync(join(dir, 'sshKey.mjs'), moduleSource)
+    writeFileSync(join(dir, 'run.mjs'), RUNNER)
+    // stderr → pipe (not inherit) so an expected broken-variant crash doesn't
+    // dump a stack trace into the test logs; it's still captured on the thrown
+    // error's `.stderr` for assertions.
+    return execFileSync(process.execPath, ['run.mjs'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('assertSupportedPrivateKey under native Node ESM↔CJS interop (#335)', () => {
+  it('accepts a real key through the same module shape the packaged app sees', () => {
+    const out = runInNode(compiled)
+    const result = JSON.parse(out.trim())
+
+    // The condition that makes the unit suite blind: ssh2's `utils` is absent as
+    // a top-level export, only `default.utils` carries the parser. If this ever
+    // flips, this guard is moot and should be revisited.
+    expect(result.raw.utils).toBe('undefined')
+    expect(result.raw.defaultParseKey).toBe('function')
+
+    // The field crash: a valid key must be accepted, not throw on `.parseKey`.
+    expect(result.accepted).toBe(true)
+    // Format detection still runs on the real parser.
+    expect(result.formatErr).toMatch(/Unsupported private key format/)
+  })
+
+  it('would fail without the default.utils fallback (proves this test catches the regression)', () => {
+    // Sentinel guard: if the fix is refactored away from this expression the
+    // simulation is no longer meaningful — fail loudly instead of silently.
+    expect(compiled).toContain('mod.default?.utils')
+
+    const broken = compiled.replace('mod.default?.utils', 'undefined')
+    expect(() => runInNode(broken)).toThrow(/Cannot read properties of undefined \(reading 'parseKey'\)/)
+  })
+})

--- a/src/main/companion/sshKey.ts
+++ b/src/main/companion/sshKey.ts
@@ -35,7 +35,12 @@ async function loadParseKey(): Promise<
   const spec = 'ssh2'
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mod = (await import(spec)) as any
-  return mod.utils.parseKey
+  // ssh2 is CommonJS. `utils` is not a statically-detected named export, so under
+  // Node's native ESM↔CJS interop (the packaged app) `mod.utils` is undefined and
+  // only `mod.default.utils` is populated. Vite/vitest hoists it, which is why this
+  // passed tests but threw "reading 'parseKey'" in the build. See issue #335.
+  const utils = mod.utils ?? mod.default?.utils
+  return utils.parseKey
 }
 
 /**

--- a/src/main/ipc/buildTransport.interop.test.ts
+++ b/src/main/ipc/buildTransport.interop.test.ts
@@ -1,0 +1,127 @@
+// =============================================================================
+// End-to-end interop guard for the SSH connect path — issue #335.
+//
+// This reproduces the user's exact crash (`Cannot read properties of undefined
+// (reading 'parseKey')`) through the REAL `buildTransport` — key read →
+// normalize → format-validate against real ssh2 → construct SshTransport — not a
+// hand-isolated unit. The catch: the bug only exists under Node's native ESM↔CJS
+// interop (the packaged app), where ssh2's `utils` is not a statically-detected
+// export. vitest's own loader resolves `ssh2.utils` via runtime require-interop,
+// so a test running *inside* vitest can never see the crash — which is exactly
+// why it shipped green.
+//
+// So we don't run buildTransport inside vitest. We esbuild-bundle the real
+// module graph (electron + electron-log shimmed, ssh2 left EXTERNAL so the child
+// imports the genuine package), then drive `buildTransport` in a plain `node`
+// child against a generated key. The fixed code accepts the key and returns a
+// transport; a variant with the `mod.default?.utils` fallback neutered crashes
+// with the user's TypeError — proving this test would catch a regression.
+//
+// No server needed: buildTransport validates the key before any network I/O, so
+// this runs in CI. The live-server happy path lives in companionConnectE2e.itest.ts.
+// =============================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { build } from 'esbuild'
+import { generateKeyPairSync } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '..', '..', '..')
+
+// Minimal electron the buildTransport graph touches (app paths + the secret
+// store's safeStorage). No real Electron runtime, no keychain.
+const ELECTRON_SHIM = `
+export const app = { isPackaged:false, getAppPath:()=>process.cwd(), getName:()=>'Cate', getPath:()=>process.env.E2E_USERDATA }
+export const safeStorage = { isEncryptionAvailable:()=>true, encryptString:(s)=>Buffer.from('enc:'+s), decryptString:(b)=>Buffer.from(b).toString().replace(/^enc:/,'') }
+export const ipcMain = { handle:()=>{} }
+export const dialog = { showOpenDialog: async()=>({ canceled:true, filePaths:[] }) }
+export const BrowserWindow = { fromWebContents:()=>undefined, getAllWindows:()=>[] }
+export default { app, safeStorage, ipcMain, dialog, BrowserWindow }
+`
+
+// Drives the REAL buildTransport with a server spec + key path. buildTransport
+// stops at constructing the transport (no connect), so a success print means the
+// key passed read + normalize + the ssh2 format check.
+const DRIVER = `
+import { buildTransport } from ${JSON.stringify(join(repoRoot, 'src/main/ipc/companion.ts'))}
+const spec = { kind:'server', host:'127.0.0.1', user:'u', port:22, remotePath:'/x', auth:{ keyPath: process.env.E2E_KEY } }
+const t = await buildTransport('srv_probe', spec)
+console.log('BUILD_OK:' + t.kind)
+`
+
+let dir = ''
+let fixedOut = ''
+let brokenOut = ''
+let bundleSource = ''
+let env: NodeJS.ProcessEnv = process.env
+
+beforeAll(async () => {
+  const cacheRoot = join(repoRoot, 'node_modules', '.cache')
+  mkdirSync(cacheRoot, { recursive: true })
+  dir = mkdtempSync(join(cacheRoot, 'buildtransport-interop-'))
+
+  writeFileSync(join(dir, 'electron.mjs'), ELECTRON_SHIM)
+  writeFileSync(join(dir, 'driver.ts'), DRIVER)
+
+  await build({
+    entryPoints: [join(dir, 'driver.ts')],
+    outfile: join(dir, 'out.mjs'),
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    // ssh2 stays external → the child imports the genuine package through Node's
+    // native interop, which is the whole point. node-pty/fsevents are never on
+    // the buildTransport path but are externalised to keep the bundle native-free.
+    external: ['ssh2', 'node-pty', 'fsevents'],
+    alias: {
+      electron: join(dir, 'electron.mjs'),
+      'electron-log/main': join(repoRoot, 'src/test/electronLogStub.ts'),
+      'electron-log/renderer': join(repoRoot, 'src/test/electronLogStub.ts'),
+      'electron-log': join(repoRoot, 'src/test/electronLogStub.ts'),
+    },
+    logLevel: 'silent',
+  })
+
+  bundleSource = readFileSync(join(dir, 'out.mjs'), 'utf8')
+  fixedOut = join(dir, 'out.mjs')
+  brokenOut = join(dir, 'broken.mjs')
+  // Neuter the fallback to simulate the pre-#335 code (`mod.utils.parseKey`).
+  writeFileSync(brokenOut, bundleSource.replace('mod.default?.utils', 'undefined'))
+
+  // RSA PKCS#1 — a format ssh2.parseKey accepts (matches sshKey.test.ts).
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: 'pkcs1', format: 'pem' },
+    publicKeyEncoding: { type: 'pkcs1', format: 'pem' },
+  })
+  const keyFile = join(dir, 'id_rsa')
+  writeFileSync(keyFile, privateKey)
+  env = { ...process.env, E2E_KEY: keyFile, E2E_USERDATA: dir }
+}, 60_000)
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('buildTransport SSH key path under native Node ESM↔CJS interop (#335)', () => {
+  it('accepts a valid key end-to-end through the real buildTransport', () => {
+    // Sentinel: the simulation below is only meaningful while the fix uses this
+    // expression. If a refactor moves it, fail loudly here.
+    expect(bundleSource).toContain('mod.default?.utils')
+
+    const out = execFileSync(process.execPath, [fixedOut], { env, encoding: 'utf8' })
+    expect(out.trim()).toBe('BUILD_OK:server')
+  })
+
+  it("reverting the fix reproduces the user's crash (proves this test catches it)", () => {
+    // stderr → pipe so the expected crash trace doesn't pollute the test log;
+    // it's still captured on the thrown error for the assertion.
+    expect(() =>
+      execFileSync(process.execPath, [brokenOut], { env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }),
+    ).toThrow(/Cannot read properties of undefined \(reading 'parseKey'\)/)
+  })
+})

--- a/src/main/ipc/companionConnectE2e.itest.ts
+++ b/src/main/ipc/companionConnectE2e.itest.ts
@@ -1,0 +1,341 @@
+// =============================================================================
+// END-TO-END companion harness — drives the REAL ipc handlers through EVERY layer
+// the renderer touches, against a real remote (SSH server) and/or a real WSL
+// distro:
+//
+//   COMPANION_CONNECT  → persist auth (real sshSecretStore, encrypted) + mint id
+//   COMPANION_INSTALL  → buildTransport → CompanionManager.connect → Ssh/WslTransport
+//                        → probe → bootstrap/install → launch → handshake → register
+//   COMPANION_ENSURE   → restore from the stored connection and reconnect; hold to
+//                        prove it doesn't self-drop (#335)
+//   COMPANION_DELETE   → uninstall (+ unpin host key for SSH)
+//
+// Unlike sshLive.itest.ts (which constructs SshTransport directly with a hand-read
+// key and a stubbed host-key check — so it never exercises buildTransport, key
+// reading, path normalization, format validation, the secret store, or the WSL
+// branch at all), this harness goes through buildTransport for every auth
+// parameter and BOTH transports.
+//
+// Opt-in only, gated per transport so each block runs where it can:
+//   SSH:  CATE_LIVE_SSH=1   (any host with a reachable server + key)
+//   WSL:  CATE_LIVE_WSL=1   (a Windows host with the named distro installed)
+// A *.itest.ts name keeps the normal vitest `include` from picking it up. NOT CI.
+//
+// Run (SSH):  CATE_LIVE_SSH=1 CATE_LIVE_SSH_HOST=1.2.3.4 CATE_LIVE_SSH_USER=leigh \
+//             CATE_LIVE_SSH_ROOT=/home/leigh CATE_LIVE_SSH_KEY=~/.ssh/id_ed25519 \
+//             npx vitest run --config vitest.live.config.ts \
+//             src/main/ipc/companionConnectE2e.itest.ts
+//
+// Run (WSL, on Windows):  set CATE_LIVE_WSL=1 & set CATE_LIVE_WSL_DISTRO=Ubuntu-24.04 ^
+//             & set CATE_LIVE_WSL_PATH=/home/leigh ^
+//             & npx vitest run --config vitest.live.config.ts src/main/ipc/companionConnectE2e.itest.ts
+//
+// Optional SSH extras (each test self-skips when its env is absent):
+//   passphrase: CATE_LIVE_SSH_KEY_ENC=<encrypted key> CATE_LIVE_SSH_PASSPHRASE=...
+//   ssh-agent:  CATE_LIVE_SSH_USE_AGENT=1   (needs a running agent / SSH_AUTH_SOCK)
+//
+// Run it in the NATURAL dev mode (don't set CATE_COMPANION_DEV=0). isPackaged is
+// mocked false, so the harness installs from the local dist-companion tarball via
+// bootstrapDev — self-consistent. Forcing CATE_COMPANION_DEV=0 takes the
+// production remote-pull path, which writes a bare-version `.ok` while isInstalled
+// (seeing the same local tarball) expects a version:hash marker — so the next
+// install=false probe reports "not installed". That mismatch is specific to
+// "production pull + a local tarball present" and never occurs in a packaged app
+// (no local tarball) or real dev mode (bootstrapDev).
+// =============================================================================
+
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { execFileSync } from 'child_process'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs'
+
+// ── Electron + windowRegistry stubs (hoisted so the vi.mock factories can see
+// them). The status broadcaster is rerouted into `captured` so we can assert the
+// exact phase stream the renderer would receive. ───────────────────────────────
+const H = vi.hoisted(() => ({
+  handlers: new Map<string, (event: unknown, arg: unknown) => unknown>(),
+  captured: [] as { companionId: string; phase: string; message?: string }[],
+  state: { userDataDir: '' },
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: () => process.cwd(),
+    getName: () => 'Cate',
+    // userData → a throwaway dir so the real secret / known-hosts stores round-trip
+    // on disk without touching the developer's actual Cate state.
+    getPath: (name: string) => (name === 'userData' ? H.state.userDataDir : join(H.state.userDataDir, name)),
+  },
+  // Reversible stand-in for the OS keychain — exercises sshSecretStore's encrypt
+  // branch + base64 round-trip without a real Electron runtime.
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (s: string) => Buffer.from('enc:' + s, 'utf8'),
+    decryptString: (b: Buffer) => Buffer.from(b).toString('utf8').replace(/^enc:/, ''),
+  },
+  ipcMain: { handle: (channel: string, fn: (event: unknown, arg: unknown) => unknown) => H.handlers.set(channel, fn) },
+  dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] as string[] }) },
+  BrowserWindow: { fromWebContents: () => undefined, getAllWindows: () => [] },
+}))
+
+vi.mock('../windowRegistry', () => ({
+  broadcastToAll: (_channel: string, payload: { companionId: string; phase: string; message?: string }) => {
+    H.captured.push(payload)
+  },
+}))
+
+import {
+  COMPANION_CONNECT,
+  COMPANION_ENSURE,
+  COMPANION_INSTALL,
+  COMPANION_DELETE,
+} from '../../shared/ipc-channels'
+import type { RemoteConnectSpec, CompanionConnection, CompanionConnectResult } from '../../shared/types'
+
+// ── Shared harness wiring (both transport blocks drive the same handlers). ──────
+let companions: typeof import('../companion/companionManager').companions
+
+const invoke = <T = CompanionConnectResult>(channel: string, arg: unknown): Promise<T> => {
+  const fn = H.handlers.get(channel)
+  if (!fn) throw new Error(`no handler registered for ${channel}`)
+  return Promise.resolve(fn({ sender: {} }, arg)) as Promise<T>
+}
+/** Phases captured since a mark, for asserting the renderer-visible stream. */
+const phasesSince = (mark: number): string[] => H.captured.slice(mark).map((e) => e.phase)
+const readJson = (file: string): Record<string, unknown> => {
+  const p = join(H.state.userDataDir, file)
+  return existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : {}
+}
+
+beforeAll(async () => {
+  H.state.userDataDir = mkdtempSync(join(tmpdir(), 'cate-e2e-'))
+  ;(await import('./companion')).registerCompanionHandlers()
+  companions = (await import('../companion/companionManager')).companions
+})
+afterAll(async () => {
+  try { await companions?.disposeAll() } catch { /* ignore */ }
+  if (H.state.userDataDir) rmSync(H.state.userDataDir, { recursive: true, force: true })
+})
+
+// =============================================================================
+// SSH server
+// =============================================================================
+const LIVE_SSH = process.env.CATE_LIVE_SSH === '1' && !!process.env.CATE_LIVE_SSH_HOST
+
+const HOST = process.env.CATE_LIVE_SSH_HOST ?? ''
+const USER = process.env.CATE_LIVE_SSH_USER ?? 'root'
+const PORT = Number(process.env.CATE_LIVE_SSH_PORT ?? '22')
+const ROOT = process.env.CATE_LIVE_SSH_ROOT ?? '/root/'
+const expandTilde = (p: string): string => p.replace(/^~(?=$|\/)/, homedir())
+const KEY = expandTilde(process.env.CATE_LIVE_SSH_KEY ?? join(homedir(), '.ssh', 'id_ed25519'))
+
+const ENC_KEY = process.env.CATE_LIVE_SSH_KEY_ENC ? expandTilde(process.env.CATE_LIVE_SSH_KEY_ENC) : ''
+const PASSPHRASE = process.env.CATE_LIVE_SSH_PASSPHRASE ?? ''
+const USE_AGENT = process.env.CATE_LIVE_SSH_USE_AGENT === '1' && !!process.env.SSH_AUTH_SOCK
+
+/** Live companion daemons on the SSH server (one per live transport; >1 = leak). */
+function serverDaemonCount(): number {
+  try {
+    const out = execFileSync(
+      'ssh',
+      ['-i', KEY, '-p', String(PORT), '-o', 'IdentitiesOnly=yes', '-o', 'BatchMode=yes', `${USER}@${HOST}`,
+       "pgrep -f 'companion[.]cjs' | wc -l"],
+      { encoding: 'utf8' },
+    )
+    return parseInt(out.trim(), 10) || 0
+  } catch {
+    return -1 // ssh probe itself failed — don't fail the test on the out-of-band check
+  }
+}
+
+describe.skipIf(!LIVE_SSH)('SSH companion connect — full e2e through the IPC handlers', () => {
+  // Established by the CONNECT test, reused by the rest (one stored record / workspace).
+  let connection: Extract<CompanionConnection, { kind: 'server' }>
+
+  const serverSpec = (auth: { keyPath?: string; passphrase?: string; useAgent?: boolean }): RemoteConnectSpec => ({
+    kind: 'server', host: HOST, user: USER, port: PORT, remotePath: ROOT, auth,
+  })
+  /** Re-persist the GOOD key as the stored secret (recover after negative tests
+   *  that deliberately store a broken keyPath). */
+  const saveGoodSecret = () => invoke(COMPANION_CONNECT, serverSpec({ keyPath: KEY }))
+
+  test('CONNECT persists the SSH auth (encrypted) and mints a stable connection', async () => {
+    const res = await invoke(COMPANION_CONNECT, serverSpec({ keyPath: KEY }))
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    if (!res.ok) return
+    expect(res.companionId).toMatch(/^srv_/)
+    expect(res.connection.kind).toBe('server')
+    connection = res.connection as Extract<CompanionConnection, { kind: 'server' }>
+
+    // The real sshSecretStore wrote the key path (plaintext) under our temp userData.
+    const secrets = readJson('companion-ssh-secrets.json')
+    expect(secrets[res.companionId]).toMatchObject({ keyPath: KEY })
+  })
+
+  test('INSTALL brings the daemon up end-to-end and pins the host key (TOFU)', async () => {
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_INSTALL, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    expect(phasesSince(mark)).toContain('connected')
+    // Exactly one live daemon — extras would mean a leaked/duplicate transport.
+    const daemons = serverDaemonCount()
+    expect(daemons === -1 || daemons <= 1, `daemon count=${daemons}`).toBe(true)
+    // The REAL verifyAndPinHostKey ran (sshLive.itest.ts stubs it) and pinned.
+    const known = readJson('companion-known-hosts.json')
+    expect(Object.keys(known)).toContain(`${HOST}:${PORT}`)
+  }, 180_000)
+
+  test('ENSURE restores from the stored connection and HOLDS without self-dropping (#335)', async () => {
+    await companions.disposeConnection(connection.companionId)
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    const afterConnect = H.captured.length
+    await new Promise((r) => setTimeout(r, 6000))
+    const duringHold = phasesSince(afterConnect)
+    expect(companions.isConnected(connection.companionId), `dropped during hold: ${JSON.stringify(duringHold)}`).toBe(true)
+    expect(duringHold, 'no phase changes expected during a quiet hold').toEqual([])
+    expect(phasesSince(mark)).toContain('connected')
+  }, 60_000)
+
+  test('quoted + ~ key paths still resolve (normalizeKeyPath in the live path)', async () => {
+    await companions.disposeConnection(connection.companionId)
+    // A pasted, quoted path — the exact #335 sub-bug that ENOENT'd against the app dir.
+    await invoke(COMPANION_CONNECT, serverSpec({ keyPath: `"${KEY}"` }))
+    let res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok, `quoted path failed: ${JSON.stringify(res)}`).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+
+    // A ~-relative path, when the key lives under $HOME.
+    if (KEY.startsWith(homedir())) {
+      await companions.disposeConnection(connection.companionId)
+      const tildePath = '~' + KEY.slice(homedir().length)
+      await invoke(COMPANION_CONNECT, serverSpec({ keyPath: tildePath }))
+      res = await invoke(COMPANION_ENSURE, connection)
+      expect(res.ok, `~ path failed: ${JSON.stringify(res)}`).toBe(true)
+    }
+    await saveGoodSecret()
+  }, 60_000)
+
+  test('unsupported key format (PuTTY .ppk) is rejected up front with guidance', async () => {
+    const ppk = join(H.state.userDataDir, 'fake.ppk')
+    writeFileSync(ppk, 'PuTTY-User-Key-File-2: ssh-rsa\nEncryption: none\n')
+    await companions.disposeConnection(connection.companionId)
+    await invoke(COMPANION_CONNECT, serverSpec({ keyPath: ppk }))
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.error).toMatch(/PuTTY .ppk/)
+    // The handler maps a pre-connect build failure to an 'unreachable' phase so the
+    // lock overlay shows the real reason instead of a bare "failed to connect".
+    expect(phasesSince(mark)).toContain('unreachable')
+    await saveGoodSecret()
+  })
+
+  test('a missing key file fails with a clear, path-named error (not a raw errno)', async () => {
+    const missing = join(H.state.userDataDir, 'does-not-exist.pem')
+    await companions.disposeConnection(connection.companionId)
+    await invoke(COMPANION_CONNECT, serverSpec({ keyPath: missing }))
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.error).toMatch(/Couldn't read the SSH private key/)
+      expect(res.error).toContain(missing)
+      expect(res.error).toMatch(/file not found/)
+    }
+    await saveGoodSecret()
+  })
+
+  test.skipIf(!(ENC_KEY && PASSPHRASE))('connects with a passphrase-protected key', async () => {
+    await companions.disposeConnection(connection.companionId)
+    await invoke(COMPANION_CONNECT, serverSpec({ keyPath: ENC_KEY, passphrase: PASSPHRASE }))
+    // The passphrase round-trips through the encrypted secret store on read-back.
+    const stored = readJson('companion-ssh-secrets.json')[connection.companionId] as { passphrase?: string }
+    expect(stored.passphrase, 'passphrase should be stored encrypted, not plaintext').not.toBe(PASSPHRASE)
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    await saveGoodSecret()
+  }, 60_000)
+
+  test.skipIf(!USE_AGENT)('connects via ssh-agent (no key file)', async () => {
+    await companions.disposeConnection(connection.companionId)
+    await invoke(COMPANION_CONNECT, serverSpec({ useAgent: true }))
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    await saveGoodSecret()
+  }, 60_000)
+
+  test('DELETE uninstalls the daemon and unpins the host key', async () => {
+    const res = await invoke<{ ok: boolean; error?: string }>(COMPANION_DELETE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    const known = readJson('companion-known-hosts.json')
+    expect(Object.keys(known)).not.toContain(`${HOST}:${PORT}`)
+  }, 60_000)
+})
+
+// =============================================================================
+// WSL distro (Windows only — drives the WslTransport branch of buildTransport).
+// =============================================================================
+const LIVE_WSL = process.env.CATE_LIVE_WSL === '1' && !!process.env.CATE_LIVE_WSL_DISTRO
+
+const WSL_DISTRO = process.env.CATE_LIVE_WSL_DISTRO ?? ''
+const WSL_PATH = process.env.CATE_LIVE_WSL_PATH ?? '/root'
+
+describe.skipIf(!LIVE_WSL)('WSL companion connect — full e2e through the IPC handlers', () => {
+  let connection: Extract<CompanionConnection, { kind: 'wsl' }>
+
+  const wslSpec = (): RemoteConnectSpec => ({ kind: 'wsl', distro: WSL_DISTRO, distroPath: WSL_PATH })
+
+  test('CONNECT mints a stable wsl_ connection (no secret to persist)', async () => {
+    const res = await invoke(COMPANION_CONNECT, wslSpec())
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    if (!res.ok) return
+    expect(res.companionId).toMatch(/^wsl_/)
+    expect(res.connection.kind).toBe('wsl')
+    connection = res.connection as Extract<CompanionConnection, { kind: 'wsl' }>
+  })
+
+  test('an unknown distro is rejected with a clear message (buildTransport guard)', async () => {
+    const bogus: CompanionConnection = {
+      kind: 'wsl', companionId: 'wsl_bogus_0000000000', distro: 'cate-no-such-distro', distroPath: WSL_PATH,
+    }
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_ENSURE, bogus)
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.error).toMatch(/not found|only available on Windows|No WSL distros/)
+    expect(phasesSince(mark)).toContain('unreachable')
+  })
+
+  test('INSTALL brings the daemon up end-to-end inside the distro', async () => {
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_INSTALL, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    expect(phasesSince(mark)).toContain('connected')
+  }, 180_000)
+
+  test('ENSURE restores from the stored connection and HOLDS without self-dropping', async () => {
+    await companions.disposeConnection(connection.companionId)
+    const mark = H.captured.length
+    const res = await invoke(COMPANION_ENSURE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+    expect(companions.isConnected(connection.companionId)).toBe(true)
+    const afterConnect = H.captured.length
+    await new Promise((r) => setTimeout(r, 6000))
+    const duringHold = phasesSince(afterConnect)
+    expect(companions.isConnected(connection.companionId), `dropped during hold: ${JSON.stringify(duringHold)}`).toBe(true)
+    expect(duringHold, 'no phase changes expected during a quiet hold').toEqual([])
+    expect(phasesSince(mark)).toContain('connected')
+  }, 60_000)
+
+  test('DELETE uninstalls the daemon inside the distro', async () => {
+    const res = await invoke<{ ok: boolean; error?: string }>(COMPANION_DELETE, connection)
+    expect(res.ok, JSON.stringify(res)).toBe(true)
+  }, 60_000)
+})


### PR DESCRIPTION
The #337 key validation reached ssh2's parser via `mod.utils.parseKey`. ssh2 is CommonJS and `utils` isn't a statically detected export, so in the packaged app `mod.utils` is undefined and every SSH connect died with `Cannot read properties of undefined (reading 'parseKey')`. vitest hoists `utils`, so the unit tests passed and it shipped.

Fix: read the parser via `mod.utils ?? mod.default?.utils`.

### Tests
The crash only reproduces under native ESM/CJS interop (vitest masks it), so the new tests run the real code in a child node process:
- `sshKey.interop.test.ts` and `buildTransport.interop.test.ts` (end to end through `buildTransport`; reverting the fix turns it red). Both run in CI.
- `companionConnectE2e.itest.ts`: opt-in full-stack SSH + WSL harness, ran green against a live server.