### PR TITLE
fix(fs-watch): defer watcher start until workspace roots are registered

### DIFF
--- a/src/renderer/lib/fs/fsWatchManager.test.ts
+++ b/src/renderer/lib/fs/fsWatchManager.test.ts
@@ -1,0 +1,121 @@
+// =============================================================================
+// Tests for fsWatchManager — verifies that the watcher start is deferred until
+// workspace registration (awaitWorkspaceSync) has completed, closing the
+// startup race where a watch beats allowed-root registration and is denied with
+// "outside allowed directories" for the whole session.
+// =============================================================================
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FsWatchEvent } from './fsWatchManager'
+
+// A controllable awaitWorkspaceSync: a fresh pending promise per test that the
+// test resolves to simulate workspace registration completing.
+const sync = vi.hoisted(() => {
+  const state = { resolve: () => {}, promise: Promise.resolve() as Promise<void> }
+  const reset = () => {
+    state.promise = new Promise<void>((r) => { state.resolve = r })
+  }
+  return { state, reset }
+})
+
+vi.mock('../../stores/appStore/helpers', () => ({
+  awaitWorkspaceSync: () => sync.state.promise,
+}))
+
+const ROOT = '/proj'
+const WS = 'w1'
+
+let api: {
+  fsWatchStart: ReturnType<typeof vi.fn>
+  fsWatchStop: ReturnType<typeof vi.fn>
+  onFsWatchEvent: ReturnType<typeof vi.fn>
+}
+let eventCb: ((e: FsWatchEvent) => void) | null = null
+let watchFsRoot: typeof import('./fsWatchManager').watchFsRoot
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(async () => {
+  sync.reset()
+  eventCb = null
+  api = {
+    fsWatchStart: vi.fn().mockResolvedValue(undefined),
+    fsWatchStop: vi.fn().mockResolvedValue(undefined),
+    onFsWatchEvent: vi.fn((cb: (e: FsWatchEvent) => void) => {
+      eventCb = cb
+      return () => { eventCb = null }
+    }),
+  }
+  ;(globalThis as unknown as { window: unknown }).window = { electronAPI: api }
+  // Fresh module state (the entries Map) for each test.
+  vi.resetModules()
+  ;({ watchFsRoot } = await import('./fsWatchManager'))
+})
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window
+})
+
+describe('fsWatchManager — start ordering', () => {
+  it('does not start the watcher until workspace sync resolves', async () => {
+    const stop = watchFsRoot(ROOT, vi.fn(), WS)
+
+    // Event subscription is wired synchronously, but the start is deferred.
+    expect(api.onFsWatchEvent).toHaveBeenCalledTimes(1)
+    expect(api.fsWatchStart).not.toHaveBeenCalled()
+
+    sync.state.resolve()
+    await flush()
+
+    expect(api.fsWatchStart).toHaveBeenCalledTimes(1)
+    expect(api.fsWatchStart).toHaveBeenCalledWith(ROOT, WS)
+    stop()
+  })
+
+  it('never starts (or stops) the watcher if unsubscribed before sync resolves', async () => {
+    const stop = watchFsRoot(ROOT, vi.fn(), WS)
+    stop() // torn down while sync still pending
+
+    sync.state.resolve()
+    await flush()
+
+    expect(api.fsWatchStart).not.toHaveBeenCalled()
+    // No spurious stop for a watcher that never started (no "outside allowed
+    // directories" noise from a quick subscribe/unsubscribe during the race).
+    expect(api.fsWatchStop).not.toHaveBeenCalled()
+  })
+
+  it('forwards events to the listener once started', async () => {
+    const listener = vi.fn()
+    const stop = watchFsRoot(ROOT, listener, WS)
+    sync.state.resolve()
+    await flush()
+
+    eventCb!({ type: 'update', path: '/proj/file.txt' })
+    expect(listener).toHaveBeenCalledWith({ type: 'update', path: '/proj/file.txt' })
+
+    // Events outside the root are filtered out.
+    eventCb!({ type: 'update', path: '/other/file.txt' })
+    expect(listener).toHaveBeenCalledTimes(1)
+    stop()
+  })
+})
+
+describe('fsWatchManager — refcounting', () => {
+  it('starts once for multiple subscribers and stops on the last unsubscribe', async () => {
+    const a = watchFsRoot(ROOT, vi.fn(), WS)
+    const b = watchFsRoot(ROOT, vi.fn(), WS)
+    sync.state.resolve()
+    await flush()
+
+    // One shared watcher despite two subscribers.
+    expect(api.onFsWatchEvent).toHaveBeenCalledTimes(1)
+    expect(api.fsWatchStart).toHaveBeenCalledTimes(1)
+
+    a()
+    expect(api.fsWatchStop).not.toHaveBeenCalled()
+    b()
+    expect(api.fsWatchStop).toHaveBeenCalledTimes(1)
+    expect(api.fsWatchStop).toHaveBeenCalledWith(ROOT, WS)
+  })
+})

--- a/src/renderer/lib/fs/fsWatchManager.ts
+++ b/src/renderer/lib/fs/fsWatchManager.ts
@@ -14,6 +14,8 @@
 // transition, and fans the single onFsWatchEvent stream out to every subscriber.
 // =============================================================================
 
