### PR TITLE
fix(update): make the install-loop give-up counter actually reachable

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -220,6 +220,22 @@ describe('initAutoUpdater — event telemetry', () => {
     expect(h.sendEvent).toHaveBeenCalledWith('update_downloaded', expect.objectContaining({ version: '1.2.3' }))
     expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 0 })
   })
+
+  it('on update-downloaded: preserves attempts when re-staging the same version', async () => {
+    await initAndGet()
+    // A silent install failure re-downloads the same version next launch — the
+    // accumulated failure count must survive so the loop detector can progress.
+    h.cell.value = { pendingVersion: '1.2.3', attempts: 1 }
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+    expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 1 })
+  })
+
+  it('on update-downloaded: resets attempts for a genuinely new version', async () => {
+    await initAndGet()
+    h.cell.value = { pendingVersion: '1.2.3', attempts: 1 }
+    h.autoUpdater.emit('update-downloaded', { version: '2.0.0' })
+    expect(h.cell.value).toEqual({ pendingVersion: '2.0.0', attempts: 0 })
+  })
 })
 
 describe('install-loop detection on launch', () => {
@@ -248,6 +264,37 @@ describe('install-loop detection on launch', () => {
     initAutoUpdater()
     expect(h.dialog.showMessageBox).not.toHaveBeenCalled()
     expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 1 })
+  })
+
+  it('reaches the manual fallback across launches despite re-downloading each launch', async () => {
+    // Regression: the silent-install-failure loop re-downloads the same version
+    // every launch. If update-downloaded zeroed the attempt counter, the give-up
+    // path would be unreachable. Drive the real launch → re-download → launch loop.
+    h.app.getVersion.mockReturnValue('1.2.2') // the install never advances
+
+    const launch = async () => {
+      h.autoUpdater.removeAllListeners() // fresh process: only this launch's handlers
+      const { initAutoUpdater } = await loadModule()
+      initAutoUpdater()
+    }
+
+    // Launch 1: update downloads and stages.
+    await launch()
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+    expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 0 })
+
+    // Launch 2: install silently failed → retry (no prompt); the updater then
+    // re-downloads the SAME version, which must NOT reset the attempt counter.
+    await launch()
+    expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 1 })
+    expect(h.dialog.showMessageBox).not.toHaveBeenCalled()
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+    expect(h.cell.value).toEqual({ pendingVersion: '1.2.3', attempts: 1 })
+
+    // Launch 3: still on the old version → counter hits the cap → manual fallback.
+    await launch()
+    expect(h.sendEvent).toHaveBeenCalledWith('update_install_failed_repeatedly', expect.anything())
+    expect(h.dialog.showMessageBox).toHaveBeenCalled()
   })
 })
 

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -167,6 +167,11 @@ function wireUpdaterEvents(eligible: boolean): void {
   })
 
   autoUpdater.on('update-not-available', (info) => {
+    // This check found nothing, so a later `error` is a transient check failure,
+    // not a known-update-failed-to-apply — drop the session's available-version
+    // marker so the error handler stays silent (a still-staged install is
+    // tracked separately via updatePendingInstall, which it also honors).
+    availableVersion = null
     log.info('[auto-updater] no update available (current v%s)', String(info?.version ?? app.getVersion()))
   })
 
@@ -183,7 +188,18 @@ function wireUpdaterEvents(eligible: boolean): void {
   autoUpdater.on('update-downloaded', (info) => {
     const version = String(info?.version ?? '')
     updatePendingInstall = true
-    if (persistInstallState) updateStateStore.set({ pendingVersion: version || null, attempts: 0 })
+    if (persistInstallState) {
+      // Preserve the failed-attempt count when re-staging the SAME version. A
+      // silent install failure re-downloads the same update every launch, so
+      // zeroing attempts here would reset the install-loop detector before it
+      // could ever reach MAX_INSTALL_ATTEMPTS — making the give-up → manual-
+      // fallback path unreachable in exactly the trap it exists to catch. Only a
+      // genuinely new version (different from what's recorded) starts over at 0.
+      const staged = version || null
+      const prev = updateStateStore.get()
+      const attempts = prev.pendingVersion === staged ? prev.attempts : 0
+      updateStateStore.set({ pendingVersion: staged, attempts })
+    }
     log.info('[auto-updater] update downloaded: v%s — will install on quit', version)
     track('update_downloaded', { version: version || null })
   })
@@ -196,10 +212,10 @@ function wireUpdaterEvents(eligible: boolean): void {
     // signature" — a signing/staging failure, the classic trapped-user cause),
     // the staged install won't apply: drop the pending flag so quit takes the
     // normal path, and offer the reliable manual download. A bare check error
-    // (no update found this session) stays silent.
-    if (availableVersion) {
+    // (no update found, nothing staged this session) stays silent.
+    if (availableVersion || updatePendingInstall) {
       updatePendingInstall = false
-      void promptManualReinstall(availableVersion, { offerMove: !eligible })
+      void promptManualReinstall(availableVersion ?? '', { offerMove: !eligible })
     }
   })
 }


### PR DESCRIPTION
## Problem

The install-loop detector is meant to give up on auto-update and show the manual-reinstall fallback after `MAX_INSTALL_ATTEMPTS` (2) consecutive silent install failures. It never could.

A silent failure (Squirrel.Mac swap dies with no `error` event) re-downloads the same staged version every launch. `update-downloaded` zeroed `attempts` each time, so across the loop the counter went `0 -> 1 -> 0 -> 1` and never reached the cap. The give-up path was unreachable in exactly the trap it exists to catch. Existing tests passed because they seeded `attempts: 1` directly and never drove the real loop.

## Fix

- `update-downloaded` preserves `attempts` when re-staging the **same** version; only a genuinely new version resets to 0.
- Clear `availableVersion` on `update-not-available` so a later transient check error stays silent, and let the error handler also fire the fallback when an install is already staged.
- Regression test drives the real launch -> re-download -> launch loop (fails without the fix), plus focused same/new-version tests.

## Test

`vitest run` updateState + auto-updater: 34 pass. Typecheck clean. Verified the regression test fails with the fix reverted.