### PR TITLE
fix(agent): stop reporting missing pi-agent dirs as Access denied

### DIFF
--- a/src/main/ipc/pathValidation.test.ts
+++ b/src/main/ipc/pathValidation.test.ts
@@ -105,6 +105,35 @@ describe('pathValidation', () => {
     await expect(validatePathStrict(targetPath, 1)).rejects.toThrow(/outside allowed directories/)
   })
 
+  // Paths that don't exist yet must validate (not error as "Access denied") so a
+  // first-run worktree can list its empty pi-agent sessions dir and mkdir the
+  // extensions tree. Resolving the nearest existing ancestor still blocks symlink
+  // escapes — the regression that motivated the realpath check in the first place.
+  describe('not-yet-created paths', () => {
+    test('validatePathStrict resolves a deep missing path under the root (the sessions case)', async () => {
+      // Mirrors pi-agent/sessions/<encoded-cwd>: none of these segments exist yet.
+      const missing = path.join(rootDir, '.cate', 'pi-agent', 'sessions', '--encoded--')
+      await expect(validatePathStrict(missing)).resolves.toBe(await fs.realpath(rootDir) + missing.slice(rootDir.length))
+    })
+
+    test('validatePathForCreation allows a target whose parent chain is missing (the extensions case)', async () => {
+      const dest = path.join(rootDir, '.cate', 'pi-agent', 'extensions', 'subagent')
+      await expect(validatePathForCreation(dest)).resolves.toContain(
+        path.join('.cate', 'pi-agent', 'extensions', 'subagent'),
+      )
+    })
+
+    test('still rejects a symlink that escapes the root, even for a missing leaf', async () => {
+      // An existing symlink inside the root points outside it; a not-yet-created
+      // child under that symlink must resolve through it and be denied.
+      const link = path.join(rootDir, 'escape')
+      await fs.symlink(outsideDir, link)
+      await expect(validatePathStrict(path.join(link, 'new-file.txt'))).rejects.toThrow(
+        /outside allowed directories/,
+      )
+    })
+  })
+
   // Phase 1 threads a per-workspace `scopeId` through the validators and records
   // roots per scope, but does NOT yet restrict access by scope — the check stays a
   // union of every scope's roots (strict enforcement is deferred to Phase 3). These

--- a/src/main/ipc/pathValidation.ts
+++ b/src/main/ipc/pathValidation.ts
@@ -98,6 +98,39 @@ function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
   return false
 }
 
+/**
+ * Resolve a path to its real (symlink-free) form, tolerating a target that
+ * does not exist yet. `fs.realpath` throws ENOENT for a missing path, but
+ * several callers legitimately validate before creation: a fresh
+ * `pi-agent/sessions/<cwd>` dir that `readDir` should report as empty, or a
+ * `mkdir` destination whose parent chain doesn't exist yet. For those we
+ * realpath the nearest EXISTING ancestor and re-append the missing tail.
+ *
+ * This keeps the symlink-escape protection intact: every segment that actually
+ * exists is resolved (a symlink can only exist if its segment exists), so a
+ * symlink pointing outside an allowed root still resolves and gets rejected.
+ * Only not-yet-created segments — which cannot be symlinks — stay literal.
+ * Non-ENOENT errors (e.g. EACCES) are rethrown so genuine access failures keep
+ * surfacing as access errors rather than being mistaken for "doesn't exist".
+ */
+async function realpathAllowingMissing(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath)
+  const missing: string[] = []
+  let cur = resolved
+  for (;;) {
+    try {
+      const real = await fs.realpath(cur)
+      return missing.length ? path.join(real, ...missing) : real
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    }
+    const parent = path.dirname(cur)
+    if (parent === cur) return resolved // reached the fs root with nothing existing
+    missing.unshift(path.basename(cur))
+    cur = parent
+  }
+}
+
 async function normalizeCreationTarget(filePath: string): Promise<string> {
   const parentDir = path.dirname(path.resolve(filePath))
   const baseName = path.basename(filePath)
@@ -108,7 +141,7 @@ async function normalizeCreationTarget(filePath: string): Promise<string> {
 
   let realParent: string
   try {
-    realParent = await fs.realpath(parentDir)
+    realParent = await realpathAllowingMissing(parentDir)
   } catch (err) {
     throw new Error(`Access denied: cannot resolve real path for parent "${parentDir}": ${err}`)
   }
@@ -219,7 +252,7 @@ export async function validatePathStrict(filePath: string, ownerWindowId?: numbe
 
   let real: string
   try {
-    real = await fs.realpath(filePath)
+    real = await realpathAllowingMissing(filePath)
   } catch (err) {
     throw new Error(`Access denied: cannot resolve real path for "${filePath}": ${err}`)
   }


### PR DESCRIPTION
## Problem

Opening the Agent panel in a git worktree where pi had never run threw a flood of errors:

```
[AgentPanel] listSessions failed: Access denied: cannot resolve real path for ".../.cate/pi-agent/sessions/--...--"
[installSubagents] install failed: Access denied: cannot resolve real path for parent ".../.cate/pi-agent/extensions"
```

The path validators (`validatePathStrict`, `normalizeCreationTarget`) call `fs.realpath` on paths that don't exist yet. `realpath` throws `ENOENT`, and both `catch` blocks wrapped it as "Access denied", conflating "doesn't exist" with a security denial. So `listSessions` crashed instead of returning an empty list, and the subagent/plan-mode installs failed before they could mkdir their target.

## Fix

Resolve the nearest existing ancestor and re-append the missing tail instead of failing outright. `readDir` then swallows the missing dir to `[]`, and the recursive `mkdir` creates the chain.

Symlink-escape protection is unchanged: every segment that actually exists is still fully resolved, and a not-yet-created segment cannot be a symlink. Non-ENOENT errors (e.g. EACCES) still surface as access errors.

Covers worktrees created outside Cate, remote hosts, and brand-new repos too, not just the worktree case.

## Tests

3 new cases in `pathValidation.test.ts`: deep missing read (sessions), missing parent-chain mkdir (extensions), and a guard that a symlink escaping the root is still denied for a missing leaf. Full suite green, typecheck clean.