### PR TITLE
feat(editor): surface and resolve external file changes in editor panels

### DIFF
--- a/src/renderer/lib/editor/externalConflict.test.ts
+++ b/src/renderer/lib/editor/externalConflict.test.ts
@@ -1,0 +1,48 @@
+// =============================================================================
+// Tests for classifyExternalEvent — the pure routing decision for a filesystem
+// event that lands on a file open in an EditorPanel.
+// =============================================================================
+
+import { describe, expect, it } from 'vitest'
+import { classifyExternalEvent, shouldBlockOverwrite } from './externalConflict'
+
+describe('classifyExternalEvent', () => {
+  it('routes a delete to conflict-deleted regardless of dirty state', () => {
+    expect(classifyExternalEvent('delete', false)).toBe('conflict-deleted')
+    expect(classifyExternalEvent('delete', true)).toBe('conflict-deleted')
+  })
+
+  it('reloads a clean buffer on an external update or create', () => {
+    expect(classifyExternalEvent('update', false)).toBe('reload')
+    expect(classifyExternalEvent('create', false)).toBe('reload')
+  })
+
+  it('raises a changed-conflict when the buffer has unsaved edits', () => {
+    expect(classifyExternalEvent('update', true)).toBe('conflict-changed')
+    expect(classifyExternalEvent('create', true)).toBe('conflict-changed')
+  })
+})
+
+describe('shouldBlockOverwrite', () => {
+  it('blocks when disk diverged from the loaded baseline and differs from the buffer', () => {
+    // baseline = what we loaded, disk = agent rewrote it, buffer = user edits
+    expect(shouldBlockOverwrite('orig', 'agent-version', 'user-version')).toBe(true)
+  })
+
+  it('does not block when disk still matches the baseline (no external change)', () => {
+    expect(shouldBlockOverwrite('orig', 'orig', 'user-version')).toBe(false)
+  })
+
+  it('does not block when the disk version already equals our buffer', () => {
+    // e.g. the user/agent converged on the same content — nothing to lose
+    expect(shouldBlockOverwrite('orig', 'same', 'same')).toBe(false)
+  })
+
+  it('does not block without a baseline (untitled / never loaded)', () => {
+    expect(shouldBlockOverwrite(null, 'anything', 'buffer')).toBe(false)
+  })
+
+  it('does not block when the file is unreadable/deleted (disk read failed)', () => {
+    expect(shouldBlockOverwrite('orig', null, 'buffer')).toBe(false)
+  })
+})

--- a/src/renderer/lib/editor/externalConflict.ts
+++ b/src/renderer/lib/editor/externalConflict.ts
@@ -1,0 +1,55 @@
+// =============================================================================
+// externalConflict — pure routing for filesystem events that hit a file open in
+// an EditorPanel.
+//
+// An external mutation (another editor, a git checkout, an AI agent) reaches the
+// open buffer through the workspace-root fs watcher. How we react depends on
+// whether the user has unsaved edits:
+//   - clean buffer + change  → reload the model from disk (silent, live update)
+//   - dirty buffer + change  → raise a conflict so the user's edits aren't
+//                              clobbered and the agent's change isn't lost
+//   - delete (any state)     → raise a deletion conflict; saving re-creates the
+//                              file, closing discards it for good
+// =============================================================================
+
+export type ExternalEventType = 'create' | 'update' | 'delete'
+
+/** What the EditorPanel should do with an external fs event for its file. */
+export type ExternalAction = 'reload' | 'conflict-changed' | 'conflict-deleted'
+
+/**
+ * Decide how to react to an external filesystem event on the open file.
+ *
+ * `isDirty` is whether the editor buffer has unsaved user edits.
+ */
+export function classifyExternalEvent(
+  eventType: ExternalEventType,
+  isDirty: boolean,
+): ExternalAction {
+  if (eventType === 'delete') return 'conflict-deleted'
+  return isDirty ? 'conflict-changed' : 'reload'
+}
+
+/**
+ * Save-time guard (does not depend on the fs watcher): decide whether writing
+ * the buffer would silently clobber an external change.
+ *
+ * - `baseline`  — disk content we last synced with (load or previous save); null
+ *                 means no known baseline (untitled / unloaded) → never block.
+ * - `diskNow`   — content read from disk right before writing; null means the
+ *                 read failed (file deleted/unreadable) → don't block, let the
+ *                 write proceed (e.g. a Save-to-restore re-creates the file).
+ * - `buffer`    — what we're about to write.
+ *
+ * Block only when the file changed on disk since we loaded it AND that on-disk
+ * version differs from our buffer (if it already equals the buffer, there's
+ * nothing to lose by writing).
+ */
+export function shouldBlockOverwrite(
+  baseline: string | null,
+  diskNow: string | null,
+  buffer: string,
+): boolean {
+  if (baseline === null || diskNow === null) return false
+  return diskNow !== baseline && diskNow !== buffer
+}

--- a/src/renderer/lib/editor/threeWayMerge.test.ts
+++ b/src/renderer/lib/editor/threeWayMerge.test.ts
@@ -1,0 +1,76 @@
+// =============================================================================
+// Tests for threeWayMerge — line-based 3-way merge used by the editor's
+// "Keep both" conflict resolution (baseline = common ancestor, mine = buffer,
+// theirs = on-disk/agent version).
+// =============================================================================
+
+import { describe, expect, it } from 'vitest'
+import { threeWayMerge } from './threeWayMerge'
+
+describe('threeWayMerge', () => {
+  it('returns the unchanged text when nothing diverged', () => {
+    const r = threeWayMerge('a\nb\nc', 'a\nb\nc', 'a\nb\nc')
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe('a\nb\nc')
+  })
+
+  it('takes my side when only I changed it', () => {
+    const r = threeWayMerge('a\nb\nc', 'a\nB\nc', 'a\nb\nc')
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe('a\nB\nc')
+  })
+
+  it('takes their side when only they changed it', () => {
+    const r = threeWayMerge('a\nb\nc', 'a\nb\nc', 'a\nb\nC')
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe('a\nb\nC')
+  })
+
+  it('keeps both when the edits touch different lines', () => {
+    // mine changes line 1, theirs changes line 3 — disjoint → clean merge
+    const r = threeWayMerge('a\nb\nc', 'A\nb\nc', 'a\nb\nC')
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe('A\nb\nC')
+  })
+
+  it('keeps both for the real case: I edit line 1, the agent appends below', () => {
+    const base = 'Hallo test. AAAAA'
+    const mine = 'Hallo test. AAAAAaaaaaaa'
+    const theirs = 'Hallo test. AAAAA\n\nThe Quiet Machine\na single test at last turns green.'
+    const r = threeWayMerge(base, mine, theirs)
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe(
+      'Hallo test. AAAAAaaaaaaa\n\nThe Quiet Machine\na single test at last turns green.',
+    )
+  })
+
+  it('merges cleanly when both make the identical change', () => {
+    const r = threeWayMerge('a\nb\nc', 'a\nX\nc', 'a\nX\nc')
+    expect(r.clean).toBe(true)
+    expect(r.merged).toBe('a\nX\nc')
+  })
+
+  it('emits conflict markers when both edit the same line differently', () => {
+    const r = threeWayMerge('a\nb\nc', 'a\nMINE\nc', 'a\nTHEIRS\nc')
+    expect(r.clean).toBe(false)
+    expect(r.merged).toContain('<<<<<<<')
+    expect(r.merged).toContain('MINE')
+    expect(r.merged).toContain('=======')
+    expect(r.merged).toContain('THEIRS')
+    expect(r.merged).toContain('>>>>>>>')
+    // unconflicted context is preserved around the markers
+    expect(r.merged.startsWith('a\n')).toBe(true)
+    expect(r.merged.endsWith('\nc')).toBe(true)
+  })
+
+  it('uses the provided side labels in conflict markers', () => {
+    const r = threeWayMerge('b', 'MINE', 'THEIRS', { mine: 'Your edits', theirs: 'On disk' })
+    expect(r.merged).toContain('<<<<<<< Your edits')
+    expect(r.merged).toContain('>>>>>>> On disk')
+  })
+
+  it('preserves a trailing newline', () => {
+    const r = threeWayMerge('a\nb\n', 'A\nb\n', 'a\nb\n')
+    expect(r.merged).toBe('A\nb\n')
+  })
+})

