### PR TITLE
fix(window): restore Win/Linux menu access via title-bar menu bar

### DIFF
--- a/src/main/ipc/menu.ts
+++ b/src/main/ipc/menu.ts
@@ -4,7 +4,8 @@
 // =============================================================================
 
 import { BrowserWindow, Menu, ipcMain, type MenuItemConstructorOptions } from 'electron'
-import { MENU_SHOW_CONTEXT } from '../../shared/ipc-channels'
+import { MENU_SHOW_CONTEXT, MENU_GET_BAR_ITEMS, MENU_POPUP_BAR_ITEM } from '../../shared/ipc-channels'
+import { getMenuBarLabels, popupMenuBarItem } from '../menu'
 
 interface ContextMenuTemplateItem {
   id?: string
@@ -57,6 +58,20 @@ export function registerHandlers(): void {
           callback: () => resolve(chosen),
         })
       })
+    },
+  )
+
+  // Custom menu bar (frameless Windows/Linux title bar). The renderer draws the
+  // top-level labels; clicking one pops the live application menu's matching
+  // native submenu — so menu.ts stays the single source of truth.
+  ipcMain.handle(MENU_GET_BAR_ITEMS, () => getMenuBarLabels())
+
+  ipcMain.handle(
+    MENU_POPUP_BAR_ITEM,
+    (event, payload: { index: number; x: number; y: number }) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win) return
+      popupMenuBarItem(payload.index, win, Math.round(payload.x), Math.round(payload.y))
     },
   )
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -77,6 +77,27 @@ export function rebuildApplicationMenu(): void {
   buildApplicationMenu()
 }
 
