### PR TITLE
fix: contain watcher EMFILE runtime crashes

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -176,9 +176,30 @@ function createWatcher(dirPath: string, subscribers: Map<string, SubscriberEntry
       if (pathHasPrefix(fp, sub.prefix)) sub.dispatch(type, fp)
     }
   }
+
+  const dropActiveWatcher = (): void => {
+    const shared = sharedWatchers.get(dirPath)
+    if (shared?.watcher !== watcher) return
+
+    sharedWatchers.delete(dirPath)
+    for (const [key, normPath] of watcherKeys) {
+      if (normPath === dirPath) watcherKeys.delete(key)
+    }
+    for (const sub of subscribers.values()) sub.cancelFlush()
+    subscribers.clear()
+  }
+
+  const handleError = (err: unknown): void => {
+    log.warn('[fs-watch] watcher error for %s: %O', dirPath, err)
+    dropActiveWatcher()
+    watcher.removeAllListeners()
+    void watcher.close()
+  }
+
   watcher.on('add', (fp: string) => fanOut('create', fp))
   watcher.on('change', (fp: string) => fanOut('update', fp))
   watcher.on('unlink', (fp: string) => fanOut('delete', fp))
+  watcher.on('error', handleError)
   return watcher
 }
 

--- a/src/main/ipc/fsWatchError.test.ts
+++ b/src/main/ipc/fsWatchError.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Handler = (...args: unknown[]) => void
+
+interface MockWatcher {
+  handlers: Map<string, Set<Handler>>
+  close: ReturnType<typeof vi.fn>
+  on: (event: string, cb: Handler) => MockWatcher
+  removeAllListeners: () => MockWatcher
+  emit: (event: string, ...args: unknown[]) => void
+}
+
+const mockState = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  watchers: [] as MockWatcher[],
+  watch: vi.fn(),
+}))
+
+function createMockWatcher(): MockWatcher {
+  const watcher: MockWatcher = {
+    handlers: new Map(),
+    close: vi.fn(async () => {}),
+    on(event, cb) {
+      const set = this.handlers.get(event) ?? new Set<Handler>()
+      set.add(cb)
+      this.handlers.set(event, set)
+      return this
+    },
+    removeAllListeners() {
+      this.handlers.clear()
+      return this
+    },
+    emit(event, ...args) {
+      for (const cb of this.handlers.get(event) ?? []) cb(...args)
+    },
+  }
+  mockState.watchers.push(watcher)
+  return watcher
+}
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      mockState.handlers.set(channel, fn)
+    },
+  },
+}))
+
+vi.mock('chokidar', () => ({ watch: mockState.watch }))
+
+vi.mock('../windowRegistry', () => ({
+  windowFromEvent: () => ({ id: 1 }),
+  sendToWindow: vi.fn(),
+}))
+
+vi.mock('../store', () => ({
+  getSettingSync: (key: string) => (key === 'fileExclusions' ? [] : undefined),
+}))
+
+const { registerHandlers } = await import('./filesystem')
+const { addAllowedRoot, removeAllowedRoot } = await import('./pathValidation')
+const { FS_WATCH_START, FS_WATCH_STOP } = await import('../../shared/ipc-channels')
+
+registerHandlers()
+const watchStart = mockState.handlers.get(FS_WATCH_START)!
+const watchStop = mockState.handlers.get(FS_WATCH_STOP)!
+const fakeEvent = { sender: {} } as unknown
+const root = '/repo'
+
+describe('filesystem watch error handling', () => {
+  beforeEach(async () => {
+    await Promise.resolve(watchStop(fakeEvent, root)).catch(() => {})
+    removeAllowedRoot(root)
+    mockState.watchers.length = 0
+    mockState.watch.mockReset()
+    mockState.watch.mockImplementation(createMockWatcher)
+    addAllowedRoot(root)
+  })
+
+  test('contains chokidar errors and recreates the watcher on the next start', async () => {
+    await watchStart(fakeEvent, root)
+    const first = mockState.watchers[0]
+
+    expect(() => first.emit('error', Object.assign(new Error('too many open files'), { code: 'EMFILE' }))).not.toThrow()
+    expect(first.close).toHaveBeenCalledTimes(1)
+
+    await watchStart(fakeEvent, root)
+
+    expect(mockState.watch).toHaveBeenCalledTimes(2)
+    expect(mockState.watchers[1]).not.toBe(first)
+  })
+})

