### PR TITLE
refactor(updater): emit update-check telemetry once per session

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -185,6 +185,18 @@ describe('initAutoUpdater — event telemetry', () => {
     expect(h.sendEvent).toHaveBeenCalledWith('update_check_started', expect.anything())
   })
 
+  it('emits update_check_started only once per session despite the 15-min poll', async () => {
+    // The updater checks on launch and every 15 minutes thereafter. Tracking
+    // every check turns this into an uptime heartbeat that swamps real
+    // user-action events in analytics — collapse it to once per process.
+    await initAndGet()
+    h.autoUpdater.emit('checking-for-update')
+    h.autoUpdater.emit('checking-for-update')
+    h.autoUpdater.emit('checking-for-update')
+    const calls = h.sendEvent.mock.calls.filter((c) => c[0] === 'update_check_started')
+    expect(calls.length).toBe(1)
+  })
+
   it('emits update_available with the version', async () => {
     await initAndGet()
     h.autoUpdater.emit('update-available', { version: '1.2.3' })

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -74,6 +74,13 @@ let manualPrompted = false
  *  0/25/50/75/100% milestones instead of on every progress tick. */
 let lastProgressBucket = -1
 
+/** Whether we've already tracked an `update_check_started` this session. The
+ *  updater checks on launch AND every 15 minutes, so tracking every check turns
+ *  the event into an uptime heartbeat that swamps real user-action events in
+ *  analytics. Collapse it to once per process — enough to count "sessions that
+ *  checked" without the 15-minute noise. */
+let checkStartedTracked = false
+
 /** Version of the update found this session (set on update-available), so an
  *  `error` event can tell "a known update failed to apply" (→ offer the manual
  *  download) apart from a transient check failure (→ stay silent). */
@@ -185,7 +192,10 @@ function runCheck(eligible: boolean): Promise<unknown> {
 function wireUpdaterEvents(eligible: boolean): void {
   autoUpdater.on('checking-for-update', () => {
     log.info('[auto-updater] checking for update')
-    track('update_check_started')
+    if (!checkStartedTracked) {
+      checkStartedTracked = true
+      track('update_check_started')
+    }
     pushStatus({ state: 'checking', version: availableVersion })
   })
 


### PR DESCRIPTION
## Summary

The auto-updater checks for updates on launch **and every 15 minutes** thereafter. Each check emitted `update_check_started`, which turned the event into a per-uptime heartbeat rather than a per-session signal — so it scaled with how long an app stayed open rather than with anything meaningful, and dwarfed user-action events in analytics.

This collapses the emission to **once per process**: enough to count sessions that ran a check, while keeping the event proportionate to the rest of the telemetry.

## Changes
- `src/main/auto-updater.ts` — session-scoped guard so `update_check_started` is tracked once per process; the 15-minute poll no longer re-emits it.
- `src/main/auto-updater.test.ts` — covers the throttle (3 checks → 1 event).

## Verification
- `auto-updater` suite green (26/26), including the new test.

Behavior change is telemetry-only; the update-check cadence itself is unchanged.