### PR TITLE
chore: release v1.2.5-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.4",
+  "version": "1.2.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.4",
+      "version": "1.2.5-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.4",
+  "version": "1.2.5-beta.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Beta release. Bumps version to 1.2.5-beta.1. Tag v1.2.5-beta.1 will be pushed after merge to trigger the signed multi-platform build and publish it as a GitHub pre-release.