### PR TITLE
fix(companion): ship the Intel (darwin-x64) daemon in macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,11 @@ jobs:
           fi
 
   release:
-    needs: create-release
+    # Depends on `companion` too: the macOS app embeds BOTH the arm64 and the
+    # Intel (darwin-x64) companion daemon, and the x64 one can only be built on
+    # an Intel runner (the `companion` job's macos-13 target). The mac app job
+    # pulls that published tarball below before packaging.
+    needs: [create-release, companion]
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +127,27 @@ jobs:
           node scripts/build-companion-tarball.mjs
           cp dist-companion/cate-companion-*.tgz dist-companion/companion-host.tgz
 
+      # A single macOS .app can run on either CPU (x64 natively on Intel, arm64
+      # on Apple Silicon, x64 under Rosetta), and the LOCAL workspace runs the
+      # companion daemon whose bundled node + node-pty are arch-specific — an
+      # arm64 daemon simply cannot exec on an Intel Mac, so the terminal panel
+      # never opens (#384). The app therefore ships BOTH arches and picks one at
+      # runtime (shippedCompanionTarball() → companion-host-<arch>.tgz). The host
+      # tarball staged above is darwin-arm64 (macos-latest is Apple Silicon); the
+      # Intel one can only be built on an Intel runner, so pull the darwin-x64
+      # tarball the `companion` job published to this release.
+      - name: Stage both macOS companion arches (Intel + Apple Silicon)
+        if: matrix.platform == 'mac'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          cp dist-companion/companion-host.tgz dist-companion/companion-host-arm64.tgz
+          gh release download "$TAG_NAME" --repo "${{ github.repository }}" \
+            --pattern 'cate-companion-*-darwin-x64.tgz' --dir dist-companion --clobber
+          cp dist-companion/cate-companion-*-darwin-x64.tgz dist-companion/companion-host-x64.tgz
+
       # Note: the functional + content-search e2e suite used to gate the macOS
       # release here, but the hosted mac runner flaked on the synthetic-mouse
       # drag/detach specs often enough to redden otherwise-green releases (the
@@ -206,6 +231,13 @@ jobs:
             docker: true
           - os: macos-latest
             target: darwin-arm64
+          # Intel macOS. node-pty's native binary can't be cross-built for x64
+          # from an Apple Silicon host (build-companion-tarball.mjs refuses), so
+          # this must run on an Intel runner. macos-13 is GitHub's last hosted
+          # Intel image — if it's retired, this needs a self-hosted Intel runner
+          # or Intel support has to be dropped.
+          - os: macos-13
+            target: darwin-x64
           - os: windows-latest
             target: win32-x64
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -54,13 +54,19 @@ extraResources:
     to: skills
     filter:
       - "**/*"
-  # Ship the host-target companion tarball under a fixed name so the packaged
-  # LOCAL workspace can run the same daemon tarball as remote hosts (resolved at
-  # runtime via shippedCompanionTarball() → resources/companion-host.tgz).
-  # scripts/package.mjs always produces this file before electron-builder runs
-  # (copying cate-companion-<version>-<target>.tgz → companion-host.tgz).
-  - from: dist-companion/companion-host.tgz
-    to: companion-host.tgz
+  # Ship the companion daemon tarball(s) so the packaged LOCAL workspace runs the
+  # same daemon as remote hosts. Linux/Windows stage one host-arch
+  # companion-host.tgz; macOS stages BOTH companion-host-x64.tgz (Intel) and
+  # companion-host-arm64.tgz, because one .app can run on either CPU and the
+  # daemon's bundled node + node-pty are arch-specific (an arm64 daemon can't
+  # exec on Intel → terminal never opens). Resolved at runtime by
+  # shippedCompanionTarball() → resources/companion-host-<arch>.tgz (legacy
+  # resources/companion-host.tgz fallback). The glob copies whatever this runner
+  # staged without erroring on the arches it didn't build (see release.yml).
+  - from: dist-companion
+    to: .
+    filter:
+      - companion-host*.tgz
 publish:
   provider: github
   owner: 0-AI-UG

--- a/src/main/companion/companionArtifacts.ts
+++ b/src/main/companion/companionArtifacts.ts
@@ -101,12 +101,23 @@ export function localTarballIfPresent(version: string, target: CompanionTarget):
   return existsSync(cached) ? cached : null
 }
 
