### PR TITLE
chore: release v1.2.5-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.5-beta.1",
+  "version": "1.2.5-beta.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Cuts a second beta to test the auto-updater install path end-to-end (PR #341). Publishes as a GitHub pre-release, so only in-app beta opt-in users are offered it.