### PR TITLE
fix(editor): watch hidden files and re-sync on reopen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-06-08T11:22:33.767Z",
+  "generatedAt": "2026-06-15T16:45:17.662Z",
   "skills": [
     {
       "id": "academic-research-skills/academic-paper",
       "name": "academic-paper",
-      "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+      "description": "12-agent academic paper writing pipeline. 11 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure/rebuttal-audit). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, audit my rebuttal, check my response draft, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見, 評估回覆.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -12,8 +12,8 @@
         "ref": "main",
         "path": "academic-paper"
       },
-      "stars": 28798,
-      "updatedAt": "2026-06-08T06:37:09Z",
+      "stars": 31685,
+      "updatedAt": "2026-06-15T05:54:12Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
     },
@@ -28,8 +28,8 @@
         "ref": "main",
         "path": "academic-paper-reviewer"
       },
-      "stars": 28798,
-      "updatedAt": "2026-06-08T06:37:09Z",
+      "stars": 31685,
+      "updatedAt": "2026-06-15T05:54:12Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
     },
@@ -44,15 +44,15 @@
         "ref": "main",
         "path": "academic-pipeline"
       },
-      "stars": 28798,
-      "updatedAt": "2026-06-08T06:37:09Z",
+      "stars": 31685,
+      "updatedAt": "2026-06-15T05:54:12Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
     },
     {
       "id": "academic-research-skills/deep-research",
       "name": "deep-research",
-      "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+      "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 8 modes: full research, quick brief, paper review, lit-review, fact-check, three-way literature scan, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, WHY HOW WHAT papers, 3W literature scan, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 三段式文獻掃描, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -60,8 +60,8 @@
         "ref": "main",
         "path": "deep-research"
       },
-      "stars": 28798,
-      "updatedAt": "2026-06-08T06:37:09Z",
+      "stars": 31685,
+      "updatedAt": "2026-06-15T05:54:12Z",
       "provenance": "curated",
       "sourceId": "academic-research-skills"
     },
@@ -76,8 +76,8 @@
         "ref": "main",
         "path": "skills/api-and-interface-design"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -92,8 +92,8 @@
         "ref": "main",
         "path": "skills/browser-testing-with-devtools"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -108,8 +108,8 @@
         "ref": "main",
         "path": "skills/ci-cd-and-automation"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -124,8 +124,8 @@
         "ref": "main",
         "path": "skills/code-review-and-quality"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -140,8 +140,8 @@
         "ref": "main",
         "path": "skills/code-simplification"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -156,8 +156,8 @@
         "ref": "main",
         "path": "skills/context-engineering"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -172,8 +172,8 @@
         "ref": "main",
         "path": "skills/debugging-and-error-recovery"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -188,8 +188,8 @@
         "ref": "main",
         "path": "skills/deprecation-and-migration"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -204,8 +204,8 @@
         "ref": "main",
         "path": "skills/documentation-and-adrs"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -220,8 +220,8 @@
         "ref": "main",
         "path": "skills/doubt-driven-development"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -236,8 +236,8 @@
         "ref": "main",
         "path": "skills/frontend-ui-engineering"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -252,8 +252,8 @@
         "ref": "main",
         "path": "skills/git-workflow-and-versioning"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -268,8 +268,8 @@
         "ref": "main",
         "path": "skills/idea-refine"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -284,8 +284,8 @@
         "ref": "main",
         "path": "skills/incremental-implementation"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -300,8 +300,24 @@
         "ref": "main",
         "path": "skills/interview-me"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
+      "provenance": "curated",
+      "sourceId": "addyosmani-agent-skills"
+    },
+    {
+      "id": "addyosmani-agent-skills/observability-and-instrumentation",
+      "name": "observability-and-instrumentation",
+      "description": "Instruments code so production behavior is visible and diagnosable. Use when adding logging, metrics, tracing, or alerting. Use when shipping any feature that runs in production and you need evidence it works. Use when production issues are reported but you can't tell what happened from the available data.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "addyosmani/agent-skills",
+        "ref": "main",
+        "path": "skills/observability-and-instrumentation"
+      },
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -316,8 +332,8 @@
         "ref": "main",
         "path": "skills/performance-optimization"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -332,8 +348,8 @@
         "ref": "main",
         "path": "skills/planning-and-task-breakdown"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -348,8 +364,8 @@
         "ref": "main",
         "path": "skills/security-and-hardening"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -364,8 +380,8 @@
         "ref": "main",
         "path": "skills/shipping-and-launch"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -380,8 +396,8 @@
         "ref": "main",
         "path": "skills/source-driven-development"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -396,8 +412,8 @@
         "ref": "main",
         "path": "skills/spec-driven-development"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -412,8 +428,8 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -428,8 +444,8 @@
         "ref": "main",
         "path": "skills/using-agent-skills"
       },
-      "stars": 49057,
-      "updatedAt": "2026-06-07T22:33:29Z",
+      "stars": 60131,
+      "updatedAt": "2026-06-14T08:41:45Z",
       "provenance": "curated",
       "sourceId": "addyosmani-agent-skills"
     },
@@ -444,8 +460,8 @@
         "ref": "main",
         "path": "skills/algorithmic-art"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -460,8 +476,8 @@
         "ref": "main",
         "path": "skills/brand-guidelines"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -476,15 +492,15 @@
         "ref": "main",
         "path": "skills/canvas-design"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
     {
       "id": "anthropic-skills/claude-api",
       "name": "claude-api",
-      "description": "Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration. TRIGGER — read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens). SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).",
+      "description": "Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration. TRIGGER — read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" — whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) — never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens). SKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named — don't Read the file).",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -492,8 +508,8 @@
         "ref": "main",
         "path": "skills/claude-api"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -508,8 +524,8 @@
         "ref": "main",
         "path": "skills/doc-coauthoring"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -524,15 +540,15 @@
         "ref": "main",
         "path": "skills/docx"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
     {
       "id": "anthropic-skills/frontend-design",
       "name": "frontend-design",
-      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+      "description": "Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -540,8 +556,8 @@
         "ref": "main",
         "path": "skills/frontend-design"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -556,8 +572,8 @@
         "ref": "main",
         "path": "skills/internal-comms"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -572,8 +588,8 @@
         "ref": "main",
         "path": "skills/mcp-builder"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -588,8 +604,8 @@
         "ref": "main",
         "path": "skills/pdf"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -604,8 +620,8 @@
         "ref": "main",
         "path": "skills/pptx"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -620,8 +636,8 @@
         "ref": "main",
         "path": "skills/skill-creator"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -636,8 +652,8 @@
         "ref": "main",
         "path": "skills/slack-gif-creator"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -652,8 +668,8 @@
         "ref": "main",
         "path": "template"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -668,8 +684,8 @@
         "ref": "main",
         "path": "skills/theme-factory"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -684,8 +700,8 @@
         "ref": "main",
         "path": "skills/web-artifacts-builder"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -700,8 +716,8 @@
         "ref": "main",
         "path": "skills/webapp-testing"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -716,8 +732,8 @@
         "ref": "main",
         "path": "skills/xlsx"
       },
-      "stars": 147839,
-      "updatedAt": "2026-06-07T20:21:35Z",
+      "stars": 151045,
+      "updatedAt": "2026-06-09T20:35:19Z",
       "provenance": "curated",
       "sourceId": "anthropic-skills"
     },
@@ -732,26 +748,10 @@
         "ref": "main",
         "path": ".agents/skills/career-ops"
       },
-      "stars": 49967,
-      "updatedAt": "2026-06-08T08:31:34Z",
+      "stars": 53876,
+      "updatedAt": "2026-06-15T15:54:51Z",
       "provenance": "curated",
       "sourceId": "career-ops"
-    },
-    {
-      "id": "caveman/cavecrew",
-      "name": "cavecrew",
-      "description": "Decision guide for delegating to caveman-style subagents. Tells the main thread WHEN to spawn `cavecrew-investigator` (locate code), `cavecrew-builder` (1-2 file edit), or `cavecrew-reviewer` (diff review) instead of doing the work inline or using vanilla `Explore`. Subagent output is caveman-compressed so the tool-result injected back into main context is ~60% smaller — main context lasts longer across long sessions. Trigger: \"delegate to subagent\", \"use cavecrew\", \"spawn investigator/builder/reviewer\", \"save context\", \"compressed agent output\".",
-      "tags": [],
-      "format": "skill-md",
-      "source": {
-        "repo": "JuliusBrussee/caveman",
-        "ref": "main",
-        "path": ".agents/skills/cavecrew"
-      },
-      "stars": 69990,
-      "updatedAt": "2026-05-20T10:44:54Z",
-      "provenance": "curated",
-      "sourceId": "caveman"
     },
     {
       "id": "coreyhaines-marketing-skills/ab-testing",
@@ -764,8 +764,8 @@
         "ref": "main",
         "path": "skills/ab-testing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -780,8 +780,8 @@
         "ref": "main",
         "path": "skills/ad-creative"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -796,8 +796,8 @@
         "ref": "main",
         "path": "skills/ads"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -812,8 +812,8 @@
         "ref": "main",
         "path": "skills/ai-seo"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -828,8 +828,8 @@
         "ref": "main",
         "path": "skills/analytics"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -844,8 +844,8 @@
         "ref": "main",
         "path": "skills/aso"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -860,8 +860,8 @@
         "ref": "main",
         "path": "skills/churn-prevention"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -876,8 +876,8 @@
         "ref": "main",
         "path": "skills/co-marketing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -892,8 +892,8 @@
         "ref": "main",
         "path": "skills/cold-email"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -908,8 +908,8 @@
         "ref": "main",
         "path": "skills/community-marketing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -924,8 +924,8 @@
         "ref": "main",
         "path": "skills/competitor-profiling"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -940,8 +940,8 @@
         "ref": "main",
         "path": "skills/competitors"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -956,8 +956,8 @@
         "ref": "main",
         "path": "skills/content-strategy"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -972,8 +972,8 @@
         "ref": "main",
         "path": "skills/copy-editing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -988,8 +988,8 @@
         "ref": "main",
         "path": "skills/copywriting"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1004,8 +1004,8 @@
         "ref": "main",
         "path": "skills/cro"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1020,8 +1020,8 @@
         "ref": "main",
         "path": "skills/customer-research"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1036,8 +1036,8 @@
         "ref": "main",
         "path": "skills/directory-submissions"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1052,8 +1052,8 @@
         "ref": "main",
         "path": "skills/emails"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1068,8 +1068,8 @@
         "ref": "main",
         "path": "skills/free-tools"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1084,8 +1084,8 @@
         "ref": "main",
         "path": "skills/image"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1100,8 +1100,8 @@
         "ref": "main",
         "path": "skills/launch"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1116,8 +1116,8 @@
         "ref": "main",
         "path": "skills/lead-magnets"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1132,8 +1132,8 @@
         "ref": "main",
         "path": "skills/marketing-ideas"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1148,8 +1148,8 @@
         "ref": "main",
         "path": "skills/marketing-plan"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1164,8 +1164,8 @@
         "ref": "main",
         "path": "skills/marketing-psychology"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1180,8 +1180,8 @@
         "ref": "main",
         "path": "skills/onboarding"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1196,8 +1196,8 @@
         "ref": "main",
         "path": "skills/paywalls"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1212,8 +1212,8 @@
         "ref": "main",
         "path": "skills/popups"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1228,8 +1228,8 @@
         "ref": "main",
         "path": "skills/pricing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1244,8 +1244,8 @@
         "ref": "main",
         "path": "skills/product-marketing"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1260,8 +1260,8 @@
         "ref": "main",
         "path": "skills/programmatic-seo"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1276,8 +1276,24 @@
         "ref": "main",
         "path": "skills/prospecting"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
+      "provenance": "curated",
+      "sourceId": "coreyhaines-marketing-skills"
+    },
+    {
+      "id": "coreyhaines-marketing-skills/public-relations",
+      "name": "public-relations",
+      "description": "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get featured,' 'media list,' 'media kit,' 'press kit,' 'newsjacking,' 'news hijack,' 'HARO,' 'Qwoted,' 'Featured,' 'Help A Reporter,' 'reporter request,' 'tech press,' 'TechCrunch,' 'earned media,' 'thought leadership placement,' 'op-ed,' 'guest article,' 'press contacts,' or 'how do I get press.' Use this for earned media work — finding journalists, pitching stories, newsjacking, and responding to press requests. For startup/SaaS/AI directory submissions, see directory-submissions. For product launches, see launch. For social-media engagement, see social. For cold-email outreach to prospects, see cold-email.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "coreyhaines31/marketingskills",
+        "ref": "main",
+        "path": "skills/public-relations"
+      },
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1292,8 +1308,8 @@
         "ref": "main",
         "path": "skills/referrals"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1308,8 +1324,8 @@
         "ref": "main",
         "path": "skills/revops"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1324,8 +1340,8 @@
         "ref": "main",
         "path": "skills/sales-enablement"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1340,8 +1356,8 @@
         "ref": "main",
         "path": "skills/schema"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1356,8 +1372,8 @@
         "ref": "main",
         "path": "skills/seo-audit"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1372,8 +1388,8 @@
         "ref": "main",
         "path": "skills/signup"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1388,8 +1404,8 @@
         "ref": "main",
         "path": "skills/site-architecture"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1404,15 +1420,15 @@
         "ref": "main",
         "path": "skills/sms"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
     {
       "id": "coreyhaines-marketing-skills/social",
       "name": "social",
-      "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative.",
+      "description": "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms, or wants to do social listening and engagement triage. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' 'create a reel,' 'social listening,' 'brand mentions,' 'competitor monitoring,' 'top posts to comment on,' or 'find people asking for.' Use this for social media content creation, repurposing, scheduling, short-form video scripting, and social listening. For broader content strategy, see content-strategy. For paid ads, see ad-creative. For earned media, see public-relations.",
       "tags": [],
       "format": "skill-md",
       "source": {
@@ -1420,8 +1436,8 @@
         "ref": "main",
         "path": "skills/social"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
     },
@@ -1436,10 +1452,810 @@
         "ref": "main",
         "path": "skills/video"
       },
-      "stars": 32427,
-      "updatedAt": "2026-06-05T22:53:41Z",
+      "stars": 33415,
+      "updatedAt": "2026-06-13T06:46:27Z",
       "provenance": "curated",
       "sourceId": "coreyhaines-marketing-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-deploy",
