### PR TITLE
docs(readme): refresh demo gif and tighten README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-  <a href="https://www.producthunt.com/products/cate?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-cate" target="_blank" rel="noopener noreferrer"><img alt="CATE - Figma like open canvas for development | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1150094&theme=neutral&t=1779630669260"></a>
-</p>
-
-<p align="center">
-  <img src="assets/cate-logo.svg" alt="Cate" width="240" />
+  <img src="assets/cate-logo.svg" alt="Cate" width="140" />
 </p>
 
 <h1 align="center">Cate</h1>
@@ -17,7 +13,6 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/v/release/0-AI-UG/cate?style=flat-square" alt="Release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/0-AI-UG/cate?style=flat-square" alt="MIT License" /></a>
   <a href="https://github.com/0-AI-UG/cate/actions"><img src="https://img.shields.io/github/actions/workflow/status/0-AI-UG/cate/ci.yml?style=flat-square" alt="CI" /></a>
   <a href="https://github.com/0-AI-UG/cate/releases"><img src="https://img.shields.io/github/downloads/0-AI-UG/cate/total?style=flat-square" alt="Downloads" /></a>
@@ -29,29 +24,44 @@
   <img src="assets/demo.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate is a desktop IDE built on an infinite canvas. Instead of stacking windows and tabs, you spread editors, terminals, browsers, documents, and AI agents across freeform space and arrange them however you think about the project. Float panels on the canvas, dock them into tabs and splits, or detach them into their own OS windows. Cate restores everything when you reopen the folder.
+Cate is a desktop IDE built on an infinite canvas. Instead of stacking windows and tabs, you spread editors, terminals, browsers, documents, and AI agents across freeform space and arrange them however you think about the project. Float panels on the canvas, dock them into tabs and splits, or detach them into their own OS windows — and Cate restores everything when you reopen the folder. It's not a window manager (tiling WMs like Hyprland, Niri, and GlazeWM arrange OS windows for everything you run); Cate arranges the tools for a single project, closer to Figma than to a WM.
 
-## Getting started
-
-Open a folder. Cate makes it a workspace and brings back your layout, panel positions, and terminals each time you return. Right-click the canvas to add panels, press `Cmd+K` for the command palette, and drag panels onto the dock to build tabs and splits. There are no config files to set up.
-
-## Why a canvas?
-
-Alt-tab is fine until you have a dozen terminals, six open files, docs in another window, and notes spread across desktops. Past that point, finding the right window is the bottleneck.
-
-Cate gives each project one canvas that remembers where you left things. This is not a window manager. Tiling WMs like Hyprland, Niri, and GlazeWM arrange OS windows for everything you run; Cate arranges the tools for a single project, closer to Figma than to a WM.
+**Getting started:** open a folder and it becomes a workspace. Right-click the canvas to add panels, press `Cmd+K` for the command palette, and drag panels onto the dock to build tabs and splits. No config files.
 
 ## What's inside
 
-**Canvas and layout.** Zoom and pan an infinite canvas, dock panels into tabs and splits across four zones, detach panels into separate windows, and save named layouts. Keep several projects open and restore them on restart.
+- **Canvas & layout** — zoom and pan an infinite canvas; dock panels into tabs and splits across four zones; detach panels into separate windows; save named layouts; keep several projects open and restore them on restart.
+- **Editors & terminals** — Monaco editors with syntax highlighting, multi-cursor, find/replace, diffs, and Markdown preview; native xterm.js terminals backed by `node-pty` with shell auto-detection; document panels for PDFs, DOCX, and images.
+- **Git** — git-aware file tree with live watching, plus a source-control sidebar for staging, branches, worktrees, history, and inline diffs. Full-text project search.
+- **AI agents** — in-app coding agent (Pi) with chat threads and per-chat model memory. Connect Anthropic, OpenAI Codex, GitHub Copilot, Gemini, OpenRouter, Groq, Mistral, DeepSeek, and more via OAuth or API key. Install extensions from the marketplace.
+- **Navigation** — canvas-wide search across files, terminal scrollback, and panel titles; command palette; panel-to-panel keyboard navigation.
 
-**Editors and terminals.** Monaco editor panels with syntax highlighting, multi-cursor, find/replace, diffs, and Markdown preview. Native xterm.js terminals backed by `node-pty`, rooted in the workspace with shell auto-detection. Document panels render PDFs, DOCX, and images.
+## Keyboard shortcuts
 
-**Git.** A git-aware file tree with live watching and search, plus a source-control sidebar for staging, branches, worktrees, history, and inline diffs. Full-text project search.
+macOS shown below; on Windows/Linux use `Ctrl` in place of `Cmd`.
 
-**AI agents.** Run an in-app coding agent (Pi) with chat threads and per-chat model memory. Connect Anthropic, OpenAI Codex, GitHub Copilot, Gemini, OpenRouter, Groq, Mistral, DeepSeek, and others via OAuth or API key. Install extensions from the marketplace.
+| Panels & files | | View & navigation | |
+|---|---|---|---|
+| New terminal | `Cmd+T` | Command palette | `Cmd+K` |
+| New editor | `Cmd+Shift+E` | Search everything | `Cmd+Shift+F` |
+| New browser | `Cmd+Shift+B` | Toggle sidebar | `Cmd+B` |
+| New agent | `Cmd+Shift+A` | Toggle file explorer | `Cmd+Shift+X` |
+| New canvas | `Cmd+Shift+C` | Toggle minimap | `Cmd+Shift+M` |
+| New file | `Cmd+N` | Focus next / previous panel | `Ctrl+Tab` / `Ctrl+Shift+Tab` |
+| Save file | `Cmd+S` | Move between panels | `Cmd+←↑↓→` |
+| Close panel | `Cmd+W` | Delete focused panel | `Cmd+Backspace` |
 
-**Navigation.** Canvas-wide search across files, terminal scrollback, and panel titles (`Cmd+Shift+F`). Panel switcher (`Ctrl+Space`). Command palette (`Cmd+K`).
+| Canvas | |
+|---|---|
+| Zoom in / out | `Cmd+=` / `Cmd+-` |
+| Reset zoom | `Cmd+0` |
+| Zoom to fit / selection | `Cmd+1` / `Cmd+2` |
+| Auto-layout canvas | `Cmd+Shift+L` |
+| Pan canvas | `Shift+←↑↓→` |
+| Toggle select / hand tool | `Shift+Space` |
+| Undo / redo | `Cmd+Z` / `Cmd+Shift+Z` |
+
+Every shortcut is rebindable in Settings.
 
 ## Install
 


### PR DESCRIPTION
Replaces the README demo gif with a new recording and refreshes the README copy.

- Replace `assets/demo.gif` with a new demo (900px, ~10.5 MB, down from 14.5 MB)
- Remove the Product Hunt badge and the release version shield
- Shrink the logo (240 → 140)
- Condense prose into one intro paragraph plus bullets
- Add a keyboard shortcuts table (sourced from `DEFAULT_SHORTCUTS`)

Direct push to `main` was rejected by the `Protected Main` ruleset (PR required, force pushes blocked, no bypass actors), so this goes through a PR.