-/** The host-target companion tarball shipped inside the packaged app
- *  (resources/companion-host.tgz), or null in dev / when absent. */
+/** The host-target companion tarball shipped inside the packaged app, or null in
+ *  dev / when absent. macOS ships a per-arch daemon (companion-host-<arch>.tgz)
+ *  because one .app can run on either CPU — an Intel Mac (process.arch === 'x64',
+ *  natively or under Rosetta) must get the x64 daemon, since an arm64 node/node-pty
+ *  can't exec there. Other platforms ship a single host-arch companion-host.tgz.
+ *  The legacy unsuffixed name is kept as a fallback for older packagings. */
 export function shippedCompanionTarball(): string | null {
   if (!app.isPackaged) return null
-  const p = path.join(process.resourcesPath, 'companion-host.tgz')
-  return existsSync(p) ? p : null
+  const names =
+    process.platform === 'darwin'
+      ? [`companion-host-${process.arch}.tgz`, 'companion-host.tgz']
+      : ['companion-host.tgz']
+  for (const name of names) {
+    const p = path.join(process.resourcesPath, name)
+    if (existsSync(p)) return p
+  }
+  return null
 }
 
 /** Short content hash of a local tarball, for the remote `.ok` marker. */


### PR DESCRIPTION
## Problem (issue #384 — terminal panel won't open on an installed .dmg)

Terminals, file watching, content search and the `pi` agent are all backed by the **cate-companion** daemon — a self-contained per-target tarball (bundled `node` + `node-pty` + `rg` + `pi`) that the local workspace runs as a child process, just like a remote SSH/WSL host. The local one ships inside the app as `resources/companion-host.tgz`.

Two gaps left Intel Macs without a working terminal:

1. **The embedded companion was always arm64.** The app builds both `x64` and `arm64` `.dmg`s on the Apple Silicon `macos-latest` runner, but the host companion tarball is staged with no `--target` (so it's `darwin-arm64`) and bundled into **both** apps. On an Intel Mac the bundled arm64 `runtime/bin/node` can't exec → the local companion never starts → terminal panel never opens.
2. **No `darwin-x64` companion existed anywhere.** The per-target `companion` matrix omitted `darwin-x64`, so even the release-download fallback 404'd.

## Fix

Keep the single-runner dual-arch **app** build untouched (so the one correct `latest-mac.yml` the updater relies on is unchanged) and instead ship **both** macOS companion arches, selecting one at runtime:

- **`.github/workflows/release.yml`** — add a `darwin-x64` companion target on a **`macos-13`** (Intel) runner; `node-pty`'s native binary can't be cross-built for x64 from Apple Silicon. The mac app job now stages `companion-host-arm64.tgz` and pulls the just-published `darwin-x64` tarball into `companion-host-x64.tgz` before packaging (`release` now `needs` `companion`).
- **`electron-builder.yml`** — ship `companion-host*.tgz` via a glob so each runner embeds whatever it staged (one host tarball on Linux/Windows, both arches on macOS) without erroring on arches it didn't build.
- **`src/main/companion/companionArtifacts.ts`** — `shippedCompanionTarball()` resolves `companion-host-<arch>.tgz` on macOS (Intel app → `x64`, including under Rosetta), with the legacy unsuffixed name as a fallback.

The downloaded `darwin-x64` tarball is already Developer ID-signed (the `companion` job signs darwin natives), so it notarizes inside the app.

## Notes / caveats

- **`macos-13` is GitHub's last hosted Intel image.** If it's retired, the Intel companion needs a self-hosted Intel runner or Intel support has to be dropped (there's no darwin cross-build for `node-pty`).
- **Release timing** — coupling the app build to the `companion` job serializes them. `publish-release` already depended on `companion`, so the final gate is unchanged, but app artifacts now build after the companion targets. A follow-up could split a dedicated x64-only companion job to avoid waiting on the slow QEMU `linux-arm64` target.

## Testing

- `npm run typecheck` — clean.
- `src/main/companion/local-daemon-tarball.test.ts` — passes (provisions + runs the daemon from a real tarball and serves a PTY).
- CI matrix exercises the new `darwin-x64` companion build + the two-arch embed.