+      "name": "agent-platform-deploy",
+      "description": "Deploy open models or custom weights from Model Garden to Agent Platform endpoints, check deployment status, verify serving endpoints, or clean up resources by undeploying models and deleting endpoints. Use when asked to deploy models on Agent Platform, list available Model Garden models, check if a model is deployable, query deployment cost, troubleshoot deployment errors (like quota limits), or undeploy/clean up endpoints. Also use when copying and deploying a 1P Tuned Model. Don't use for public Vertex AI deployments (use the `vertex-deploy` skill) or for running model evaluations (use the `agent-platform-eval` skill).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-deploy"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-endpoint-management",
+      "name": "agent-platform-endpoint-management",
+      "description": "Manages Agent Platform serving endpoints. Use when you need to create, list, describe, update, or delete serving endpoints for model deployment on Agent Platform. Also use when troubleshooting endpoint permission, quota, or resource busy errors. Don't use for deploying models to endpoints or for running model evaluations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-endpoint-management"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-eval-flywheel",
+      "name": "agent-platform-eval-flywheel",
+      "description": "Measure and improve the quality of AI models and agents on Google Cloud using the Eval Quality Flywheel methodology. Use when evaluating an agent or model, building an eval dataset, picking or writing evaluation metrics, analyzing failures, comparing results before and after a fix, or when guidance is needed on Agent Platform eval methodology — including dataset schema, LLM-as-judge scoring, and common failure causes. For fine-tuning, use agent-platform-tuning. For deployment, use agent-platform-deploy.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-eval-flywheel"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-inference",
+      "name": "agent-platform-inference",
+      "description": "Connects to and performs inference with Google Cloud Agent Platform GenAI models, including First-Party Gemini models and Third-Party OpenMaaS models (Llama, DeepSeek, Qwen, etc.). Use when you need to generate code for calling Gemini or OpenMaaS models, authenticate with GenAI SDK, OpenAI SDK, or legacy Agent Platform SDK, configure base URLs and global/regional endpoints, or troubleshoot 429 Resource Exhausted (DSQ), 400 User Validation, or 404 Not Found errors. Don't use for deploying models to endpoints or for running model evaluations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-inference"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-migrate-from-ai-studio",
+      "name": "agent-platform-migrate-from-ai-studio",
+      "description": "Guides agents and users through migrating from Gemini API in Google AI Studio to Gemini Enterprise Agent Platform (formerly Vertex AI). Use this skill when moving applications to Google Cloud, to leverage Cloud credits, or to unify inferencing with other Cloud infrastructure (IAM, billing, telemetry).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-migrate-from-ai-studio"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-model-registry",
+      "name": "agent-platform-model-registry",
+      "description": "Agent Platform Model Registry Management. Use when you need to upload, list, describe, update, or delete machine learning models (and their versions) in the Agent Platform Model Registry. Don't use for model training, model deployment to endpoints, or managing non-Agent Platform models.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-model-registry"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-prompt-management",
+      "name": "agent-platform-prompt-management",
+      "description": "Manages and orchestrates prompts in Agent Platform. Use when you need to create, list, retrieve, version, or delete managed prompts in Agent Platform. Don't use for model training, model deployment to endpoints, or managing non-Agent Platform prompts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-prompt-management"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-rag-engine-management",
+      "name": "agent-platform-rag-engine-management",
+      "description": "Manage and query Agent Platform RAG Engine Corpora and retrieve grounded contexts using the Google GenAI SDK. Use when listing RAG corpora or files, inspecting a corpus, retrieving contexts, or generating content grounded in a RAG corpus. Do not use for standard database queries (use SQL/Spanner skills), Google Workspace RAG, or other RAG products like gRAG.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-rag-engine-management"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-skill-registry",
+      "name": "agent-platform-skill-registry",
+      "description": "Interact with the Gemini Enterprise Agent Platform Skill Registry to create and search for available skills. Use this skill to enable agents to register functionality or discover new capabilities.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-skill-registry"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-tuning",
+      "name": "agent-platform-tuning",
+      "description": "Agent Platform Model Tuning. Use when you need to fine-tune open models or Gemini models using Agent Platform infrastructure. Don't use for model training outside Agent Platform, model deployment to endpoints (use `agent-platform-deploy`), or managing serving endpoints (use `agent-platform-endpoint-management`).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-tuning"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/agent-platform-tuning-management",
+      "name": "agent-platform-tuning-management",
+      "description": "Manages GenAI tuning jobs in Agent Platform. Use this to list, get, or cancel ongoing model tuning jobs. Don't use for fine-tuning models (use `agent-platform-tuning`), deploying models to endpoints (use `agent-platform-deploy`), or managing serving endpoints (use `agent-platform-endpoint-management`).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/agent-platform-tuning-management"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/alloydb-basics",
+      "name": "alloydb-basics",
+      "description": "Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB model context protocol (MCP) tools for automated database operations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/alloydb-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/bigquery-basics",
+      "name": "bigquery-basics",
+      "description": "Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights. Use when you need to interact with BigQuery, run SQL queries, manage BigQuery resources, or leverage BigQuery's built-in ML capabilities. Also use when performing data analysis, ingesting data into BigQuery, or developing AI applications on BigQuery.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/bigquery-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/cloud-run-basics",
+      "name": "cloud-run-basics",
+      "description": "Manages Cloud Run services, jobs, and worker pools. Use when you need to deploy applications responding to HTTP requests (services), run event-triggered or scheduled tasks (jobs), or handle always-on pull-based background processing (worker pools).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/cloud-run-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/cloud-sql-basics",
+      "name": "cloud-sql-basics",
+      "description": "This file generates or explains Cloud SQL resources. Use this file when the user asks to create a Cloud SQL instance or database for MySQL, PostgreSQL, or SQL Server. Cloud SQL manages third-party MySQL, PostgreSQL, and SQL Server instances as resources in Cloud SQL. For example, when Cloud SQL creates an open-source MySQL instance, the resulting resource is a Cloud SQL for MySQL instance that Google Cloud manages. Cloud SQL handles backups, high availability, and secure connectivity for relational database workloads.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/cloud-sql-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/firebase-basics",
+      "name": "firebase-basics",
+      "description": "Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/firebase-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/gcloud",
+      "name": "gcloud",
+      "description": "Interacts with Google Cloud services using the gcloud CLI safely and efficiently. Covers command validation, data reduction, safety guardrails with a denylist, and workflows for discovery and investigation. You MUST read this skill before invoking any gcloud command. Use when managing cloud resources, querying configurations, or troubleshooting issues via gcloud. Don't use when writing or debugging Google Cloud client library code or raw REST/gRPC API interactions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/gcloud"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/gemini-agents-api",
+      "name": "gemini-agents-api",
+      "description": "Manages custom Agent resources on Gemini Enterprise Agent Platform. Use when the user wants to programmatically create, configure, list, update, or delete stateful, server-managed Agent resources (including mounting files, skills, and tools) before executing conversations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/gemini-agents-api"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/gemini-api",
+      "name": "gemini-api",
+      "description": "Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like multimodal inputs, tools, media generation, caching, batch prediction, and Live API.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/gemini-api"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/gemini-interactions-api",
+      "name": "gemini-interactions-api",
+      "description": "Guides the usage of Gemini Interactions API on Gemini Enterprise Agent Platform. Use when the user wants to use the stateful, server-managed Interactions API for multi-turn conversations, background execution, streaming, structured output, and function calling on the Agent Platform.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/gemini-interactions-api"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/gke-basics",
+      "name": "gke-basics",
+      "description": "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/gke-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-networking-observability",
+      "name": "google-cloud-networking-observability",
+      "description": "Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs (including cost estimation), NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics. Don't use for generic VM management or non-observability tasks.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-networking-observability"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-recipe-auth",
+      "name": "google-cloud-recipe-auth",
+      "description": "Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and best practices for secure access.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-recipe-auth"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-recipe-onboarding",
+      "name": "google-cloud-recipe-onboarding",
+      "description": "Guides a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource. Use when a new developer wants to initialize their first Google Cloud project, configure billing, and verify deployment. Don't use for enterprise organization setup (use Google Cloud Setup guided flow for that instead). Don't use for complex multi-project architectures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-recipe-onboarding"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-cost-optimization",
+      "name": "google-cloud-waf-cost-optimization",
+      "description": "Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify cost requirements and constraints, and provide actionable recommendations for build, deploy, and manage the workload cost-efficiently in Google Cloud.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-cost-optimization"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-operational-excellence",
+      "name": "google-cloud-waf-operational-excellence",
+      "description": "Generates operations-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Operational Excellence pillar of the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify operational requirements, and provide actionable recommendations for deployment, monitoring, and incident management.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-operational-excellence"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-performance-optimization",
+      "name": "google-cloud-waf-performance-optimization",
+      "description": "Generates performance-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Performance Optimization pillar of the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify performance requirements, and provide actionable recommendations for resource allocation, modular design, and elasticity.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-performance-optimization"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-reliability",
+      "name": "google-cloud-waf-reliability",
+      "description": "Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework. Use this skill to evaluate a workload, identify reliability requirements, and provide actionable recommendations for build, deploy, and manage the workload reliably in Google Cloud.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-reliability"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-security",
+      "name": "google-cloud-waf-security",
+      "description": "Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify security requirements, and provide actionable recommendations for IAM, network security, data protection, and operational security.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-security"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/google-cloud-waf-sustainability",
+      "name": "google-cloud-waf-sustainability",
+      "description": "Generates sustainability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF). Use this skill to evaluate a workload, identify environmental impact requirements, and provide actionable recommendations to build, deploy, and manage the workload sustainably in Google Cloud.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/google-cloud-waf-sustainability"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "google-skills/workload-manager-basics",
+      "name": "workload-manager-basics",
+      "description": "Use this skill to manage Google Cloud Workload Manager evaluations, rules, scanned resources, and validation results by using public client libraries and the REST API. Use when you need to inspect workload best-practice rules, create and run evaluations for Google Cloud general best practices, SAP, SQL Server, or custom organizational rules, review violations, export results to BigQuery, or automate Workload Manager through client libraries because no service-specific public CLI or MCP server is available. Don't use for general Google Compute Engine instance management, VPC configuration, or standard IAM auditing.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "google/skills",
+        "ref": "main",
+        "path": "skills/cloud/workload-manager-basics"
+      },
+      "stars": 13698,
+      "updatedAt": "2026-06-13T19:49:32Z",
+      "provenance": "curated",
+      "sourceId": "google-skills"
+    },
+    {
+      "id": "huggingface-skills/hf-cli",
+      "name": "hf-cli",
+      "description": "Hugging Face Hub CLI (`hf`) for downloading, uploading, and managing models, datasets, spaces, buckets, repos, papers, jobs, and more on the Hugging Face Hub. Use when: handling authentication; managing local cache; managing Hugging Face Buckets; running or scheduling jobs on Hugging Face infrastructure; managing Hugging Face repos; discussions and pull requests; browsing models, datasets and spaces; reading, searching, or browsing academic papers; managing collections; querying datasets; configuring spaces; setting up webhooks; or deploying and managing HF Inference Endpoints. Make sure to use this skill whenever the user mentions 'hf', 'huggingface', 'Hugging Face', 'huggingface-cli', or 'hugging face cli', or wants to do anything related to the Hugging Face ecosystem and to AI and ML in general. Also use for cloud storage needs like training checkpoints, data pipelines, or agent traces. Use even if the user doesn't explicitly ask for a CLI command. Replaces the deprecated `huggingface-cli`.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/hf-cli"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/hf-mem",
+      "name": "hf-mem",
+      "description": "Hugging Face CLI to estimate the required memory to load Safetensors or GGUF model weights for inference from the Hugging Face Hub",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/hf-mem"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-best",
+      "name": "huggingface-best",
+      "description": "Use when the user asks about finding the best, top, or recommended model for a task, wants to know what AI model to use, or wants to compare models by benchmark scores. Triggers on: \"best model for X\", \"what model should I use for\", \"top models for [task]\", \"which model runs on my laptop/machine/device\", \"recommend a model for\", \"what LLM should I use for\", \"compare models for\", \"what's state of the art for\", or any question about choosing an AI model for a specific use case. Always use this skill when the user wants model recommendations or comparisons, even if they don't explicitly mention HuggingFace or benchmarks.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-best"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-community-evals",
+      "name": "huggingface-community-evals",
+      "description": "Run evaluations for Hugging Face Hub models using inspect-ai and lighteval on local hardware. Use for backend selection, local GPU evals, and choosing between vLLM / Transformers / accelerate. Not for HF Jobs orchestration, model-card PRs, .eval_results publication, or community-evals automation.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-community-evals"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-datasets",
+      "name": "huggingface-datasets",
+      "description": "Use this skill for Hugging Face Dataset Viewer API workflows that fetch subset/split metadata, paginate rows, search text, apply filters, download parquet URLs, and read size or statistics.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-datasets"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-gradio",
+      "name": "huggingface-gradio",
+      "description": "Build Gradio web UIs and demos in Python. Use when creating or editing Gradio apps, components, event listeners, layouts, or chatbots.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-gradio"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-llm-trainer",
+      "name": "huggingface-llm-trainer",
+      "description": "Train or fine-tune language and vision models using TRL (Transformer Reinforcement Learning) or Unsloth with Hugging Face Jobs infrastructure. Covers SFT, DPO, GRPO and reward modeling training methods, plus GGUF conversion for local deployment. Includes guidance on the TRL Jobs package, UV scripts with PEP 723 format, dataset preparation and validation, hardware selection, cost estimation, Trackio monitoring, Hub authentication, model selection/leaderboards and model persistence. Use for tasks involving cloud GPU training, GGUF conversion, or when users mention training on Hugging Face Jobs without local GPU setup.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-llm-trainer"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-local-models",
+      "name": "huggingface-local-models",
+      "description": "Use to select models to run locally with llama.cpp and GGUF on CPU, Mac Metal, CUDA, or ROCm. Covers finding GGUFs, quant selection, running servers, exact GGUF file lookup, conversion, and OpenAI-compatible local serving.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-local-models"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-lora-space-builder",
+      "name": "huggingface-lora-space-builder",
+      "description": "Build and publish a Gradio demo on Hugging Face Spaces for a user-provided LoRA. Use when someone asks to create, generate, ship, or publish a Space, demo, Gradio app, or playground for a LoRA — including LoRAs for Qwen-Image, Qwen-Image-Edit, LTX-Video, Wan, FLUX, SDXL, or other diffusion base models. Also triggers when someone describes a LoRA they trained or hosts on the Hub and wants to share it. Covers picking the right base pipeline and `diffusers` inference recipe, designing a UI tailored to the LoRA's task and inputs (Union/multi-task control, edit, video, image, etc.), respecting model-card recommendations (trigger words, steps, guidance, LoRA scale, example inputs), and shipping to ZeroGPU hardware as a private Space by default.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-lora-space-builder"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-paper-publisher",
+      "name": "huggingface-paper-publisher",
+      "description": "Publish and manage research papers on Hugging Face Hub. Supports creating paper pages, linking papers to models/datasets, claiming authorship, and generating professional markdown-based research articles.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-paper-publisher"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-papers",
+      "name": "huggingface-papers",
+      "description": "Look up and read Hugging Face paper pages in markdown, and use the papers API for structured metadata such as authors, linked models/datasets/spaces, Github repo and project page. Use when the user shares a Hugging Face paper page URL, an arXiv URL or ID, or asks to summarize, explain, or analyze an AI research paper.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-papers"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-spaces",
+      "name": "huggingface-spaces",
+      "description": "Build, deploy, and maintain applications on Hugging Face Spaces — Gradio / Docker / Static SDKs, ZeroGPU and dedicated hardware, model loading, debugging, buckets, inference providers, community grants. Use whenever the user asks to create or host an app on Hugging Face, port code onto ZeroGPU, fix a Space that won't build or run, or otherwise work with `hf spaces …`, `@spaces.GPU`, Space README frontmatter, or the `spaces` Python package.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-spaces"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-tool-builder",
+      "name": "huggingface-tool-builder",
+      "description": "Use this skill when the user wants to build tool/scripts or achieve a task where using data from the Hugging Face API would help. This is especially useful when chaining or combining API calls or the task will be repeated/automated. This Skill creates a reusable script to fetch, enrich or process data.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-tool-builder"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-trackio",
+      "name": "huggingface-trackio",
+      "description": "Track and visualize ML training experiments with Trackio. Use when logging metrics during training (Python API), firing alerts for training diagnostics, or retrieving/analyzing logged metrics (CLI). Supports real-time dashboard visualization, alerts with webhooks, HF Space syncing, and JSON output for automation.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-trackio"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-vision-trainer",
+      "name": "huggingface-vision-trainer",
+      "description": "Trains and fine-tunes vision models for object detection (D-FINE, RT-DETR v2, DETR, YOLOS), image classification (timm models — MobileNetV3, MobileViT, ResNet, ViT/DINOv3 — plus any Transformers classifier), and SAM/SAM2 segmentation using Hugging Face Transformers on Hugging Face Jobs cloud GPUs. Covers COCO-format dataset preparation, Albumentations augmentation, mAP/mAR evaluation, accuracy metrics, SAM segmentation with bbox/point prompts, DiceCE loss, hardware selection, cost estimation, Trackio monitoring, and Hub persistence. Use when users mention training object detection, image classification, SAM, SAM2, segmentation, image matting, DETR, D-FINE, RT-DETR, ViT, timm, MobileNet, ResNet, bounding box models, or fine-tuning vision models on Hugging Face Jobs.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-vision-trainer"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/huggingface-zerogpu",
+      "name": "huggingface-zerogpu",
+      "description": "AI demos and GPU compute with Gradio Spaces and Hugging Face Spaces ZeroGPU. Use when writing or reviewing code that uses `@spaces.GPU`, configuring `python_version` or `requirements.txt` for a ZeroGPU Space, or handling ZeroGPU-specific code constraints — pickle-based process isolation, `gr.State` semantics across the worker boundary, no `torch.compile` (use AoTI instead), CUDA wheel-only builds (no `nvcc` at build or runtime), large vs xlarge sizing, and dynamic duration callables. Make sure to use this skill whenever the user mentions ZeroGPU, `@spaces.GPU`, or the `spaces` Python package, or hits ZeroGPU-specific code errors like `PicklingError` across the worker boundary, `illegal duration`, or `flash-attn` wheel-build failures — even when the user does not explicitly ask for ZeroGPU coding guidance. Trigger on `import spaces` or `@spaces.GPU` in code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/huggingface-zerogpu"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/train-sentence-transformers",
+      "name": "train-sentence-transformers",
+      "description": "Train or fine-tune sentence-transformers models across `SentenceTransformer` (bi-encoder; dense or static embedding model; for retrieval, similarity, clustering, classification, paraphrase mining, dedup, multimodal), `CrossEncoder` (reranker; pair scoring for two-stage retrieval / pair classification), and `SparseEncoder` (SPLADE, sparse embedding model; for learned-sparse retrieval). Covers loss selection, hard-negative mining, evaluators, distillation, LoRA, Matryoshka, and Hugging Face Hub publishing. Use for any sentence-transformers training task.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/train-sentence-transformers"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/transformers-js",
+      "name": "transformers-js",
+      "description": "Use Transformers.js to run state-of-the-art machine learning models directly in JavaScript/TypeScript. Supports NLP (text classification, translation, summarization), computer vision (image classification, object detection), audio (speech recognition, audio classification), and multimodal tasks. Works in browsers and server-side runtimes (Node.js, Bun, Deno) with WebGPU/WASM using pre-trained models from Hugging Face Hub.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/transformers-js"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
+    },
+    {
+      "id": "huggingface-skills/trl-training",
+      "name": "trl-training",
+      "description": "Train and fine-tune transformer language models using TRL (Transformers Reinforcement Learning). Supports SFT, DPO, GRPO, KTO, RLOO and Reward Model training via CLI commands.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "huggingface/skills",
+        "ref": "main",
+        "path": "skills/trl-training"
+      },
+      "stars": 10674,
+      "updatedAt": "2026-06-12T09:25:39Z",
+      "provenance": "curated",
+      "sourceId": "huggingface-skills"
     },
     {
       "id": "humanizer/humanizer",
@@ -1452,10 +2268,26 @@
         "ref": "main",
         "path": ""
       },
-      "stars": 22903,
+      "stars": 24308,
       "updatedAt": "2026-06-07T23:28:05Z",
       "provenance": "curated",
       "sourceId": "humanizer"
+    },
+    {
+      "id": "karpathy-skills/karpathy-guidelines",
+      "name": "karpathy-guidelines",
+      "description": "Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "multica-ai/andrej-karpathy-skills",
+        "ref": "main",
+        "path": "skills/karpathy-guidelines"
+      },
+      "stars": 176016,
+      "updatedAt": "2026-04-20T10:05:04Z",
+      "provenance": "curated",
+      "sourceId": "karpathy-skills"
     },
     {
       "id": "last30days/last30days",
@@ -1468,8 +2300,8 @@
         "ref": "main",
         "path": "skills/last30days"
       },
-      "stars": 32901,
-      "updatedAt": "2026-06-06T16:58:08Z",
+      "stars": 42711,
+      "updatedAt": "2026-06-10T00:33:31Z",
       "provenance": "curated",
       "sourceId": "last30days"
     },
