### PR TITLE
feat(canvas): multi-node selection with marquee, group drag, and bulk close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -18,6 +18,7 @@ import { useDragStore, useDragSourceVisibility } from '../drag'
 import { useNodeResize } from '../hooks/useNodeResize'
 import { useCanvasNodeStyle } from './useCanvasNodeStyle'
 import { useCanvasNodeDrag } from './useCanvasNodeDrag'
+import { useGroupNodeDrag } from './useGroupNodeDrag'
 import { useNodeResizeCursor } from './useNodeResizeCursor'
 import { NodeResizeOverlay } from './NodeResizeOverlay'
 import type { DockStore } from '../stores/dockStore'
@@ -168,6 +169,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   const focusNode = useCanvasStoreContext((s) => s.focusNode)
   const removeNode = useCanvasStoreContext((s) => s.removeNode)
   const toggleMaximize = useCanvasStoreContext((s) => s.toggleMaximize)
+  const isSelected = useCanvasStoreContext((s) => s.selectedNodeIds.has(nodeId))
   const isDockDragging = useDragStore((s) => s.isDragging)
   const { hidden: isWholeNodeDragSource } = useDragSourceVisibility(nodeId)
 
@@ -181,12 +183,17 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     wasDragged,
   } = useCanvasNodeDrag(nodeId, dockStoreApi, canvasApi)
 
+  // Group move: when this node is part of a multi-selection, dragging it moves
+  // the whole selection together instead of running the single-node dock drag.
+  const { startGroupDrag } = useGroupNodeDrag(nodeId, canvasApi, wasDragged)
+
   // Wrap node-drag with the tab-vs-window routing. The tab bar uses this for
   // both empty-area mousedown (panelId undefined → whole node drag) and
   // individual tab mousedown (panelId set → detach that tab when the mini-dock
   // has multiple panels, else whole-node drag).
   const handleHeaderMouseDown = useCallback((e: React.MouseEvent, panelId?: string) => {
     if (handToolPanShouldWin(e)) return
+    if (startGroupDrag(e)) return
     if (panelId) {
       const total = collectPanelIds(dockStoreApi.getState().zones.center.layout).length
       if (total > 1) {
@@ -195,7 +202,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
       }
     }
     handleDragStart(e)
-  }, [handleDragStart, handleTabDetachStart, dockStoreApi])
+  }, [handleDragStart, handleTabDetachStart, dockStoreApi, startGroupDrag])
 
   const maximized = node ? checkMaximized(node) : false
 
@@ -293,6 +300,16 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     },
     [dockStoreApi, wsId, confirmCloseForPanels],
   )
+
+  // A tab was detached into its own window via the "Move into New Window" menu
+  // action. moveTabToNewWindow undocks the panel from this mini-dock but can't
+  // know it lives inside a canvas node — so if that emptied the node, remove it
+  // here. Mirrors the drag-out path (removeFromSource → finalizeRemoveNode) so a
+  // single-panel node leaves the canvas instead of lingering as an empty husk.
+  const handlePanelRemoved = useCallback(() => {
+    const remaining = collectPanelIds(dockStoreApi.getState().zones.center.layout)
+    if (remaining.length === 0) canvasApi.getState().finalizeRemoveNode(nodeId)
+  }, [dockStoreApi, canvasApi, nodeId])
 
   const handleClose = useCallback(async () => {
     const panelIds = collectPanelIds(layout)
@@ -429,6 +446,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
           getPanelTitle={getPanelTitle}
           getPanel={getPanel}
           onClosePanel={handleClosePanel}
+          onPanelRemoved={handlePanelRemoved}
           excludePanelTypes={CANVAS_EXCLUDED_TYPES}
           localOnly
           compact
@@ -519,9 +537,10 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
         handleToggleMaximize()
         return
       }
+      if (startGroupDrag(e)) return
       handleDragStart(e)
     },