--- a/src/main/runtime/transports/localTransport.dispose.test.ts
+++ b/src/main/runtime/transports/localTransport.dispose.test.ts
@@ -34,6 +34,11 @@ const UNKILLABLE_EXCEPT_HARD = `
   setInterval(() => {}, 1000);
 `
 
+const EXITS_IMMEDIATELY = `
+  process.stdout.write('ready\\n');
+  process.exit(0);
+`
+
 beforeAll(async () => {
   dir = await mkdtemp(path.join(os.tmpdir(), 'cate-dispose-test-'))
 })
@@ -44,6 +49,7 @@ afterAll(async () => {
 
 async function launchWith(script: string, name: string): Promise<{
   transport: LocalSubprocessTransport
+  channel: Awaited<ReturnType<LocalSubprocessTransport['launch']>>
   exit: Promise<{ code: number | null }>
 }> {
   const bundlePath = path.join(dir, `${name}.cjs`)
@@ -59,7 +65,7 @@ async function launchWith(script: string, name: string): Promise<{
     channel.onData((chunk) => { if (chunk.toString().includes('ready')) resolve() })
   })
   const exit = new Promise<{ code: number | null }>((resolve) => channel.onClose(resolve))
-  return { transport, exit }
+  return { transport, channel, exit }
 }
 
 describe('LocalSubprocessTransport graceful shutdown (FIX 16)', () => {
@@ -83,5 +89,12 @@ describe('LocalSubprocessTransport graceful shutdown (FIX 16)', () => {
     // after the grace window — exit code is null (killed by signal).
     expect(code).toBe(null)
     expect(Date.now() - start).toBeGreaterThanOrEqual(1000)
+  }, 15_000)
+
+  test('write after daemon exit fails synchronously instead of surfacing EPIPE as uncaught', async () => {
+    const { channel, exit } = await launchWith(EXITS_IMMEDIATELY, 'exits-immediately')
+    await exit
+
+    expect(() => channel.write('{"t":"req","id":1,"method":"ping","params":[]}\n')).toThrow('Runtime stdin is closed')
   }, 15_000)
 })

--- a/src/main/runtime/transports/localTransport.ts
+++ b/src/main/runtime/transports/localTransport.ts
@@ -127,10 +127,11 @@ export class LocalSubprocessTransport implements RuntimeTransport {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: this.opts.env ?? process.env,
     })