@@ -1484,8 +2316,8 @@
         "ref": "main",
         "path": "skills/productivity/caveman"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1500,8 +2332,8 @@
         "ref": "main",
         "path": "skills/deprecated/design-an-interface"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1516,8 +2348,8 @@
         "ref": "main",
         "path": "skills/engineering/diagnose"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1532,8 +2364,8 @@
         "ref": "main",
         "path": "skills/personal/edit-article"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1548,8 +2380,8 @@
         "ref": "main",
         "path": "skills/misc/git-guardrails-claude-code"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1564,8 +2396,8 @@
         "ref": "main",
         "path": "skills/productivity/grill-me"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1580,8 +2412,8 @@
         "ref": "main",
         "path": "skills/engineering/grill-with-docs"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1596,8 +2428,8 @@
         "ref": "main",
         "path": "skills/productivity/handoff"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1612,8 +2444,8 @@
         "ref": "main",
         "path": "skills/engineering/improve-codebase-architecture"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1628,8 +2460,8 @@
         "ref": "main",
         "path": "skills/misc/migrate-to-shoehorn"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1644,8 +2476,8 @@
         "ref": "main",
         "path": "skills/personal/obsidian-vault"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1660,8 +2492,8 @@
         "ref": "main",
         "path": "skills/engineering/prototype"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1676,8 +2508,8 @@
         "ref": "main",
         "path": "skills/deprecated/qa"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1692,8 +2524,8 @@
         "ref": "main",
         "path": "skills/deprecated/request-refactor-plan"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1708,8 +2540,8 @@
         "ref": "main",
         "path": "skills/in-progress/review"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1724,8 +2556,8 @@
         "ref": "main",
         "path": "skills/misc/scaffold-exercises"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1740,8 +2572,8 @@
         "ref": "main",
         "path": "skills/engineering/setup-matt-pocock-skills"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1756,8 +2588,8 @@
         "ref": "main",
         "path": "skills/misc/setup-pre-commit"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1772,8 +2604,8 @@
         "ref": "main",
         "path": "skills/engineering/tdd"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1786,10 +2618,10 @@
       "source": {
         "repo": "mattpocock/skills",
         "ref": "main",
-        "path": "skills/in-progress/teach"
+        "path": "skills/productivity/teach"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1804,8 +2636,8 @@
         "ref": "main",
         "path": "skills/engineering/to-issues"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1820,8 +2652,8 @@
         "ref": "main",
         "path": "skills/engineering/to-prd"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1836,8 +2668,8 @@
         "ref": "main",
         "path": "skills/engineering/triage"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1852,8 +2684,8 @@
         "ref": "main",
         "path": "skills/deprecated/ubiquitous-language"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1868,8 +2700,8 @@
         "ref": "main",
         "path": "skills/productivity/write-a-skill"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1884,8 +2716,8 @@
         "ref": "main",
         "path": "skills/in-progress/writing-beats"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1900,8 +2732,8 @@
         "ref": "main",
         "path": "skills/in-progress/writing-fragments"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1916,8 +2748,8 @@
         "ref": "main",
         "path": "skills/in-progress/writing-shape"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1932,8 +2764,8 @@
         "ref": "main",
         "path": "skills/engineering/zoom-out"
       },
-      "stars": 121042,
-      "updatedAt": "2026-06-07T17:44:50Z",
+      "stars": 129812,
+      "updatedAt": "2026-06-12T08:25:23Z",
       "provenance": "curated",
       "sourceId": "mattpocock-skills"
     },
@@ -1948,8 +2780,8 @@
         "ref": "main",
         "path": ""
       },
-      "stars": 16101,
-      "updatedAt": "2026-06-08T01:19:25Z",
+      "stars": 16468,
+      "updatedAt": "2026-06-15T16:17:27Z",
       "provenance": "curated",
       "sourceId": "notebooklm"
     },
@@ -1964,8 +2796,8 @@
         "ref": "main",
         "path": "skills/defuddle"
       },
-      "stars": 34895,
-      "updatedAt": "2026-06-08T02:02:00Z",
+      "stars": 35711,
+      "updatedAt": "2026-06-08T16:12:01Z",
       "provenance": "curated",
       "sourceId": "obsidian-skills"
     },
@@ -1980,8 +2812,8 @@
         "ref": "main",
         "path": "skills/json-canvas"
       },
-      "stars": 34895,
-      "updatedAt": "2026-06-08T02:02:00Z",
+      "stars": 35711,
+      "updatedAt": "2026-06-08T16:12:01Z",
       "provenance": "curated",
       "sourceId": "obsidian-skills"
     },
@@ -1996,8 +2828,8 @@
         "ref": "main",
         "path": "skills/obsidian-bases"
       },
-      "stars": 34895,
-      "updatedAt": "2026-06-08T02:02:00Z",
+      "stars": 35711,
+      "updatedAt": "2026-06-08T16:12:01Z",
       "provenance": "curated",
       "sourceId": "obsidian-skills"
     },
@@ -2012,8 +2844,8 @@
         "ref": "main",
         "path": "skills/obsidian-cli"
       },
-      "stars": 34895,
-      "updatedAt": "2026-06-08T02:02:00Z",
+      "stars": 35711,
+      "updatedAt": "2026-06-08T16:12:01Z",
       "provenance": "curated",
       "sourceId": "obsidian-skills"
     },
@@ -2028,10 +2860,698 @@
         "ref": "main",
         "path": "skills/obsidian-markdown"
       },
-      "stars": 34895,
-      "updatedAt": "2026-06-08T02:02:00Z",
+      "stars": 35711,
+      "updatedAt": "2026-06-08T16:12:01Z",
       "provenance": "curated",
       "sourceId": "obsidian-skills"
+    },
+    {
+      "id": "openai-skills/aspnet-core",
+      "name": "aspnet-core",
+      "description": "Build, review, refactor, or architect ASP.NET Core web applications using current official guidance for .NET web development. Use when working on Blazor Web Apps, Razor Pages, MVC, Minimal APIs, controller-based Web APIs, SignalR, gRPC, middleware, dependency injection, configuration, authentication, authorization, testing, performance, deployment, or ASP.NET Core upgrades.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/aspnet-core"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/chatgpt-apps",
+      "name": "chatgpt-apps",
+      "description": "Build, scaffold, refactor, and troubleshoot ChatGPT Apps SDK applications that combine an MCP server and widget UI. Use when Codex needs to design tools, register UI resources, wire the MCP Apps bridge or ChatGPT compatibility APIs, apply Apps SDK metadata or CSP or domain settings, or produce a docs-aligned project scaffold. Prefer a docs-first workflow by invoking the openai-docs skill or OpenAI developer docs MCP tools before generating code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/chatgpt-apps"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/cli-creator",
+      "name": "cli-creator",
+      "description": "Build a composable CLI for Codex from API docs, an OpenAPI spec, existing curl examples, an SDK, a web app, an admin tool, or a local script. Use when the user wants Codex to create a command-line tool that can run from any repo, expose composable read/write commands, return stable JSON, manage auth, and pair with a companion skill.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/cli-creator"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/cloudflare-deploy",
+      "name": "cloudflare-deploy",
+      "description": "Deploy applications and infrastructure to Cloudflare using Workers, Pages, and related platform services. Use when the user asks to deploy, host, publish, or set up a project on Cloudflare.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/cloudflare-deploy"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/define-goal",
+      "name": "define-goal",
+      "description": "Help the user define a concrete, measurable goal before starting work, especially when they ask to use the goal tool, create a goal, set an objective, clarify success criteria, or turn a fuzzy intention into a quantitative outcome. Use this skill for goal creation and goal refinement only; it does not manage durable snapshots, decision logs, or long-running execution artifacts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/define-goal"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma",
+      "name": "figma",
+      "description": "Use the Figma MCP server to fetch design context, screenshots, variables, and assets from Figma, and to translate Figma nodes into production code. Trigger when a task involves Figma URLs, node IDs, design-to-code implementation, or Figma MCP setup and troubleshooting.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-code-connect-components",
+      "name": "figma-code-connect-components",
+      "description": "Connects Figma design components to code components using Code Connect mapping tools. Use when user says \"code connect\", \"connect this component to code\", \"map this component\", \"link component to code\", \"create code connect mapping\", or wants to establish mappings between Figma designs and code implementations. For canvas writes via `use_figma`, use `figma-use`.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-code-connect-components"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-create-design-system-rules",
+      "name": "figma-create-design-system-rules",
+      "description": "Generates custom design system rules for the user's codebase. Use when user says \"create design system rules\", \"generate rules for my project\", \"set up design rules\", \"customize design system guidelines\", or wants to establish project-specific conventions for Figma-to-code workflows. Requires Figma MCP server connection.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-create-design-system-rules"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-create-new-file",
+      "name": "figma-create-new-file",
+      "description": "Create a new blank Figma file. Use when the user wants to create a new Figma design or FigJam file, or when you need a new file before calling use_figma. Handles plan resolution via whoami if needed. Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file figjam My Whiteboard)",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-create-new-file"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-generate-design",
+      "name": "figma-generate-design",
+      "description": "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layout into Figma. Triggers: 'write to Figma', 'create in Figma from code', 'push page to Figma', 'take this app/page and build it in Figma', 'create a screen', 'build a landing page in Figma', 'update the Figma screen to match code'. This is the preferred workflow skill whenever the user wants to build or update a full page, screen, or view in Figma from code or a description. Discovers design system components, variables, and styles via search_design_system, imports them, and assembles screens incrementally section-by-section using design system tokens instead of hardcoded values.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-generate-design"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-generate-library",
+      "name": "figma-generate-library",
+      "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variables/tokens, build component libraries, set up theming (light/dark modes), document foundations, or reconcile gaps between code and Figma. This skill teaches WHAT to build and in WHAT ORDER — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should be loaded together.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-generate-library"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-implement-design",
+      "name": "figma-implement-design",
+      "description": "Translates Figma designs into production-ready application code with 1:1 visual fidelity. Use when implementing UI code from Figma files, when user mentions \"implement design\", \"generate code\", \"implement component\", provides Figma URLs, or asks to build components matching Figma specs. For Figma canvas writes via `use_figma`, use `figma-use`.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-implement-design"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/figma-use",
+      "name": "figma-use",
+      "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` directly without loading this skill first. Skipping it causes common, hard-to-debug failures. Trigger whenever the user wants to perform a write action or a unique read action that requires JavaScript execution in the Figma file context — e.g. create/edit/delete nodes, set up variables or tokens, build components and variants, modify auto-layout or fills, bind variables to properties, or inspect file structure programmatically.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/figma-use"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/gh-address-comments",
+      "name": "gh-address-comments",
+      "description": "Help address review/issue comments on the open GitHub PR for the current branch using gh CLI; verify gh auth first and prompt the user to authenticate if not logged in.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/gh-address-comments"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/gh-fix-ci",
+      "name": "gh-fix-ci",
+      "description": "Use when a user asks to debug or fix failing GitHub PR checks that run in GitHub Actions; use `gh` to inspect checks and logs, summarize failure context, draft a fix plan, and implement only after explicit approval. Treat external providers (for example Buildkite) as out of scope and report only the details URL.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/gh-fix-ci"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/hatch-pet",
+      "name": "hatch-pet",
+      "description": "Create, repair, validate, visually QA, and package Codex-compatible animated pets and pet spritesheets from character art, generated images, company or prospect brand cues, or visual references. Use when a user wants a lightweight-worker Codex pet workflow, a non-pixel custom pet style, a prospect or company mascot pet, or a full 8x9 animated pet atlas with transparent unused cells, QA contact sheets, and pet.json packaging. This skill composes the installed $imagegen system skill for visual generation and uses bundled scripts for deterministic spritesheet assembly.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/hatch-pet"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/imagegen",
+      "name": "imagegen",
+      "description": "Generate or edit raster images when the task benefits from AI-created bitmap visuals such as photos, illustrations, textures, sprites, mockups, or transparent-background cutouts. Use when Codex should create a brand-new image, transform an existing image, or derive visual variants from references, and the output should be a bitmap asset rather than repo-native code or vector. Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.system/imagegen"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/jupyter-notebook",
+      "name": "jupyter-notebook",
+      "description": "Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) for experiments, explorations, or tutorials; prefer the bundled templates and run the helper script `new_notebook.py` to generate a clean starting notebook.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/jupyter-notebook"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/linear",
+      "name": "linear",
+      "description": "Manage issues, projects & team workflows in Linear. Use when the user wants to read, create or updates tickets in Linear.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/linear"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/migrate-to-codex",
+      "name": "migrate-to-codex",
+      "description": "Migrate supported instruction files, skills, agents, and MCP config into Codex project and global files.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/migrate-to-codex"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/netlify-deploy",
+      "name": "netlify-deploy",
+      "description": "Deploy web projects to Netlify using the Netlify CLI (`npx netlify`). Use when the user asks to deploy, host, publish, or link a site/repo on Netlify, including preview and production deploys.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/netlify-deploy"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/notion-knowledge-capture",
+      "name": "notion-knowledge-capture",
+      "description": "Capture conversations and decisions into structured Notion pages; use when turning chats/notes into wiki entries, how-tos, decisions, or FAQs with proper linking.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/notion-knowledge-capture"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/notion-meeting-intelligence",
+      "name": "notion-meeting-intelligence",
+      "description": "Prepare meeting materials with Notion context and Codex research; use when gathering context, drafting agendas/pre-reads, and tailoring materials to attendees.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/notion-meeting-intelligence"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/notion-research-documentation",
+      "name": "notion-research-documentation",
+      "description": "Research across Notion and synthesize into structured documentation; use when gathering info from multiple Notion sources to produce briefs, comparisons, or reports with citations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/notion-research-documentation"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/notion-spec-to-implementation",
+      "name": "notion-spec-to-implementation",
+      "description": "Turn Notion specs into implementation plans, tasks, and progress tracking; use when implementing PRDs/feature specs and creating Notion plans + tasks from them.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/notion-spec-to-implementation"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/openai-docs",
+      "name": "openai-docs",
+      "description": "Use when the user asks how to build with OpenAI products or APIs, asks about Codex itself or choosing Codex surfaces, needs up-to-date official documentation with citations, help choosing the latest model for a use case, or model upgrade and prompt-upgrade guidance; use OpenAI docs MCP tools for non-Codex docs questions, use the Codex manual helper first for broad Codex self-knowledge, and restrict fallback browsing to official OpenAI domains.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/openai-docs"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/pdf",
+      "name": "pdf",
+      "description": "Use when tasks involve reading, creating, or reviewing PDF files where rendering and layout matter; prefer visual checks by rendering pages (Poppler) and use Python tools such as `reportlab`, `pdfplumber`, and `pypdf` for generation and extraction.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/pdf"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/playwright",
+      "name": "playwright",
+      "description": "Use when the task requires automating a real browser from the terminal (navigation, form filling, snapshots, screenshots, data extraction, UI-flow debugging) via `playwright-cli` or the bundled wrapper script.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/playwright"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/playwright-interactive",
+      "name": "playwright-interactive",
+      "description": "Persistent browser and Electron interaction through `js_repl` for fast iterative UI debugging.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/playwright-interactive"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/plugin-creator",
+      "name": "plugin-creator",
+      "description": "Create and scaffold plugin directories for Codex with a required `.codex-plugin/plugin.json`, optional plugin folders/files, and baseline placeholders you can edit before publishing or testing. Use when Codex needs to create a new local plugin, add optional plugin structure, or generate or update repo-root `.agents/plugins/marketplace.json` entries for plugin ordering and availability metadata.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.system/plugin-creator"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/render-deploy",
+      "name": "render-deploy",
+      "description": "Deploy applications to Render by analyzing codebases, generating render.yaml Blueprints, and providing Dashboard deeplinks. Use when the user wants to deploy, host, publish, or set up their application on Render's cloud platform.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/render-deploy"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/screenshot",
+      "name": "screenshot",
+      "description": "Use when the user explicitly asks for a desktop or system screenshot (full screen, specific app or window, or a pixel region), or when tool-specific capture capabilities are unavailable and an OS-level capture is needed.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/screenshot"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/security-best-practices",
+      "name": "security-best-practices",
+      "description": "Perform language and framework specific security best-practice reviews and suggest improvements. Trigger only when the user explicitly requests security best practices guidance, a security review/report, or secure-by-default coding help. Trigger only for supported languages (python, javascript/typescript, go). Do not trigger for general code review, debugging, or non-security tasks.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/security-best-practices"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/security-ownership-map",
+      "name": "security-ownership-map",
+      "description": "Analyze git repositories to build a security ownership topology (people-to-file), compute bus factor and sensitive-code ownership, and export CSV/JSON for graph databases and visualization. Trigger only when the user explicitly wants a security-oriented ownership or bus-factor analysis grounded in git history (for example: orphaned sensitive code, security maintainers, CODEOWNERS reality checks for risk, sensitive hotspots, or ownership clusters). Do not trigger for general maintainer lists or non-security ownership questions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/security-ownership-map"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/security-threat-model",
+      "name": "security-threat-model",
+      "description": "Repository-grounded threat modeling that enumerates trust boundaries, assets, attacker capabilities, abuse paths, and mitigations, and writes a concise Markdown threat model. Trigger only when the user explicitly asks to threat model a codebase or path, enumerate threats/abuse paths, or perform AppSec threat modeling. Do not trigger for general architecture summaries, code review, or non-security design work.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/security-threat-model"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/sentry",
+      "name": "sentry",
+      "description": "Use when the user asks to inspect Sentry issues or events, summarize recent production errors, or pull basic Sentry health data via the Sentry CLI; perform read-only queries using the `sentry` command.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/sentry"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/skill-creator",
+      "name": "skill-creator",
+      "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.system/skill-creator"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/skill-installer",
+      "name": "skill-installer",
+      "description": "Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.system/skill-installer"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/speech",
+      "name": "speech",
+      "description": "Use when the user asks for text-to-speech narration or voiceover, accessibility reads, audio prompts, or batch speech generation via the OpenAI Audio API; run the bundled CLI (`scripts/text_to_speech.py`) with built-in voices and require `OPENAI_API_KEY` for live calls. Custom voice creation is out of scope.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/speech"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/transcribe",
+      "name": "transcribe",
+      "description": "Transcribe audio files to text with optional diarization and known-speaker hints. Use when a user asks to transcribe speech from audio/video, extract text from recordings, or label speakers in interviews or meetings.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/transcribe"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/vercel-deploy",
+      "name": "vercel-deploy",
+      "description": "Deploy applications and websites to Vercel. Use when the user requests deployment actions like \"deploy my app\", \"deploy and give me the link\", \"push this live\", or \"create a preview deployment\".",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/vercel-deploy"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/winui-app",
+      "name": "winui-app",
+      "description": "Bootstrap, develop, and design modern WinUI 3 desktop applications with C# and the Windows App SDK using official Microsoft guidance, WinUI Gallery patterns, Windows App SDK samples, and CommunityToolkit components. Use when creating a brand new app, preparing a machine for WinUI, reviewing, refactoring, planning, troubleshooting, environment-checking, or setting up WinUI 3 XAML, controls, navigation, windowing, theming, accessibility, responsiveness, performance, deployment, or related Windows app design and development work.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/winui-app"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
+    },
+    {
+      "id": "openai-skills/yeet",
+      "name": "yeet",
+      "description": "Use only when the user explicitly asks to stage, commit, push, and open a GitHub pull request in one flow using the GitHub CLI (`gh`).",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "openai/skills",
+        "ref": "main",
+        "path": "skills/.curated/yeet"
+      },
+      "stars": 22229,
+      "updatedAt": "2026-05-29T16:20:41Z",
+      "provenance": "curated",
+      "sourceId": "openai-skills"
     },
     {
       "id": "superpowers/brainstorming",
@@ -2044,8 +3564,8 @@
         "ref": "main",
         "path": "skills/brainstorming"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2060,8 +3580,8 @@
         "ref": "main",
         "path": "skills/dispatching-parallel-agents"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2076,8 +3596,8 @@
         "ref": "main",
         "path": "skills/executing-plans"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2092,8 +3612,8 @@
         "ref": "main",
         "path": "skills/finishing-a-development-branch"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2108,8 +3628,8 @@
         "ref": "main",
         "path": "skills/receiving-code-review"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2124,8 +3644,8 @@
         "ref": "main",
         "path": "skills/requesting-code-review"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2140,8 +3660,8 @@
         "ref": "main",
         "path": "skills/subagent-driven-development"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2156,8 +3676,8 @@
         "ref": "main",
         "path": "skills/systematic-debugging"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2172,8 +3692,8 @@
         "ref": "main",
         "path": "skills/test-driven-development"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2188,8 +3708,8 @@
         "ref": "main",
         "path": "skills/using-git-worktrees"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2204,8 +3724,8 @@
         "ref": "main",
         "path": "skills/using-superpowers"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2220,8 +3740,8 @@
         "ref": "main",
         "path": "skills/verification-before-completion"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2236,8 +3756,8 @@
         "ref": "main",
         "path": "skills/writing-plans"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2252,8 +3772,8 @@
         "ref": "main",
         "path": "skills/writing-skills"
       },
