### PR TITLE
feat(telemetry): backfill pre-existing installs as a one-time census

### DIFF
--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -27,7 +27,7 @@ vi.mock('./logger', () => ({
   default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }))
 
-const { decideUpdateAction, sanitizeFeedbackPayload, sanitizeUsageProps } = await import('./analytics')
+const { decideUpdateAction, decideCensusAction, sanitizeFeedbackPayload, sanitizeUsageProps } = await import('./analytics')
 
 describe('sanitizeUsageProps', () => {
   test('keeps small primitives and drops everything else', () => {
@@ -158,6 +158,38 @@ describe('decideUpdateAction', () => {
     const action = decideUpdateAction('1.1.0', state)
     if (action.kind !== 'version_changed') throw new Error('expected version_changed')
     expect((action.nextState as Record<string, unknown>).futureField).toBe('preserve me')
+  })
+})
+
+describe('decideCensusAction', () => {
+  test('previously-silent install (lastSeenVersion set, no prior install-id): backfills once', () => {
+    const action = decideCensusAction({ lastSeenVersion: '1.0.0' }, false)
+    expect(action.kind).toBe('backfill')
+    if (action.kind !== 'backfill') return
+    expect(action.fromVersion).toBe('1.0.0')
+    expect(action.nextState).toEqual({ lastSeenVersion: '1.0.0', censusSent: true })
+  })
+
+  test('genuinely-new install (no lastSeenVersion): no backfill — app_install covers it', () => {
+    expect(decideCensusAction({}, false).kind).toBe('none')
+  })
+
+  test('install that already sent telemetry (install-id pre-existed): no backfill', () => {
+    expect(decideCensusAction({ lastSeenVersion: '1.0.0' }, true).kind).toBe('none')
+  })
+
+  test('census already sent: never re-fires, even if other conditions hold', () => {
+    expect(decideCensusAction({ lastSeenVersion: '1.0.0', censusSent: true }, false).kind).toBe('none')
+  })
+
+  test('preserves unrelated state fields when marking censusSent', () => {
+    const action = decideCensusAction(
+      { lastSeenVersion: '1.0.0', pendingFeedbackForVersion: '1.0.0' },
+      false,
+    )
+    if (action.kind !== 'backfill') throw new Error('expected backfill')
+    expect(action.nextState.pendingFeedbackForVersion).toBe('1.0.0')
+    expect(action.nextState.censusSent).toBe(true)
   })
 })
 

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -6,6 +6,12 @@
 // What we send:
 //   - app_start                : version, platform, arch, locale, electron version
 //   - app_install              : first launch of this install
+//   - app_install_backfill     : one-time census of a pre-existing install that
+//                                ran an earlier (opt-in) build but never sent
+//                                telemetry. Carries from_version (last seen) so
+//                                the backend can count it as a recovered install
+//                                without inflating "new installs". See
+//                                decideCensusAction.
 //   - app_updated              : from_version → to_version (detected via lastSeenVersion)
 //   - update_download_clicked  : user clicked "Download" on the update button
 //   - update_install_clicked   : user clicked "Restart" to install
@@ -26,6 +32,7 @@
 import { app, BrowserWindow, ipcMain, net, shell } from 'electron'
 import log from './logger'
 import { getCommonContext } from './appContext'
+import { installIdPreexisted } from './installId'
 import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, appendLine, removeFile } from './jsonFileStore'
 import { ANALYTICS_FEEDBACK_PROMPT, ANALYTICS_FEEDBACK_SUBMIT, ANALYTICS_FEEDBACK_DISMISS, ANALYTICS_FEEDBACK_GET_PENDING, ANALYTICS_LINK_CLICK, ANALYTICS_TRACK_USAGE, OPEN_EXTERNAL_URL } from '../shared/ipc-channels'
 
@@ -50,6 +57,9 @@ export interface AnalyticsState {
   pendingFeedbackForVersion?: string
   /** Track previous version so the feedback event can include both. */
   pendingFeedbackFromVersion?: string
+  /** Set once the one-time install census (app_install_backfill) has been
+   *  emitted for a previously-silent install, so it never re-fires. */
+  censusSent?: boolean
 }
 
 function readState(): AnalyticsState {
@@ -343,6 +353,34 @@ export type UpdateAction =
       prompt?: { from: string; to: string }
     }
 
+// ---------------------------------------------------------------------------
+// Install census — one-time backfill of installs that existed under an earlier
+// opt-in build but never sent telemetry. Such an install has a recorded
+// `lastSeenVersion` (checkAndReportUpdate wrote it even when sends were gated
+// off) yet no install-id file (the id is written only inside the send path).
+// We emit a single `app_install_backfill` so the backend can count it as a
+// recovered install. Genuinely-new installs have no lastSeenVersion; installs
+// that already sent telemetry had their install-id file pre-exist — neither
+// qualifies, so this can't double-count. Pure for unit testing.
+// ---------------------------------------------------------------------------
+
+export type CensusAction =
+  | { kind: 'none' }
+  | { kind: 'backfill'; fromVersion: string; nextState: AnalyticsState }
+
+export function decideCensusAction(state: AnalyticsState, installIdPreexistedFlag: boolean): CensusAction {
+  if (state.censusSent) return { kind: 'none' }
+  // Already counted: a pre-existing install-id means telemetry was sent before.
+  if (installIdPreexistedFlag) return { kind: 'none' }
+  // Brand-new install: nothing to backfill (a normal app_install covers it).
+  if (!state.lastSeenVersion) return { kind: 'none' }
+  return {
+    kind: 'backfill',
+    fromVersion: state.lastSeenVersion,
+    nextState: { ...state, censusSent: true },
+  }
+}
+
 function isMajorOrMinorBump(from: string, to: string): boolean {
   const pa = from.replace(/^v/, '').split('.').map(Number)
   const pb = to.replace(/^v/, '').split('.').map(Number)
@@ -408,6 +446,17 @@ export async function checkAndReportUpdate(mainWin: BrowserWindow): Promise<void
   }
 
   const current = app.getVersion()
+
+  // One-time install census: backfill a pre-existing install that ran an
+  // earlier opt-in build but never sent telemetry. Runs alongside (not instead
+  // of) the normal app_start/app_updated flow. Persist censusSent first, then
+  // re-read so the update decision below preserves the flag.
+  const census = decideCensusAction(readState(), installIdPreexisted())
+  if (census.kind === 'backfill') {
+    void sendEvent('app_install_backfill', { from_version: census.fromVersion, prior_run: true })
+    updateState({ censusSent: true })
+  }
+
   const state = readState()
   const action = decideUpdateAction(current, state)
 

--- a/src/main/installId.test.ts
+++ b/src/main/installId.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+
+// installId persists to disk via jsonFileStore; back it with an in-memory file
+// so we can exercise the "did a valid id already exist?" capture without fs.
+let store: Record<string, string> = {}
+vi.mock('./jsonFileStore', () => ({
+  readTextFile: (name: string) => (name in store ? store[name] : null),
+  writeTextFile: (name: string, value: string) => { store[name] = value },
+}))
+
+const VALID = '12345678-1234-1234-1234-1234567890ab'
+
+beforeEach(() => {
+  store = {}
+  vi.resetModules()
+})
+
+describe('installIdPreexisted', () => {
+  test('false when no id file exists (a freshly generated id is written)', async () => {
+    const { getInstallId, installIdPreexisted } = await import('./installId')
+    expect(installIdPreexisted()).toBe(false)
+    // The generated id is now persisted for subsequent sessions.
+    expect(getInstallId()).toMatch(/^[0-9a-f-]{36}$/i)
+  })
+
+  test('true when a valid id file already exists on first access', async () => {
+    store['install-id'] = VALID
+    const { getInstallId, installIdPreexisted } = await import('./installId')
+    expect(installIdPreexisted()).toBe(true)
+    expect(getInstallId()).toBe(VALID)
+  })
+
+  test('a malformed stored id counts as not pre-existing and is replaced', async () => {
+    store['install-id'] = 'not-a-uuid'
+    const { getInstallId, installIdPreexisted } = await import('./installId')
+    expect(installIdPreexisted()).toBe(false)
+    expect(getInstallId()).toMatch(/^[0-9a-f-]{36}$/i)
+  })
+})

--- a/src/main/installId.ts
+++ b/src/main/installId.ts
@@ -9,16 +9,33 @@ import { readTextFile, writeTextFile } from './jsonFileStore'
 
 const FILENAME = 'install-id'
 let cached: string | null = null
+// Captured on the very first getInstallId() call (which is the only writer of
+// the file): was a valid id already on disk? Since the file is written only
+// from inside the telemetry send path, a pre-existing id means this install has
+// sent telemetry before. A missing id on an install that has clearly run before
+// (see analytics census) marks a previously-silent install worth backfilling.
+let preexisted: boolean | null = null
 
 export function getInstallId(): string {
   if (cached) return cached
   const raw = readTextFile(FILENAME)?.trim()
-  if (raw && /^[0-9a-f-]{36}$/i.test(raw)) {
-    cached = raw
+  const valid = !!(raw && /^[0-9a-f-]{36}$/i.test(raw))
+  if (preexisted === null) preexisted = valid
+  if (valid) {
+    cached = raw!
     return cached
   }
   const id = crypto.randomUUID()
   writeTextFile(FILENAME, id)
   cached = id
   return id
+}
+
+/** Whether a valid install-id file already existed the first time the id was
+ *  read this session — i.e. this install has sent telemetry under a prior
+ *  (opt-in) build. Forces a read so the answer is well-defined even if nothing
+ *  else has touched the id yet. */
+export function installIdPreexisted(): boolean {
+  getInstallId()
+  return preexisted === true
 }


### PR DESCRIPTION
## Why

Telemetry is now always-on (#377), but installs that ran earlier **opt-in** builds and never sent telemetry are absent from the install funnel — they undercount silently. This recovers them.

## What

A one-time **install census**: on the first always-on launch of a previously-silent install, emit `app_install_backfill` (`{ from_version, prior_run: true }`) alongside the normal `app_start`/`app_updated`, so it can be counted as a **recovered install** without inflating genuine new-install numbers.

### Detection (can't double-count)
The `install-id` file is written **only inside the send path**, so its presence means telemetry was sent before. The census fires only when:
- `lastSeenVersion` is set (ran a prior version), **and**
- the install-id did **not** pre-exist (never sent), **and**
- `censusSent` is not yet set (fires once).

Genuinely-new installs have no `lastSeenVersion`; already-counted installs had the id pre-exist — neither qualifies.

## Changes
- `installId.ts` — capture, on first read, whether a valid id pre-existed; expose `installIdPreexisted()`.
- `analytics.ts` — `censusSent` state flag; pure `decideCensusAction()`; wire into `checkAndReportUpdate` (additive, behind existing E2E/dev/packaged gates).
- Tests: `analytics.test.ts` census matrix + new `installId.test.ts`.

## Notes
- Forward-acting: recovered installs fill in as users update; true history (past sessions/dates) remains unrecoverable.
- Dashboard side (separate "Recovered Installs" KPI) lands in the cero-analytics repo.

## Test plan
- [x] `npx vitest run src/main/analytics.test.ts src/main/installId.test.ts` — green
- [x] Related: `analyticsEnabled.test.ts`, `auto-updater.test.ts` — green