### PR TITLE
Consolidate file-conflict UI into one minimal header bar

### DIFF
--- a/src/renderer/panels/EditorConflictBanner.test.tsx
+++ b/src/renderer/panels/EditorConflictBanner.test.tsx
@@ -42,10 +42,12 @@ describe('EditorConflictBanner — changed', () => {
       root.render(
         <EditorConflictBanner
           kind="changed"
+          showDiff={false}
           onReload={onReload}
           onKeepMine={onKeepMine}
           onKeepBoth={onKeepBoth}
           onViewDiff={onViewDiff}
+          onCloseDiff={vi.fn()}
           onSaveToRestore={vi.fn()}
           onDismiss={vi.fn()}
         />,
@@ -62,6 +64,35 @@ describe('EditorConflictBanner — changed', () => {
     expect(onKeepBoth).toHaveBeenCalledTimes(1)
     expect(onViewDiff).toHaveBeenCalledTimes(1)
   })
+
+  it('swaps View diff for Close diff while the diff overlay is open', () => {
+    const onViewDiff = vi.fn()
+    const onCloseDiff = vi.fn()
+    act(() => {
+      root.render(
+        <EditorConflictBanner
+          kind="changed"
+          showDiff={true}
+          onReload={vi.fn()}
+          onKeepMine={vi.fn()}
+          onKeepBoth={vi.fn()}
+          onViewDiff={onViewDiff}
+          onCloseDiff={onCloseDiff}
+          onSaveToRestore={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      )
+    })
+
+    expect(
+      Array.from(host.querySelectorAll('button')).some((b) => b.textContent?.trim() === 'View diff'),
+    ).toBe(false)
+
+    act(() => { buttonByText('Close diff').click() })
+
+    expect(onCloseDiff).toHaveBeenCalledTimes(1)
+    expect(onViewDiff).not.toHaveBeenCalled()
+  })
 })
 
 describe('EditorConflictBanner — deleted', () => {
@@ -72,10 +103,12 @@ describe('EditorConflictBanner — deleted', () => {
       root.render(
         <EditorConflictBanner
           kind="deleted"
+          showDiff={false}
           onReload={vi.fn()}
           onKeepMine={vi.fn()}
           onKeepBoth={vi.fn()}
           onViewDiff={vi.fn()}
+          onCloseDiff={vi.fn()}
           onSaveToRestore={onSaveToRestore}
           onDismiss={onDismiss}
         />,

--- a/src/renderer/panels/EditorConflictBanner.tsx
+++ b/src/renderer/panels/EditorConflictBanner.tsx
@@ -1,10 +1,12 @@
 // =============================================================================
-// EditorConflictBanner — a non-blocking strip shown above the editor when the
-// open file has diverged from disk.
+// EditorConflictBanner — a single, minimal header strip shown above the editor
+// when the open file has diverged from disk. It doubles as the diff toolbar:
+// while the disk ⇆ buffer diff overlay is open it stays put (no second bar),
+// just swapping its label and offering "Close diff".
 //
 //   kind="changed" — an external tool rewrote the file while the buffer had
-//                    unsaved edits. Offers Reload (take disk), Keep mine, and
-//                    View diff (disk ⇆ buffer in a Monaco diff overlay).
+//                    unsaved edits. Offers Reload (take disk), Keep mine,
+//                    Keep both, and View/Close diff (disk ⇆ buffer overlay).
 //   kind="deleted" — the file was removed from disk while open. The buffer is
 //                    now unsaved work with no file behind it; Save to restore
 //                    re-creates it, Dismiss keeps the buffer dirty so the
@@ -15,10 +17,12 @@ import { Warning } from '@phosphor-icons/react'
 
 export interface EditorConflictBannerProps {
   kind: 'changed' | 'deleted'
+  showDiff: boolean
   onReload: () => void
   onKeepMine: () => void
   onKeepBoth: () => void
   onViewDiff: () => void
+  onCloseDiff: () => void
   onSaveToRestore: () => void
   onDismiss: () => void
 }
@@ -26,20 +30,23 @@ export interface EditorConflictBannerProps {
 function BannerButton({
   onClick,
   children,
+  active,
   emphasis,
 }: {
   onClick: () => void
   children: string
+  active?: boolean
   emphasis?: boolean
 }) {
+  const tone = emphasis
+    ? 'text-warning hover:bg-warning/15'
+    : active
+      ? 'bg-surface-3 text-primary hover:bg-surface-4'
+      : 'text-secondary hover:bg-surface-3 hover:text-primary'
   return (
     <button
       onClick={onClick}
-      className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
-        emphasis
-          ? 'bg-warning text-white hover:opacity-90'
-          : 'bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary'
-      }`}
+      className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${tone}`}
     >
       {children}
     </button>
@@ -48,28 +55,41 @@ function BannerButton({
 
 export default function EditorConflictBanner({
   kind,
+  showDiff,
   onReload,
   onKeepMine,
   onKeepBoth,
   onViewDiff,
+  onCloseDiff,
   onSaveToRestore,
   onDismiss,
 }: EditorConflictBannerProps) {
+  const label =
+    kind === 'deleted'
+      ? 'Deleted on disk. Save to restore, or lose it on close.'
+      : showDiff
+        ? 'On disk vs your unsaved changes'
+        : 'Changed on disk. Your unsaved edits are kept.'
+
   return (
     <div
       role="alert"
-      className="flex items-center gap-2 shrink-0 px-2 py-0.5 border-b border-warning bg-warning-tint"
+      className="flex items-center gap-2 shrink-0 px-2 py-1 border-b border-subtle"
+      style={{ backgroundColor: 'var(--node-chrome-bg, var(--surface-1))' }}
     >
       <Warning size={12} weight="fill" className="text-warning shrink-0" />
-      <span className="text-[11px] text-primary leading-tight flex-1 min-w-0 truncate">
-        {kind === 'changed'
-          ? 'Changed on disk. Your unsaved edits are kept.'
-          : 'Deleted on disk. Save to restore, or lose it on close.'}
+      <span className="text-[11px] text-secondary leading-tight flex-1 min-w-0 truncate">
+        {label}
       </span>
-      <div className="flex items-center gap-1 shrink-0">
+      <div className="flex items-center gap-0.5 shrink-0">
         {kind === 'changed' ? (
           <>
-            <BannerButton onClick={onViewDiff}>View diff</BannerButton>
+            <BannerButton
+              onClick={showDiff ? onCloseDiff : onViewDiff}
+              active={showDiff}
+            >
+              {showDiff ? 'Close diff' : 'View diff'}
+            </BannerButton>
             <BannerButton onClick={onReload}>Reload</BannerButton>
             <BannerButton onClick={onKeepMine}>Keep mine</BannerButton>
             <BannerButton onClick={onKeepBoth} emphasis>Keep both</BannerButton>

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -703,6 +703,14 @@ export default function EditorPanel({
       automaticLayout: false,
       scrollBeyondLastLine: false,
       minimap: { enabled: false },
+      renderOverviewRuler: false,
+      overviewRulerLanes: 0,
+      scrollbar: {
+        verticalScrollbarSize: 8,
+        horizontalScrollbarSize: 8,
+        verticalSliderSize: 8,
+        horizontalSliderSize: 8,
+      },
       padding: { top: 8, bottom: 8 },
     })
     diff.setModel({ original, modified })
@@ -759,27 +767,20 @@ export default function EditorPanel({
       {conflict && !diffMode && (
         <EditorConflictBanner
           kind={conflict.kind}
+          showDiff={showDiff}
           onReload={reload}
           onKeepMine={keepMine}
           onKeepBoth={keepBoth}
           onViewDiff={openDiff}
+          onCloseDiff={closeDiff}
           onSaveToRestore={saveToRestore}
           onDismiss={dismiss}
         />
       )}
       <div className="flex-1 min-h-0 relative">
         {showDiff && conflict?.kind === 'changed' && (
-          <div className="absolute inset-0 z-30 flex flex-col bg-surface-1">
-            <div className="flex items-center justify-between shrink-0 px-2 py-0.5 border-b border-subtle">
-              <span className="text-[11px] text-secondary">On disk vs your unsaved changes</span>
-              <button
-                onClick={closeDiff}
-                className="px-2 py-0.5 rounded text-[11px] font-medium bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary transition-colors"
-              >
-                Close diff
-              </button>
-            </div>
-            <div ref={diffOverlayRef} className="flex-1 min-h-0" />
+          <div className="absolute inset-0 z-30 bg-surface-1">
+            <div ref={diffOverlayRef} className="w-full h-full" />
           </div>
         )}
         {markdownPreview && isMarkdown && (


### PR DESCRIPTION
## Summary

Tidies the "Changed on disk" file-conflict UI in the editor panel so it reads as one minimal header instead of two stacked bars.

- **One header bar, not two** — the orange warning banner and the separate `On disk vs your unsaved changes` / `Close diff` toolbar are merged into a single strip styled to match the window chrome (same `--node-chrome-bg` treatment as the markdown header). Dropped the loud orange tint; the warning icon is the only color accent.
- **Diff-aware bar** — the label adapts (`Changed on disk…` → `On disk vs your unsaved changes`) and `View diff` toggles to `Close diff` in place. The diff overlay no longer renders its own header row.
- **Minimal buttons** — ghost-style (transparent until hover); `Keep both` uses the app's subtle warning accent instead of a solid orange fill.
- **Slimmer diff right edge** — removed the wide diff overview ruler and switched to thin 8px scrollbars.

## Test plan

- `npx tsc --noEmit` clean
- `EditorConflictBanner.test.tsx` updated for the new `showDiff` / `onCloseDiff` props, plus a new test for the View↔Close diff toggle — all passing