+    child.stdin?.on('error', () => { /* EPIPE after daemon exit is reported via close */ })
     this.child = child
 
     return {
-      write: (line) => { child.stdin?.write(line) },
+      write: (line) => { writeToChildStdin(child, line) },
       onData: (cb) => { child.stdout?.on('data', cb) },
       onStderr: (cb) => { child.stderr?.on('data', cb) },
       onClose: (cb) => { child.on('close', (code) => cb({ code })) },
@@ -148,6 +149,14 @@ export class LocalSubprocessTransport implements RuntimeTransport {
     this.child = null
     if (child) await gracefulStop(child)
   }
+}
+
+function writeToChildStdin(child: ChildProcess, line: string): void {
+  const stdin = child.stdin
+  if (!stdin || stdin.destroyed || stdin.writableEnded || child.exitCode !== null || child.signalCode !== null) {
+    throw new Error('Runtime stdin is closed')
+  }
+  stdin.write(line)
 }
 
 /**

--- a/src/main/runtime/transports/wslTransport.ts
+++ b/src/main/runtime/transports/wslTransport.ts
@@ -151,9 +151,10 @@ export class WslTransport implements RuntimeTransport {
     const args = ['-d', this.opts.distro, '-e', nodeBin, `${this.installDir}/runtime.cjs`, '--root', this.opts.root, '--id', this.opts.id]
     if (this.opts.exclusions?.length) args.push('--exclude', this.opts.exclusions.join(','))
     const child = spawn('wsl.exe', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    child.stdin?.on('error', () => { /* EPIPE after daemon exit is reported via close */ })
     this.child = child
     return {
-      write: (line) => { child.stdin?.write(line) },
+      write: (line) => { writeToChildStdin(child, line) },
       onData: (cb) => { child.stdout?.on('data', cb) },
       onStderr: (cb) => { child.stderr?.on('data', cb) },
       onClose: (cb) => { child.on('close', (code) => cb({ code })) },
@@ -165,4 +166,12 @@ export class WslTransport implements RuntimeTransport {
     this.child?.kill()
     this.child = null
   }
+}
+
+function writeToChildStdin(child: ChildProcess, line: string): void {
+  const stdin = child.stdin
+  if (!stdin || stdin.destroyed || stdin.writableEnded || child.exitCode !== null || child.signalCode !== null) {
+    throw new Error('Runtime stdin is closed')
+  }
+  stdin.write(line)
 }

--- a/src/runtime/capabilities/index.ts
+++ b/src/runtime/capabilities/index.ts
@@ -70,27 +70,94 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
   // via the rebuild below.
   const buildIgnored = (rootPath: string) => fileLeaf.createFsIgnoreMatcher(rootPath, new Set(exclusionSet))
 
