### PR TITLE
fix(terminal): repair detached-window terminal rendering (v1.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-06-09
+
+Bug-fix release for terminals detached into their own window.
+
+### Fixed
+
+- **Detached terminals no longer render blank or grey**: the GPU renderer now rebuilds and repaints once the new window is actually shown, instead of staying empty until the next output.
+- **Detached terminal scrollback keeps its formatting**: replayed history is written with proper line breaks, so multi-column output (like `ls`) lines up again instead of cascading down the screen.
+
 ## [1.1.1] - 2026-06-01
 
 Polish release: grid snapping on the canvas, steadier sidebar and window handling, a big batch of new editor themes, and opt-in usage analytics for agent messages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/renderer/lib/terminal/registryState.ts
+++ b/src/renderer/lib/terminal/registryState.ts
@@ -38,6 +38,15 @@ export interface RegistryEntry {
   savedViewport?: { line: number; atBottom: boolean }
   /** True once a scroll listener has been attached — prevents duplicates across re-attach cycles. */
   hasScrollListener: boolean
+  /**
+   * True once a document visibilitychange listener has been attached. The
+   * WebGL renderer's drawing buffer comes up blank (preserveDrawingBuffer is
+   * false) whenever the window paints fresh — a detached window revealed after
+   * being created hidden, or any window restored from minimized. The listener
+   * forces an atlas rebuild + redraw on the visible transition so the terminal
+   * doesn't stay blank/garbled. Flagged so re-attach cycles don't stack copies.
+   */
+  hasVisibilityListener: boolean
   /** Owning workspace — used to route auto-detected URLs to the right browser panel. */
   workspaceId: string
   /**

--- a/src/renderer/lib/terminal/scrollbackCapture.ts
+++ b/src/renderer/lib/terminal/scrollbackCapture.ts
@@ -43,9 +43,26 @@ export function captureScrollback(
     const lastRow = buffer.baseY + buffer.cursorY
     const endRow = options.excludeCursorRow ? lastRow : lastRow + 1
     const lines: string[] = []
+    let current = ''
     for (let i = 0; i < endRow; i++) {
       const line = buffer.getLine(i)
-      lines.push(line ? line.translateToString(true) : '')
+      // A logical line wider than the terminal is stored as several buffer rows;
+      // xterm flags every continuation row `isWrapped`. If the NEXT row
+      // continues this one, this segment is not the end of its logical line:
+      // keep its FULL width (no trailing-space trim — those spaces are real
+      // inter-column padding, e.g. `ls`/`git status`) and don't break the line.
+      // Coalescing the wrapped rows back into one logical line lets the
+      // destination terminal re-wrap at ITS own width on replay. Joining each
+      // buffer row with a hard '\n' (the old behaviour) instead bakes the SOURCE
+      // window's wrap points in; a narrower target then wraps each segment AGAIN,
+      // scattering multi-column output across the panel.
+      const next = buffer.getLine(i + 1)
+      const continues = i + 1 < endRow && next != null && next.isWrapped
+      current += line ? line.translateToString(!continues) : ''
+      if (!continues) {
+        lines.push(current)
+        current = ''
+      }
     }
     // Trim trailing blank lines so a freshly-cleared terminal doesn't carry a
     // wall of empty rows across a transfer / save.

--- a/src/renderer/lib/terminal/terminalDom.ts
+++ b/src/renderer/lib/terminal/terminalDom.ts
@@ -11,6 +11,30 @@ import { registry, has, type RegistryEntry } from './registryState'
 import { finalizeReconnect } from './terminalLifecycle'
 
 /**
+ * Force the WebGL renderer to rebuild its glyph atlas and redraw every cell.
+ *
+ * A detached window is created hidden (show:false) and only revealed on
+ * ready-to-show. The WebGL renderer initializes while the window is still
+ * hidden, so its glyph atlas is built against whatever devicePixelRatio the
+ * not-yet-composited window reports and its drawing buffer is never painted.
+ * Once the window is shown a stale atlas yields garbled text (wrong cell
+ * metrics) and a quiet terminal stays blank (the buffer comes up empty and,
+ * with preserveDrawingBuffer:false, nothing redraws it). clearTextureAtlas()
+ * rebuilds the atlas at the now-correct DPR; refresh() repaints into the live
+ * buffer. No-op (besides a cheap refresh) on the canvas renderer fallback.
+ */
+function forceWebglRepaint(panelId: string): void {
+  const entry = registry.get(panelId)
+  if (!entry) return
+  try {
+    entry.webglAddon?.clearTextureAtlas()
+    entry.terminal.refresh(0, entry.terminal.rows - 1)
+  } catch {
+    /* renderer mid-dispose — ignore */
+  }
+}
+
+/**
  * Calls fitAddon.fit() and corrects for sub-pixel overflow.
  *
  * FitAddon calculates rows from getComputedStyle height, which can be
@@ -125,6 +149,22 @@ export function attach(panelId: string, container: HTMLDivElement): void {
     }
   }
 
+  // Repaint when the window becomes visible. A detached window is created
+  // hidden (show:false) and revealed on ready-to-show; if the WebGL renderer
+  // initialized while the window was still hidden, its drawing buffer never
+  // painted and its atlas was built against a stale DPR — leaving the terminal
+  // blank or garbled until something forces a redraw. The same blank-buffer
+  // race happens on minimize/restore. Force an atlas rebuild + refresh on every
+  // visible transition. Registered once per entry (survives re-attach cycles).
+  if (!entry.hasVisibilityListener) {
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible') forceWebglRepaint(panelId)
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    entry.cleanupListeners.push(() => document.removeEventListener('visibilitychange', onVisible))
+    entry.hasVisibilityListener = true
+  }
+
   // Force layout reflow so the browser has calculated the new container size
   // before we resize the terminal / WebGL canvas.
   void container.offsetHeight
@@ -192,6 +232,18 @@ export function attach(panelId: string, container: HTMLDivElement): void {
         terminal.scrollToBottom()
       }
     } catch { /* ignore */ }
+
+    // Rebuild the WebGL atlas + redraw now that we have run post-show with a
+    // real container size, then again on the next two frames. A detached
+    // window opens hidden and only paints once shown; its renderer initialized
+    // while hidden against a stale DPR/size, so the first paint can be blank or
+    // garbled until the atlas is rebuilt at the live DPR. The extra frames
+    // cover a window still settling its size/DPR on the first painted frame.
+    forceWebglRepaint(panelId)
+    requestAnimationFrame(() => {
+      forceWebglRepaint(panelId)
+      requestAnimationFrame(() => forceWebglRepaint(panelId))
+    })
 
     // Now that the xterm is sized to its real container, replay captured
     // scrollback and release the main-side PTY buffer. Order matters:

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -276,6 +276,7 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
     cleanupListeners,
     lastScrollTop: 0,
     hasScrollListener: false,
+    hasVisibilityListener: false,
     workspaceId: opts.workspaceId,
     alive: true,
   }