--- a/src/renderer/lib/editor/threeWayMerge.ts
+++ b/src/renderer/lib/editor/threeWayMerge.ts
@@ -1,0 +1,202 @@
+// =============================================================================
+// threeWayMerge — a small, dependency-free line-based 3-way merge.
+//
+// Given a common ancestor (`base`) and two derived versions (`mine` = the editor
+// buffer, `theirs` = the on-disk/agent version), produce a single text that
+// keeps both sides' edits. Edits that touch different regions combine cleanly;
+// edits that overlap the same region are emitted with git-style conflict markers
+// and `clean: false` so the caller can flag them for manual resolution.
+// =============================================================================
+
+export interface MergeResult {
+  merged: string
+  clean: boolean
+}
+
+export interface MergeLabels {
+  mine: string
+  theirs: string
+}
+
+// A contiguous change relative to `base`: replace base[start, end) with `lines`.
+interface Hunk {
+  start: number
+  end: number
+  lines: string[]
+}
+
+// LCS-based line diff of base → other, coalesced into replace-hunks.
+function diffToHunks(base: string[], other: string[]): Hunk[] {
+  const n = base.length
+  const m = other.length
+
+  // dp[i][j] = LCS length of base[i:] and other[j:]
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = base[i] === other[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+
+  const hunks: Hunk[] = []
+  let i = 0
+  let j = 0
+  let curStart = -1
+  let curEnd = 0
+  let ins: string[] = []
+  const flush = () => {
+    if (curStart >= 0) {
+      hunks.push({ start: curStart, end: curEnd, lines: ins })
+      curStart = -1
+      ins = []
+    }
+  }
+
+  while (i < n && j < m) {
+    if (base[i] === other[j]) {
+      flush()
+      i++
+      j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      // delete base[i]
+      if (curStart < 0) curStart = i
+      curEnd = i + 1
+      i++
+    } else {
+      // insert other[j] at the current base position
+      if (curStart < 0) {
+        curStart = i
+        curEnd = i
+      }
+      ins.push(other[j])
+      j++
+    }
+  }
+  while (i < n) {
+    if (curStart < 0) curStart = i
+    curEnd = i + 1
+    i++
+  }
+  while (j < m) {
+    if (curStart < 0) {
+      curStart = i
+      curEnd = i
+    }
+    ins.push(other[j])
+    j++
+  }
+  flush()
+
+  return hunks
+}
+
+function sameLines(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((line, idx) => line === b[idx])
+}
+
+// Two hunks overlap if their base ranges intersect. Pure insertions (start===end)
+// at the same anchor don't intersect by this test, so they're combined rather
+// than conflicted (both insertions are kept).
+function overlaps(a: Hunk, b: Hunk): boolean {
+  return a.start < b.end && b.start < a.end
+}
+
+export function threeWayMerge(
+  base: string,
+  mine: string,
+  theirs: string,
+  labels: MergeLabels = { mine: 'Your changes', theirs: 'On disk' },
+): MergeResult {
+  if (mine === theirs) return { merged: mine, clean: true }
+  if (mine === base) return { merged: theirs, clean: true }
+  if (theirs === base) return { merged: mine, clean: true }
+
+  const baseLines = base.split('\n')
+  const mineHunks = diffToHunks(baseLines, mine.split('\n'))
+  const theirHunks = diffToHunks(baseLines, theirs.split('\n'))
+
+  const out: string[] = []
+  let clean = true
+  let pos = 0 // next base line to emit
+  let mi = 0
+  let ti = 0
+
+  const emitBaseUpTo = (until: number) => {
+    for (let k = pos; k < until; k++) out.push(baseLines[k])
+    pos = Math.max(pos, until)
+  }
+
+  while (mi < mineHunks.length || ti < theirHunks.length) {
+    const a = mineHunks[mi]
+    const b = theirHunks[ti]
+
+    // Only one side has remaining hunks → apply it straight.
+    if (!b) {
+      emitBaseUpTo(a.start)
+      out.push(...a.lines)
+      pos = Math.max(pos, a.end)
+      mi++
+      continue
+    }
+    if (!a) {
+      emitBaseUpTo(b.start)
+      out.push(...b.lines)
+      pos = Math.max(pos, b.end)
+      ti++
+      continue
+    }
+
+    // Apply whichever hunk starts earlier; if they collide, resolve together.
+    if (a.end <= b.start && !(a.start === b.start)) {
+      emitBaseUpTo(a.start)
+      out.push(...a.lines)
+      pos = Math.max(pos, a.end)
+      mi++
+      continue
+    }
+    if (b.end <= a.start && !(a.start === b.start)) {
+      emitBaseUpTo(b.start)
+      out.push(...b.lines)
+      pos = Math.max(pos, b.end)
+      ti++
+      continue
+    }
+
+    // Same anchor or overlapping ranges.
+    if (sameLines(a.lines, b.lines) && a.start === b.start && a.end === b.end) {
+      // Identical edit on both sides → apply once.
+      emitBaseUpTo(a.start)
+      out.push(...a.lines)
+      pos = Math.max(pos, a.end)
+      mi++
+      ti++
+      continue
+    }
+
+    if (!overlaps(a, b) && a.start === b.start && a.end === a.start && b.end === b.start) {
+      // Both are pure insertions at the same anchor → keep both, mine first.
+      emitBaseUpTo(a.start)
+      out.push(...a.lines, ...b.lines)
+      mi++
+      ti++
+      continue
+    }
+
+    // Genuine conflict: overlapping edits to the same region.
+    const start = Math.min(a.start, b.start)
+    const end = Math.max(a.end, b.end)
+    emitBaseUpTo(start)
+    out.push(`<<<<<<< ${labels.mine}`)
+    out.push(...a.lines)
+    out.push('=======')
+    out.push(...b.lines)
+    out.push(`>>>>>>> ${labels.theirs}`)
+    pos = Math.max(pos, end)
+    clean = false
+    mi++
+    ti++
+  }
+
+  emitBaseUpTo(baseLines.length)
+  return { merged: out.join('\n'), clean }
+}

--- a/src/renderer/lib/editor/useFileSync.test.tsx
+++ b/src/renderer/lib/editor/useFileSync.test.tsx
@@ -1,0 +1,282 @@
+// =============================================================================
+// Integration tests for useFileSync — the buffer↔disk state machine.
+//
+// No @testing-library/react in the project, so the hook is driven through a tiny
+// harness component rendered with createRoot + act (the pattern the shell tests
+// use). The Monaco model is a minimal stub (getValue/setValue/isDisposed); the
+// filesystem (window.electronAPI), the root watcher (watchFsRoot), and the panel
+// store (useAppStore) are mocked so each scenario is deterministic.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+import { useFileSync, type FileSync, type UseFileSyncParams } from './useFileSync'
+
+// --- shared mock state (hoisted so the vi.mock factories can see it) ----------
+
+const h = vi.hoisted(() => ({
+  watchListener: null as ((e: { type: string; path: string }) => void) | null,
+  store: {
+    setPanelDirty: vi.fn(),
+    updatePanelTitle: vi.fn(),
+    updatePanelFilePath: vi.fn(),
+    setPanelUnsavedContent: vi.fn(),
+    workspaces: [] as unknown[],
+  },
+}))
+
+vi.mock('../fs/fsWatchManager', () => ({
+  watchFsRoot: (_root: string, listener: (e: { type: string; path: string }) => void) => {
+    h.watchListener = listener
+    return () => {
+      h.watchListener = null
+    }
+  },
+}))
+
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: Object.assign(() => undefined, { getState: () => h.store }),
+}))
+
+vi.mock('./modelCache', () => ({ isLoadFailed: () => false }))
+
+// --- harness ------------------------------------------------------------------
+
+let latest: FileSync | null = null
+function Harness(props: UseFileSyncParams) {
+  latest = useFileSync(props)
+  return null
+}
+
+let host: HTMLDivElement
+let root: Root
+
+interface FakeModel {
+  getValue: () => string
+  setValue: (v: string) => void
+  isDisposed: () => boolean
+}
+
+function makeModel(initial: string): FakeModel {
+  let value = initial
+  return {
+    getValue: () => value,
+    setValue: (v: string) => { value = v },
+    isDisposed: () => false,
+  }
+}
+
+const FILE = '/proj/test.txt'
+
+function electronApi() {
+  return (window as unknown as { electronAPI: Record<string, ReturnType<typeof vi.fn>> }).electronAPI
+}
+
+function mount(model: FakeModel, overrides: Partial<UseFileSyncParams> = {}) {
+  const params: UseFileSyncParams = {
+    workspaceId: 'w1',
+    panelId: 'p1',
+    filePath: FILE,
+    rootPath: '/proj',
+    diffMode: undefined,
+    getModel: () => model as unknown as NonNullable<ReturnType<UseFileSyncParams['getModel']>>,
+    ...overrides,
+  }
+  act(() => {
+    root.render(<Harness {...params} />)
+  })
+}
+
+// Flush pending microtasks + a macrotask turn (covers fsRead .then chains and
+// the 150ms delete-verify timer when given enough time).
+async function settle(ms = 0) {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, ms))
+  })
+}
+
+beforeEach(() => {
+  h.watchListener = null
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    fsReadFile: vi.fn(),
+    fsWriteFile: vi.fn().mockResolvedValue(undefined),
+    saveFileDialog: vi.fn(),
+  }
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  latest = null
+})
+
+describe('useFileSync — save guard', () => {
+  it('writes the buffer when disk has not diverged from the baseline', async () => {
+    const model = makeModel('hello')
+    mount(model)
+    act(() => { latest!.noteLoaded('hello') })
+    model.setValue('hello world')
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue('hello') // disk == baseline
+
+    let ok = false
+    await act(async () => { ok = await latest!.save() })
+
+    expect(ok).toBe(true)
+    expect(electronApi().fsWriteFile).toHaveBeenCalledWith(FILE, 'hello world', 'w1')
+    expect(latest!.conflict).toBeNull()
+    expect(latest!.isDirtyRef.current).toBe(false)
+  })
+
+  it('refuses to overwrite when disk diverged, raising a changed conflict', async () => {
+    const model = makeModel('mine')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue('theirs') // changed underneath us
+
+    let ok = true
+    await act(async () => { ok = await latest!.save() })
+
+    expect(ok).toBe(false)
+    expect(electronApi().fsWriteFile).not.toHaveBeenCalled()
+    expect(latest!.conflict).toEqual({ kind: 'changed', diskContent: 'theirs' })
+  })
+})
+
+describe('useFileSync — external changes', () => {
+  it('raises a changed conflict when the file changes under a dirty buffer', async () => {
+    const model = makeModel('mine')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue('theirs')
+
+    act(() => { h.watchListener!({ type: 'update', path: FILE }) })
+    await settle()
+
+    expect(latest!.conflict).toEqual({ kind: 'changed', diskContent: 'theirs' })
+    expect(model.getValue()).toBe('mine') // buffer untouched
+  })
+
+  it('silently reloads a clean buffer from disk', async () => {
+    const model = makeModel('base')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    electronApi().fsReadFile.mockResolvedValue('fresh from disk')
+
+    act(() => { h.watchListener!({ type: 'update', path: FILE }) })
+    await settle()
+
+    expect(model.getValue()).toBe('fresh from disk')
+    expect(latest!.conflict).toBeNull()
+  })
+
+  it('raises a deleted conflict and marks dirty when the file is removed', async () => {
+    const model = makeModel('content')
+    mount(model)
+    act(() => { latest!.noteLoaded('content') })
+    electronApi().fsReadFile.mockRejectedValue(new Error('ENOENT'))
+
+    act(() => { h.watchListener!({ type: 'delete', path: FILE }) })
+    await settle(200) // delete is verified after a 150ms guard
+
+    expect(latest!.conflict).toEqual({ kind: 'deleted' })
+    expect(latest!.isDirtyRef.current).toBe(true)
+    expect(h.store.setPanelDirty).toHaveBeenCalledWith('w1', 'p1', true)
+  })
+
+  it('treats a delete+recreate (atomic write) as a normal change, not a deletion', async () => {
+    const model = makeModel('base')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    // The verify-read a tick later succeeds → it was an atomic replace.
+    electronApi().fsReadFile.mockResolvedValue('rewritten')
+
+    act(() => { h.watchListener!({ type: 'delete', path: FILE }) })
+    await settle(200)
+
+    expect(latest!.conflict).toBeNull()
+    expect(model.getValue()).toBe('rewritten') // clean buffer reloaded
+  })
+})
+
+describe('useFileSync — resolutions', () => {
+  it('reload takes the disk version and clears the conflict', async () => {
+    const model = makeModel('mine')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue('theirs')
+    act(() => { h.watchListener!({ type: 'update', path: FILE }) })
+    await settle()
+
+    act(() => { latest!.reload() })
+
+    expect(model.getValue()).toBe('theirs')
+    expect(latest!.conflict).toBeNull()
+    expect(latest!.isDirtyRef.current).toBe(false)
+  })
+
+  it('keepBoth merges non-overlapping edits and keeps both', async () => {
+    const base = 'Hallo test. AAAAA'
+    const mine = 'Hallo test. AAAAAaaaaaaa'
+    const theirs = 'Hallo test. AAAAA\n\nThe Quiet Machine'
+    const model = makeModel(mine)
+    mount(model)
+    act(() => { latest!.noteLoaded(base) })
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue(theirs)
+    act(() => { h.watchListener!({ type: 'update', path: FILE }) })
+    await settle()
+    expect(latest!.conflict).toEqual({ kind: 'changed', diskContent: theirs })
+
+    act(() => { latest!.keepBoth() })
+
+    expect(model.getValue()).toBe('Hallo test. AAAAAaaaaaaa\n\nThe Quiet Machine')
+    expect(latest!.conflict).toBeNull()
+  })
+
+  it('keepMine adopts disk as baseline so the next save force-writes the buffer', async () => {
+    const model = makeModel('mine')
+    mount(model)
+    act(() => { latest!.noteLoaded('base') })
+    act(() => { latest!.noteUserEdit() })
+    electronApi().fsReadFile.mockResolvedValue('theirs')
+    act(() => { h.watchListener!({ type: 'update', path: FILE }) })
+    await settle()
+
+    act(() => { latest!.keepMine() })
+    expect(latest!.conflict).toBeNull()
+
+    // Disk still holds 'theirs' (now the baseline) → save no longer blocks.
+    electronApi().fsReadFile.mockResolvedValue('theirs')
+    let ok = false
+    await act(async () => { ok = await latest!.save() })
+
+    expect(ok).toBe(true)
+    expect(electronApi().fsWriteFile).toHaveBeenCalledWith(FILE, 'mine', 'w1')
+  })
+
+  it('saveToRestore writes a deleted file back to disk', async () => {
+    const model = makeModel('rescued content')
+    mount(model)
+    act(() => { latest!.noteLoaded('rescued content') })
+    electronApi().fsReadFile.mockRejectedValue(new Error('ENOENT'))
+    act(() => { h.watchListener!({ type: 'delete', path: FILE }) })
+    await settle(200)
+    expect(latest!.conflict).toEqual({ kind: 'deleted' })
+
+    // The save re-read also fails (still gone) → guard falls through and writes.
+    await act(async () => { await latest!.saveToRestore() })
+
+    expect(electronApi().fsWriteFile).toHaveBeenCalledWith(FILE, 'rescued content', 'w1')
+    expect(latest!.conflict).toBeNull()
+  })
+})