-  // Registry of active fs-watch subscriptions, so setExclusions can rebuild each
-  // with the new ignore list. Keyed by a unique handle (an object identity) so a
-  // concurrent unsub during a rebuild removes exactly its own entry.
-  interface WatchEntry {
+  interface WatchSubscriber {
     prefix: string
     onChange: (changedPath: string, type: FsChangeType) => void
-    watcher: ReturnType<typeof watch>
   }
-  const activeWatches = new Set<WatchEntry>()
+
+  interface SharedWatch {
+    root: string
+    watcher: ReturnType<typeof watch>
+    subscribers: Set<WatchSubscriber>
+  }
+
+  // One recursive chokidar instance can cover several runtime.file.watch()
+  // subscribers under the same root. This keeps the local daemon from opening a
+  // second full-tree watch for the git monitor, agent auth sync, and any future
+  // nested subscriptions in the same workspace.
+  //
+  // Concurrency note: the SharedWatch object is still the identity token. Every
+  // stale unsubscribe/error/rebuild path checks `watchPool.get(root) === shared`
+  // before deleting or closing the current watcher, so an old handle cannot tear
+  // down a newer watcher that reused the same root key.
+  const watchPool = new Map<string, SharedWatch>()
+
+  const pathHasPrefix = (filePath: string, prefix: string): boolean => {
+    const fp = filePath.replace(/\\/g, '/')
+    const pre = prefix.replace(/\\/g, '/')
+    if (fp === pre) return true
+    if (!fp.startsWith(pre)) return false
+    const next = fp.charCodeAt(pre.length)
+    return next === 47 /* / */ || next === 92 /* \ */
+  }
 
   // Create a chokidar watcher for `prefix` with the CURRENT ignore list, wiring
   // its add/change/unlink to onChange. Used on first watch and on every rebuild.
-  const spawnWatcher = (prefix: string, onChange: (changedPath: string, type: FsChangeType) => void) => {
+  const spawnWatcher = (shared: SharedWatch) => {
     // Full-tree watch (no `depth` cap) — clients assume events for nested
     // paths; the ignore matcher prunes hidden/excluded subtrees.
-    const root = validatePath(prefix)
-    const w = watch(root, { ignoreInitial: true, ignored: buildIgnored(root) })
-    w.on('add', (fp) => onChange(fp, 'create'))
-    w.on('change', (fp) => onChange(fp, 'update'))
-    w.on('unlink', (fp) => onChange(fp, 'delete'))
+    const w = watch(shared.root, { ignoreInitial: true, ignored: buildIgnored(shared.root) })
+    const fanOut = (fp: string, type: FsChangeType) => {
+      for (const sub of shared.subscribers) {
+        if (pathHasPrefix(fp, sub.prefix)) sub.onChange(fp, type)
+      }
+    }
+    w.on('add', (fp) => fanOut(fp, 'create'))
+    w.on('change', (fp) => fanOut(fp, 'update'))
+    w.on('unlink', (fp) => fanOut(fp, 'delete'))
+    w.on('error', () => {
+      // EMFILE/EPERM/etc. must not crash the daemon. Drop this broken watcher;
+      // polling callers (for example git monitor) continue, and a later watch
+      // request can attempt a fresh watcher.
+      if (watchPool.get(shared.root) === shared && shared.watcher === w) {
+        watchPool.delete(shared.root)
+      }
+      w.removeAllListeners()
+      void w.close()
+    })
     return w
+  }
+
+  const findCoveringWatch = (prefix: string): SharedWatch | null => {
+    let best: SharedWatch | null = null
+    for (const shared of watchPool.values()) {
+      if (!pathHasPrefix(prefix, shared.root)) continue
+      if (!best || shared.root.length > best.root.length) best = shared
+    }
+    return best
+  }
+
+  const subscribeWatch = (
+    prefix: string,
+    onChange: (changedPath: string, type: FsChangeType) => void,
+  ): (() => void) => {
+    const root = validatePath(prefix)
+    let shared = findCoveringWatch(root)
+    if (!shared) {
+      shared = { root, watcher: null as never, subscribers: new Set<WatchSubscriber>() }
+      shared.watcher = spawnWatcher(shared)
+      watchPool.set(root, shared)
+    }
+    const sub: WatchSubscriber = { prefix: root, onChange }
+    shared.subscribers.add(sub)
+
+    return () => {
+      sub.onChange = () => { /* unsubscribed */ }
+      shared.subscribers.delete(sub)
+      if (shared.subscribers.size > 0) return
+      if (watchPool.get(shared.root) === shared) watchPool.delete(shared.root)
+      void shared.watcher.close()
+    }
   }
 
   // The daemon is the AUTHORITATIVE path check: only it can realpath its own
@@ -129,17 +196,10 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
       // hidden dotfiles and the daemon's exclusionSet, so the watcher never
       // floods with node_modules/.git events. Electron-free (no getSettingSync).
       //
-      // The watcher is tracked in activeWatches so setExclusions can rebuild it
-      // with a fresh ignore list — the chokidar `ignored` is fixed at creation,
-      // so a live exclusion change must recreate the watcher.
-      const entry: WatchEntry = { prefix, onChange, watcher: spawnWatcher(prefix, onChange) }
-      activeWatches.add(entry)
-      return () => {
-        // Remove from the registry FIRST so a concurrent setExclusions rebuild
-        // never resurrects a just-unsubscribed watcher.
-        activeWatches.delete(entry)
-        void entry.watcher.close()
-      }
+      // The shared watcher is tracked in watchPool so setExclusions can rebuild
+      // it with a fresh ignore list — the chokidar `ignored` is fixed at
+      // creation, so a live exclusion change must recreate the watcher.
+      return subscribeWatch(prefix, onChange)
     },
   }
 