-      "stars": 221029,
-      "updatedAt": "2026-06-03T05:46:02Z",
+      "stars": 228619,
+      "updatedAt": "2026-06-13T22:17:11Z",
       "provenance": "curated",
       "sourceId": "superpowers"
     },
@@ -2268,8 +3788,8 @@
         "ref": "main",
         "path": "skills/brandkit"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2284,8 +3804,8 @@
         "ref": "main",
         "path": "skills/taste-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2300,8 +3820,8 @@
         "ref": "main",
         "path": "skills/taste-skill-v1"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2316,8 +3836,8 @@
         "ref": "main",
         "path": "skills/output-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2332,8 +3852,8 @@
         "ref": "main",
         "path": "skills/gpt-tasteskill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2348,8 +3868,8 @@
         "ref": "main",
         "path": "skills/soft-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2364,8 +3884,8 @@
         "ref": "main",
         "path": "skills/image-to-code-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2380,8 +3900,8 @@
         "ref": "main",
         "path": "skills/imagegen-frontend-mobile"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2396,8 +3916,8 @@
         "ref": "main",
         "path": "skills/imagegen-frontend-web"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2412,8 +3932,8 @@
         "ref": "main",
         "path": "skills/brutalist-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2428,8 +3948,8 @@
         "ref": "main",
         "path": "skills/minimalist-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2444,8 +3964,8 @@
         "ref": "main",
         "path": "skills/redesign-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2460,8 +3980,8 @@
         "ref": "main",
         "path": "skills/stitch-skill"
       },
-      "stars": 37929,
-      "updatedAt": "2026-05-26T19:31:39Z",
+      "stars": 44341,
+      "updatedAt": "2026-06-12T15:11:11Z",
       "provenance": "curated",
       "sourceId": "taste-skill"
     },
@@ -2476,7 +3996,7 @@
         "ref": "main",
         "path": ".claude/skills/banner-design"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2492,7 +4012,7 @@
         "ref": "main",
         "path": ".claude/skills/brand"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2508,7 +4028,7 @@
         "ref": "main",
         "path": ".claude/skills/design"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2524,7 +4044,7 @@
         "ref": "main",
         "path": ".claude/skills/design-system"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2540,7 +4060,7 @@
         "ref": "main",
         "path": ".claude/skills/slides"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2556,7 +4076,7 @@
         "ref": "main",
         "path": ".claude/skills/ui-styling"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2572,7 +4092,7 @@
         "ref": "main",
         "path": ".claude/skills/ui-ux-pro-max"
       },
-      "stars": 88756,
+      "stars": 91967,
       "updatedAt": "2026-04-03T05:08:19Z",
       "provenance": "curated",
       "sourceId": "ui-ux-pro-max"
@@ -2588,8 +4108,8 @@
         "ref": "main",
         "path": "skills/deploy-to-vercel"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2604,8 +4124,8 @@
         "ref": "main",
         "path": "skills/vercel-cli-with-tokens"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2620,8 +4140,8 @@
         "ref": "main",
         "path": "skills/vercel-optimize"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2636,8 +4156,8 @@
         "ref": "main",
         "path": "skills/react-best-practices"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2652,8 +4172,8 @@
         "ref": "main",
         "path": "skills/react-view-transitions"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2668,8 +4188,8 @@
         "ref": "main",
         "path": "skills/web-design-guidelines"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
     },
@@ -2684,10 +4204,2506 @@
         "ref": "main",
         "path": "skills/writing-guidelines"
       },
-      "stars": 27715,
-      "updatedAt": "2026-06-03T17:03:05Z",
+      "stars": 27945,
+      "updatedAt": "2026-06-10T21:21:47Z",
       "provenance": "curated",
       "sourceId": "vercel-agent-skills"