--- a/src/renderer/lib/editor/useFileSync.ts
+++ b/src/renderer/lib/editor/useFileSync.ts
@@ -1,0 +1,407 @@
+// =============================================================================
+// useFileSync — the single owner of an editor buffer's relationship with its
+// file on disk.
+//
+// One hook, one state machine. Everything about keeping a Monaco buffer in sync
+// with disk lives here so EditorPanel can stay a thin Monaco-lifecycle + render
+// component:
+//
+//   • baseline   — the disk content we last synced with (load / save)
+//   • dirty      — whether the buffer has unsaved user edits
+//   • conflict   — none | changed (external edit vs our unsaved edits)
+//                       | deleted (file removed while open)
+//
+// Inputs of divergence and how they resolve:
+//   - user edit            → mark dirty (noteUserEdit)
+//   - external change, clean buffer → silent reload + advance baseline
+//   - external change, dirty buffer → `changed` conflict
+//   - external delete      → `deleted` conflict (+ keep buffer as unsaved work)
+//   - save                 → re-read disk and refuse to clobber a divergence
+//                            (watcher-independent guard)
+//
+// Resolutions: reload (take disk), keepMine (my buffer wins), keepBoth (3-way
+// merge), saveToRestore (re-create a deleted file), dismiss.
+//
+// The heavy lifting is delegated to pure, separately-tested helpers:
+// classifyExternalEvent, shouldBlockOverwrite, threeWayMerge.
+// =============================================================================
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { MutableRefObject } from 'react'
+import type * as monaco from 'monaco-editor'
+import log from '../logger'
+import { useAppStore } from '../../stores/appStore'
+import { watchFsRoot } from '../fs/fsWatchManager'
+import { isLoadFailed } from './modelCache'
+import { classifyExternalEvent, shouldBlockOverwrite } from './externalConflict'
+import { threeWayMerge } from './threeWayMerge'
+
+// Paths whose model is mid programmatic replace (reload/merge pulled from disk).
+// A shared cached model can back several editors, so setValue fires
+// onDidChangeModelContent on every one of them — marking the path here for the
+// synchronous duration of setValue lets each panel's change listener tell that
+// apart from a real user edit. Module-level so it's shared across hook instances
+// that point at the same file.
+const externalReplacePaths = new Set<string>()
+
+export type EditorConflict = { kind: 'changed'; diskContent?: string } | { kind: 'deleted' } | null
+
+export interface UseFileSyncParams {
+  workspaceId: string
+  panelId: string
+  filePath: string | undefined
+  rootPath: string | undefined
+  diffMode: 'staged' | 'working' | undefined
+  /** Live accessor for the panel's Monaco model (owned by EditorPanel). */
+  getModel: () => monaco.editor.ITextModel | null
+  /** Called when the hook replaces the buffer from disk (reload / merge), so the
+   *  markdown preview can refresh. */
+  onExternalReplace?: (content: string) => void
+}
+
+export interface FileSync {
+  /** Authoritative file path; updated in place after a Save-As. */
+  filePathRef: MutableRefObject<string | undefined>
+  /** Whether the buffer has unsaved edits. */
+  isDirtyRef: MutableRefObject<boolean>
+  conflict: EditorConflict
+  showDiff: boolean
+  openDiff: () => void
+  closeDiff: () => void
+  /** Record the disk content the buffer was loaded from (the sync baseline). */
+  noteLoaded: (content: string) => void
+  /** Flag a real user edit (mark dirty + title marker). */
+  noteUserEdit: () => void
+  /** True while a programmatic disk-driven replace is in flight for this file —
+   *  the change listener uses it to ignore the resulting content event. */
+  isExternalReplace: () => boolean
+  /** Guarded save (Save-As when untitled, overwrite-guard otherwise). */
+  save: () => Promise<boolean>
+  reload: () => void
+  keepMine: () => void
+  keepBoth: () => void
+  saveToRestore: () => Promise<void>
+  dismiss: () => void
+}
+
+export function useFileSync({
+  workspaceId,
+  panelId,
+  filePath,
+  rootPath,
+  diffMode,
+  getModel,
+  onExternalReplace,
+}: UseFileSyncParams): FileSync {
+  const isDirtyRef = useRef(false)
+  const filePathRef = useRef(filePath)
+  // The disk content we last synced with: set on load and after every save. The
+  // save guard and 3-way merge use it; null = no baseline (untitled / unloaded).
+  const baselineRef = useRef<string | null>(null)
+
+  // Only overwrite the ref from the prop when the prop is itself defined. In
+  // detached/dock windows the shell keeps its own local `panels` state and never
+  // emits the global appStore update we issue after a Save-As, so the prop stays
+  // undefined for this mount's lifetime — without this guard every re-render
+  // would wipe the path we just learned and the next Cmd+S would reopen Save-As.
+  if (filePath !== undefined) filePathRef.current = filePath
+
+  const [conflict, setConflict] = useState<EditorConflict>(null)
+  const [showDiff, setShowDiff] = useState(false)
+
+  const onExternalReplaceRef = useRef(onExternalReplace)
+  onExternalReplaceRef.current = onExternalReplace
+
+  // ---------------------------------------------------------------------------
+  // Dirty marker (buffer ↔ panel title/state)
+  // ---------------------------------------------------------------------------
+
+  const noteUserEdit = useCallback(() => {
+    if (isDirtyRef.current) return
+    isDirtyRef.current = true
+    useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
+    if (filePathRef.current) {
+      const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
+      useAppStore.getState().updatePanelTitle(workspaceId, panelId, `${fileName} •`)
+    }
+  }, [workspaceId, panelId])
+
+  const clearDirty = useCallback(() => {
+    isDirtyRef.current = false
+    useAppStore.getState().setPanelDirty(workspaceId, panelId, false)
+    if (filePathRef.current) {
+      const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
+      useAppStore.getState().updatePanelTitle(workspaceId, panelId, fileName)
+    }
+  }, [workspaceId, panelId])
+
+  const noteLoaded = useCallback((content: string) => {
+    baselineRef.current = content
+  }, [])
+
+  const isExternalReplace = useCallback(
+    () => !!filePathRef.current && externalReplacePaths.has(filePathRef.current),
+    [],
+  )
+
+  // Replace the buffer from a disk-derived string without it being mistaken for a
+  // user edit. Returns false if there's no live model to write into.
+  const replaceBuffer = useCallback((content: string): boolean => {
+    const model = getModel()
+    if (!model || model.isDisposed()) return false
+    const path = filePathRef.current
+    if (path) externalReplacePaths.add(path)
+    try {
+      model.setValue(content)
+    } finally {
+      if (path) externalReplacePaths.delete(path)
+    }
+    onExternalReplaceRef.current?.(content)
+    return true
+  }, [getModel])
+
+  // ---------------------------------------------------------------------------
+  // Save (guarded)
+  // ---------------------------------------------------------------------------
+
+  const save = useCallback(async (): Promise<boolean> => {
+    if (diffMode) return false
+    const model = getModel()
+    if (!model || model.isDisposed()) return false
+
+    // Never write a buffer that failed to load — its contents are an empty
+    // placeholder, and saving would truncate the real file.
+    if (filePathRef.current && isLoadFailed(filePathRef.current)) {
+      log.warn('[useFileSync] Refusing to save — file never loaded successfully:', filePathRef.current)
+      return false
+    }
+
+    const content = model.getValue()
+
+    // Untitled buffer: prompt for a destination via the native Save-As dialog.
+    let targetPath = filePathRef.current
+    let isInitialSave = false
+    if (!targetPath) {
+      const currentPanel = useAppStore
+        .getState()
+        .workspaces.find((w) => w.id === workspaceId)?.panels[panelId]
+      const cleanTitle = currentPanel?.title?.replace(/\s•\s*$/, '').trim()
+      const defaultName = cleanTitle && cleanTitle !== 'Untitled' ? cleanTitle : 'Untitled.txt'
+      const sep = rootPath?.includes('\\') ? '\\' : '/'
+      const defaultPath = rootPath ? `${rootPath}${sep}${defaultName}` : defaultName
+      const chosen = await window.electronAPI.saveFileDialog({ defaultName, defaultPath })
+      if (!chosen) return false
+      targetPath = chosen
+      isInitialSave = true
+    }
+
+    // External-change guard (watcher-independent): re-read before overwriting.
+    // If the file changed on disk since we last synced AND that version differs
+    // from our buffer, surface the conflict instead of clobbering it. Skipped for
+    // the initial Save-As (no baseline) and when the read fails (deleted file →
+    // fall through so a Save-to-restore re-creates it).
+    if (!isInitialSave && baselineRef.current !== null) {
+      let diskNow: string | null = null
+      try {
+        diskNow = await window.electronAPI.fsReadFile(targetPath, workspaceId)
+      } catch {
+        diskNow = null
+      }
+      if (shouldBlockOverwrite(baselineRef.current, diskNow, content)) {
+        setConflict({ kind: 'changed', diskContent: diskNow ?? undefined })
+        return false
+      }
+    }
+
+    try {
+      await window.electronAPI.fsWriteFile(targetPath, content, workspaceId)
+    } catch (err) {
+      log.error('[useFileSync] Failed to save file:', err)
+      return false
+    }
+
+    baselineRef.current = content
+    clearDirty()
+    // clearDirty restores the title for an already-known path; for the initial
+    // Save-As below we also set the freshly-derived name.
+    const fileName = targetPath.split(/[\\/]/).pop() || 'Untitled'
+    useAppStore.getState().updatePanelTitle(workspaceId, panelId, fileName)
+
+    if (isInitialSave) {
+      filePathRef.current = targetPath
+      useAppStore.getState().updatePanelFilePath(workspaceId, panelId, targetPath)
+      useAppStore.getState().setPanelUnsavedContent(workspaceId, panelId, undefined)
+      window.dispatchEvent(
+        new CustomEvent('editor:panel-saved-as', {
+          detail: { panelId, filePath: targetPath, title: fileName },
+        }),
+      )
+    }
+    return true
+  }, [workspaceId, panelId, diffMode, rootPath, getModel, clearDirty])
+
+  // ---------------------------------------------------------------------------
+  // Conflict resolutions
+  // ---------------------------------------------------------------------------
+
+  // Take the on-disk version, discarding the unsaved buffer edits.
+  const reload = useCallback(() => {
+    const content = conflict?.kind === 'changed' ? conflict.diskContent ?? '' : ''
+    replaceBuffer(content)
+    baselineRef.current = content
+    clearDirty()
+    setShowDiff(false)
+    setConflict(null)
+  }, [conflict, clearDirty, replaceBuffer])
+
+  // Keep the unsaved buffer over the external version. Adopt the on-disk content
+  // as the new baseline so the next save writes the buffer straight over it
+  // instead of re-flagging the same conflict.
+  const keepMine = useCallback(() => {
+    if (conflict?.kind === 'changed' && conflict.diskContent !== undefined) {
+      baselineRef.current = conflict.diskContent
+    }
+    setShowDiff(false)
+    setConflict(null)
+  }, [conflict])
+
+  // Merge both sides: baseline = common ancestor, buffer = mine, disk = theirs.
+  // Non-overlapping edits combine cleanly; overlapping edits get conflict
+  // markers. The result lands in the buffer (dirty) for the user to review and
+  // save — nothing is written to disk here.
+  const keepBoth = useCallback(() => {
+    if (conflict?.kind !== 'changed') return
+    const model = getModel()
+    if (!model || model.isDisposed()) return
+    const theirs = conflict.diskContent ?? ''
+    const { merged } = threeWayMerge(baselineRef.current ?? '', model.getValue(), theirs, {
+      mine: 'Your changes',
+      theirs: 'On disk',
+    })
+    if (!replaceBuffer(merged)) return
+    noteUserEdit()
+    // Disk still holds `theirs`; make it the baseline so saving the merged buffer
+    // passes the guard (disk === baseline) and writes cleanly.
+    baselineRef.current = theirs
+    setShowDiff(false)
+    setConflict(null)
+  }, [conflict, getModel, replaceBuffer, noteUserEdit])
+
+  // Re-create a deleted file from the buffer contents.
+  const saveToRestore = useCallback(async () => {
+    const ok = await save()
+    if (ok) {
+      setShowDiff(false)
+      setConflict(null)
+    }
+  }, [save])
+
+  // Dismiss without resolving (deleted-conflict Dismiss). The buffer stays dirty
+  // so the close-confirm still protects it.
+  const dismiss = useCallback(() => {
+    setShowDiff(false)
+    setConflict(null)
+  }, [])
+
+  // ---------------------------------------------------------------------------
+  // Watch the file on disk for external edits / deletion
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!filePath || !rootPath || diffMode) return
+    // Remote/companion files live behind a locator the local root watcher can't
+    // match; their changes aren't covered here (the save guard still applies).
+    if (filePath.startsWith('cate-companion://')) return
+
+    const targetPosix = filePath.replace(/\\/g, '/')
+    let disposed = false
+
+    // Apply a fresh on-disk version: silently reload a clean buffer, or raise a
+    // `changed` conflict when the buffer is dirty so unsaved edits aren't lost.
+    const applyDiskContent = (content: string) => {
+      if (disposed) return
+      const model = getModel()
+      if (!model || model.isDisposed()) return
+      // Disk already matches the buffer (e.g. our own save fired the event) —
+      // nothing diverges, so clear any stale conflict and skip the reset.
+      if (model.getValue() === content) {
+        baselineRef.current = content
+        setConflict(null)
+        return
+      }
+      if (isDirtyRef.current) {
+        setConflict({ kind: 'changed', diskContent: content })
+        return
+      }
+      replaceBuffer(content)
+      baselineRef.current = content
+      setConflict(null)
+    }
+
+    const stop = watchFsRoot(
+      rootPath,
+      (event) => {
+        if (event.path.replace(/\\/g, '/') !== targetPosix) return
+
+        if (classifyExternalEvent(event.type, isDirtyRef.current) === 'conflict-deleted') {
+          // Guard against atomic-write churn (delete + immediate recreate): a
+          // real read a tick later tells us whether the file is truly gone.
+          window.setTimeout(() => {
+            if (disposed) return
+            window.electronAPI
+              .fsReadFile(filePath, workspaceId)
+              .then((content) => applyDiskContent(content))
+              .catch(() => {
+                if (disposed) return
+                // Genuinely deleted: the buffer is now unsaved work with no file
+                // behind it. Mark it dirty so the dot shows and close-confirm
+                // protects it, and offer to restore.
+                noteUserEdit()
+                setConflict({ kind: 'deleted' })
+              })
+          }, 150)
+          return
+        }
+
+        window.electronAPI
+          .fsReadFile(filePath, workspaceId)
+          .then((content) => applyDiskContent(content))
+          .catch(() => { /* vanished between event and read — leave buffer as-is */ })
+      },
+      workspaceId,
+    )
+
+    return () => {
+      disposed = true
+      stop()
+    }
+  }, [filePath, rootPath, workspaceId, diffMode, getModel, replaceBuffer, noteUserEdit])
+
+  // Reset conflict state when the panel switches files (a single EditorPanel
+  // mount is reused across dock tabs, so stale conflict UI must not carry over).
+  useEffect(() => {
+    setConflict(null)
+    setShowDiff(false)
+  }, [filePath])
+
+  const openDiff = useCallback(() => setShowDiff(true), [])
+  const closeDiff = useCallback(() => setShowDiff(false), [])
+
+  return {
+    filePathRef,
+    isDirtyRef,
+    conflict,
+    showDiff,
+    openDiff,
+    closeDiff,
+    noteLoaded,
+    noteUserEdit,
+    isExternalReplace,
+    save,
+    reload,
+    keepMine,
+    keepBoth,
+    saveToRestore,
+    dismiss,
+  }
+}

