### PR TITLE
chore: release v1.2.5-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.5-beta.3",
+  "version": "1.2.5-beta.4",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Bump to v1.2.5-beta.4. No code change beyond the version; this is the successor build used to verify that beta.3's auto-update fix works (beta.3 to beta.4 runs beta.3's fixed full-download path).