+    },
+    {
+      "id": "wshobson-agents/accessibility-compliance",
+      "name": "accessibility-compliance",
+      "description": "Implement WCAG 2.2 compliant interfaces with mobile accessibility, inclusive design patterns, and assistive technology support. Use when auditing accessibility, implementing ARIA patterns, building for screen readers, or ensuring inclusive user experiences.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/accessibility-compliance"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/airflow-dag-patterns",
+      "name": "airflow-dag-patterns",
+      "description": "Build production Apache Airflow DAGs with best practices for operators, sensors, testing, and deployment. Use when creating data pipelines, orchestrating workflows, or scheduling batch jobs.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/data-engineering/skills/airflow-dag-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/angular-migration",
+      "name": "angular-migration",
+      "description": "Migrate from AngularJS to Angular using hybrid mode, incremental component rewriting, and dependency injection updates. Use when upgrading AngularJS applications, planning framework migrations, or modernizing legacy Angular code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/framework-migration/skills/angular-migration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/anti-reversing-techniques",
+      "name": "anti-reversing-techniques",
+      "description": "Understand anti-reversing, obfuscation, and protection techniques encountered during software analysis. Use this skill when analyzing malware evasion techniques, when implementing anti-debugging protections for CTF challenges, when reverse engineering packed binaries, or when building security research tools that need to detect virtualized environments.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/reverse-engineering/skills/anti-reversing-techniques"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/api-design-principles",
+      "name": "api-design-principles",
+      "description": "Master REST and GraphQL API design principles to build intuitive, scalable, and maintainable APIs that delight developers. Use when designing new APIs, reviewing API specifications, or establishing API design standards.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/api-design-principles"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/architecture-decision-records",
+      "name": "architecture-decision-records",
+      "description": "Write and maintain Architecture Decision Records (ADRs) following best practices for technical decision documentation. Use when documenting significant technical decisions, reviewing past architectural choices, or establishing decision processes.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/documentation-generation/skills/architecture-decision-records"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/architecture-patterns",
+      "name": "architecture-patterns",
+      "description": "Implement proven backend architecture patterns including Clean Architecture, Hexagonal Architecture, and Domain-Driven Design. Use this skill when designing clean architecture for a new microservice, when refactoring a monolith to use bounded contexts, when implementing hexagonal or onion architecture patterns, or when debugging dependency cycles between application layers.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/architecture-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/async-python-patterns",
+      "name": "async-python-patterns",
+      "description": "Master Python asyncio, concurrent programming, and async/await patterns for high-performance applications. Use when building async APIs, concurrent systems, or I/O-bound applications requiring non-blocking operations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/async-python-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/attack-tree-construction",
+      "name": "attack-tree-construction",
+      "description": "Build comprehensive attack trees to visualize threat paths. Use when mapping attack scenarios, identifying defense gaps, or communicating security risks to stakeholders.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/security-scanning/skills/attack-tree-construction"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/auth-implementation-patterns",
+      "name": "auth-implementation-patterns",
+      "description": "Master authentication and authorization patterns including JWT, OAuth2, session management, and RBAC to build secure, scalable access control systems. Use when implementing auth systems, securing APIs, or debugging security issues.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/auth-implementation-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/backtesting-frameworks",
+      "name": "backtesting-frameworks",
+      "description": "Build robust backtesting systems for trading strategies with proper handling of look-ahead bias, survivorship bias, and transaction costs. Use when developing trading algorithms, validating strategies, or building backtesting infrastructure.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/quantitative-trading/skills/backtesting-frameworks"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/bash-defensive-patterns",
+      "name": "bash-defensive-patterns",
+      "description": "Master defensive Bash programming techniques for production-grade scripts. Use when writing robust shell scripts, CI/CD pipelines, or system utilities requiring fault tolerance and safety.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/shell-scripting/skills/bash-defensive-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/bats-testing-patterns",
+      "name": "bats-testing-patterns",
+      "description": "Master Bash Automated Testing System (Bats) for comprehensive shell script testing. Use when writing tests for shell scripts, CI/CD pipelines, or requiring test-driven development of shell utilities.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/shell-scripting/skills/bats-testing-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/bazel-build-optimization",
+      "name": "bazel-build-optimization",
+      "description": "Optimize Bazel builds for large-scale monorepos. Use when configuring Bazel, implementing remote execution, or optimizing build performance for enterprise codebases.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/bazel-build-optimization"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/billing-automation",
+      "name": "billing-automation",
+      "description": "Build automated billing systems for recurring payments, invoicing, subscription lifecycle, and dunning management. Use when implementing subscription billing, automating invoicing, or managing recurring payment systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/payment-processing/skills/billing-automation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/binary-analysis-patterns",
+      "name": "binary-analysis-patterns",
+      "description": "Master binary analysis patterns including disassembly, decompilation, control flow analysis, and code pattern recognition. Use when analyzing executables, understanding compiled code, or performing static analysis on binaries.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/reverse-engineering/skills/binary-analysis-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/block-no-verify-hook",
+      "name": "block-no-verify-hook",
+      "description": "Configure a PreToolUse hook to prevent AI agents from skipping git pre-commit hooks with --no-verify and other bypass flags. Use when setting up Claude Code projects that enforce commit quality gates.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/block-no-verify/skills/block-no-verify-hook"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/brand-landingpage",
+      "name": "brand-landingpage",
+      "description": "Brand-first landing page designer — runs a brand-identity interview (colors, typography, shape language), then generates and iterates on a polished landing page via Stitch with deployment-ready HTML. Use when the user asks to create, design, or build a landing page, homepage, or marketing page and has no established visual direction. Skip when they have a design mockup, need a dashboard or app UI, are working at component level, building a multi-page app, or restyling with known design tokens — use frontend-design instead.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/brand-landingpage/skills/brand-landingpage"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/changelog-automation",
+      "name": "changelog-automation",
+      "description": "Automate changelog generation from commits, PRs, and releases following Keep a Changelog format. Use when setting up release workflows, generating release notes, or standardizing commit conventions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/documentation-generation/skills/changelog-automation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/code-review-excellence",
+      "name": "code-review-excellence",
+      "description": "Master effective code review practices to provide constructive feedback, catch bugs early, and foster knowledge sharing while maintaining team morale. Use when reviewing pull requests, establishing review standards, or mentoring developers.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/code-review-excellence"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/competitive-landscape",
+      "name": "competitive-landscape",
+      "description": "Analyze competition, identify differentiation opportunities, and develop winning market positioning strategies using Porter's Five Forces, Blue Ocean Strategy, and positioning maps. Use this skill when evaluating competitors, assessing market positioning, identifying sustainable competitive advantages, or preparing competitive strategy analysis for a startup or investor pitch.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/startup-business-analyst/skills/competitive-landscape"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/context-driven-development",
+      "name": "context-driven-development",
+      "description": "Creates and maintains project context artifacts (product.md, tech-stack.md, workflow.md, tracks.md) in a `conductor/` directory. Scaffolds new projects from scratch, extracts context from existing codebases, validates artifact consistency before implementation, and synchronizes documents as the project evolves. Use when setting up a project, creating or updating product docs, managing a tech stack file, defining development workflows, tracking work units, onboarding to an existing codebase, or running project scaffolding.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/conductor/skills/context-driven-development"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/cost-optimization",
+      "name": "cost-optimization",
+      "description": "Optimize cloud costs across AWS, Azure, GCP, and OCI through resource rightsizing, tagging strategies, reserved instances, and spending analysis. Use when reducing cloud expenses, analyzing infrastructure costs, or implementing cost governance policies.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/cost-optimization"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/cqrs-implementation",
+      "name": "cqrs-implementation",
+      "description": "Implement Command Query Responsibility Segregation for scalable architectures. Use when separating read and write models, optimizing query performance, or building event-sourced systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/cqrs-implementation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/data-quality-frameworks",
+      "name": "data-quality-frameworks",
+      "description": "Implement data quality validation with Great Expectations, dbt tests, and data contracts. Use when building data quality pipelines, implementing validation rules, or establishing data contracts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/data-engineering/skills/data-quality-frameworks"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/data-storytelling",
+      "name": "data-storytelling",
+      "description": "Transform data into compelling narratives using visualization, context, and persuasive structure. Use when presenting analytics to stakeholders, creating data reports, or building executive presentations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/business-analytics/skills/data-storytelling"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/database-migration",
+      "name": "database-migration",
+      "description": "Execute database migrations across ORMs and platforms with zero-downtime strategies, data transformation, and rollback procedures. Use when migrating databases, changing schemas, performing data transformations, or implementing zero-downtime deployment strategies.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/framework-migration/skills/database-migration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/dbt-transformation-patterns",
+      "name": "dbt-transformation-patterns",
+      "description": "Master dbt (data build tool) for analytics engineering with model organization, testing, documentation, and incremental strategies. Use when building data transformations, creating data models, or implementing analytics engineering best practices.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/data-engineering/skills/dbt-transformation-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/debugging-strategies",
+      "name": "debugging-strategies",
+      "description": "Master systematic debugging techniques, profiling tools, and root cause analysis to efficiently track down bugs across any codebase or technology stack. Use when investigating bugs, performance issues, or unexpected behavior.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/debugging-strategies"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/defi-protocol-templates",
+      "name": "defi-protocol-templates",
+      "description": "Implement DeFi protocols with production-ready templates for staking, AMMs, governance, and lending systems. Use when building decentralized finance applications or smart contract protocols.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/blockchain-web3/skills/defi-protocol-templates"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/dependency-upgrade",
+      "name": "dependency-upgrade",
+      "description": "Manage major dependency version upgrades with compatibility analysis, staged rollout, and comprehensive testing. Use when upgrading framework versions, updating major dependencies, or managing breaking changes in libraries.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/framework-migration/skills/dependency-upgrade"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/deployment-pipeline-design",
+      "name": "deployment-pipeline-design",
+      "description": "Design multi-stage CI/CD pipelines with approval gates, security checks, and deployment orchestration. Use this skill when designing zero-downtime deployment pipelines, implementing canary rollout strategies, setting up multi-environment promotion workflows, or debugging failed deployment gates in CI/CD.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cicd-automation/skills/deployment-pipeline-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/design-system-patterns",
+      "name": "design-system-patterns",
+      "description": "Build scalable design systems with design tokens, theming infrastructure, and component architecture patterns. Use when creating design tokens, implementing theme switching, building component libraries, or establishing design system foundations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/design-system-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/distributed-tracing",
+      "name": "distributed-tracing",
+      "description": "Implement distributed tracing with Jaeger and Tempo to track requests across microservices and identify performance bottlenecks. Use when debugging microservices, analyzing request flows, or implementing observability for distributed systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/observability-monitoring/skills/distributed-tracing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/dotnet-backend-patterns",
+      "name": "dotnet-backend-patterns",
+      "description": "Master C#/.NET backend development patterns for building robust APIs, MCP servers, and enterprise applications. Covers async/await, dependency injection, Entity Framework Core, Dapper, configuration, caching, and testing with xUnit. Use when developing .NET backends, reviewing C# code, or designing API architectures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/dotnet-contribution/skills/dotnet-backend-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/e2e-testing-patterns",
+      "name": "e2e-testing-patterns",
+      "description": "Master end-to-end testing with Playwright and Cypress to build reliable test suites that catch bugs, improve confidence, and enable fast deployment. Use when implementing E2E tests, debugging flaky tests, or establishing testing standards.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/e2e-testing-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/embedding-strategies",
+      "name": "embedding-strategies",
+      "description": "Select and optimize embedding models for semantic search and RAG applications. Use when choosing embedding models, implementing chunking strategies, or optimizing embedding quality for specific domains.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/embedding-strategies"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/employment-contract-templates",
+      "name": "employment-contract-templates",
+      "description": "Create employment contracts, offer letters, and HR policy documents following legal best practices. Use when drafting employment agreements, creating HR policies, or standardizing employment documentation.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/hr-legal-compliance/skills/employment-contract-templates"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/error-handling-patterns",
+      "name": "error-handling-patterns",
+      "description": "Master error handling patterns across languages including exceptions, Result types, error propagation, and graceful degradation to build resilient applications. Use when implementing error handling, designing APIs, or improving application reliability.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/error-handling-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/evaluation-methodology",
+      "name": "evaluation-methodology",
+      "description": "PluginEval quality methodology — dimensions, rubrics, statistical methods, and scoring formulas. Use this skill when understanding how plugin quality is measured, when interpreting a low score on a specific dimension, when deciding how to improve a skill's triggering accuracy or orchestration fitness, when calibrating scoring thresholds for your marketplace, or when explaining quality badges to external partners like Neon.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/plugin-eval/skills/evaluation-methodology"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/event-store-design",
+      "name": "event-store-design",
+      "description": "Design and implement event stores for event-sourced systems. Use when building event sourcing infrastructure, choosing event store technologies, or implementing event persistence patterns.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/event-store-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/fastapi-templates",
+      "name": "fastapi-templates",
+      "description": "Create production-ready FastAPI projects with async patterns, dependency injection, and comprehensive error handling. Use when building new FastAPI applications or setting up backend API projects.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/api-scaffolding/skills/fastapi-templates"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/gdpr-data-handling",
+      "name": "gdpr-data-handling",
+      "description": "Implement GDPR-compliant data handling with consent management, data subject rights, and privacy by design. Use when building systems that process EU personal data, implementing privacy controls, or conducting GDPR compliance reviews.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/hr-legal-compliance/skills/gdpr-data-handling"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/git-advanced-workflows",
+      "name": "git-advanced-workflows",
+      "description": "Master advanced Git workflows including rebasing, cherry-picking, bisect, worktrees, and reflog to maintain clean history and recover from any situation. Use when managing complex Git histories, collaborating on feature branches, or troubleshooting repository issues.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/git-advanced-workflows"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/github-actions-templates",
+      "name": "github-actions-templates",
+      "description": "Create production-ready GitHub Actions workflows for automated testing, building, and deploying applications. Use when setting up CI/CD with GitHub Actions, automating development workflows, or creating reusable workflow templates.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cicd-automation/skills/github-actions-templates"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/gitlab-ci-patterns",
+      "name": "gitlab-ci-patterns",
+      "description": "Build GitLab CI/CD pipelines with multi-stage workflows, caching, and distributed runners for scalable automation. Use when implementing GitLab CI/CD, optimizing pipeline performance, or setting up automated testing and deployment.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cicd-automation/skills/gitlab-ci-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/gitops-workflow",
+      "name": "gitops-workflow",
+      "description": "Implement GitOps workflows with ArgoCD and Flux for automated, declarative Kubernetes deployments with continuous reconciliation. Use when implementing GitOps practices, automating Kubernetes deployments, or setting up declarative infrastructure management.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/kubernetes-operations/skills/gitops-workflow"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/go-concurrency-patterns",
+      "name": "go-concurrency-patterns",
+      "description": "Master Go concurrency with goroutines, channels, sync primitives, and context. Use when building concurrent Go applications, implementing worker pools, or debugging race conditions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/systems-programming/skills/go-concurrency-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/godot-gdscript-patterns",
+      "name": "godot-gdscript-patterns",
+      "description": "Master Godot 4 GDScript patterns including signals, scenes, state machines, and optimization. Use when building Godot games, implementing game systems, or learning GDScript best practices.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/game-development/skills/godot-gdscript-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/grafana-dashboards",
+      "name": "grafana-dashboards",
+      "description": "Create and manage production Grafana dashboards for real-time visualization of system and application metrics. Use when building monitoring dashboards, visualizing metrics, or creating operational observability interfaces.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/observability-monitoring/skills/grafana-dashboards"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/hads",
+      "name": "hads",
+      "description": "Use when writing technical documentation that needs to be readable by both humans and AI models, converting existing docs to HADS format, validating a HADS document, or optimizing documentation for token-efficient AI consumption.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/documentation-standards/skills/hads"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/helm-chart-scaffolding",
+      "name": "helm-chart-scaffolding",
+      "description": "Design, organize, and manage Helm charts for templating and packaging Kubernetes applications with reusable configurations. Use when creating Helm charts, packaging Kubernetes applications, or implementing templated deployments.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/kubernetes-operations/skills/helm-chart-scaffolding"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/hybrid-cloud-networking",
+      "name": "hybrid-cloud-networking",
+      "description": "Configure secure, high-performance connectivity between on-premises infrastructure and cloud platforms using VPN and dedicated connections. Use when building hybrid cloud architectures, connecting data centers to cloud, or implementing secure cross-premises networking.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/hybrid-cloud-networking"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/hybrid-search-implementation",
+      "name": "hybrid-search-implementation",
+      "description": "Combine vector and keyword search for improved retrieval. Use when implementing RAG systems, building search engines, or when neither approach alone provides sufficient recall.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/hybrid-search-implementation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/incident-runbook-templates",
+      "name": "incident-runbook-templates",
+      "description": "Create structured incident response runbooks with step-by-step procedures, escalation paths, and recovery actions. Use this skill when building a service outage runbook for a payment processing system; creating database incident procedures covering connection pool exhaustion, replication lag, and disk space alerts; onboarding new on-call engineers who need step-by-step recovery guides written for a 3 AM brain; or standardizing escalation matrices across multiple engineering teams.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/incident-response/skills/incident-runbook-templates"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/interaction-design",
+      "name": "interaction-design",
+      "description": "Design and implement microinteractions, motion design, transitions, and user feedback patterns. Use when adding polish to UI interactions, implementing loading states, or creating delightful user experiences.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/interaction-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/istio-traffic-management",
+      "name": "istio-traffic-management",
+      "description": "Configure Istio traffic management including routing, load balancing, circuit breakers, and canary deployments. Use when implementing service mesh traffic policies, progressive delivery, or resilience patterns.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/istio-traffic-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/javascript-testing-patterns",
+      "name": "javascript-testing-patterns",
+      "description": "Implement comprehensive testing strategies using Jest, Vitest, and Testing Library for unit tests, integration tests, and end-to-end testing with mocking, fixtures, and test-driven development. Use when writing JavaScript/TypeScript tests, setting up test infrastructure, or implementing TDD/BDD workflows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/javascript-typescript/skills/javascript-testing-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/k8s-manifest-generator",
+      "name": "k8s-manifest-generator",
+      "description": "Create production-ready Kubernetes manifests for Deployments, Services, ConfigMaps, and Secrets following best practices and security standards. Use when generating Kubernetes YAML manifests, creating K8s resources, or implementing production-grade Kubernetes configurations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/kubernetes-operations/skills/k8s-manifest-generator"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/k8s-security-policies",
+      "name": "k8s-security-policies",
+      "description": "Implement Kubernetes security policies including NetworkPolicy, PodSecurityPolicy, and RBAC for production-grade security. Use when securing Kubernetes clusters, implementing network isolation, or enforcing pod security standards.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/kubernetes-operations/skills/k8s-security-policies"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/kpi-dashboard-design",
+      "name": "kpi-dashboard-design",
+      "description": "Design effective KPI dashboards with metrics selection, visualization best practices, and real-time monitoring patterns. Use this skill when building an executive SaaS metrics dashboard tracking MRR, churn, and LTV/CAC ratios; designing an operations center with live service health and request throughput; creating a cohort retention analysis view for a product team; or debugging a dashboard where metrics contradict each other due to inconsistent calculation methodology.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/business-analytics/skills/kpi-dashboard-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/langchain-architecture",
+      "name": "langchain-architecture",
+      "description": "Design LLM applications using LangChain 1.x and LangGraph for agents, memory, and tool integration. Use when building LangChain applications, implementing AI agents, or creating complex LLM workflows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/langchain-architecture"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/linkerd-patterns",
+      "name": "linkerd-patterns",
+      "description": "Implement Linkerd service mesh patterns for lightweight, security-focused service mesh deployments. Use when setting up Linkerd, configuring traffic policies, or implementing zero-trust networking with minimal overhead.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/linkerd-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/llm-evaluation",
+      "name": "llm-evaluation",
+      "description": "Implement comprehensive evaluation strategies for LLM applications using automated metrics, human feedback, and benchmarking. Use when testing LLM performance, measuring AI application quality, or establishing evaluation frameworks.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/llm-evaluation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/market-sizing-analysis",
+      "name": "market-sizing-analysis",
+      "description": "Calculate TAM/SAM/SOM for market opportunities using top-down, bottom-up, and value theory methodologies. Use this skill when sizing markets, estimating addressable revenue, validating market opportunity for a new venture, or building investor-ready market analysis for a startup pitch or business plan.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/startup-business-analyst/skills/market-sizing-analysis"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/memory-forensics",
+      "name": "memory-forensics",
+      "description": "Master memory forensics techniques including memory acquisition, process analysis, and artifact extraction using Volatility and related tools. Use when analyzing memory dumps, investigating incidents, or performing malware analysis from RAM captures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/reverse-engineering/skills/memory-forensics"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/memory-safety-patterns",
+      "name": "memory-safety-patterns",
+      "description": "Implement memory-safe programming with RAII, ownership, smart pointers, and resource management across Rust, C++, and C. Use when writing safe systems code, managing resources, or preventing memory bugs.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/systems-programming/skills/memory-safety-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/microservices-patterns",
+      "name": "microservices-patterns",
+      "description": "Design microservices architectures with service boundaries, event-driven communication, and resilience patterns. Use when building distributed systems, decomposing monoliths, or implementing microservices.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/microservices-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/ml-pipeline-workflow",
+      "name": "ml-pipeline-workflow",
+      "description": "Build end-to-end MLOps pipelines from data preparation through model training, validation, and production deployment. Use when creating ML pipelines, implementing MLOps practices, or automating model training and deployment workflows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/machine-learning-ops/skills/ml-pipeline-workflow"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/mobile-android-design",
+      "name": "mobile-android-design",
+      "description": "Master Material Design 3 and Jetpack Compose patterns for building native Android apps. Use when designing Android interfaces, implementing Compose UI, or following Google's Material Design guidelines.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/mobile-android-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/mobile-ios-design",
+      "name": "mobile-ios-design",
+      "description": "Master iOS Human Interface Guidelines and SwiftUI patterns for building native iOS apps. Use when designing iOS interfaces, implementing SwiftUI views, or ensuring apps follow Apple's design principles.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/mobile-ios-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/modern-javascript-patterns",
+      "name": "modern-javascript-patterns",
+      "description": "Master ES6+ features including async/await, destructuring, spread operators, arrow functions, promises, modules, iterators, generators, and functional programming patterns for writing clean, efficient JavaScript code. Use when refactoring legacy code, implementing modern patterns, or optimizing JavaScript applications.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/javascript-typescript/skills/modern-javascript-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/monorepo-management",
+      "name": "monorepo-management",
+      "description": "Master monorepo management with Turborepo, Nx, and pnpm workspaces to build efficient, scalable multi-package repositories with optimized builds and dependency management. Use when setting up monorepos, optimizing builds, or managing shared dependencies.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/monorepo-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/mtls-configuration",
+      "name": "mtls-configuration",
+      "description": "Configure mutual TLS (mTLS) for zero-trust service-to-service communication. Use when implementing zero-trust networking, certificate management, or securing internal service communication.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/mtls-configuration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/multi-cloud-architecture",
+      "name": "multi-cloud-architecture",
+      "description": "Design multi-cloud architectures using a decision framework to select and integrate services across AWS, Azure, GCP, and OCI. Use when building multi-cloud systems, avoiding vendor lock-in, or leveraging best-of-breed services from multiple providers.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/multi-cloud-architecture"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/multi-reviewer-patterns",
+      "name": "multi-reviewer-patterns",
+      "description": "Coordinate parallel code reviews across multiple quality dimensions with finding deduplication, severity calibration, and consolidated reporting. Use this skill when organizing multi-reviewer code reviews, calibrating finding severity, or consolidating review results.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/multi-reviewer-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/nextjs-app-router-patterns",
+      "name": "nextjs-app-router-patterns",
+      "description": "Master Next.js 14+ App Router with Server Components, streaming, parallel routes, and advanced data fetching. Use when building Next.js applications, implementing SSR/SSG, or optimizing React Server Components.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/frontend-mobile-development/skills/nextjs-app-router-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/nft-standards",
+      "name": "nft-standards",
+      "description": "Implement NFT standards (ERC-721, ERC-1155) with proper metadata handling, minting strategies, and marketplace integration. Use when creating NFT contracts, building NFT marketplaces, or implementing digital asset systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/blockchain-web3/skills/nft-standards"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/nodejs-backend-patterns",
+      "name": "nodejs-backend-patterns",
+      "description": "Build production-ready Node.js backend services with Express/Fastify, implementing middleware patterns, error handling, authentication, database integration, and API design best practices. Use when creating Node.js servers, REST APIs, GraphQL backends, or microservices architectures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/javascript-typescript/skills/nodejs-backend-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/nx-workspace-patterns",
+      "name": "nx-workspace-patterns",
+      "description": "Configure and optimize Nx monorepo workspaces. Use when setting up Nx, configuring project boundaries, optimizing build caching, or implementing affected commands.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/nx-workspace-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/on-call-handoff-patterns",
+      "name": "on-call-handoff-patterns",
+      "description": "Master on-call shift handoffs with context transfer, escalation procedures, and documentation. Use this skill when transitioning on-call responsibilities between engineers and ensuring the incoming responder has full situational awareness, when writing a shift summary that captures active incidents, ongoing investigations, and recent changes, when handing off mid-incident so a fresh engineer can take over the incident commander role without losing context, when onboarding a new engineer to the on-call rotation for the first time, or when auditing and improving the quality of existing handoff processes across teams.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/incident-response/skills/on-call-handoff-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/openapi-spec-generation",
+      "name": "openapi-spec-generation",
+      "description": "Generate and maintain OpenAPI 3.1 specifications from code, design-first specs, and validation patterns. Use when creating API documentation, generating SDKs, or ensuring API contract compliance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/documentation-generation/skills/openapi-spec-generation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/parallel-debugging",
+      "name": "parallel-debugging",
+      "description": "Debug complex issues using competing hypotheses with parallel investigation, evidence collection, and root cause arbitration. Use this skill when debugging bugs with multiple potential causes, performing root cause analysis, or organizing parallel investigation workflows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/parallel-debugging"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/parallel-feature-development",
+      "name": "parallel-feature-development",
+      "description": "Coordinate parallel feature development with file ownership strategies, conflict avoidance rules, and integration patterns for multi-agent implementation. Use this skill when decomposing a large feature into independent work streams, when two or more agents need to implement different layers of the same system simultaneously, when establishing file ownership to prevent merge conflicts in a shared codebase, when designing interface contracts so parallel implementers can build against each other's APIs before they are ready, or when deciding whether to use vertical slices versus horizontal layers for a full-stack feature.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/parallel-feature-development"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/paypal-integration",
+      "name": "paypal-integration",
+      "description": "Integrate PayPal payment processing with support for express checkout, subscriptions, and refund management. Use when implementing PayPal payments, processing online transactions, or building e-commerce checkout flows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/payment-processing/skills/paypal-integration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/pci-compliance",
+      "name": "pci-compliance",
+      "description": "Implement PCI DSS compliance requirements for secure handling of payment card data and payment systems. Use when securing payment processing, achieving PCI compliance, or implementing payment card security measures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/payment-processing/skills/pci-compliance"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/postgresql-table-design",
+      "name": "postgresql-table-design",
+      "description": "Use this skill when designing or reviewing a PostgreSQL-specific schema. Covers best-practices, data types, indexing, constraints, performance patterns, and advanced features",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/database-design/skills/postgresql"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/postmortem-writing",
+      "name": "postmortem-writing",
+      "description": "Write effective blameless postmortems with root cause analysis, timelines, and action items. Use when conducting incident reviews, writing postmortem documents, or improving incident response processes.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/incident-response/skills/postmortem-writing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/projection-patterns",
+      "name": "projection-patterns",
+      "description": "Build read models and projections from event streams. Use when implementing CQRS read sides, building materialized views, or optimizing query performance in event-sourced systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/projection-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/prometheus-configuration",
+      "name": "prometheus-configuration",
+      "description": "Set up Prometheus for comprehensive metric collection, storage, and monitoring of infrastructure and applications. Use when implementing metrics collection, setting up monitoring infrastructure, or configuring alerting systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/observability-monitoring/skills/prometheus-configuration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/prompt-engineering-patterns",
+      "name": "prompt-engineering-patterns",
+      "description": "This skill should be used when the user asks to \"optimize a prompt\", \"improve prompt performance\", \"design a prompt template\", \"write better prompts\", \"debug prompt issues\", \"use chain-of-thought\", \"structured prompting\", \"few-shot prompting\", or wants to apply advanced prompt engineering patterns for production LLM applications.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/prompt-engineering-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/protect-mcp-setup",
+      "name": "protect-mcp-setup",
+      "description": "Configure Cedar policy enforcement and Ed25519 signed receipts for Claude Code tool calls. Use when setting up projects that need cryptographic audit trails, policy-gated tool execution, or compliance-ready evidence of agent actions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/protect-mcp/skills/protect-mcp-setup"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/protocol-reverse-engineering",
+      "name": "protocol-reverse-engineering",
+      "description": "Master network protocol reverse engineering including packet analysis, protocol dissection, and custom protocol documentation. Use when analyzing network traffic, understanding proprietary protocols, or debugging network communication.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/reverse-engineering/skills/protocol-reverse-engineering"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-anti-patterns",
+      "name": "python-anti-patterns",
+      "description": "Use this skill when reviewing Python code for common anti-patterns to avoid. Use as a checklist when reviewing code, before finalizing implementations, or when debugging issues that might stem from known bad practices.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-anti-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-background-jobs",
+      "name": "python-background-jobs",
+      "description": "Python background job patterns including task queues, workers, and event-driven architecture. Use when implementing async task processing, job queues, long-running operations, or decoupling work from request/response cycles.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-background-jobs"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-code-style",
+      "name": "python-code-style",
+      "description": "Python code style, linting, formatting, naming conventions, and documentation standards. Use when writing new code, reviewing style, configuring linters, writing docstrings, or establishing project standards.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-code-style"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-configuration",
+      "name": "python-configuration",
+      "description": "Python configuration management via environment variables and typed settings. Use when externalizing config, setting up pydantic-settings, managing secrets, or implementing environment-specific behavior.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-configuration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-design-patterns",
+      "name": "python-design-patterns",
+      "description": "Python design patterns including KISS, Separation of Concerns, Single Responsibility, and composition over inheritance. Use this skill when designing a new service or component from scratch and choosing how to layer responsibilities, when refactoring a God class or monolithic function that has grown too large, when deciding whether to add a new abstraction or live with duplication, when evaluating a pull request for structural issues like tight coupling or leaking internal types, when choosing between inheritance and composition for a new class hierarchy, or when a codebase is becoming hard to test because of entangled I/O and business logic.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-design-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-error-handling",
+      "name": "python-error-handling",
+      "description": "Python error handling patterns including input validation, exception hierarchies, and partial failure handling. Use when implementing validation logic, designing exception strategies, handling batch processing failures, or building robust APIs.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-error-handling"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-observability",
+      "name": "python-observability",
+      "description": "Python observability patterns including structured logging, metrics, and distributed tracing. Use when adding logging, implementing metrics collection, setting up tracing, or debugging production systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-observability"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-packaging",
+      "name": "python-packaging",
+      "description": "Create distributable Python packages with proper project structure, setup.py/pyproject.toml, and publishing to PyPI. Use when packaging Python libraries, creating CLI tools, or distributing Python code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-packaging"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-performance-optimization",
+      "name": "python-performance-optimization",
+      "description": "Profile and optimize Python code using cProfile, memory profilers, and performance best practices. Use when debugging slow Python code, optimizing bottlenecks, or improving application performance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-performance-optimization"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-project-structure",
+      "name": "python-project-structure",
+      "description": "Python project organization, module architecture, and public API design. Use when setting up new projects, organizing modules, defining public interfaces with __all__, or planning directory layouts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-project-structure"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-resilience",
+      "name": "python-resilience",
+      "description": "Python resilience patterns including automatic retries, exponential backoff, timeouts, and fault-tolerant decorators. Use when adding retry logic, implementing timeouts, building fault-tolerant services, or handling transient failures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-resilience"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-resource-management",
+      "name": "python-resource-management",
+      "description": "Python resource management with context managers, cleanup patterns, and streaming. Use when managing connections, file handles, implementing cleanup logic, or building streaming responses with accumulated state.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-resource-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-testing-patterns",
+      "name": "python-testing-patterns",
+      "description": "Implement comprehensive testing strategies with pytest, fixtures, mocking, and test-driven development. Use when writing Python tests, setting up test suites, or implementing testing best practices.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-testing-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/python-type-safety",
+      "name": "python-type-safety",
+      "description": "Python type safety with type hints, generics, protocols, and strict type checking. Use when adding type annotations, implementing generic classes, defining structural interfaces, or configuring mypy/pyright.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/python-type-safety"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/rag-implementation",
+      "name": "rag-implementation",
+      "description": "Build Retrieval-Augmented Generation (RAG) systems for LLM applications with vector databases and semantic search. Use when implementing knowledge-grounded AI, building document Q&A systems, or integrating LLMs with external knowledge bases.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/rag-implementation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/react-modernization",
+      "name": "react-modernization",
+      "description": "Upgrade React applications to latest versions, migrate from class components to hooks, and adopt concurrent features. Use when modernizing React codebases, migrating to React Hooks, or upgrading to latest React versions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/framework-migration/skills/react-modernization"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/react-native-architecture",
+      "name": "react-native-architecture",
+      "description": "Build production React Native apps with Expo, navigation, native modules, offline sync, and cross-platform patterns. Use when developing mobile apps, implementing native integrations, or architecting React Native projects.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/frontend-mobile-development/skills/react-native-architecture"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/react-native-design",
+      "name": "react-native-design",
+      "description": "Master React Native styling, navigation, and Reanimated animations for cross-platform mobile development. Use when building React Native apps, implementing navigation patterns, or creating performant animations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/react-native-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/react-state-management",
+      "name": "react-state-management",
+      "description": "Master modern React state management with Redux Toolkit, Zustand, Jotai, and React Query. Use when setting up global state, managing server state, or choosing between state management solutions.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/frontend-mobile-development/skills/react-state-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/recsys-pipeline-architect",
+      "name": "recsys-pipeline-architect",
+      "description": "Design composable recommendation, ranking, and feed pipelines using the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced X For You algorithm. Use when building any system that picks \"the top K items for a (user, context)\" — content feeds, search ranking, RAG rerankers, task prioritizers, notification triage, ad selection.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/machine-learning-ops/skills/recsys-pipeline-architect"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/responsive-design",
+      "name": "responsive-design",
+      "description": "Implement modern responsive layouts using container queries, fluid typography, CSS Grid, and mobile-first breakpoint strategies. Use when building adaptive interfaces, implementing fluid layouts, or creating component-level responsive behavior.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/responsive-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/review-agent-setup",
+      "name": "review-agent-setup",
+      "description": "Configure human-in-the-loop gating for AI agent review actions in Claude Code. Use when setting up a project where an agent may post PR reviews, comments, merges, or edit CI configuration, and you want a cryptographically auditable approval trail with Cedar-enforced gates.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/review-agent-governance/skills/review-agent-setup"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/risk-metrics-calculation",
+      "name": "risk-metrics-calculation",
+      "description": "Calculate portfolio risk metrics including VaR, CVaR, Sharpe, Sortino, and drawdown analysis. Use when measuring portfolio risk, implementing risk limits, or building risk monitoring systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/quantitative-trading/skills/risk-metrics-calculation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/rust-async-patterns",
+      "name": "rust-async-patterns",
+      "description": "Master Rust async programming with Tokio, async traits, error handling, and concurrent patterns. Use when building async Rust applications, implementing concurrent systems, or debugging async code.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/systems-programming/skills/rust-async-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/saga-orchestration",
+      "name": "saga-orchestration",
+      "description": "Implement saga patterns for distributed transactions and cross-aggregate workflows. Use this skill when implementing distributed transactions across microservices where 2PC is unavailable, designing compensating actions for failed order workflows that span inventory, payment, and shipping services, building event-driven saga coordinators for travel booking systems that must roll back hotel, flight, and car rental reservations atomically, or debugging stuck saga states in production where compensation steps never complete.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/saga-orchestration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/sast-configuration",
+      "name": "sast-configuration",
+      "description": "Configure Static Application Security Testing (SAST) tools for automated vulnerability detection in application code. Use when setting up security scanning, implementing DevSecOps practices, or automating code vulnerability detection.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/security-scanning/skills/sast-configuration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/scan",
+      "name": "scan",
+      "description": "Scans the codebase to generate project-doc.md and AGENTS.md. Use when bootstrapping a new agent-driven repo, refreshing project documentation after architectural changes, or running a delta scan to detect drift. Runs a full scan on first use and a smart delta scan on subsequent runs. Uses understand-anything + context-mode when available, falls back to native tools otherwise. Only updates AGENTS.md on detected architectural changes with human confirmation.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ship-mate/skills/scan"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/screen-reader-testing",
+      "name": "screen-reader-testing",
+      "description": "Test web applications with screen readers including VoiceOver, NVDA, and JAWS. Use when validating screen reader compatibility, debugging accessibility issues, or ensuring assistive technology support.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/accessibility-compliance/skills/screen-reader-testing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/secrets-management",
+      "name": "secrets-management",
+      "description": "Implement secure secrets management for CI/CD pipelines using Vault, AWS Secrets Manager, or native platform solutions. Use when handling sensitive credentials, rotating secrets, or securing CI/CD environments.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cicd-automation/skills/secrets-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/security-requirement-extraction",
+      "name": "security-requirement-extraction",
+      "description": "Derive security requirements from threat models and business context. Use when translating threats into actionable requirements, creating security user stories, or building security test cases.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/security-scanning/skills/security-requirement-extraction"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/service-mesh-observability",
+      "name": "service-mesh-observability",
+      "description": "Implement comprehensive observability for service meshes including distributed tracing, metrics, and visualization. Use when setting up mesh monitoring, debugging latency issues, or implementing SLOs for service communication.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/service-mesh-observability"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/shellcheck-configuration",
+      "name": "shellcheck-configuration",
+      "description": "Master ShellCheck static analysis configuration and usage for shell script quality. Use when setting up linting infrastructure, fixing code issues, or ensuring script portability.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/shell-scripting/skills/shellcheck-configuration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/signed-audit-trails-recipe",
+      "name": "signed-audit-trails-recipe",
+      "description": "Step-by-step cookbook for setting up cryptographically signed audit trails on Claude Code tool calls. Use when explaining, evaluating, or demonstrating the pattern before committing to the protect-mcp runtime hooks. Covers Cedar policy, Ed25519 receipts, offline verification, tamper detection, CI/CD integration, and SLSA composition.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/signed-audit-trails/skills/signed-audit-trails-recipe"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/similarity-search-patterns",
+      "name": "similarity-search-patterns",
+      "description": "Implement efficient similarity search with vector databases. Use when building semantic search, implementing nearest neighbor queries, or optimizing retrieval performance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/similarity-search-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/slo-implementation",
+      "name": "slo-implementation",
+      "description": "Define and implement Service Level Indicators (SLIs) and Service Level Objectives (SLOs) with error budgets and alerting. Use when establishing reliability targets, implementing SRE practices, or measuring service performance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/observability-monitoring/skills/slo-implementation"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/social-publishing",
+      "name": "social-publishing",
+      "description": "Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via the SocialClaw API. Use when the user wants to publish, schedule, or manage social media content programmatically. Requires SOCIALCLAW_API_KEY.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/social-publishing/skills/social-publishing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/solidity-security",
+      "name": "solidity-security",
+      "description": "Master smart contract security best practices to prevent common vulnerabilities and implement secure Solidity patterns. Use when writing smart contracts, auditing existing contracts, or implementing security measures for blockchain applications.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/blockchain-web3/skills/solidity-security"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/spark-optimization",
+      "name": "spark-optimization",
+      "description": "Optimize Apache Spark jobs with partitioning, caching, shuffle optimization, and memory tuning. Use when improving Spark performance, debugging slow jobs, or scaling data processing pipelines.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/data-engineering/skills/spark-optimization"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/sql-optimization-patterns",
+      "name": "sql-optimization-patterns",
+      "description": "Master SQL query optimization, indexing strategies, and EXPLAIN analysis to dramatically improve database performance and eliminate slow queries. Use when debugging slow queries, designing database schemas, or optimizing application performance.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/sql-optimization-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/startup-financial-modeling",
+      "name": "startup-financial-modeling",
+      "description": "Build comprehensive 3-5 year financial models with revenue projections, cost structures, cash flow analysis, and scenario planning for early-stage startups. Use this skill when creating financial projections, calculating burn rate or runway, modeling fundraising scenarios, or preparing investor-ready financials for a seed or Series A raise.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/startup-business-analyst/skills/startup-financial-modeling"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/startup-metrics-framework",
+      "name": "startup-metrics-framework",
+      "description": "Track, calculate, and optimize key performance metrics for SaaS, marketplace, consumer, and B2B startups from seed through Series A, including unit economics, growth efficiency, and cash management. Use this skill when defining a metrics framework, calculating CAC/LTV/burn multiple, benchmarking business health, or preparing metrics dashboards for investors or board reporting.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/startup-business-analyst/skills/startup-metrics-framework"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/stride-analysis-patterns",
+      "name": "stride-analysis-patterns",
+      "description": "Apply STRIDE methodology to systematically identify threats. Use when analyzing system security, conducting threat modeling sessions, or creating security documentation.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/security-scanning/skills/stride-analysis-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/stripe-integration",
+      "name": "stripe-integration",
+      "description": "Implement Stripe payment processing for robust, PCI-compliant payment flows including checkout, subscriptions, and webhooks. Use when integrating Stripe payments, building subscription systems, or implementing secure checkout flows.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/payment-processing/skills/stripe-integration"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/tailwind-design-system",
+      "name": "tailwind-design-system",
+      "description": "Build scalable design systems with Tailwind CSS v4, design tokens, component libraries, and responsive patterns. Use when creating component libraries, implementing design systems, or standardizing UI patterns.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/frontend-mobile-development/skills/tailwind-design-system"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/task-coordination-strategies",
+      "name": "task-coordination-strategies",
+      "description": "Decompose complex tasks, design dependency graphs, and coordinate multi-agent work with proper task descriptions and workload balancing. Use this skill when breaking down work for agent teams, managing task dependencies, or monitoring team progress.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/task-coordination-strategies"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/team-communication-protocols",
+      "name": "team-communication-protocols",
+      "description": "Structured messaging protocols for agent team communication including message type selection, plan approval, shutdown procedures, and anti-patterns to avoid. Use this skill when establishing communication norms for a newly spawned team, when deciding whether to send a direct message or a broadcast, when a team-lead needs to review and approve an implementer's plan before work begins, when orchestrating a graceful team shutdown after all tasks are complete, or when debugging why teammates are not coordinating correctly at integration points.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/team-communication-protocols"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/team-composition-analysis",
+      "name": "team-composition-analysis",
+      "description": "Design optimal team structures, hiring plans, compensation strategies, and equity allocation for early-stage startups from pre-seed through Series A. Use this skill when planning headcount, determining which roles to hire next, setting compensation or equity ranges, designing org structure, or building a hiring budget aligned to funding milestones.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/startup-business-analyst/skills/team-composition-analysis"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/team-composition-patterns",
+      "name": "team-composition-patterns",
+      "description": "Design optimal agent team compositions with sizing heuristics, preset configurations, and agent type selection. Use this skill when deciding how many agents to spawn for a task, when choosing between a review team versus a feature team versus a debug team, when selecting the correct subagent_type for each role to ensure agents have the tools they need, when configuring display modes (tmux, iTerm2, in-process) for a CI or local environment, or when building a custom team composition for a non-standard workflow such as a migration or security audit.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/agent-teams/skills/team-composition-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/temporal-python-testing",
+      "name": "temporal-python-testing",
+      "description": "Test Temporal workflows with pytest, time-skipping, and mocking strategies. Covers unit testing, integration testing, replay testing, and local development setup. Use when implementing Temporal workflow tests or debugging test failures.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/temporal-python-testing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/terraform-module-library",
+      "name": "terraform-module-library",
+      "description": "Build reusable Terraform modules for AWS, Azure, GCP, and OCI infrastructure following infrastructure-as-code best practices. Use when creating infrastructure modules, standardizing cloud provisioning, or implementing reusable IaC components.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/cloud-infrastructure/skills/terraform-module-library"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/threat-mitigation-mapping",
+      "name": "threat-mitigation-mapping",
+      "description": "Map identified threats to appropriate security controls and mitigations. Use when prioritizing security investments, creating remediation plans, or validating control effectiveness.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/security-scanning/skills/threat-mitigation-mapping"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/track-management",
+      "name": "track-management",
+      "description": "Use this skill when creating, managing, or working with Conductor tracks - the logical work units for features, bugs, and refactors. Applies to spec.md, plan.md, and track lifecycle operations.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/conductor/skills/track-management"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/turborepo-caching",
+      "name": "turborepo-caching",
+      "description": "Configure Turborepo for efficient monorepo builds with local and remote caching. Use when setting up Turborepo, optimizing build pipelines, or implementing distributed caching.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/developer-essentials/skills/turborepo-caching"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/typescript-advanced-types",
+      "name": "typescript-advanced-types",
+      "description": "Master TypeScript's advanced type system including generics, conditional types, mapped types, template literals, and utility types for building type-safe applications. Use when implementing complex type logic, creating reusable type utilities, or ensuring compile-time type safety in TypeScript projects.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/javascript-typescript/skills/typescript-advanced-types"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/unity-ecs-patterns",
+      "name": "unity-ecs-patterns",
+      "description": "Master Unity ECS (Entity Component System) with DOTS, Jobs, and Burst for high-performance game development. Use when building data-oriented games, optimizing performance, or working with large entity counts.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/game-development/skills/unity-ecs-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/uv-package-manager",
+      "name": "uv-package-manager",
+      "description": "Master the uv package manager for fast Python dependency management, virtual environments, and modern Python project workflows. Use when setting up Python projects, managing dependencies, or optimizing Python development workflows with uv.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/python-development/skills/uv-package-manager"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/vector-index-tuning",
+      "name": "vector-index-tuning",
+      "description": "Optimize vector index performance for latency, recall, and memory. Use when tuning HNSW parameters, selecting quantization strategies, or scaling vector search infrastructure.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/llm-application-dev/skills/vector-index-tuning"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/visual-design-foundations",
+      "name": "visual-design-foundations",
+      "description": "Apply typography, color theory, spacing systems, and iconography principles to create cohesive visual designs. Use when establishing design tokens, building style guides, or improving visual hierarchy and consistency.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/visual-design-foundations"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/wcag-audit-patterns",
+      "name": "wcag-audit-patterns",
+      "description": "Conduct WCAG 2.2 accessibility audits with automated testing, manual verification, and remediation guidance. Use when auditing websites for accessibility, fixing WCAG violations, or implementing accessible design patterns.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/accessibility-compliance/skills/wcag-audit-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/web-component-design",
+      "name": "web-component-design",
+      "description": "Master React, Vue, and Svelte component patterns including CSS-in-JS, composition strategies, and reusable component architecture. Use when building UI component libraries, designing component APIs, or implementing frontend design systems.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/ui-design/skills/web-component-design"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/web3-testing",
+      "name": "web3-testing",
+      "description": "Test smart contracts comprehensively using Hardhat and Foundry with unit tests, integration tests, and mainnet forking. Use when testing Solidity contracts, setting up blockchain test suites, or validating DeFi protocols.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/blockchain-web3/skills/web3-testing"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/workflow-orchestration-patterns",
+      "name": "workflow-orchestration-patterns",
+      "description": "Design durable workflows with Temporal for distributed systems. Covers workflow vs activity separation, saga patterns, state management, and determinism constraints. Use when building long-running processes, distributed transactions, or microservice orchestration.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/backend-development/skills/workflow-orchestration-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
+    },
+    {
+      "id": "wshobson-agents/workflow-patterns",
+      "name": "workflow-patterns",
+      "description": "Use this skill when implementing tasks according to Conductor's TDD workflow, handling phase checkpoints, managing git commits for tasks, or understanding the verification protocol.",
+      "tags": [],
+      "format": "skill-md",
+      "source": {
+        "repo": "wshobson/agents",
+        "ref": "main",
+        "path": "plugins/conductor/skills/workflow-patterns"
+      },
+      "stars": 36782,
+      "updatedAt": "2026-06-15T01:09:29Z",
+      "provenance": "curated",
+      "sourceId": "wshobson-agents"
     }
   ]
 }