--- a/src/renderer/panels/EditorConflictBanner.test.tsx
+++ b/src/renderer/panels/EditorConflictBanner.test.tsx
@@ -1,0 +1,95 @@
+// =============================================================================
+// Tests for EditorConflictBanner — the non-blocking strip shown when an open
+// file diverges from disk (changed by an external tool, or deleted).
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+import EditorConflictBanner from './EditorConflictBanner'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+})
+
+function buttonByText(label: string): HTMLButtonElement {
+  const btn = Array.from(host.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label,
+  )
+  if (!btn) throw new Error(`button "${label}" not found; have: ${Array.from(host.querySelectorAll('button')).map((b) => b.textContent).join(', ')}`)
+  return btn as HTMLButtonElement
+}
+
+describe('EditorConflictBanner — changed', () => {
+  it('renders Reload, Keep mine, Keep both and View diff and wires their handlers', () => {
+    const onReload = vi.fn()
+    const onKeepMine = vi.fn()
+    const onKeepBoth = vi.fn()
+    const onViewDiff = vi.fn()
+    act(() => {
+      root.render(
+        <EditorConflictBanner
+          kind="changed"
+          onReload={onReload}
+          onKeepMine={onKeepMine}
+          onKeepBoth={onKeepBoth}
+          onViewDiff={onViewDiff}
+          onSaveToRestore={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      )
+    })
+
+    act(() => { buttonByText('Reload').click() })
+    act(() => { buttonByText('Keep mine').click() })
+    act(() => { buttonByText('Keep both').click() })
+    act(() => { buttonByText('View diff').click() })
+
+    expect(onReload).toHaveBeenCalledTimes(1)
+    expect(onKeepMine).toHaveBeenCalledTimes(1)
+    expect(onKeepBoth).toHaveBeenCalledTimes(1)
+    expect(onViewDiff).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('EditorConflictBanner — deleted', () => {
+  it('renders Save to restore + Dismiss and not the change actions', () => {
+    const onSaveToRestore = vi.fn()
+    const onDismiss = vi.fn()
+    act(() => {
+      root.render(
+        <EditorConflictBanner
+          kind="deleted"
+          onReload={vi.fn()}
+          onKeepMine={vi.fn()}
+          onKeepBoth={vi.fn()}
+          onViewDiff={vi.fn()}
+          onSaveToRestore={onSaveToRestore}
+          onDismiss={onDismiss}
+        />,
+      )
+    })
+
+    expect(
+      Array.from(host.querySelectorAll('button')).some((b) => b.textContent?.trim() === 'Reload'),
+    ).toBe(false)
+
+    act(() => { buttonByText('Save to restore').click() })
+    act(() => { buttonByText('Dismiss').click() })
+
+    expect(onSaveToRestore).toHaveBeenCalledTimes(1)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/panels/EditorConflictBanner.tsx
+++ b/src/renderer/panels/EditorConflictBanner.tsx
@@ -1,0 +1,86 @@
+// =============================================================================
+// EditorConflictBanner — a non-blocking strip shown above the editor when the
+// open file has diverged from disk.
+//
+//   kind="changed" — an external tool rewrote the file while the buffer had
+//                    unsaved edits. Offers Reload (take disk), Keep mine, and
+//                    View diff (disk ⇆ buffer in a Monaco diff overlay).
+//   kind="deleted" — the file was removed from disk while open. The buffer is
+//                    now unsaved work with no file behind it; Save to restore
+//                    re-creates it, Dismiss keeps the buffer dirty so the
+//                    close-confirm still protects it.
+// =============================================================================
+
+import { Warning } from '@phosphor-icons/react'
+
+export interface EditorConflictBannerProps {
+  kind: 'changed' | 'deleted'
+  onReload: () => void
+  onKeepMine: () => void
+  onKeepBoth: () => void
+  onViewDiff: () => void
+  onSaveToRestore: () => void
+  onDismiss: () => void
+}
+
+function BannerButton({
+  onClick,
+  children,
+  emphasis,
+}: {
+  onClick: () => void
+  children: string
+  emphasis?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
+        emphasis
+          ? 'bg-warning text-white hover:opacity-90'
+          : 'bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+export default function EditorConflictBanner({
+  kind,
+  onReload,
+  onKeepMine,
+  onKeepBoth,
+  onViewDiff,
+  onSaveToRestore,
+  onDismiss,
+}: EditorConflictBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-2 shrink-0 px-2 py-0.5 border-b border-warning bg-warning-tint"
+    >
+      <Warning size={12} weight="fill" className="text-warning shrink-0" />
+      <span className="text-[11px] text-primary leading-tight flex-1 min-w-0 truncate">
+        {kind === 'changed'
+          ? 'Changed on disk. Your unsaved edits are kept.'
+          : 'Deleted on disk. Save to restore, or lose it on close.'}
+      </span>
+      <div className="flex items-center gap-1 shrink-0">
+        {kind === 'changed' ? (
+          <>
+            <BannerButton onClick={onViewDiff}>View diff</BannerButton>
+            <BannerButton onClick={onReload}>Reload</BannerButton>
+            <BannerButton onClick={onKeepMine}>Keep mine</BannerButton>
+            <BannerButton onClick={onKeepBoth} emphasis>Keep both</BannerButton>
+          </>
+        ) : (
+          <>
+            <BannerButton onClick={onDismiss}>Dismiss</BannerButton>
+            <BannerButton onClick={onSaveToRestore} emphasis>Save to restore</BannerButton>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -32,9 +32,9 @@ import {
   resolveLoadedModel,
   markLoadFailed,
   clearLoadFailed,
-  isLoadFailed,
 } from '../lib/editor/modelCache'
-import { watchFsRoot } from '../lib/fs/fsWatchManager'
+import { useFileSync } from '../lib/editor/useFileSync'
+import EditorConflictBanner from './EditorConflictBanner'
 import { Tooltip } from '../ui/Tooltip'
 
 // -----------------------------------------------------------------------------
@@ -140,13 +140,6 @@ monacoGlobal.MonacoEnvironment = {
     }
   },
 }
-
-// File paths whose model is mid external-reload (setValue pulled from disk). A
-// shared cached model can back several editors, so the setValue fires
-// onDidChangeModelContent on every one of them — we mark the path here for the
-// synchronous duration of setValue so those change events aren't mistaken for a
-// user edit and flip the panel(s) to dirty.
-const externalReloadPaths = new Set<string>()
 
 // -----------------------------------------------------------------------------
 // Monaco theme — a single 'cate-active' theme built from the active unified
@@ -301,16 +294,7 @@ export default function EditorPanel({
   const containerRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
   const diffEditorRef = useRef<monaco.editor.IStandaloneDiffEditor | null>(null)
-  const isDirtyRef = useRef(false)
-  const filePathRef = useRef(filePath)
-
-  // Only overwrite the ref from the prop when the prop is itself defined.
-  // In detached/dock windows the shell keeps its own local `panels` state
-  // and doesn't observe the global appStore update we issue after a
-  // Save-As, so the `filePath` prop stays undefined for the lifetime of
-  // this mount. Without this guard, every re-render would wipe out the
-  // path we just learned and the next Cmd+S would re-open Save-As.
-  if (filePath !== undefined) filePathRef.current = filePath
+  const diffOverlayRef = useRef<HTMLDivElement>(null)
 
   const [markdownContent, setMarkdownContent] = useState('')
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -332,86 +316,42 @@ export default function EditorPanel({
   const rootPath = ws?.rootPath
   const isMarkdown = !!filePath && /\.mdx?$/i.test(filePath)
 
-  // ---------------------------------------------------------------------------
-  // Save handler (regular editor only)
-  // ---------------------------------------------------------------------------
+  const markdownPreviewRef = useRef(markdownPreview)
+  markdownPreviewRef.current = markdownPreview
 
-  const save = useCallback(async (): Promise<boolean> => {
-    const editor = editorRef.current
-    if (!editor || diffMode) return false
+  // Live accessor for our Monaco model, handed to the sync hook so it can read
+  // and replace the buffer without owning the editor's lifecycle.
+  const getModel = useCallback(() => editorRef.current?.getModel() ?? null, [])
+  // Keep the markdown preview in step when the hook replaces the buffer from disk
+  // (external reload / merge).
+  const onExternalReplace = useCallback((content: string) => {
+    if (markdownPreviewRef.current) setMarkdownContent(content)
+  }, [])
 
-    // Never write a buffer that failed to load (or never finished loading) back
-    // to disk — its contents are an empty placeholder, not the user's file, and
-    // saving would truncate the real file.
-    if (filePathRef.current && isLoadFailed(filePathRef.current)) {
-      log.warn('[EditorPanel] Refusing to save — file never loaded successfully:', filePathRef.current)
-      return false
-    }
-
-    const content = editor.getValue()
-
-    // Untitled buffer (no filePath): prompt the user for a destination via the
-    // native Save-As dialog. Once a path is chosen, persist it on the panel
-    // state so future saves (Cmd+S, close-confirm) write to the same file.
-    let targetPath = filePathRef.current
-    let isInitialSave = false
-    if (!targetPath) {
-      const currentPanel = useAppStore
-        .getState()
-        .workspaces.find((w) => w.id === workspaceId)?.panels[panelId]
-      const cleanTitle = currentPanel?.title?.replace(/\s•\s*$/, '').trim()
-      const defaultName = cleanTitle && cleanTitle !== 'Untitled' ? cleanTitle : 'Untitled.txt'
-      // Pick the separator that matches the workspace root so the prefilled
-      // path looks native on the user's platform (Electron's Save dialog
-      // accepts either on Windows but mixed slashes look sloppy).
-      const sep = rootPath?.includes('\\') ? '\\' : '/'
-      const defaultPath = rootPath ? `${rootPath}${sep}${defaultName}` : defaultName
-      const chosen = await window.electronAPI.saveFileDialog({ defaultName, defaultPath })
-      if (!chosen) return false
-      targetPath = chosen
-      isInitialSave = true
-    }
-
-    try {
-      await window.electronAPI.fsWriteFile(targetPath, content, workspaceId)
-    } catch (err) {
-      log.error('[EditorPanel] Failed to save file:', err)
-      return false
-    }
-
-    isDirtyRef.current = false
-    useAppStore.getState().setPanelDirty(workspaceId, panelId, false)
-
-    // Use both separators so the basename is correct on Windows (`\\`) as
-    // well as POSIX (`/`).
-    const fileName = targetPath.split(/[\\/]/).pop() || 'Untitled'
-    useAppStore.getState().updatePanelTitle(workspaceId, panelId, fileName)
-
-    if (isInitialSave) {
-      // Persist the new filePath in the global appStore (the source of
-      // truth for the main window's panels). In detached/dock windows the
-      // shell maintains its own local panels state instead, so we ALSO
-      // update filePathRef directly: that makes the next Cmd+S in this
-      // exact mount write to the chosen file instead of reopening Save-As,
-      // regardless of whether the prop ever updates.
-      filePathRef.current = targetPath
-      useAppStore.getState().updatePanelFilePath(workspaceId, panelId, targetPath)
-      // Clear the unsaved-content cache so the remount-from-disk path is
-      // the single source of truth for the editor model when the prop
-      // does flip (main window).
-      useAppStore.getState().setPanelUnsavedContent(workspaceId, panelId, undefined)
-      // Notify the surrounding detached/dock shell (DockWindowShell) so its
-      // session sync — which feeds persistence and close prompts in detached
-      // windows — flushes the new filePath, title, and clean dirty flag. The
-      // main window ignores this event because it reads from appStore directly.
-      window.dispatchEvent(
-        new CustomEvent('editor:panel-saved-as', {
-          detail: { panelId, filePath: targetPath, title: fileName },
-        }),
-      )
-    }
-    return true
-  }, [workspaceId, panelId, diffMode, rootPath])
+  // The whole buffer↔disk lifecycle lives in this one hook: baseline tracking,
+  // dirty state, external-change/delete conflicts, the guarded save, and the
+  // reload / keep-mine / keep-both / restore resolutions.
+  const sync = useFileSync({
+    workspaceId,
+    panelId,
+    filePath,
+    rootPath,
+    diffMode,
+    getModel,
+    onExternalReplace,
+  })
+  const {
+    conflict,
+    showDiff,
+    save,
+    reload,
+    keepMine,
+    keepBoth,
+    openDiff,
+    closeDiff,
+    saveToRestore,
+    dismiss,
+  } = sync
 
   // ---------------------------------------------------------------------------
   // Mount: create regular editor OR diff editor
@@ -564,6 +504,10 @@ export default function EditorPanel({
         retainModel(filePath)
         modelRetained = true
         editor.setModel(cached)
+        // Best-effort baseline from the warm model (assumed to mirror disk). If
+        // the file changed on disk while this panel was closed, the save guard
+        // catches the divergence on the next save.
+        sync.noteLoaded(cached.getValue())
         applyPendingReveal()
       } else {
         const language = detectLanguage(filePath)
@@ -587,6 +531,8 @@ export default function EditorPanel({
             retainModel(targetPath)
             modelRetained = true
             editor.setModel(model)
+            // Freshly read from disk — this is our sync point for the save guard.
+            sync.noteLoaded(content)
             applyPendingReveal()
           })
           .catch((err) => {
@@ -607,8 +553,7 @@ export default function EditorPanel({
       createdModel = model
       editor.setModel(model)
       if (restored) {
-        isDirtyRef.current = true
-        useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
+        sync.noteUserEdit()
       }
     }
 
@@ -621,24 +566,14 @@ export default function EditorPanel({
 
     let unsavedSaveTimer: ReturnType<typeof setTimeout> | null = null
     const changeDisposable = editor.onDidChangeModelContent(() => {
-      // A disk-driven reload (see the fs-watch effect below) replaces the model
-      // value; that isn't a user edit, so don't flip the panel to dirty.
-      if (filePathRef.current && externalReloadPaths.has(filePathRef.current)) return
-      if (!isDirtyRef.current) {
-        isDirtyRef.current = true
-        useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
-
-        if (filePathRef.current) {
-          const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
-          useAppStore
-            .getState()
-            .updatePanelTitle(workspaceId, panelId, `${fileName} \u2022`)
-        }
-      }
+      // A disk-driven reload/merge (in useFileSync) replaces the model value;
+      // that isn't a user edit, so don't flip the panel to dirty.
+      if (sync.isExternalReplace()) return
+      sync.noteUserEdit()
 
       // Persist scratch-editor content to the store (debounced) so it
       // survives canvas/workspace switches and app restarts.
-      if (!filePathRef.current) {
+      if (!sync.filePathRef.current) {
         if (unsavedSaveTimer) clearTimeout(unsavedSaveTimer)
         unsavedSaveTimer = setTimeout(() => {
           const value = editor.getModel()?.getValue() ?? ''
@@ -744,58 +679,44 @@ export default function EditorPanel({
   }, [markdownPreview, isMarkdown, filePath, workspaceId])
 
   // ---------------------------------------------------------------------------
-  // Reload the editor model when the file changes on disk externally
-  //
-  // Monaco models are cached at module level and survive panel unmount, and the
-  // markdown preview renders from the model's value — so without this an edit
-  // made by an external tool (another editor, an AI agent, git checkout) never
-  // reaches the open buffer or its preview, and reopening the file reuses the
-  // stale cached model. Watch the workspace root (the watcher is refcounted and
-  // shared with the file explorer, so this adds no new OS watcher) and pull the
-  // fresh content into the model when our file is updated on disk. Skipped while
-  // the buffer is dirty so we never clobber the user's unsaved edits.
+  // Diff overlay — disk (original) ⇆ unsaved buffer (modified), read-only.
+  // Mounted only while the user has the diff open on a `changed` conflict.
+  // (The buffer↔disk watch, reload, and conflict logic all live in useFileSync.)
   // ---------------------------------------------------------------------------
 
-  const markdownPreviewRef = useRef(markdownPreview)
-  markdownPreviewRef.current = markdownPreview
-
   useEffect(() => {
-    if (!filePath || !rootPath || diffMode) return
-    // Remote/companion files live behind a locator the local root watcher can't
-    // match; their changes aren't covered here.
-    if (filePath.startsWith('cate-companion://')) return
+    if (!showDiff || conflict?.kind !== 'changed' || !diffOverlayRef.current) return
 
-    const targetPosix = filePath.replace(/\\/g, '/')
+    const fontSize = useSettingsStore.getState().editorFontSize
+    const fontFamily = resolveEditorFontFamily(useSettingsStore.getState().editorFontFamily)
+    const language = filePath ? detectLanguage(filePath) : 'plaintext'
+    const bufferValue = editorRef.current?.getModel()?.getValue() ?? ''
 
-    return watchFsRoot(
-      rootPath,
-      (event) => {
-        if (event.type === 'delete') return
-        if (event.path.replace(/\\/g, '/') !== targetPosix) return
-        // The user's unsaved work wins until they save it themselves.
-        if (isDirtyRef.current) return
+    const original = monaco.editor.createModel(conflict.diskContent ?? '', language)
+    const modified = monaco.editor.createModel(bufferValue, language)
+    const diff = monaco.editor.createDiffEditor(diffOverlayRef.current, {
+      theme: CATE_MONACO_THEME,
+      fontFamily,
+      fontSize: fontSize || 12,
+      readOnly: true,
+      renderSideBySide: true,
+      automaticLayout: false,
+      scrollBeyondLastLine: false,
+      minimap: { enabled: false },
+      padding: { top: 8, bottom: 8 },
+    })
+    diff.setModel({ original, modified })
 
-        window.electronAPI
-          .fsReadFile(filePath, workspaceId)
-          .then((content) => {
-            const model = editorRef.current?.getModel()
-            if (!model || model.isDisposed()) return
-            // No-op when disk already matches the buffer (e.g. our own save
-            // fired the event) — avoids a needless full-model reset.
-            if (model.getValue() === content) return
-            externalReloadPaths.add(filePath)
-            try {
-              model.setValue(content)
-            } finally {
-              externalReloadPaths.delete(filePath)
-            }
-            if (markdownPreviewRef.current) setMarkdownContent(content)
-          })
-          .catch(() => { /* file vanished or unreadable — leave the buffer as-is */ })
-      },
-      workspaceId,
-    )
-  }, [filePath, rootPath, workspaceId, diffMode])
+    const layoutObserver = new ResizeObserver(() => diff.layout())
+    layoutObserver.observe(diffOverlayRef.current)
+
+    return () => {
+      layoutObserver.disconnect()
+      diff.dispose()
+      original.dispose()
+      modified.dispose()
+    }
+  }, [showDiff, conflict, filePath])
 
   // ---------------------------------------------------------------------------
   // Watch app theme changes and update Monaco theme
@@ -835,7 +756,32 @@ export default function EditorPanel({
           </button>
         </div>
       )}
+      {conflict && !diffMode && (
+        <EditorConflictBanner
+          kind={conflict.kind}
+          onReload={reload}
+          onKeepMine={keepMine}
+          onKeepBoth={keepBoth}
+          onViewDiff={openDiff}
+          onSaveToRestore={saveToRestore}
+          onDismiss={dismiss}
+        />
+      )}
       <div className="flex-1 min-h-0 relative">
+        {showDiff && conflict?.kind === 'changed' && (
+          <div className="absolute inset-0 z-30 flex flex-col bg-surface-1">
+            <div className="flex items-center justify-between shrink-0 px-2 py-0.5 border-b border-subtle">
+              <span className="text-[11px] text-secondary">On disk vs your unsaved changes</span>
+              <button
+                onClick={closeDiff}
+                className="px-2 py-0.5 rounded text-[11px] font-medium bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary transition-colors"
+              >
+                Close diff
+              </button>
+            </div>
+            <div ref={diffOverlayRef} className="flex-1 min-h-0" />
+          </div>
+        )}
         {markdownPreview && isMarkdown && (
           <MarkdownPreview content={markdownContent} />
         )}


### PR DESCRIPTION
## What

When a file open in an editor panel is changed or deleted on disk by an external tool (another editor, git, an AI agent), Cate now surfaces it instead of silently reloading or silently losing the user's unsaved work.

| Situation | Behavior |
|---|---|
| Clean buffer + external change | Silent live reload (unchanged) |
| **Unsaved** buffer + external change | Conflict banner: **View diff / Reload / Keep mine / Keep both** |
| File **deleted** while open | Buffer marked dirty + *"save to restore"* banner |
| Save while disk diverged | Re-reads disk first and **refuses to overwrite** the external change |

The save-time guard is watcher-independent, so it protects against data loss even where the fs watcher isn't delivering events.

**Keep both** runs a line-based 3-way merge (baseline = loaded content, mine = buffer, theirs = disk): non-overlapping edits combine cleanly; overlapping edits get git-style conflict markers for manual resolution. The merged result lands in the buffer for review — nothing is written to disk until the user saves.

## Architecture

The whole buffer↔disk lifecycle lives in one `useFileSync` hook, composed from pure, unit-tested helpers:

- `externalConflict.ts` — `classifyExternalEvent`, `shouldBlockOverwrite`
- `threeWayMerge.ts` — line-based 3-way merge
- `useFileSync.ts` — the state machine (baseline / dirty / conflict, watch, guarded save, resolutions)

`EditorPanel` stays a thin Monaco-lifecycle + render component; `EditorConflictBanner` is a dumb presentational strip.

## Tests

- Pure helpers: classify (3), overwrite-guard (5), 3-way merge (9)
- Banner rendering + callbacks (2)
- `useFileSync` state-machine integration (10): save writes vs blocks, external change (dirty/clean), delete + atomic-write recreate, reload, keepBoth merge, keepMine force-save, saveToRestore

Full suite: 176 files / 1579 tests passing.