-    [handleDragStart, handleToggleMaximize],
+    [handleDragStart, handleToggleMaximize, startGroupDrag],
   )
 
   const handleGrabStripContextMenu = useCallback(
@@ -554,6 +573,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   const { containerStyle, glowStyle } = useCanvasNodeStyle({
     node,
     isFocused,
+    isSelected,
     activityState,
     isAnimatingLayout,
     isHovered,

--- a/src/renderer/canvas/useCanvasNodeStyle.ts
+++ b/src/renderer/canvas/useCanvasNodeStyle.ts
@@ -14,6 +14,10 @@ const SHADOW_UNFOCUSED = `0 12px 36px -14px rgba(0,0,0,0.28), 0 4px 10px -5px rg
 const SHADOW_HOVERED = `${SHADOW_UNFOCUSED}, 0 0 18px rgba(255,255,255,0.015)`
 // Active/focused pane: a very faint bright (white) halo — no blue tint.
 const FOCUS_GLOW = `0 0 20px 1px rgba(255,255,255,0.025), 0 0 8px rgba(255,255,255,0.02)`
+// Selected-but-not-activated pane (e.g. marquee selection, or jumped to via
+// Cmd+Arrow): a crisp accent outline ring so it's clearly "this is selected"
+// without the active-pane halo. Distinct from the focus glow above.
+const SELECTION_RING = `0 0 0 2px var(--focus-blue), 0 0 14px -2px var(--focus-blue)`
 
 function boxShadow(hovered: boolean): string {
   if (hovered) return SHADOW_HOVERED
@@ -35,6 +39,7 @@ function activityOutline(activity: NodeActivityState | undefined): string {
 interface StyleArgs {
   node: CanvasNodeState | undefined
   isFocused: boolean
+  isSelected: boolean
   activityState: NodeActivityState | undefined
   isAnimatingLayout: boolean
   isHovered: boolean
@@ -53,6 +58,7 @@ export function useCanvasNodeStyle(args: StyleArgs) {
   const {
     node,
     isFocused,
+    isSelected,
     activityState,
     isAnimatingLayout,
     isHovered,
@@ -107,11 +113,11 @@ export function useCanvasNodeStyle(args: StyleArgs) {
       pointerEvents: isExiting || isWholeNodeDragSource ? 'none' : undefined,
       userSelect: 'none',
     }
-  }, [node, isFocused, activityState, isAnimatingLayout, isHovered, chromeTint, isWholeNodeDragSource, worktreeDim])
+  }, [node, isFocused, isSelected, activityState, isAnimatingLayout, isHovered, chromeTint, isWholeNodeDragSource, worktreeDim])
 
   const glowStyle = useMemo<React.CSSProperties | null>(() => {
     if (!node) return null
-    if (!(isFocused || worktreeHighlight)) return null
+    if (!(isFocused || isSelected || worktreeHighlight)) return null
     // Hide the focus glow while the node is the drag source — the source node
     // itself is hidden (containerStyle.opacity = 0 above) and the glow would
     // otherwise float at the node's original origin while the ghost moves.
@@ -130,17 +136,19 @@ export function useCanvasNodeStyle(args: StyleArgs) {
       zIndex: 999,
       borderRadius: CORNER_RADIUS,
       // Worktree highlight (hover/lens) → colored ring in the branch color;
-      // else focused/active → soft halo.
+      // else focused/active → soft halo; else selected-only → outline ring.
       boxShadow:
         worktreeHighlight && worktreeColor
           ? `0 0 0 2px ${worktreeColor}, 0 0 18px -2px ${worktreeColor}`
-          : FOCUS_GLOW,
+          : isFocused
+            ? FOCUS_GLOW
+            : SELECTION_RING,
       pointerEvents: 'none',
       transform: isEntering ? 'scale(0.85)' : isExiting ? 'scale(0.9)' : 'scale(1)',
       opacity: isEntering || isExiting ? 0 : 1,
       transition: `${layoutTransition}transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 150ms ease-out, box-shadow 200ms ease`,
     }
-  }, [node, isFocused, isAnimatingLayout, isWholeNodeDragSource, worktreeHighlight, worktreeColor])
+  }, [node, isFocused, isSelected, isAnimatingLayout, isWholeNodeDragSource, worktreeHighlight, worktreeColor])
 
   return { containerStyle, glowStyle }
 }

--- a/src/renderer/canvas/useGroupNodeDrag.ts
+++ b/src/renderer/canvas/useGroupNodeDrag.ts
@@ -1,0 +1,88 @@
+// =============================================================================
+// useGroupNodeDrag — moves every selected canvas node together when the user
+// drags a node that's part of a multi-selection. The dock-aware drag op
+// (useCanvasNodeDrag) only ever moves a single node, so this takes over the
+// gesture for groups: a pure canvas-space translate of all selected nodes,
+// with no docking/detach semantics (those don't apply to a multi-node move).
+// =============================================================================
+
+import React, { useCallback } from 'react'
+import type { Point } from '../../shared/types'
+import type { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+
+const DEAD_ZONE_PX = 4
+
+export function useGroupNodeDrag(
+  nodeId: string,
+  canvasApi: ReturnType<typeof useCanvasStoreApi>,
+  // Shared with the single-node drag op so the click that follows mouseup is
+  // suppressed (otherwise the node's onClick collapses the selection to one).
+  wasDragged: { current: boolean },
+) {
+  // Returns true when it has hijacked the gesture as a group move; the caller
+  // must then NOT fall through to the single-node dock drag.
+  const startGroupDrag = useCallback(
+    (e: React.MouseEvent): boolean => {
+      if (e.button !== 0) return false
+      const state = canvasApi.getState()
+      const selected = state.selectedNodeIds
+      // Only take over for a real multi-selection that includes this node.
+      if (selected.size <= 1 || !selected.has(nodeId)) return false
+
+      const startOrigins = new Map<string, Point>()
+      for (const id of selected) {
+        const n = state.nodes[id]
+        if (n) startOrigins.set(id, { x: n.origin.x, y: n.origin.y })
+      }
+      if (startOrigins.size <= 1) return false
+
+      const zoom = state.zoomLevel
+      const startX = e.clientX
+      const startY = e.clientY
+      let moved = false
+      let pushed = false
+
+      const onMove = (ev: MouseEvent) => {
+        const dxClient = ev.clientX - startX
+        const dyClient = ev.clientY - startY
+        if (!moved) {
+          if (Math.hypot(dxClient, dyClient) < DEAD_ZONE_PX) return
+          moved = true
+          wasDragged.current = true
+          document.body.classList.add('canvas-interacting')
+        }
+        // History once, on the first real movement.
+        if (!pushed) {
+          canvasApi.getState().pushHistory()
+          pushed = true
+        }
+        const dxCanvas = dxClient / zoom
+        const dyCanvas = dyClient / zoom
+        const moveNode = canvasApi.getState().moveNode
+        for (const [id, origin] of startOrigins) {
+          moveNode(id, { x: origin.x + dxCanvas, y: origin.y + dyCanvas })
+        }
+      }
+
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove, true)
+        window.removeEventListener('mouseup', onUp, true)
+        document.body.classList.remove('canvas-interacting')
+        // Keep wasDragged true through the click that fires after mouseup, then
+        // clear it so a later plain click can select again.
+        if (moved) setTimeout(() => { wasDragged.current = false }, 0)
+      }
+
+      window.addEventListener('mousemove', onMove, true)
+      window.addEventListener('mouseup', onUp, true)
+      // Prevent the press from kicking off the single-node drag/focus path; the
+      // following click still fires (so a no-drag press collapses to one node).
+      e.preventDefault()
+      e.stopPropagation()
+      return true
+    },
+    [canvasApi, nodeId, wasDragged],
+  )
+
+  return { startGroupDrag }
+}

--- a/src/renderer/canvas/useMultiNodeSelection.ts
+++ b/src/renderer/canvas/useMultiNodeSelection.ts
@@ -1,0 +1,27 @@
+// =============================================================================
+// useMultiNodeSelection — helpers for branching canvas UI on whether more than
+// one canvas node is selected at once. Canvas context menus use this to hide
+// per-node actions (split / new tab) and surface bulk actions (Close All) only
+// when a multi-selection is active.
+// =============================================================================
+
+import { useCallback } from 'react'
+import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+
+export function useMultiNodeSelection() {
+  const canvasApi = useCanvasStoreApi()
+
+  // Imperative read — for async menu builders / event handlers that need the
+  // value at call time rather than as a reactive subscription.
+  const isMultiSelected = useCallback(
+    () => canvasApi.getState().selectedNodeIds.size > 1,
+    [canvasApi],
+  )
+
+  // Close (remove) every selected node at once. Mirrors the Delete shortcut.
+  const closeSelection = useCallback(() => {
+    canvasApi.getState().deleteSelection()
+  }, [canvasApi])
+
+  return { isMultiSelected, closeSelection }
+}

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -14,6 +14,8 @@ import { useAppStore } from '../stores/appStore'
 import type { DockStore } from '../stores/dockStore'
 import { getPanelDef } from '../panels/registry'
 import { setActivePanel } from '../lib/activePanel'
+import { useMultiNodeSelection } from '../canvas/useMultiNodeSelection'
+import type { NativeContextMenuItem } from '../../shared/electron-api'
 
 export interface DockTabActionsParams {
   stack: DockTabStackType
@@ -37,6 +39,34 @@ export function useDockTabActions(params: DockTabActionsParams) {
   const setActiveTab = useCallback((stackId: string, index: number) => {
     dockStoreApi.getState().setActiveTab(stackId, index)
   }, [dockStoreApi])
+
+  // Canvas-node mini-docks (localOnly) branch their context menus on whether
+  // several nodes are selected at once: hide per-node split / new-tab and show
+  // the bulk "Close All" instead. Side/main dock zones have no node selection,
+  // so they always keep the full menu.
+  const { isMultiSelected, closeSelection } = useMultiNodeSelection()
+  const isMultiNodeSelection = useCallback(
+    () => !!localOnly && isMultiSelected(),
+    [localOnly, isMultiSelected],
+  )
+  // Close All shows for every dock zone, but on a canvas mini-dock only while a
+  // multi-selection is active (where it closes the whole selection).
+  const showCloseAll = useCallback(
+    () => !localOnly || isMultiNodeSelection(),
+    [localOnly, isMultiNodeSelection],
+  )
+  // While several nodes are selected, every node context menu (tab or tab-bar)
+  // collapses to this single bulk menu — the gesture targets the whole
+  // selection, not one tab/node. Returns true when it handled the event.
+  const showMultiSelectionMenu = useCallback(async (): Promise<boolean> => {
+    if (!isMultiNodeSelection()) return false
+    if (!window.electronAPI) return true
+    const id = await window.electronAPI.showContextMenu([
+      { id: 'close-all', label: 'Close All' },
+    ])
+    if (id === 'close-all') closeSelection()
+    return true
+  }, [isMultiNodeSelection, closeSelection])
 
   // --- Inline rename --------------------------------------------------------
   const [renameId, setRenameId] = useState<string | null>(null)
@@ -154,21 +184,26 @@ export function useDockTabActions(params: DockTabActionsParams) {
       e.preventDefault()
       e.stopPropagation()
       if (!window.electronAPI) return
+      // Multi-selection: same bulk menu as the tab-bar (Close All).
+      if (await showMultiSelectionMenu()) return
       const idx = stack.panelIds.indexOf(panelId)
       const hasOthers = stack.panelIds.length > 1
       const hasRight = idx >= 0 && idx < stack.panelIds.length - 1
       const panel = getPanelLocal(panelId)
-      const id = await window.electronAPI.showContextMenu([
+      const menu: NativeContextMenuItem[] = [
         { id: 'rename', label: 'Rename' },
-        { type: 'separator' as const },
+        { type: 'separator' },
         { id: 'close', label: 'Close', accelerator: 'Cmd+W' },
         { id: 'close-others', label: 'Close Others', enabled: hasOthers },
         { id: 'close-right', label: 'Close to the Right', enabled: hasRight },
-        { id: 'close-all', label: 'Close All', accelerator: 'Cmd+K Cmd+W' },
-        { type: 'separator' as const },
+        ...(showCloseAll()
+          ? [{ id: 'close-all', label: 'Close All', accelerator: 'Cmd+K Cmd+W' } as NativeContextMenuItem]
+          : []),
+        { type: 'separator' },
         { id: 'split-right', label: 'Split Right' },
         { id: 'move-window', label: 'Move into New Window' },
-      ])
+      ]
+      const id = await window.electronAPI.showContextMenu(menu)
       switch (id) {
         case 'rename':
           if (panel) beginRename(panelId, panel.title)
@@ -187,6 +222,8 @@ export function useDockTabActions(params: DockTabActionsParams) {
           break
         }
         case 'close-all':
+          // Multi-selection is handled by the early bulk menu above, so here
+          // close-all only ever means "close this stack's tabs".
           stack.panelIds.slice().forEach((p) => onClosePanel?.(p))
           break
         case 'split-right': {
@@ -198,7 +235,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
           break
       }
     },
-    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, workspaceId, splitWithType],
+    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, workspaceId, splitWithType, showMultiSelectionMenu, showCloseAll],
   )
 
   // Tab-bar (empty-area) context menu — split/new menus. Returns a handler
@@ -210,21 +247,29 @@ export function useDockTabActions(params: DockTabActionsParams) {
       if (e.target !== e.currentTarget) return
       e.preventDefault()
       if (!window.electronAPI) return
-      const id = await window.electronAPI.showContextMenu([
-        {
+      // Multi-selection: same bulk menu as the tab context menu (Close All).
+      if (await showMultiSelectionMenu()) return
+      // Build as groups so separators only appear between non-empty sections.
+      const groups: NativeContextMenuItem[][] = [
+        [{
           label: 'New Tab',
           submenu: visibleSplitItems.map((m) => ({ id: `new:${m.type}`, label: m.label })),
-        },
-        { type: 'separator' },
-        {
+        }],
+        [{
           label: 'Split With',
           submenu: visibleSplitItems.map((m) => ({ id: `split:${m.type}`, label: m.label })),
-        },
-        { type: 'separator' },
-        { id: 'close-all', label: 'Close All', enabled: stack.panelIds.length > 0 },
-      ])
+        }],
+      ]
+      if (showCloseAll()) {
+        groups.push([{ id: 'close-all', label: 'Close All', enabled: stack.panelIds.length > 0 }])
+      }
+      const menu = groups.flatMap((g, i) =>
+        i === 0 ? g : [{ type: 'separator' } as NativeContextMenuItem, ...g],
+      )
+      const id = await window.electronAPI.showContextMenu(menu)
       if (!id) return
       if (id === 'close-all') {
+        // Multi-selection handled by the early bulk menu; here it's stack tabs.
         stack.panelIds.slice().forEach((p) => onClosePanel?.(p))
         return
       }
@@ -233,7 +278,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
       else if (kind === 'split') splitWithType(type)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [stack.panelIds, onClosePanel, excludeKey, addTabOfType, splitWithType],
+    [stack.panelIds, onClosePanel, excludeKey, addTabOfType, splitWithType, showMultiSelectionMenu, showCloseAll],
   )
 
   const handleTabClick = useCallback(

--- a/src/renderer/hooks/useCanvasInteraction.ts
+++ b/src/renderer/hooks/useCanvasInteraction.ts
@@ -231,6 +231,13 @@ export function useCanvasInteraction(
         e.preventDefault()
         return
       }
+      // While a marquee selection is in progress, swallow wheel input. The
+      // marquee is anchored in canvas-space; letting the wheel pan/zoom the
+      // world mid-drag would shift the box off the cursor.
+      if (useUIStore.getState().marquee) {
+        e.preventDefault()
+        return
+      }
       const target = e.target as HTMLElement
       // `handleWheel` is wired via a native `wheel` listener in Canvas.tsx (cast
       // to React's type), so `e` carries Chromium's `wheelDeltaY` at runtime.
@@ -247,9 +254,13 @@ export function useCanvasInteraction(
       }
 
       // --- Plain scroll over a FOCUSED panel: let it scroll its own content ---
-      // This takes priority over mouse-wheel zoom so a mouse user can still
-      // scroll code in an editor or scrollback in a terminal. Zooming over a
-      // focused panel needs the explicit Cmd/Ctrl modifier handled above.
+      // A scroll over the focused panel scrolls that panel (code in an editor,
+      // scrollback in a terminal, the page in a browser) — for both a trackpad
+      // two-finger scroll and a physical mouse wheel. Only a scroll outside the
+      // focused panel (empty canvas, or an unfocused panel) pans/zooms the
+      // canvas, so the rule is simply: inside focus → scroll, outside focus →
+      // pan (trackpad) / zoom (mouse). Zooming the focused panel's surroundings
+      // still needs the explicit Cmd/Ctrl modifier / pinch handled above.
 
       // Browser panels (webview) route their own wheel via Electron's
       // cross-process input; the passive:false capture listener interferes with
@@ -282,7 +293,7 @@ export function useCanvasInteraction(
         if (nodeId && nodeId === focusedNodeId) {
           const isHorizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY)
           if (!isHorizontal) {
-            return // Vertical scroll — panel handles it
+            return // Vertical scroll — focused panel handles it (scroll inside)
           }
           // Check if any element between target and panel boundary can scroll horizontally
           let el: HTMLElement | null = target
@@ -297,19 +308,25 @@ export function useCanvasInteraction(
       }
 
       // --- Scroll over empty canvas / unfocused panel: tool decides ---
-      // In the Select (click) tool, a plain scroll zooms — for both a physical
-      // mouse wheel and a trackpad two-finger scroll (Miro-style). In the Hand
-      // (drag) tool it falls through to the pan path below instead. The `mouse`
-      // flag only picks the zoom feel: discrete notch vs. continuous
-      // delta-proportional.
-      if (useUIStore.getState().activeTool !== 'hand') {
+      // Select (click) tool: a physical mouse wheel zooms (Miro-style), while a
+      // trackpad two-finger scroll pans — matching the wheelIntent contract and
+      // restoring the v1.1.1 trackpad feel. A trackpad pinch still zooms via the
+      // ctrlKey path handled above. Hand (drag) tool always pans (falls through).
+      if (useUIStore.getState().activeTool !== 'hand' && mouse) {
         applyWheelZoom(e, mouse)
         return
       }
 
-      // --- Hand tool: scroll pans the canvas ---
-      // Apply canvas-interacting class so iframes/webviews/monaco/xterm don't
-      // eat hit-testing while panning. Remove it ~150ms after the wheel goes quiet.
+      // --- Scroll pans the canvas (hand tool, or select-tool trackpad scroll) ---
+      // preventDefault stops the panel under the cursor from also scrolling
+      // natively: in the hand tool every panel is pointer-events:none so it never
+      // mattered, but the select-tool trackpad-pan path leaves panels live, and a
+      // competing native scroll makes the wheel target flap between panel and
+      // canvas — the pan stutters over a panel while it's smooth over empty
+      // canvas. (passive:false on the listener makes preventDefault honored.)
+      // Apply canvas-interacting so iframes/webviews/monaco/xterm don't eat
+      // hit-testing while panning; remove it ~150ms after the wheel goes quiet.
+      e.preventDefault()
       e.stopPropagation()
       if (!wheelPanActive.current) {
         wheelPanActive.current = true
@@ -405,6 +422,14 @@ export function useCanvasInteraction(
         const target = e.target as HTMLElement
         const isOnNode = target.closest('[data-node-id]') !== null
         if (!isOnNode) {
+          // Freeze any in-flight zoom/pan animation (a settling smooth-zoom from
+          // a recent scroll, or leftover pan inertia) before anchoring the
+          // marquee. The marquee corners are canvas-space and rendered inside the
+          // world transform; if the transform keeps animating between mousemoves
+          // the box drifts off the cursor ("the selection jumps"). handleWheel
+          // also swallows wheel input while a marquee is active so nothing moves
+          // the world mid-drag.
+          cancelAllAnimations()
           const rect = canvasRef.current?.getBoundingClientRect()
           if (!rect) return
           const { zoomLevel, viewportOffset } = canvasStoreApi.getState()
@@ -427,6 +452,11 @@ export function useCanvasInteraction(
             const dy = ev.clientY - startClientY
             if (!didDrag && Math.sqrt(dx * dx + dy * dy) >= 4) {
               didDrag = true
+              // Drop DOM focus from any panel (e.g. a Monaco textarea) so the
+              // window-level keyboard shortcuts — Delete/Backspace over the new
+              // selection — aren't swallowed by the editable that had focus.
+              const active = document.activeElement
+              if (active instanceof HTMLElement) active.blur()
             }
             if (didDrag) {
               const { zoomLevel: z, viewportOffset: vo } = canvasStoreApi.getState()
@@ -500,7 +530,7 @@ export function useCanvasInteraction(
         }
       }
     },
-    [canvasRef, startPanDrag],
+    [canvasRef, startPanDrag, cancelAllAnimations],
   )
 
   const handleMouseMove = useCallback(

--- a/src/renderer/lib/terminal/terminalDom.ts
+++ b/src/renderer/lib/terminal/terminalDom.ts
@@ -11,26 +11,38 @@ import { registry, has, type RegistryEntry } from './registryState'
 import { finalizeReconnect } from './terminalLifecycle'
 
 /**
- * Force the WebGL renderer to rebuild its glyph atlas and redraw every cell.
+ * Rebuild the WebGL glyph atlas and force a full redraw — across EVERY live
+ * terminal in this window, not just the one named by panelId.
  *
- * A detached window is created hidden (show:false) and only revealed on
- * ready-to-show. The WebGL renderer initializes while the window is still
- * hidden, so its glyph atlas is built against whatever devicePixelRatio the
- * not-yet-composited window reports and its drawing buffer is never painted.
- * Once the window is shown a stale atlas yields garbled text (wrong cell
- * metrics) and a quiet terminal stays blank (the buffer comes up empty and,
- * with preserveDrawingBuffer:false, nothing redraws it). clearTextureAtlas()
- * rebuilds the atlas at the now-correct DPR; refresh() repaints into the live
- * buffer. No-op (besides a cheap refresh) on the canvas renderer fallback.
+ * Why all of them: xterm caches a single TextureAtlas shared by every terminal
+ * with the same config (font, theme, DPR — see CharAtlasCache.acquireTextureAtlas).
+ * clearTextureAtlas() resets that SHARED atlas's glyph layout but clears only the
+ * calling terminal's render model and redraws only that terminal. Every other
+ * terminal keeps a model full of texture coordinates that now point into the
+ * re-laid-out atlas, so they render scrambled glyphs until something clears their
+ * model too — which is why resizing a terminal (terminal.resize → _clearModel)
+ * "fixed" it. Clearing one terminal therefore corrupted all its siblings.
+ *
+ * So clear every terminal in one synchronous pass: the first clearTextureAtlas()
+ * resets the shared atlas, the rest early-return on the now-empty atlas
+ * (TextureAtlas.clearTexture bails when currentRow is at 0,0) but still clear
+ * their own model. Redraws are animation-frame-debounced, so all terminals
+ * repaint together against the same freshly-reset atlas — no glyph desync.
+ *
+ * The original need still holds: a detached window opens hidden (show:false),
+ * so its WebGL renderer initializes against a stale devicePixelRatio and its
+ * drawing buffer never paints. Rebuilding the atlas at the now-correct DPR and
+ * refreshing fixes the blank/garbled terminal once the window is shown. No-op
+ * (besides a cheap refresh) on the canvas renderer fallback.
  */
-function forceWebglRepaint(panelId: string): void {
-  const entry = registry.get(panelId)
-  if (!entry) return
-  try {
-    entry.webglAddon?.clearTextureAtlas()
-    entry.terminal.refresh(0, entry.terminal.rows - 1)
-  } catch {
-    /* renderer mid-dispose — ignore */
+function forceWebglRepaint(): void {
+  for (const entry of registry.values()) {
+    try {
+      entry.webglAddon?.clearTextureAtlas()
+      entry.terminal.refresh(0, entry.terminal.rows - 1)
+    } catch {
+      /* renderer mid-dispose — ignore */
+    }
   }
 }
 
@@ -158,7 +170,7 @@ export function attach(panelId: string, container: HTMLDivElement): void {
   // visible transition. Registered once per entry (survives re-attach cycles).
   if (!entry.hasVisibilityListener) {
     const onVisible = (): void => {
-      if (document.visibilityState === 'visible') forceWebglRepaint(panelId)
+      if (document.visibilityState === 'visible') forceWebglRepaint()
     }
     document.addEventListener('visibilitychange', onVisible)
     entry.cleanupListeners.push(() => document.removeEventListener('visibilitychange', onVisible))
@@ -239,10 +251,10 @@ export function attach(panelId: string, container: HTMLDivElement): void {
     // while hidden against a stale DPR/size, so the first paint can be blank or
     // garbled until the atlas is rebuilt at the live DPR. The extra frames
     // cover a window still settling its size/DPR on the first painted frame.
-    forceWebglRepaint(panelId)
+    forceWebglRepaint()
     requestAnimationFrame(() => {
-      forceWebglRepaint(panelId)
-      requestAnimationFrame(() => forceWebglRepaint(panelId))
+      forceWebglRepaint()
+      requestAnimationFrame(() => forceWebglRepaint())
     })
 
     // Now that the xterm is sized to its real container, replay captured

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -22,6 +22,7 @@ import {
 import { getActiveTheme, subscribeTheme } from '../lib/themeManager'
 import type { Theme } from '../../shared/types'
 import { takePendingReveal } from '../lib/editor/editorReveal'
+import { watchFsRoot } from '../lib/fs/fsWatchManager'
 
 // -----------------------------------------------------------------------------
 // Monaco worker setup for Electron (Vite bundler)
@@ -127,6 +128,13 @@ const MODEL_CACHE_LIMIT = 20
 const modelCache = new Map<string, monaco.editor.ITextModel>()
 // Counts how many mounted EditorPanel instances are actively using a cached model.
 const modelRefCount = new Map<string, number>()
+
+// File paths whose model is mid external-reload (setValue pulled from disk). A
+// shared cached model can back several editors, so the setValue fires
+// onDidChangeModelContent on every one of them — we mark the path here for the
+// synchronous duration of setValue so those change events aren't mistaken for a
+// user edit and flip the panel(s) to dirty.
+const externalReloadPaths = new Set<string>()
 
 function rememberModel(filePath: string, model: monaco.editor.ITextModel): void {
   // Map preserves insertion order — re-insert to mark as most recent.
@@ -619,6 +627,9 @@ export default function EditorPanel({
 
     let unsavedSaveTimer: ReturnType<typeof setTimeout> | null = null
     const changeDisposable = editor.onDidChangeModelContent(() => {
+      // A disk-driven reload (see the fs-watch effect below) replaces the model
+      // value; that isn't a user edit, so don't flip the panel to dirty.
+      if (filePathRef.current && externalReloadPaths.has(filePathRef.current)) return
       if (!isDirtyRef.current) {
         isDirtyRef.current = true
         useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
@@ -726,6 +737,60 @@ export default function EditorPanel({
       diffEditorRef.current?.layout()
     }
   }, [markdownPreview, isMarkdown, filePath, workspaceId])
+
+  // ---------------------------------------------------------------------------
+  // Reload the editor model when the file changes on disk externally
+  //
+  // Monaco models are cached at module level and survive panel unmount, and the
+  // markdown preview renders from the model's value — so without this an edit
+  // made by an external tool (another editor, an AI agent, git checkout) never
+  // reaches the open buffer or its preview, and reopening the file reuses the
+  // stale cached model. Watch the workspace root (the watcher is refcounted and
+  // shared with the file explorer, so this adds no new OS watcher) and pull the
+  // fresh content into the model when our file is updated on disk. Skipped while
+  // the buffer is dirty so we never clobber the user's unsaved edits.
+  // ---------------------------------------------------------------------------
+
+  const markdownPreviewRef = useRef(markdownPreview)
+  markdownPreviewRef.current = markdownPreview
+
+  useEffect(() => {
+    if (!filePath || !rootPath || diffMode) return
+    // Remote/companion files live behind a locator the local root watcher can't
+    // match; their changes aren't covered here.
+    if (filePath.startsWith('cate-companion://')) return
+
+    const targetPosix = filePath.replace(/\\/g, '/')
+
+    return watchFsRoot(
+      rootPath,
+      (event) => {
+        if (event.type === 'delete') return
+        if (event.path.replace(/\\/g, '/') !== targetPosix) return
+        // The user's unsaved work wins until they save it themselves.
+        if (isDirtyRef.current) return
+
+        window.electronAPI
+          .fsReadFile(filePath, workspaceId)
+          .then((content) => {
+            const model = editorRef.current?.getModel()
+            if (!model || model.isDisposed()) return
+            // No-op when disk already matches the buffer (e.g. our own save
+            // fired the event) — avoids a needless full-model reset.
+            if (model.getValue() === content) return
+            externalReloadPaths.add(filePath)
+            try {
+              model.setValue(content)
+            } finally {
+              externalReloadPaths.delete(filePath)
+            }
+            if (markdownPreviewRef.current) setMarkdownContent(content)
+          })
+          .catch(() => { /* file vanished or unreadable — leave the buffer as-is */ })
+      },
+      workspaceId,
+    )
+  }, [filePath, rootPath, workspaceId, diffMode])
 
   // ---------------------------------------------------------------------------
   // Watch app theme changes and update Monaco theme


### PR DESCRIPTION
## What

Canvas multi-selection:
- Marquee drag over empty canvas selects multiple nodes
- Dragging any selected node moves the whole group together (`useGroupNodeDrag`)
- A selection ring marks selected-but-not-active panes (distinct from the focus halo)
- Canvas mini-dock context menus collapse to a bulk "Close All" while a multi-selection is active (`useMultiNodeSelection`)

## Also in here

- **terminal:** rebuild the shared WebGL glyph atlas across all live terminals on repaint, fixing scrambled glyphs in sibling terminals that share the atlas
- **editor:** reload the Monaco model when the file changes on disk externally (other editor, agent, git checkout), skipping while the buffer is dirty so unsaved edits are never clobbered
- **canvas:** select-tool trackpad two-finger scroll pans again (mouse wheel still zooms); freeze in-flight zoom/pan animations when anchoring a marquee so the box stays under the cursor
- node cleanup when a tab is moved out via "Move into New Window" leaves an empty node

Bumps version to 1.3.0.


Closes #363
Closes #364
Closes #365