--- a/registry/sources.json
+++ b/registry/sources.json
@@ -15,6 +15,11 @@
     { "id": "career-ops", "repo": "santifer/career-ops", "path": ".agents/skills" },
     { "id": "taste-skill", "repo": "Leonxlnx/taste-skill", "path": "skills" },
     { "id": "humanizer", "repo": "blader/humanizer", "path": "" },
-    { "id": "notebooklm", "repo": "teng-lin/notebooklm-py", "path": "" }
+    { "id": "notebooklm", "repo": "teng-lin/notebooklm-py", "path": "" },
+    { "id": "wshobson-agents", "repo": "wshobson/agents", "path": "plugins" },
+    { "id": "karpathy-skills", "repo": "multica-ai/andrej-karpathy-skills", "path": "skills" },
+    { "id": "openai-skills", "repo": "openai/skills", "path": "skills" },
+    { "id": "google-skills", "repo": "google/skills", "path": "skills" },
+    { "id": "huggingface-skills", "repo": "huggingface/skills", "path": "skills" }
   ]
 }

--- a/src/renderer/lib/editor/modelCache.test.ts
+++ b/src/renderer/lib/editor/modelCache.test.ts
@@ -10,6 +10,8 @@ import {
   markLoadFailed,
   clearLoadFailed,
   isLoadFailed,
+  rememberBaseline,
+  getBaseline,
   __resetModelCacheForTest,
   type ModelLike,
 } from './modelCache'