+// The live application menu, kept so the frameless Windows/Linux title bar can
+// render its top-level labels and pop the matching native submenus. Reassigned
+// on every buildApplicationMenu() so dynamic submenus (layout names, open panel
+// windows) stay current without the renderer re-fetching anything.
+let currentMenu: Electron.Menu | null = null
+
+/** Ordered top-level menu labels (App, File, Edit, …) for the custom menu bar.
+ *  Empty until the first buildApplicationMenu(). */
+export function getMenuBarLabels(): string[] {
+  if (!currentMenu) return []
+  return currentMenu.items.map((item) => item.label)
+}
+
+/** Pop the native submenu of top-level item `index` for `win`, anchored at the
+ *  window-relative point (x, y) — directly below its label in the title bar.
+ *  Always reads the live menu, so dynamic submenus are fresh. */
+export function popupMenuBarItem(index: number, win: BrowserWindow, x: number, y: number): void {
+  const item = currentMenu?.items[index]
+  if (item?.submenu) item.submenu.popup({ window: win, x, y })
+}
+
 export function buildApplicationMenu(): void {
   // Collect panel window entries for the Window menu
   const panelWindowItems: Electron.MenuItemConstructorOptions[] = []
@@ -307,4 +328,5 @@ export function buildApplicationMenu(): void {
 
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
+  currentMenu = menu
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -85,6 +85,8 @@ import {
   MENU_CREATE_PANEL,
   BROWSER_SHORTCUT,
   MENU_SHOW_CONTEXT,
+  MENU_GET_BAR_ITEMS,
+  MENU_POPUP_BAR_ITEM,
   DIALOG_OPEN_FOLDER,
   DIALOG_OPEN_IMAGE,
   CANVAS_READ_BACKGROUND_IMAGE,
@@ -1253,6 +1255,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   showContextMenu(items: unknown): Promise<string | null> {
     return ipcRenderer.invoke(MENU_SHOW_CONTEXT, items)
+  },
+
+  /** Ordered top-level labels of the application menu, for the frameless
+   *  Windows/Linux title-bar menu bar. */
+  getAppMenuBarItems(): Promise<string[]> {
+    return ipcRenderer.invoke(MENU_GET_BAR_ITEMS)
+  },
+
+  /** Pop the native submenu of top-level item `index` at window-relative (x, y)
+   *  — directly below its label in the title bar. */
+  popupAppMenu(index: number, x: number, y: number): Promise<void> {
+    return ipcRenderer.invoke(MENU_POPUP_BAR_ITEM, { index, x, y })
   },
 
   onMenuOpenSettings(callback: () => void): () => void {

--- a/src/renderer/drag/__tests__/setup.ts
+++ b/src/renderer/drag/__tests__/setup.ts
@@ -54,5 +54,9 @@ function createElectronAPIStub() {
     windowClose: vi.fn().mockResolvedValue(undefined),
     isWindowMaximized: vi.fn().mockReturnValue(false),
     onWindowMaximizeChange: vi.fn(() => () => {}),
+    onFullscreenChange: vi.fn(() => () => {}),
+    // Frameless title-bar menu bar (Windows/Linux).
+    getAppMenuBarItems: vi.fn().mockResolvedValue([]),
+    popupAppMenu: vi.fn().mockResolvedValue(undefined),
   } as unknown as Window['electronAPI']
 }

--- a/src/renderer/shells/TitlebarStrip.test.tsx
+++ b/src/renderer/shells/TitlebarStrip.test.tsx
@@ -1,0 +1,67 @@
+// =============================================================================
+// Tests for TitlebarStrip's frameless menu bar (Windows/Linux).
+//
+// jsdom's navigator.userAgent is not "Mac", so the Windows/Linux branch renders
+// here. Verifies the top-level application-menu labels (fetched from main) are
+// drawn as buttons and that clicking one pops the matching native submenu via
+// popupAppMenu(index, …).
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+import TitlebarStrip from './TitlebarStrip'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  vi.clearAllMocks()
+})
+
+// Render and let the async getAppMenuBarItems() resolve into state.
+async function render() {
+  await act(async () => {
+    root.render(<TitlebarStrip />)
+    await Promise.resolve()
+  })
+  return host
+}
+
+describe('TitlebarStrip menu bar', () => {
+  it('draws a button for each top-level application-menu label', async () => {
+    vi.mocked(window.electronAPI.getAppMenuBarItems).mockResolvedValue(['Cate', 'File', 'Edit', 'Help'])
+    const el = await render()
+    const labels = Array.from(el.querySelectorAll('button')).map((b) => b.textContent)
+    expect(labels).toEqual(expect.arrayContaining(['Cate', 'File', 'Edit', 'Help']))
+  })
+
+  it('pops the matching native submenu by index on click', async () => {
+    vi.mocked(window.electronAPI.getAppMenuBarItems).mockResolvedValue(['Cate', 'File', 'Help'])
+    const el = await render()
+    const fileBtn = Array.from(el.querySelectorAll('button')).find((b) => b.textContent === 'File')!
+    act(() => { fileBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    expect(window.electronAPI.popupAppMenu).toHaveBeenCalledTimes(1)
+    // 'File' is index 1; coordinates come from getBoundingClientRect.
+    expect(window.electronAPI.popupAppMenu).toHaveBeenCalledWith(1, expect.any(Number), expect.any(Number))
+  })
+
+  it('renders no menu buttons when main returns no labels', async () => {
+    vi.mocked(window.electronAPI.getAppMenuBarItems).mockResolvedValue([])
+    const el = await render()
+    // Only the window controls (Minimize/Maximize/Close) should be present.
+    const labels = Array.from(el.querySelectorAll('button')).map((b) => b.getAttribute('aria-label'))
+    expect(labels).toEqual(expect.arrayContaining(['Minimize', 'Maximize', 'Close']))
+    expect(el.textContent).toBe('')
+  })
+})

--- a/src/renderer/shells/TitlebarStrip.tsx
+++ b/src/renderer/shells/TitlebarStrip.tsx
@@ -3,11 +3,15 @@
 //
 // macOS (titleBarStyle: 'hiddenInset'): reserves space for the native traffic
 // lights and provides a themed drag region. The native bar can't be tinted to a
-// theme color, only dark/light, so we always use hidden-inset + this strip.
+// theme color, only dark/light, so we always use hidden-inset + this strip. The
+// application menu is the global system menu bar, so nothing is drawn here.
 //
 // Windows/Linux (frame: false): the window is fully frameless, so this strip is
-// the entire title bar — a themed drag region with our custom WindowControls
-// (minimize/maximize/close) on the right and double-click-to-maximize.
+// the entire title bar. Because frame:false also removes the native in-window
+// menu bar, we draw the application menu's top-level labels here (MenuBar) and
+// pop the matching native submenus on click — keeping main/menu.ts as the single
+// source of truth. Custom WindowControls (minimize/maximize/close) sit on the
+// right, with double-click-to-maximize on the empty drag region between.
 //
 // In native fullscreen the OS hides its chrome, so the strip would otherwise be
 // a dead zone at the top — subscribe to fullscreen state and collapse while it's
@@ -18,6 +22,44 @@ import { useEffect, useState } from 'react'
 import WindowControls from './WindowControls'
 
 const IS_MAC = navigator.userAgent.includes('Mac')
+
+// Drawn application menu bar for the frameless Windows/Linux title bar. Reads the
+// top-level labels from main and pops the real native submenu under each label,
+// so accelerators, native roles, and dynamic items (layouts, open windows) all
+// keep working without re-implementing the menu in the renderer.
+function MenuBar(): React.ReactElement | null {
+  const [labels, setLabels] = useState<string[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI.getAppMenuBarItems?.().then((items) => {
+      if (!cancelled) setLabels(items ?? [])
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (labels.length === 0) return null
+
+  return (
+    <div className="flex items-stretch h-full" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+      {labels.map((label, index) => (
+        <button
+          key={`${index}-${label}`}
+          type="button"
+          className="px-2.5 h-full flex items-center text-xs text-secondary hover:bg-surface-hover hover:text-primary transition-colors whitespace-nowrap"
+          onClick={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect()
+            window.electronAPI.popupAppMenu?.(index, rect.left, rect.bottom)
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
 
 export default function TitlebarStrip() {
   const [isFullscreen, setIsFullscreen] = useState<boolean>(
@@ -40,13 +82,18 @@ export default function TitlebarStrip() {
     )
   }
 
-  // Windows/Linux: full title bar with custom controls on the right.
+  // Windows/Linux: full title bar — menu bar on the left, draggable spacer in the
+  // middle (double-click to maximize), custom window controls on the right.
   return (
     <div
-      className="titlebar-drag shrink-0 bg-titlebar-bg select-none flex items-stretch justify-end"
+      className="titlebar-drag shrink-0 bg-titlebar-bg select-none flex items-stretch"
       style={{ height: 28 }}
-      onDoubleClick={() => window.electronAPI.windowToggleMaximize?.()}
     >
+      <MenuBar />
+      <div
+        className="flex-1 min-w-0"
+        onDoubleClick={() => window.electronAPI.windowToggleMaximize?.()}
+      />
       <WindowControls />
     </div>
   )

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -758,6 +758,14 @@ export interface ElectronAPI {
   /** Show a native context menu. Returns the clicked item id, or null if dismissed. */
   showContextMenu(items: NativeContextMenuItem[]): Promise<string | null>
 
+  /** Ordered top-level labels of the application menu. Backs the custom menu bar
+   *  drawn in the frameless Windows/Linux title bar. */
+  getAppMenuBarItems(): Promise<string[]>
+
+  /** Pop the native submenu of top-level menu `index` at window-relative (x, y),
+   *  anchored below its label in the title-bar menu bar. */
+  popupAppMenu(index: number, x: number, y: number): Promise<void>
+
   // ---------------------------------------------------------------------------
   // Orchestrator (cate CLI graph sync)
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -182,6 +182,14 @@ export const BROWSER_SET_PROXY = 'browser:setProxy'
 // Native context menu (renderer -> main)
 export const MENU_SHOW_CONTEXT = 'menu:showContext'
 
+/** Frameless menu bar (renderer -> main). On Windows/Linux the native menu bar
+ *  is gone (frame:false), so the custom title bar draws the top-level labels and
+ *  these channels reuse the live application menu as the single source of truth:
+ *  one returns the ordered top-level labels, the other pops a top-level item's
+ *  native submenu at a screen-relative point below its label. */
+export const MENU_GET_BAR_ITEMS = 'menu:getBarItems'
+export const MENU_POPUP_BAR_ITEM = 'menu:popupBarItem'
+
 // Dialog
 export const DIALOG_OPEN_FOLDER = 'dialog:openFolder'
 export const DIALOG_OPEN_IMAGE = 'dialog:openImage'


### PR DESCRIPTION
## Problem

On **Windows/Linux**, users can no longer reach **Check for Updates** or the menu's **Preferences/Settings** entry.

Two merges combined to cause this:

1. **#315** (`feat(window): frameless chrome + custom controls on Windows/Linux`) set `frame: false` on Win/Linux. On those platforms the native menu bar — which hosts *Check for Updates…* and *Preferences…* (`src/main/menu.ts`) — is part of the window frame, so it disappeared. The replacement `TitlebarStrip` only carried minimize/maximize/close. macOS was unaffected (its menu is the global top-of-screen bar).
2. **#318** (`switch to stock electron-updater, remove custom UI`) deleted the in-app `UpdateButton`/`updateStore`, leaving the native menu as the *only* manual update trigger.

Net result on Win/Linux: *Check for Updates* became completely unreachable, and the menu-based Settings entry vanished.

## Fix

Draw the application menu's top-level labels in the frameless title bar and pop the matching **live native submenu** on click. This keeps `src/main/menu.ts` as the single source of truth — accelerators, native roles (cut/copy/quit/devtools…), and dynamic items (saved layouts, open windows) all keep working without re-implementing the menu in the renderer. It's also consistent with how the app already uses native context menus.

The title bar now shows `Cate  File  Edit  View  Go  Layouts  Browser  Window  Help` then `_ ▢ ✕`. *Check for Updates* lives under both **Cate** and **Help**; *Preferences* under **Cate**.

### Changes
- `src/shared/ipc-channels.ts` — `MENU_GET_BAR_ITEMS`, `MENU_POPUP_BAR_ITEM`
- `src/main/menu.ts` — keep a handle to the live `Menu`; export `getMenuBarLabels()` + `popupMenuBarItem()`
- `src/main/ipc/menu.ts` — handlers returning labels / popping a submenu by index
- `src/preload/index.ts` + `src/shared/electron-api.d.ts` — `getAppMenuBarItems()` / `popupAppMenu()`
- `src/renderer/shells/TitlebarStrip.tsx` — `MenuBar` (labels left, draggable spacer with double-click-to-maximize, window controls right). macOS path unchanged. Detached panel/dock windows keep just their window controls.
- `src/renderer/shells/TitlebarStrip.test.tsx` — new tests; drag setup stub additions

## Testing

Automated (all green): `npx tsc --noEmit`, `npm run build`, `npx vitest run src/renderer/shells/` (18 passed, incl. 3 new).

Manual on a **Windows/Linux** build:
1. Confirm the title bar shows the menu-label row on the left and the min/max/close controls on the right.
2. Click **Cate** → **Check for Updates…** → update check runs.
3. Click **Cate** → **Preferences…** (and `Ctrl+,`) → Settings opens.
4. Open **Layouts** with a saved layout present → it appears in the submenu (confirms the live-menu source of truth).
5. Double-click the empty title-bar area → window maximizes/restores.

On **macOS** the title bar is unchanged (global system menu bar; no in-bar labels).

## Notes / limitations
- Scoped to the main window; detached panel/dock windows keep just their window controls (menu actions already route to the focused/main window).
- Clicking a label opens its native dropdown, but **hover-to-switch** between open menus isn't possible with native popups (they're modal) — each opens on click. Fully React-drawn dropdowns would be needed for hover-switch.