@@ -226,19 +286,18 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
     setExclusions: async (names) => {
       exclusionSet.clear()
       for (const name of names) exclusionSet.add(name)
-      // Snapshot first: rebuilding mutates nothing in activeWatches (we swap the
-      // watcher field in place), but an unsub during this loop deletes its entry,
-      // so iterating a snapshot + re-checking membership avoids reviving it.
+      // Snapshot first: rebuilding swaps each SharedWatch's watcher field in
+      // place, but an unsub during this loop deletes its pool entry, so
+      // iterating a snapshot + re-checking object identity avoids reviving it.
       // Close the OLD watcher fully before the swap is considered done, so it
       // can't keep emitting events for newly-excluded names during the overlap.
       await Promise.all(
-        [...activeWatches].map(async (entry) => {
-          if (!activeWatches.has(entry)) return // unsubscribed concurrently
-          const old = entry.watcher
-          entry.watcher = spawnWatcher(entry.prefix, entry.onChange)
-          // The entry may have been unsubscribed while we were swapping; if so its
-          // new watcher must also be closed (the unsub already closed the old one).
-          if (!activeWatches.has(entry)) void entry.watcher.close()
+        [...watchPool.values()].map(async (shared) => {
+          if (watchPool.get(shared.root) !== shared) return // unsubscribed concurrently
+          const old = shared.watcher
+          shared.watcher = spawnWatcher(shared)
+          if (watchPool.get(shared.root) !== shared) void shared.watcher.close()
+          old.removeAllListeners()
           await old.close()
         }),
       )

--- a/src/runtime/capabilities/watchPool.test.ts
+++ b/src/runtime/capabilities/watchPool.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { buildDaemonRuntime } from './index'
+import { addAllowedRoot, removeAllowedRoot } from '../../main/ipc/pathValidation'
+
+type Handler = (...args: unknown[]) => void
+
+interface MockWatcher {
+  root: string
+  handlers: Map<string, Set<Handler>>
+  close: ReturnType<typeof vi.fn>
+  on: (event: string, cb: Handler) => MockWatcher
+  removeAllListeners: () => MockWatcher
+  emit: (event: string, ...args: unknown[]) => void
+}
+
+const mockState = vi.hoisted(() => ({
+  watchers: [] as MockWatcher[],
+  watch: vi.fn(),
+}))
+
+function createMockWatcher(root: string): MockWatcher {
+  const watcher: MockWatcher = {
+    root,
+    handlers: new Map(),
+    close: vi.fn(async () => {}),
+    on(event, cb) {
+      const set = this.handlers.get(event) ?? new Set<Handler>()
+      set.add(cb)
+      this.handlers.set(event, set)
+      return this
+    },
+    removeAllListeners() {
+      this.handlers.clear()
+      return this
+    },
+    emit(event, ...args) {
+      for (const cb of this.handlers.get(event) ?? []) cb(...args)
+    },
+  }
+  mockState.watchers.push(watcher)
+  return watcher
+}
+
+vi.mock('chokidar', () => ({ watch: mockState.watch }))
+
+describe('daemon runtime watch pool', () => {
+  beforeEach(() => {
+    mockState.watchers.length = 0
+    mockState.watch.mockReset()
+    mockState.watch.mockImplementation(createMockWatcher)
+    addAllowedRoot('/repo')
+  })
+
+  afterEach(() => {
+    removeAllowedRoot('/repo')
+  })
+
+  test('shares one recursive watcher for nested file.watch subscribers', () => {
+    const runtime = buildDaemonRuntime({ id: 'srv_test', rgPath: '/rg' }).runtime
+    const rootEvents: string[] = []
+    const nestedEvents: string[] = []
+
+    const stopRoot = runtime.file.watch('/repo', (p) => rootEvents.push(p))
+    const stopNested = runtime.file.watch('/repo/src', (p) => nestedEvents.push(p))
+
+    expect(mockState.watch).toHaveBeenCalledTimes(1)
+    const watcher = mockState.watchers[0]
+
+    watcher.emit('add', '/repo/src/a.ts')
+    watcher.emit('add', '/repo/README.md')
+
+    expect(rootEvents).toEqual(['/repo/src/a.ts', '/repo/README.md'])
+    expect(nestedEvents).toEqual(['/repo/src/a.ts'])
+
+    stopNested()
+    watcher.emit('change', '/repo/src/b.ts')
+
+    expect(rootEvents).toEqual(['/repo/src/a.ts', '/repo/README.md', '/repo/src/b.ts'])
+    expect(nestedEvents).toEqual(['/repo/src/a.ts'])
+
+    stopRoot()
+    expect(watcher.close).toHaveBeenCalledTimes(1)
+  })
+
+  test('drops a broken watcher on error so the next subscription can recreate it', () => {
+    const runtime = buildDaemonRuntime({ id: 'srv_test', rgPath: '/rg' }).runtime
+
+    const stopFirst = runtime.file.watch('/repo', () => {})
+    const first = mockState.watchers[0]
+
+    expect(() => first.emit('error', Object.assign(new Error('too many open files'), { code: 'EMFILE' }))).not.toThrow()
+    expect(first.close).toHaveBeenCalledTimes(1)
+
+    const stopSecond = runtime.file.watch('/repo', () => {})
+    expect(mockState.watch).toHaveBeenCalledTimes(2)
+    expect(mockState.watchers[1]).not.toBe(first)
+
+    stopFirst()
+    stopSecond()
+  })
+
+  test('rebuilds a shared watcher once when exclusions change', async () => {
+    const runtime = buildDaemonRuntime({ id: 'srv_test', rgPath: '/rg' }).runtime
+
+    const stopRoot = runtime.file.watch('/repo', () => {})
+    const stopNested = runtime.file.watch('/repo/src', () => {})
+    const first = mockState.watchers[0]
+
+    await runtime.setExclusions(['node_modules'])
+
+    expect(mockState.watch).toHaveBeenCalledTimes(2)
+    expect(first.handlers.size).toBe(0)
+    expect(first.close).toHaveBeenCalledTimes(1)
+
+    stopNested()
+    stopRoot()
+  })
+})

--- a/src/runtime/capabilities/watchPool.test.ts
+++ b/src/runtime/capabilities/watchPool.test.ts
@@ -1,6 +1,17 @@
+import path from 'path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { buildDaemonRuntime } from './index'
 import { addAllowedRoot, removeAllowedRoot } from '../../main/ipc/pathValidation'
+
+// Build paths through path.resolve/join so they match what validatePath()
+// (= path.resolve) produces on the host OS. A POSIX literal like '/repo' becomes
+// a drive-prefixed backslash path on Windows, so hardcoded literals would never
+// match the subscriber prefix there.
+const ROOT = path.resolve('/repo')
+const SRC = path.join(ROOT, 'src')
+const FILE_A = path.join(SRC, 'a.ts')
+const FILE_B = path.join(SRC, 'b.ts')
+const README = path.join(ROOT, 'README.md')
 
 type Handler = (...args: unknown[]) => void
 
@@ -48,11 +59,11 @@ describe('daemon runtime watch pool', () => {
     mockState.watchers.length = 0
     mockState.watch.mockReset()
     mockState.watch.mockImplementation(createMockWatcher)
-    addAllowedRoot('/repo')
+    addAllowedRoot(ROOT)
   })
 
   afterEach(() => {
-    removeAllowedRoot('/repo')
+    removeAllowedRoot(ROOT)
   })
 
   test('shares one recursive watcher for nested file.watch subscribers', () => {
@@ -60,23 +71,23 @@ describe('daemon runtime watch pool', () => {
     const rootEvents: string[] = []
     const nestedEvents: string[] = []
 
-    const stopRoot = runtime.file.watch('/repo', (p) => rootEvents.push(p))
-    const stopNested = runtime.file.watch('/repo/src', (p) => nestedEvents.push(p))
+    const stopRoot = runtime.file.watch(ROOT, (p) => rootEvents.push(p))
+    const stopNested = runtime.file.watch(SRC, (p) => nestedEvents.push(p))
 
     expect(mockState.watch).toHaveBeenCalledTimes(1)
     const watcher = mockState.watchers[0]
 
-    watcher.emit('add', '/repo/src/a.ts')
-    watcher.emit('add', '/repo/README.md')
+    watcher.emit('add', FILE_A)
+    watcher.emit('add', README)
 
-    expect(rootEvents).toEqual(['/repo/src/a.ts', '/repo/README.md'])
-    expect(nestedEvents).toEqual(['/repo/src/a.ts'])
+    expect(rootEvents).toEqual([FILE_A, README])
+    expect(nestedEvents).toEqual([FILE_A])
 
     stopNested()
-    watcher.emit('change', '/repo/src/b.ts')
+    watcher.emit('change', FILE_B)
 
-    expect(rootEvents).toEqual(['/repo/src/a.ts', '/repo/README.md', '/repo/src/b.ts'])
-    expect(nestedEvents).toEqual(['/repo/src/a.ts'])
+    expect(rootEvents).toEqual([FILE_A, README, FILE_B])
+    expect(nestedEvents).toEqual([FILE_A])
 
     stopRoot()
     expect(watcher.close).toHaveBeenCalledTimes(1)
@@ -85,13 +96,13 @@ describe('daemon runtime watch pool', () => {
   test('drops a broken watcher on error so the next subscription can recreate it', () => {
     const runtime = buildDaemonRuntime({ id: 'srv_test', rgPath: '/rg' }).runtime
 
-    const stopFirst = runtime.file.watch('/repo', () => {})
+    const stopFirst = runtime.file.watch(ROOT, () => {})
     const first = mockState.watchers[0]
 
     expect(() => first.emit('error', Object.assign(new Error('too many open files'), { code: 'EMFILE' }))).not.toThrow()
     expect(first.close).toHaveBeenCalledTimes(1)
 
-    const stopSecond = runtime.file.watch('/repo', () => {})
+    const stopSecond = runtime.file.watch(ROOT, () => {})
     expect(mockState.watch).toHaveBeenCalledTimes(2)
     expect(mockState.watchers[1]).not.toBe(first)
 
@@ -102,8 +113,8 @@ describe('daemon runtime watch pool', () => {
   test('rebuilds a shared watcher once when exclusions change', async () => {
     const runtime = buildDaemonRuntime({ id: 'srv_test', rgPath: '/rg' }).runtime
 
-    const stopRoot = runtime.file.watch('/repo', () => {})
-    const stopNested = runtime.file.watch('/repo/src', () => {})
+    const stopRoot = runtime.file.watch(ROOT, () => {})
+    const stopNested = runtime.file.watch(SRC, () => {})
     const first = mockState.watchers[0]
 
     await runtime.setExclusions(['node_modules'])


### PR DESCRIPTION
## Summary

Closes #394.

This PR makes filesystem watcher failures recoverable instead of allowing them to cascade into a fatal Electron main-process `write EPIPE` dialog.

Changes:

- Pool daemon `file.watch` subscriptions under an existing covering watcher root to avoid duplicate full-tree chokidar watchers for the same workspace.
- Contain daemon and main-process chokidar `error` events, close the broken watcher, and allow a later watch request to recreate it.
- Guard local and WSL runtime stdin writes after the daemon exits so closed pipes fail as normal runtime request failures instead of uncaught `EPIPE` exceptions.
- Add regression tests for watcher pooling, watcher error recovery, and post-exit stdin writes.

## Validation

```bash
npx vitest run src/main/ipc/fsWatchError.test.ts src/runtime/capabilities/watchPool.test.ts src/main/runtime/transports/localTransport.dispose.test.ts
npx eslint src/main/ipc/filesystem.ts src/main/ipc/fsWatchError.test.ts src/runtime/capabilities/index.ts src/runtime/capabilities/watchPool.test.ts src/main/runtime/transports/localTransport.ts src/main/runtime/transports/localTransport.dispose.test.ts src/main/runtime/transports/wslTransport.ts
npm run typecheck
```