@@ -169,6 +171,38 @@ describe('modelCache — resolveLoadedModel (duplicate-URI race)', () => {
     const fresh = makeModel()
     const m = resolveLoadedModel(() => stale, () => fresh)
     expect(m).toBe(fresh)
+  })
+})
+
+describe('modelCache — disk baseline', () => {
+  it('remembers and returns the disk baseline for a path', () => {
+    expect(getBaseline('/a.ts')).toBeUndefined()
+    rememberBaseline('/a.ts', 'on disk')
+    expect(getBaseline('/a.ts')).toBe('on disk')
+  })
+
+  it('keeps baselines independent per path and overwrites in place', () => {
+    rememberBaseline('/a.ts', 'A')
+    rememberBaseline('/b.ts', 'B')
+    rememberBaseline('/a.ts', 'A2')
+    expect(getBaseline('/a.ts')).toBe('A2')
+    expect(getBaseline('/b.ts')).toBe('B')
+  })
+
+  it('drops the baseline when its model is evicted from the cache', () => {
+    const m = makeModel()
+    rememberModel('/keep.ts', m)
+    rememberBaseline('/keep.ts', 'disk')
+    // Overflow the cache so /keep.ts (unretained, oldest) is evicted.
+    for (let i = 0; i <= MODEL_CACHE_LIMIT; i++) rememberModel(`/f${i}.ts`, makeModel())
+    expect(getCachedModel('/keep.ts')).toBeUndefined()
+    expect(getBaseline('/keep.ts')).toBeUndefined()
+  })
+
+  it('is cleared by the test reset helper', () => {
+    rememberBaseline('/a.ts', 'x')
+    __resetModelCacheForTest()
+    expect(getBaseline('/a.ts')).toBeUndefined()
   })
 })
 

--- a/src/renderer/lib/editor/modelCache.ts
+++ b/src/renderer/lib/editor/modelCache.ts
@@ -20,6 +20,11 @@ export const MODEL_CACHE_LIMIT = 20
 const modelCache = new Map<string, ModelLike>()
 // Counts how many mounted EditorPanel instances are actively using a cached model.
 const modelRefCount = new Map<string, number>()
+// Disk content each cached model was last synced with (its sync baseline). Kept
+// alongside the model so that when a panel reopens and reattaches a warm model,
+// useFileSync can tell unsaved edits (buffer ≠ baseline) apart from a stale-but-
+// clean buffer — and reconcile with disk without clobbering unsaved work.
+const modelBaseline = new Map<string, string>()
 // File paths whose buffer failed to load (read error) or hasn't successfully
 // loaded yet. save() consults this to refuse writing an empty/placeholder buffer
 // back over the real file.
