### PR TITLE
chore: release v1.2.5-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.5-beta.2",
+  "version": "1.2.5-beta.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Bump to v1.2.5-beta.3. Ships the auto-update fixes from #349 (disable differential downloads + trim asarUnpack) to the beta channel.