@@ -375,6 +376,7 @@ export async function reconnectTerminal(
     cleanupListeners,
     lastScrollTop: 0,
     hasScrollListener: false,
+    hasVisibilityListener: false,
     workspaceId: opts.workspaceId,
     alive: true,
   }
@@ -409,10 +411,16 @@ export function finalizeReconnect(panelId: string): void {
   const { ptyId, scrollback } = entry.pendingReconnect
   entry.pendingReconnect = undefined
 
-  if (scrollback) {
-    entry.terminal.write(scrollback + '\r\n')
-  }
   const { electronAPI } = window
+
+  if (scrollback) {
+    // captureScrollback joins rows with bare '\n'. Writing that to xterm
+    // line-feeds WITHOUT a carriage return, so each row starts at the previous
+    // row's end column — the staircase that scattered detached `ls`/grid output.
+    // Normalize to '\r\n' so every row returns to column 0, matching how the
+    // session-restore path (replayTerminalLog) already replays its lines.
+    entry.terminal.write(scrollback.replace(/\r?\n/g, '\r\n') + '\r\n')
+  }
   electronAPI
     .panelTransferAck(ptyId)
     .catch((err) => log.warn('[terminal] Transfer ack failed:', err))

--- a/src/renderer/lib/terminal/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.test.ts
@@ -603,7 +603,32 @@ describe('captureScrollback helper', () => {
         active: {
           baseY,
           cursorY,
-          getLine: (i: number) => ({ translateToString: (_t: boolean) => rows[i] ?? '' }),
+          getLine: (i: number) =>
+            i < rows.length ? { translateToString: (_t: boolean) => rows[i], isWrapped: false } : undefined,
+        },
+      },
+    } as any
+  }
+
+  // Models xterm soft-wrap: each row carries an isWrapped flag and a full-width
+  // (untrimmed) vs trimmed rendering so the capture's trim choice is observable.
+  function fakeWrappedTerminal(
+    rows: Array<{ full: string; trimmed: string; isWrapped: boolean }>,
+    baseY: number,
+    cursorY: number,
+  ) {
+    return {
+      buffer: {
+        active: {
+          baseY,
+          cursorY,
+          getLine: (i: number) =>
+            i < rows.length
+              ? {
+                  translateToString: (trim: boolean) => (trim ? rows[i].trimmed : rows[i].full),
+                  isWrapped: rows[i].isWrapped,
+                }
+              : undefined,
         },
       },
     } as any
@@ -625,5 +650,43 @@ describe('captureScrollback helper', () => {
     const { terminalRegistry } = await import('./terminalRegistry')
     const entry = { terminal: fakeTerminal(['', ''], 1, 0) }
     expect(terminalRegistry.captureScrollback(entry)).toBeUndefined()
+  })
+
+  it('coalesces soft-wrapped rows into one logical line so the target re-wraps', async () => {
+    const { terminalRegistry } = await import('./terminalRegistry')
+    // A wide `ls`-style logical line that the source terminal soft-wrapped into
+    // three buffer rows. The continuation rows are flagged isWrapped. The middle
+    // segments keep their full width (trailing padding intact); only the final
+    // segment is trimmed. The result is ONE line — no hard newlines at the
+    // source wrap points — so a narrower target re-wraps it itself.
+    const entry = {
+      terminal: fakeWrappedTerminal(
+        [
+          { full: 'file_a    file_b    ', trimmed: 'file_a    file_b', isWrapped: false },
+          { full: 'file_c    file_d    ', trimmed: 'file_c    file_d', isWrapped: true },
+          { full: 'file_e              ', trimmed: 'file_e', isWrapped: true },
+        ],
+        2,
+        0,
+      ),
+    }
+    expect(terminalRegistry.captureScrollback(entry)).toBe(
+      'file_a    file_b    file_c    file_d    file_e',
+    )
+  })
+
+  it('keeps a hard newline between two unwrapped logical lines', async () => {
+    const { terminalRegistry } = await import('./terminalRegistry')
+    const entry = {
+      terminal: fakeWrappedTerminal(
+        [
+          { full: 'first ', trimmed: 'first', isWrapped: false },
+          { full: 'second', trimmed: 'second', isWrapped: false },
+        ],
+        1,
+        0,
+      ),
+    }
+    expect(terminalRegistry.captureScrollback(entry)).toBe('first\nsecond')
   })
 })


### PR DESCRIPTION
Terminals dragged out into their own window were broken two ways.

**Blank / grey terminal.** The xterm WebGL renderer initialized while the detached window was still hidden (created `show:false`, revealed on `ready-to-show`), so its glyph atlas was built against a stale devicePixelRatio and its drawing buffer never painted. A quiet terminal came up blank; one with output came up garbled. Now we force an atlas rebuild + full refresh once the window is shown, and repaint on every visibility transition (also fixes minimize/restore).

**Scattered scrollback.** Captured scrollback joins rows with bare `\n`, and the live-detach replay wrote it raw, so each line-feed had no carriage return and every row started at the previous row's end column. That cascaded multi-column output (`ls`, `git status`) down the screen. Replay now normalizes to `\r\n`, matching the session-restore path. Capture also coalesces soft-wrapped rows into logical lines so long lines reflow cleanly at the new width.

Bumps version to 1.2.6 + changelog.

### Test
- `npm test` (terminal, drag, shells, transfer suites): green
- Round-trip fidelity verified against a real headless xterm: a clean `ls` grid now replays identically at the same width and reflows cleanly at a different width.