+import { awaitWorkspaceSync } from '../../stores/appStore/helpers'
+
 export interface FsWatchEvent {
   type: 'create' | 'update' | 'delete'
   path: string
@@ -23,6 +25,11 @@ type Listener = (event: FsWatchEvent) => void
 interface Entry {
   listeners: Set<Listener>
   unsubscribe: (() => void) | null
+  /** Whether fsWatchStart was actually issued (it's deferred — see below). The
+   *  teardown only calls fsWatchStop when a start was issued, so a quick
+   *  subscribe/unsubscribe during the deferral window doesn't try to stop a
+   *  watcher that never started (which would log a spurious denial). */
+  started: boolean
 }
 
 const entries = new Map<string, Entry>()
@@ -42,16 +49,31 @@ export function watchFsRoot(rootPath: string, listener: Listener, workspaceId?: 
 
   let entry = entries.get(rootPath)
   if (!entry) {
-    const created: Entry = { listeners: new Set(), unsubscribe: null }
+    const created: Entry = { listeners: new Set(), unsubscribe: null, started: false }
     entries.set(rootPath, created)
-    window.electronAPI.fsWatchStart(rootPath, workspaceId).catch(() => { /* watcher unavailable */ })
     const rootPosix = toPosix(rootPath)
     // onFsWatchEvent delivers every watch event for this window; only forward
     // those under this root (matters when multiple roots are watched at once).
+    // Subscribed synchronously so events are caught the moment the watcher starts.
     created.unsubscribe = window.electronAPI.onFsWatchEvent((event) => {
       if (toPosix(event.path).startsWith(rootPosix)) {
         entries.get(rootPath)?.listeners.forEach((l) => l(event))
       }
+    })
+    // Defer the watcher start until any in-flight workspace:create/update has
+    // registered this root in the main allowedRoots set. A watch requested during
+    // session restore would otherwise beat that registration and be denied with
+    // "outside allowed directories" — and since the renderer never retries, the
+    // root would stay unwatched for the whole session (breaking the file explorer,
+    // git status, and editor external-change detection). awaitWorkspaceSync()
+    // resolves immediately when nothing is pending, so steady-state watches are
+    // unaffected.
+    awaitWorkspaceSync().then(() => {
+      // Bail if every subscriber unsubscribed (or the entry was torn down and
+      // recreated) while we waited — the current entry owns its own start.
+      if (entries.get(rootPath) !== created) return
+      created.started = true
+      window.electronAPI?.fsWatchStart(rootPath, workspaceId).catch(() => { /* watcher unavailable */ })
     })
     entry = created
   }
@@ -65,7 +87,10 @@ export function watchFsRoot(rootPath: string, listener: Listener, workspaceId?: 
     if (e.listeners.size === 0) {
       e.unsubscribe?.()
       entries.delete(rootPath)
-      window.electronAPI?.fsWatchStop(rootPath, workspaceId).catch(() => { /* already gone */ })
+      // Only stop a watcher we actually started — see Entry.started.
+      if (e.started) {
+        window.electronAPI?.fsWatchStop(rootPath, workspaceId).catch(() => { /* already gone */ })
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

A filesystem watch requested during **session restore** can fire `fsWatchStart` *before* the renderer's `workspace:create` round-trip has registered the workspace root in the main-process `allowedRoots` set. The watch is then denied with `Access denied: path "…" is outside allowed directories`, and because the renderer never retries, the root stays **unwatched for the entire session**.

Observed at startup (~20ms race):

```
fs:watchStart  /Users/.../websites-public  -> outside allowed directories
fs:watchStart  /Users/.../cate-wt-test     -> outside allowed directories
Workspace created: …websites-public        ← allowed root registered AFTER the watch failed
```

This breaks everything that relies on the root watcher: file-explorer refresh, git status, and the editor's external-change/delete detection (the editor panel never receives fs events).

## Fix

Gate the watcher start behind `awaitWorkspaceSync()` in `fsWatchManager` — the **existing** mechanism `terminal:create` already uses to avoid this exact race (see `appStore/helpers.ts`).

- The `onFsWatchEvent` subscription stays **synchronous**, so events are caught the moment the watcher starts.
- The deferred `fsWatchStart` is **skipped** if every subscriber unsubscribes (or the entry is recreated) while the sync is still pending.
- `fsWatchStop` is now only called for a watcher that was actually started, so a quick subscribe/unsubscribe during the deferral window no longer logs a spurious denial on stop.
- `awaitWorkspaceSync()` resolves immediately when nothing is pending, so steady-state watches are unaffected.

This is the single choke point all watchers go through (explorer, git, search, editor), so fixing it here fixes them all.

## Verified live

Fresh dev startup, before vs after:

| | watchStart denials | watchStop denials |
|---|---|---|
| before | 8 | 4 |
| after | **0** | **0** |

## Tests

New `fsWatchManager.test.ts`:
- start is deferred until workspace sync resolves (then `fsWatchStart` is called with the right args)
- never starts **or stops** if unsubscribed before sync resolves
- forwards events to listeners once started, filtering out-of-root paths
- refcounting: one start for N subscribers, one stop on the last unsubscribe

Full suite: 173 files / 1553 passing (+1 skipped, pre-existing env test).