### PR TITLE
fix(canvas): stop typing-to-EOL from shifting canvas and exposing a bg gap

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -552,7 +552,15 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
       data-canvas-panel-id={panelId}
       data-filedrop="canvas"
       data-filedrop-id={panelId}
-      className="relative w-full h-full overflow-hidden bg-canvas-bg"
+      // overflow-clip, not overflow-hidden: the canvas pans via the world
+      // transform and must never become a scroll container. `hidden` clips
+      // visually but still allows *programmatic* scrolling — when a panel's
+      // content overflows the viewport (e.g. an xterm helper-textarea/cursor at
+      // the far right when typing to the end of a line), the browser auto-scrolls
+      // it into view, shifting the grid + wallpaper left and exposing a blank
+      // bg-canvas-bg strip on the right. `clip` is not a scroll container, so
+      // focus/scrollIntoView can't move it.
+      className="relative w-full h-full overflow-clip bg-canvas-bg"
       style={{ cursor: idleCursor }}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}


### PR DESCRIPTION
## Problem

Typing to the end of a line in a terminal near the right edge leaves a blank strip between the canvas background and the sidebar. Toggling a sidebar fixes it.

## Cause

The canvas container used \`overflow: hidden\`, which clips visually but is **still a scroll container**. When a panel's content overflows the viewport (xterm's helper-textarea/cursor sits at the far right when you type to EOL), the browser auto-scrolls it into view, shifting the grid + wallpaper left and exposing a blank \`bg-canvas-bg\` strip. A sidebar toggle relayouts and resets the scroll, which is why it appeared to fix it.

Verified against the live DOM: focusing an off-screen child scrolled the container \`scrollLeft\` 0 → 1050 with \`hidden\`, and stayed at 0 with \`clip\`.

## Fix

\`overflow-hidden\` → \`overflow-clip\` on the canvas container. \`clip\` clips identically but is not a scroll container, so focus/\`scrollIntoView\` can't move it. The canvas only pans via its world transform, never via scroll.