@@ -58,6 +63,7 @@ export function rememberModel(filePath: string, model: ModelLike): void {
     if ((modelRefCount.get(key) ?? 0) > 0) continue
     const model = modelCache.get(key)
     modelCache.delete(key)
+    modelBaseline.delete(key)
     if (model && !model.isDisposed()) {
       try { model.dispose() } catch { /* noop */ }
     }
@@ -83,6 +89,19 @@ export function releaseModel(filePath: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Disk baseline — the on-disk content a cached model was last synced with. Set
+// on load and after every save; recovered on reopen to classify dirty vs stale.
+// ---------------------------------------------------------------------------
+
+export function rememberBaseline(filePath: string, content: string): void {
+  modelBaseline.set(filePath, content)
+}
+
+export function getBaseline(filePath: string): string | undefined {
+  return modelBaseline.get(filePath)
+}
+
+// ---------------------------------------------------------------------------
 // Load-state guard — a buffer that failed to read (or never loaded) must never
 // be written back to disk, or Cmd+S from the empty error buffer would truncate
 // the file.
@@ -104,5 +123,6 @@ export function isLoadFailed(filePath: string): boolean {
 export function __resetModelCacheForTest(): void {
   modelCache.clear()
   modelRefCount.clear()
+  modelBaseline.clear()
   loadFailedPaths.clear()
 }

--- a/src/renderer/lib/editor/useFileSync.test.tsx
+++ b/src/renderer/lib/editor/useFileSync.test.tsx
@@ -19,6 +19,8 @@ import { useFileSync, type FileSync, type UseFileSyncParams } from './useFileSyn
 
 const h = vi.hoisted(() => ({
   watchListener: null as ((e: { type: string; path: string }) => void) | null,
+  watchedPath: null as string | null,
+  baselines: new Map<string, string>(),
   store: {
     setPanelDirty: vi.fn(),
     updatePanelTitle: vi.fn(),
@@ -29,7 +31,8 @@ const h = vi.hoisted(() => ({
 }))
 
 vi.mock('../fs/fsWatchManager', () => ({
-  watchFsRoot: (_root: string, listener: (e: { type: string; path: string }) => void) => {
+  watchFsRoot: (root: string, listener: (e: { type: string; path: string }) => void) => {
+    h.watchedPath = root
     h.watchListener = listener
     return () => {
       h.watchListener = null
@@ -41,7 +44,13 @@ vi.mock('../../stores/appStore', () => ({
   useAppStore: Object.assign(() => undefined, { getState: () => h.store }),
 }))
 
-vi.mock('./modelCache', () => ({ isLoadFailed: () => false }))
+// The disk baseline lives in the model cache so it survives a panel reopen; back
+// the mock with a real map so noteLoaded/save/resync round-trip through it.
+vi.mock('./modelCache', () => ({
+  isLoadFailed: () => false,
+  rememberBaseline: (p: string, c: string) => { h.baselines.set(p, c) },
+  getBaseline: (p: string) => h.baselines.get(p),
+}))
 
 // --- harness ------------------------------------------------------------------
 
@@ -100,6 +109,8 @@ async function settle(ms = 0) {
 
 beforeEach(() => {
   h.watchListener = null
+  h.watchedPath = null
+  h.baselines.clear()
   ;(window as unknown as { electronAPI: unknown }).electronAPI = {
     fsReadFile: vi.fn(),
     fsWriteFile: vi.fn().mockResolvedValue(undefined),
@@ -278,5 +289,93 @@ describe('useFileSync — resolutions', () => {
 
     expect(electronApi().fsWriteFile).toHaveBeenCalledWith(FILE, 'rescued content', 'w1')
     expect(latest!.conflict).toBeNull()
+  })
+})
+
+describe('useFileSync — unified root watcher', () => {
+  it('subscribes to the workspace ROOT, not the file path (one shared watcher)', () => {
+    mount(makeModel('x'))
+    // The editor rides the single refcounted root watcher (shared with the file
+    // tree). The matcher is what lets hidden-file events through — see
+    // createFsIgnoreMatcher tests.
+    expect(h.watchedPath).toBe('/proj')
+  })
+
+  it('reloads a clean dotfile buffer when its watch event fires', async () => {
+    const DOT = '/proj/.gitignore'
+    const model = makeModel('old')
+    mount(model, { filePath: DOT })
+    act(() => { latest!.noteLoaded('old') })
+    electronApi().fsReadFile.mockResolvedValue('new from disk')
+
+    act(() => { h.watchListener!({ type: 'update', path: DOT }) })
+    await settle()
+
+    expect(model.getValue()).toBe('new from disk')
+    expect(latest!.conflict).toBeNull()
+  })
+})
+
+describe('useFileSync — resyncFromDisk (reopen reconcile)', () => {
+  it('catches up a clean, stale buffer to the on-disk version', async () => {
+    const model = makeModel('old disk')
+    mount(model)
+    act(() => { latest!.noteLoaded('old disk') }) // clean: buffer === baseline
+    electronApi().fsReadFile.mockResolvedValue('new disk') // changed while closed
+
+    await act(async () => { await latest!.resyncFromDisk() })
+
+    expect(model.getValue()).toBe('new disk')
+    expect(latest!.conflict).toBeNull()
+  })
+
+  it('raises a conflict (never clobbers) when unsaved edits meet a changed disk', async () => {
+    const model = makeModel('my unsaved edits')
+    mount(model)
+    act(() => { latest!.noteLoaded('original') }) // buffer diverges from baseline
+    electronApi().fsReadFile.mockResolvedValue('their disk changes')
+
+    await act(async () => { await latest!.resyncFromDisk() })
+
+    expect(latest!.conflict).toEqual({ kind: 'changed', diskContent: 'their disk changes' })
+    expect(model.getValue()).toBe('my unsaved edits') // buffer preserved
+    expect(latest!.isDirtyRef.current).toBe(true) // dirty marker restored on reopen
+  })
+
+  it('keeps unsaved edits and restores the dirty marker when disk is unchanged', async () => {
+    const model = makeModel('my unsaved edits')
+    mount(model)
+    act(() => { latest!.noteLoaded('original') })
+    electronApi().fsReadFile.mockResolvedValue('original') // disk === baseline
+
+    await act(async () => { await latest!.resyncFromDisk() })
+
+    expect(latest!.conflict).toBeNull()
+    expect(model.getValue()).toBe('my unsaved edits')
+    expect(latest!.isDirtyRef.current).toBe(true)
+  })
+
+  it('is a no-op when the file is unreadable (deleted while closed)', async () => {
+    const model = makeModel('buffer')
+    mount(model)
+    act(() => { latest!.noteLoaded('buffer') })
+    electronApi().fsReadFile.mockRejectedValue(new Error('ENOENT'))
+
+    await act(async () => { await latest!.resyncFromDisk() })
+
+    expect(latest!.conflict).toBeNull()
+    expect(model.getValue()).toBe('buffer')
+  })
+
+  it('does not touch the buffer when no baseline is known', async () => {
+    const model = makeModel('buffer')
+    mount(model) // no noteLoaded → cache has no baseline for this path
+    electronApi().fsReadFile.mockResolvedValue('something else')
+
+    await act(async () => { await latest!.resyncFromDisk() })
+
+    expect(model.getValue()).toBe('buffer')
+    expect(latest!.conflict).toBeNull()
+    expect(electronApi().fsReadFile).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/editor/useFileSync.ts
+++ b/src/renderer/lib/editor/useFileSync.ts
@@ -32,7 +32,7 @@ import type * as monaco from 'monaco-editor'
 import log from '../logger'
 import { useAppStore } from '../../stores/appStore'
 import { watchFsRoot } from '../fs/fsWatchManager'
-import { isLoadFailed } from './modelCache'
+import { isLoadFailed, getBaseline, rememberBaseline } from './modelCache'
 import { classifyExternalEvent, shouldBlockOverwrite } from './externalConflict'
 import { threeWayMerge } from './threeWayMerge'
 
@@ -77,6 +77,9 @@ export interface FileSync {
   isExternalReplace: () => boolean
   /** Guarded save (Save-As when untitled, overwrite-guard otherwise). */
   save: () => Promise<boolean>
+  /** Reconcile a reattached warm model with disk (reopen). Reloads a clean stale
+   *  buffer, raises a conflict for unsaved edits, no-ops if disk is unchanged. */
+  resyncFromDisk: () => Promise<void>
   reload: () => void
   keepMine: () => void
   keepBoth: () => void
@@ -135,9 +138,18 @@ export function useFileSync({
     }
   }, [workspaceId, panelId])
 
-  const noteLoaded = useCallback((content: string) => {
+  // Set the sync baseline (the disk content we last synced with) both locally
+  // and in the shared model cache, so a later reopen of this file can recover it
+  // and tell unsaved edits apart from a stale-but-clean buffer.
+  const setBaseline = useCallback((content: string) => {
     baselineRef.current = content
+    const path = filePathRef.current
+    if (path) rememberBaseline(path, content)
   }, [])
+
+  const noteLoaded = useCallback((content: string) => {
+    setBaseline(content)
+  }, [setBaseline])
 
   const isExternalReplace = useCallback(
     () => !!filePathRef.current && externalReplacePaths.has(filePathRef.current),
@@ -221,6 +233,7 @@ export function useFileSync({
     }
 
     baselineRef.current = content
+    rememberBaseline(targetPath, content)
     clearDirty()
     // clearDirty restores the title for an already-known path; for the initial
     // Save-As below we also set the freshly-derived name.
@@ -248,22 +261,22 @@ export function useFileSync({
   const reload = useCallback(() => {
     const content = conflict?.kind === 'changed' ? conflict.diskContent ?? '' : ''
     replaceBuffer(content)
-    baselineRef.current = content
+    setBaseline(content)
     clearDirty()
     setShowDiff(false)
     setConflict(null)
-  }, [conflict, clearDirty, replaceBuffer])
+  }, [conflict, clearDirty, replaceBuffer, setBaseline])
 
   // Keep the unsaved buffer over the external version. Adopt the on-disk content
   // as the new baseline so the next save writes the buffer straight over it
   // instead of re-flagging the same conflict.
   const keepMine = useCallback(() => {
     if (conflict?.kind === 'changed' && conflict.diskContent !== undefined) {
-      baselineRef.current = conflict.diskContent
+      setBaseline(conflict.diskContent)
     }
     setShowDiff(false)
     setConflict(null)
-  }, [conflict])
+  }, [conflict, setBaseline])
 
   // Merge both sides: baseline = common ancestor, buffer = mine, disk = theirs.
   // Non-overlapping edits combine cleanly; overlapping edits get conflict
@@ -282,10 +295,10 @@ export function useFileSync({
     noteUserEdit()
     // Disk still holds `theirs`; make it the baseline so saving the merged buffer
     // passes the guard (disk === baseline) and writes cleanly.
-    baselineRef.current = theirs
+    setBaseline(theirs)
     setShowDiff(false)
     setConflict(null)
-  }, [conflict, getModel, replaceBuffer, noteUserEdit])
+  }, [conflict, getModel, replaceBuffer, noteUserEdit, setBaseline])
 
   // Re-create a deleted file from the buffer contents.
   const saveToRestore = useCallback(async () => {
@@ -304,6 +317,68 @@ export function useFileSync({
   }, [])
 
   // ---------------------------------------------------------------------------
+  // Reconcile the buffer against disk
+  // ---------------------------------------------------------------------------
+
+  // Apply a fresh on-disk version after an external event KNOWN to have changed
+  // disk: silently reload a clean buffer, or raise a `changed` conflict when the
+  // buffer is dirty so unsaved edits aren't lost.
+  const applyDiskContent = useCallback((content: string) => {
+    const model = getModel()
+    if (!model || model.isDisposed()) return
+    // Disk already matches the buffer (e.g. our own save fired the event) —
+    // nothing diverges, so clear any stale conflict and skip the reset.
+    if (model.getValue() === content) {
+      setBaseline(content)
+      setConflict(null)
+      return
+    }
+    if (isDirtyRef.current) {
+      setConflict({ kind: 'changed', diskContent: content })
+      return
+    }
+    replaceBuffer(content)
+    setBaseline(content)
+    setConflict(null)
+  }, [getModel, replaceBuffer, setBaseline])
+
+  // Reconcile the buffer with disk when a warm cached model is reattached on
+  // reopen: while the panel was closed no watcher kept it current, so the buffer
+  // may be stale-but-clean or hold unsaved edits. Recover the baseline the model
+  // was last synced with (kept in the model cache) to tell those apart safely:
+  //   • clean buffer, disk moved → silent reload (the buffer catches up)
+  //   • unsaved edits, disk moved → `changed` conflict (never clobber edits)
+  //   • disk unchanged            → leave the buffer, just restore the dirty dot
+  const resyncFromDisk = useCallback(async () => {
+    const path = filePathRef.current
+    if (!path || diffMode || path.startsWith('cate-runtime://')) return
+    const model = getModel()
+    if (!model || model.isDisposed()) return
+    const baseline = getBaseline(path)
+    if (baseline === undefined) return // unknown baseline → don't risk a reload
+    baselineRef.current = baseline
+    const buffer = model.getValue()
+    const dirty = buffer !== baseline
+    // A warm reopen starts a fresh hook (isDirty=false); restore the marker so a
+    // genuinely-dirty buffer is treated as such by the reconcile below and the UI.
+    if (dirty && !isDirtyRef.current) noteUserEdit()
+    let disk: string
+    try {
+      disk = await window.electronAPI.fsReadFile(path, workspaceId)
+    } catch {
+      return // gone/unreadable while closed — leave it to the live watcher
+    }
+    if (disk === baseline) return // nothing changed on disk while we were closed
+    if (dirty) {
+      setConflict({ kind: 'changed', diskContent: disk })
+    } else {
+      replaceBuffer(disk)
+      setBaseline(disk)
+      setConflict(null)
+    }
+  }, [workspaceId, diffMode, getModel, replaceBuffer, noteUserEdit, setBaseline])
+
+  // ---------------------------------------------------------------------------
   // Watch the file on disk for external edits / deletion
   // ---------------------------------------------------------------------------
 
@@ -315,28 +390,6 @@ export function useFileSync({
 
     const targetPosix = filePath.replace(/\\/g, '/')
     let disposed = false
-
-    // Apply a fresh on-disk version: silently reload a clean buffer, or raise a
-    // `changed` conflict when the buffer is dirty so unsaved edits aren't lost.
-    const applyDiskContent = (content: string) => {
-      if (disposed) return
-      const model = getModel()
-      if (!model || model.isDisposed()) return
-      // Disk already matches the buffer (e.g. our own save fired the event) —
-      // nothing diverges, so clear any stale conflict and skip the reset.
-      if (model.getValue() === content) {
-        baselineRef.current = content
-        setConflict(null)
-        return
-      }
-      if (isDirtyRef.current) {
-        setConflict({ kind: 'changed', diskContent: content })
-        return
-      }
-      replaceBuffer(content)
-      baselineRef.current = content
-      setConflict(null)
-    }
 
     const stop = watchFsRoot(
       rootPath,
@@ -350,7 +403,7 @@ export function useFileSync({
             if (disposed) return
             window.electronAPI
               .fsReadFile(filePath, workspaceId)
-              .then((content) => applyDiskContent(content))
+              .then((content) => { if (!disposed) applyDiskContent(content) })
               .catch(() => {
                 if (disposed) return
                 // Genuinely deleted: the buffer is now unsaved work with no file
@@ -365,7 +418,7 @@ export function useFileSync({
 
         window.electronAPI
           .fsReadFile(filePath, workspaceId)
-          .then((content) => applyDiskContent(content))
+          .then((content) => { if (!disposed) applyDiskContent(content) })
           .catch(() => { /* vanished between event and read — leave buffer as-is */ })
       },
       workspaceId,
@@ -375,7 +428,7 @@ export function useFileSync({
       disposed = true
       stop()
     }
-  }, [filePath, rootPath, workspaceId, diffMode, getModel, replaceBuffer, noteUserEdit])
+  }, [filePath, rootPath, workspaceId, diffMode, applyDiskContent, noteUserEdit])
 
   // Reset conflict state when the panel switches files (a single EditorPanel
   // mount is reused across dock tabs, so stale conflict UI must not carry over).
@@ -398,6 +451,7 @@ export function useFileSync({
     noteUserEdit,
     isExternalReplace,
     save,
+    resyncFromDisk,
     reload,
     keepMine,
     keepBoth,

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -504,11 +504,12 @@ export default function EditorPanel({
         retainModel(filePath)
         modelRetained = true
         editor.setModel(cached)
-        // Best-effort baseline from the warm model (assumed to mirror disk). If
-        // the file changed on disk while this panel was closed, the save guard
-        // catches the divergence on the next save.
-        sync.noteLoaded(cached.getValue())
         applyPendingReveal()
+        // The warm model may be stale: nothing kept it current while this panel
+        // was closed. Reconcile with disk — a clean buffer silently catches up, a
+        // buffer with unsaved edits raises a conflict instead of being clobbered.
+        // (resyncFromDisk recovers the real disk baseline from the model cache.)
+        void sync.resyncFromDisk()
       } else {
         const language = detectLanguage(filePath)
         const targetPath = filePath

--- a/src/runtime/capabilities/file.test.ts
+++ b/src/runtime/capabilities/file.test.ts
@@ -72,6 +72,19 @@ describe('createFsIgnoreMatcher — unit', () => {
     expect(m('/Users/me/.config/proj/src/a.ts', asFile)).toBe(false)
   })
 
+  it('normalizes separators (Windows: native root, POSIX paths from chokidar)', () => {
+    // chokidar hands the predicate forward-slash paths even on Windows, while the
+    // root arrives OS-native — both must compare equal or the matcher ignores
+    // nothing and the whole tree gets watched.
+    const m = createFsIgnoreMatcher('C:\\proj', EXCLUDED)
+    expect(m('C:\\proj\\.gitignore', asFile)).toBe(false)
+    expect(m('C:/proj/.gitignore', asFile)).toBe(false)
+    expect(m('C:\\proj\\src\\a.ts', asFile)).toBe(false)
+    expect(m('C:/proj/.cate', asDir)).toBe(true)
+    expect(m('C:/proj/.cate/session.json', asFile)).toBe(true)
+    expect(m('C:\\proj\\node_modules\\pkg\\i.js', asFile)).toBe(true)
+  })
+
   it('treats a hidden-dir leaf without stats as not-ignored (chokidar re-asks)', () => {
     // No stats yet → defer (false); chokidar stats it and calls again with
     // stats.isDirectory() === true, which prunes it. Covered live below.
@@ -124,8 +137,14 @@ describe('createFsIgnoreMatcher — live chokidar', () => {
     await fs.appendFile(path.join(dir, '.git', 'HEAD'), 'b\n')
     await fs.appendFile(path.join(dir, 'node_modules', 'pkg', 'i.js'), 'b\n')
 
-    // Let fsevents settle.
-    await new Promise((r) => setTimeout(r, 600))
+    // Wait until the expected events arrive (fs.watch latency varies by OS), then
+    // a short tail so a wrongly-watched path would have had its chance to fire.
+    const want = ['.gitignore', '.env', path.join('src', 'a.ts')]
+    const deadline = Date.now() + 5000
+    while (Date.now() < deadline && !want.every((w) => events.some((e) => e.rel === w))) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    await new Promise((r) => setTimeout(r, 400))
 
     const touched = new Set(events.map((e) => e.rel))
     expect(touched.has('.gitignore')).toBe(true)
@@ -134,5 +153,5 @@ describe('createFsIgnoreMatcher — live chokidar', () => {
     expect(touched.has(path.join('.cate', 'session.json'))).toBe(false)
     expect(touched.has(path.join('.git', 'HEAD'))).toBe(false)
     expect(touched.has(path.join('node_modules', 'pkg', 'i.js'))).toBe(false)
-  }, 10_000)
+  }, 15_000)
 })

--- a/src/runtime/capabilities/file.test.ts
+++ b/src/runtime/capabilities/file.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { watch, type FSWatcher } from 'chokidar'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createFsIgnoreMatcher } from './file'
+
+// =============================================================================
+// createFsIgnoreMatcher is the SINGLE chokidar ignore predicate shared by the
+// local watcher pool (main/ipc/filesystem.ts) and the daemon watch capability
+// (runtime/capabilities/index.ts). It must:
+//   • prune excluded entries (node_modules, .git, …) and hidden DIRECTORIES
+//     (.cache, .cate) so a recursive watch stays cheap and our own state-dir
+//     writes don't echo back, AND
+//   • NOT ignore hidden FILES (.gitignore, .env) — a dotfile opened in an editor
+//     must still get live change events through this one shared watcher.
+//
+// Regression for: an editor open on a dotfile never received external-change
+// events because the matcher ignored every dot-prefixed path.
+// =============================================================================
+
+const ROOT = '/proj'
+const EXCLUDED = new Set(['node_modules', '.git', '.DS_Store', '__pycache__'])
+const asFile = { isDirectory: () => false }
+const asDir = { isDirectory: () => true }
+
+describe('createFsIgnoreMatcher — unit', () => {
+  const ignored = createFsIgnoreMatcher(ROOT, EXCLUDED)
+
+  it('does NOT ignore a hidden file at the root (the bug)', () => {
+    expect(ignored('/proj/.gitignore', asFile)).toBe(false)
+    expect(ignored('/proj/.env', asFile)).toBe(false)
+    // Stats absent (chokidar's pre-stat probe): still not ignored, so chokidar
+    // proceeds to stat it rather than pruning a file it never looked at.
+    expect(ignored('/proj/.gitignore')).toBe(false)
+  })
+
+  it('does NOT ignore a hidden file nested under a normal directory', () => {
+    expect(ignored('/proj/src/.eslintrc.json', asFile)).toBe(false)
+    expect(ignored('/proj/config/.prettierrc', asFile)).toBe(false)
+  })
+
+  it('does NOT ignore ordinary files', () => {
+    expect(ignored('/proj/src/index.ts', asFile)).toBe(false)
+    expect(ignored('/proj/README.md', asFile)).toBe(false)
+  })
+
+  it('ignores a hidden DIRECTORY leaf (so chokidar will not descend)', () => {
+    expect(ignored('/proj/.cate', asDir)).toBe(true)
+    expect(ignored('/proj/.cache', asDir)).toBe(true)
+  })
+
+  it('ignores anything under a hidden ancestor directory regardless of stats', () => {
+    expect(ignored('/proj/.cate/session.json', asFile)).toBe(true)
+    expect(ignored('/proj/.git/HEAD', asFile)).toBe(true)
+    expect(ignored('/proj/.cache/x/y.bin')).toBe(true)
+  })
+
+  it('ignores excluded entries (files or dirs, with or without stats)', () => {
+    expect(ignored('/proj/node_modules', asDir)).toBe(true)
+    expect(ignored('/proj/node_modules/pkg/index.js', asFile)).toBe(true)
+    expect(ignored('/proj/__pycache__/m.pyc')).toBe(true)
+    expect(ignored('/proj/.DS_Store', asFile)).toBe(true)
+  })
+
+  it('does not ignore the root itself or paths outside the root', () => {
+    expect(ignored('/proj', asDir)).toBe(false)
+    expect(ignored('/other/.gitignore', asFile)).toBe(false)
+    // A dotted/excluded segment in the root's OWN path must not silence the tree.
+    const m = createFsIgnoreMatcher('/Users/me/.config/proj', EXCLUDED)
+    expect(m('/Users/me/.config/proj/src/a.ts', asFile)).toBe(false)
+  })
+
+  it('treats a hidden-dir leaf without stats as not-ignored (chokidar re-asks)', () => {
+    // No stats yet → defer (false); chokidar stats it and calls again with
+    // stats.isDirectory() === true, which prunes it. Covered live below.
+    expect(ignored('/proj/.cate')).toBe(false)
+    expect(ignored('/proj/.cate', asDir)).toBe(true)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// End-to-end: drive a REAL chokidar watcher with the matcher over a real tree.
+// This is the guard that the whole watch path behaves — hidden files emit,
+// hidden/excluded dirs stay pruned (no events, not even watched).
+// -----------------------------------------------------------------------------
+
+describe('createFsIgnoreMatcher — live chokidar', () => {
+  let dir: string
+  let watcher: FSWatcher | null = null
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-watch-'))
+    await fs.mkdir(path.join(dir, 'src'))
+    await fs.mkdir(path.join(dir, '.cate'))
+    await fs.mkdir(path.join(dir, '.git'))
+    await fs.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true })
+    await fs.writeFile(path.join(dir, '.gitignore'), 'a\n')
+    await fs.writeFile(path.join(dir, '.env'), 'a\n')
+    await fs.writeFile(path.join(dir, 'src', 'a.ts'), 'a\n')
+    await fs.writeFile(path.join(dir, '.cate', 'session.json'), 'a\n')
+    await fs.writeFile(path.join(dir, '.git', 'HEAD'), 'a\n')
+    await fs.writeFile(path.join(dir, 'node_modules', 'pkg', 'i.js'), 'a\n')
+  })
+
+  afterEach(async () => {
+    await watcher?.close()
+    watcher = null
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('emits for hidden + normal files, never for hidden/excluded dirs', async () => {
+    const events: Array<{ type: string; rel: string }> = []
+    watcher = watch(dir, { ignoreInitial: true, ignored: createFsIgnoreMatcher(dir, EXCLUDED) })
+    watcher.on('all', (type, p) => events.push({ type, rel: path.relative(dir, p) }))
+    await new Promise<void>((resolve) => watcher!.once('ready', () => resolve()))
+
+    // Touch one of each category.
+    await fs.appendFile(path.join(dir, '.gitignore'), 'b\n')
+    await fs.appendFile(path.join(dir, '.env'), 'b\n')
+    await fs.appendFile(path.join(dir, 'src', 'a.ts'), 'b\n')
+    await fs.appendFile(path.join(dir, '.cate', 'session.json'), 'b\n')
+    await fs.appendFile(path.join(dir, '.git', 'HEAD'), 'b\n')
+    await fs.appendFile(path.join(dir, 'node_modules', 'pkg', 'i.js'), 'b\n')
+
+    // Let fsevents settle.
+    await new Promise((r) => setTimeout(r, 600))
+
+    const touched = new Set(events.map((e) => e.rel))
+    expect(touched.has('.gitignore')).toBe(true)
+    expect(touched.has('.env')).toBe(true)
+    expect(touched.has(path.join('src', 'a.ts'))).toBe(true)
+    expect(touched.has(path.join('.cate', 'session.json'))).toBe(false)
+    expect(touched.has(path.join('.git', 'HEAD'))).toBe(false)
+    expect(touched.has(path.join('node_modules', 'pkg', 'i.js'))).toBe(false)
+  }, 10_000)
+})

--- a/src/runtime/capabilities/file.ts
+++ b/src/runtime/capabilities/file.ts
@@ -89,11 +89,16 @@ export function createFsIgnoreMatcher(
   rootPath: string,
   excluded: ReadonlySet<string>,
 ): (filePath: string, stats?: { isDirectory(): boolean }) => boolean {
+  // Normalize separators up front. chokidar hands this predicate POSIX-style
+  // (forward-slash) paths even on Windows, while `rootPath` arrives OS-native
+  // (backslashes), so a raw `startsWith(rootPath)` would never match on Windows
+  // and the matcher would ignore nothing (over-watching the whole tree).
+  const root = rootPath.replace(/\\/g, '/')
   return (filePath: string, stats?: { isDirectory(): boolean }) => {
-    if (filePath.length <= rootPath.length || !filePath.startsWith(rootPath)) return false
-    const sep = filePath.charCodeAt(rootPath.length)
-    if (sep !== 47 /* '/' */ && sep !== 92 /* '\\' */) return false
-    const segments = filePath.slice(rootPath.length + 1).split(/[/\\]/)
+    const fp = filePath.replace(/\\/g, '/')
+    if (fp.length <= root.length || !fp.startsWith(root)) return false
+    if (fp.charCodeAt(root.length) !== 47 /* '/' */) return false
+    const segments = fp.slice(root.length + 1).split('/')
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i]
       if (excluded.has(segment)) return true

--- a/src/runtime/capabilities/file.ts
+++ b/src/runtime/capabilities/file.ts
@@ -64,22 +64,47 @@ export async function mkdirEntry(safePath: string): Promise<void> {
 /**
  * Build a chokidar `ignored` predicate for a watcher rooted at `rootPath`.
  * chokidar v4 dropped glob support, so this must be a function, not glob
- * strings. A path is ignored when any segment BELOW the watch root is hidden
- * (leading dot) or is in `excluded` — matching readDir/searchFiles, which drop
- * any entry whose basename is in the set. Only the part below the root is
- * judged so a dotted or excluded segment in the root's own absolute path
- * (e.g. a workspace under ~/.config) doesn't silence the whole tree. Returning
- * true for a directory stops chokidar from descending into it, which keeps a
- * recursive watch cheap even with huge excluded trees. Shared by the local
- * watcher pool (main/ipc/filesystem.ts) and the daemon's watch capability.
+ * strings. Only the part BELOW the watch root is judged so a dotted or excluded
+ * segment in the root's own absolute path (e.g. a workspace under ~/.config)
+ * doesn't silence the whole tree.
+ *
+ * A path is ignored when, below the root: any segment is in `excluded`, OR any
+ * ANCESTOR directory is hidden (leading dot), OR the leaf itself is a hidden
+ * DIRECTORY. Hidden *files* (`.gitignore`, `.env`, `.prettierrc`) are NOT
+ * ignored — a file the user explicitly opens in an editor must still receive
+ * live change events through this one shared watcher (the editor and the file
+ * tree share it). Pruning hidden directories keeps `.git`, `.cache` and our own
+ * `.cate` state dir out of the watch, so a recursive watch stays cheap and the
+ * app's own session writes don't echo back as external changes.
+ *
+ * The file-vs-directory call uses chokidar v4's `stats` argument (it invokes
+ * `ignored(path, stats)`). chokidar asks once before stat-ing (stats absent) and
+ * again with stats; when stats are absent we DON'T ignore the leaf, so chokidar
+ * proceeds to stat it and re-asks — a hidden directory is still pruned on that
+ * second call. Returning true for a directory stops chokidar descending into it.
+ * Shared by the local watcher pool (main/ipc/filesystem.ts) and the daemon's
+ * watch capability (runtime/capabilities/index.ts).
  */
-export function createFsIgnoreMatcher(rootPath: string, excluded: ReadonlySet<string>): (filePath: string) => boolean {
-  return (filePath: string) => {
+export function createFsIgnoreMatcher(
+  rootPath: string,
+  excluded: ReadonlySet<string>,
+): (filePath: string, stats?: { isDirectory(): boolean }) => boolean {
+  return (filePath: string, stats?: { isDirectory(): boolean }) => {
     if (filePath.length <= rootPath.length || !filePath.startsWith(rootPath)) return false
     const sep = filePath.charCodeAt(rootPath.length)
     if (sep !== 47 /* '/' */ && sep !== 92 /* '\\' */) return false
-    for (const segment of filePath.slice(rootPath.length + 1).split(/[/\\]/)) {
-      if (segment.charCodeAt(0) === 46 /* '.' */ || excluded.has(segment)) return true
+    const segments = filePath.slice(rootPath.length + 1).split(/[/\\]/)
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]
+      if (excluded.has(segment)) return true
+      if (segment.charCodeAt(0) === 46 /* '.' */) {
+        // An ancestor dotted segment is necessarily a directory → prune it.
+        if (i < segments.length - 1) return true
+        // The leaf: prune only if it's a directory (.git, .cache, .cate). A
+        // hidden file stays watched. Stats absent → defer (don't ignore);
+        // chokidar re-asks with stats and we prune the directory then.
+        if (stats?.isDirectory()) return true
+      }
     }
     return false
   }

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.3.0'
+export const RUNTIME_VERSION = '1.3.1'


### PR DESCRIPTION
## Problem

A file open in an editor that was hidden (e.g. `.gitignore`, `.env`) never picked up external changes and never live-reloaded. Reopening the panel didn't help either: it showed the stale cached buffer.

Root cause: `createFsIgnoreMatcher` (the single chokidar ignore predicate shared by the local watcher and the daemon watcher) dropped every dot-prefixed path, so chokidar never emitted events for hidden files. The editor already subscribes to the root watcher, so it just never got the events.

## Fix

- **Matcher**: prune excluded entries and hidden *directories* only (so `node_modules`, `.git`, `.cate` stay pruned, no perf change, no echo from our own state writes), but let hidden *files* through, using chokidar v4's `(path, stats)` arg to tell files from dirs. Still one unified watcher.
- **Reopen**: track each model's disk baseline in the model cache. On reopen, a clean stale buffer silently catches up; a buffer with unsaved edits raises a conflict instead of being clobbered.

## Tests

- `file.test.ts`: matcher unit cases + a live chokidar test over a real tree (hidden files fire, hidden/excluded dirs stay silent).
- `useFileSync.test.tsx`: watches the root, dotfile reloads, all `resyncFromDisk` cases.
- `modelCache.test.ts`: baseline get/remember/evict.

Full suite green (1613 tests), typecheck clean.

Note: also bundles the regenerated skills index (`registry/`).