### PR TITLE
Add OSC52 terminal clipboard support

### DIFF
--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -22,7 +22,11 @@ vi.mock('node-pty', () => ({
 
 // Captured ipcMain.handle map so tests can invoke a handler directly.
 const handlers = new Map<string, (...args: unknown[]) => unknown>()
+const clipboardWriteText = vi.fn()
 vi.mock('electron', () => ({
+  clipboard: {
+    writeText: clipboardWriteText,
+  },
   ipcMain: {
     handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
       handlers.set(channel, fn)
@@ -64,6 +68,9 @@ vi.mock('../logger', () => ({ default: { warn: () => {}, info: () => {}, error: 
 //     without a real xterm/DOM/store stack. registryState is left REAL so the
 //     dispose-during-creation path exercises the actual registry bookkeeping.
 const makeFakeTerminal = () => ({
+  parser: {
+    registerOscHandler: () => ({ dispose: () => {} }),
+  },
   loadAddon: () => {},
   registerLinkProvider: () => ({ dispose: () => {} }),
   write: () => {},
@@ -292,6 +299,26 @@ describe('scrollback IPC async fs round-trip', () => {
     const read = handlers.get(TERMINAL_LOG_READ)!
     const got = await read({}, 'pty-never-saved')
     expect(got).toBeNull()
+  })
+})
+
+describe('terminal clipboard IPC', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    handlers.clear()
+    clipboardWriteText.mockClear()
+  })
+
+  it('writes terminal clipboard text through Electron clipboard', async () => {
+    const { TERMINAL_CLIPBOARD_WRITE } = await import('../../shared/ipc-channels')
+    await import('./terminal').then((m) => m.registerHandlers())
+
+    const writeClipboard = handlers.get(TERMINAL_CLIPBOARD_WRITE)
+    if (!writeClipboard) throw new Error('clipboard IPC handler was not registered')
+
+    await writeClipboard({}, 'copied from remote tmux')
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('copied from remote tmux')
   })
 })
 

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -11,7 +11,7 @@
 // A terminal id is mapped to its runtime so write/resize/kill route correctly.
 // =============================================================================
 
-import { ipcMain } from 'electron'
+import { clipboard, ipcMain } from 'electron'
 import fs from 'fs/promises'
 import path from 'path'
 import {
@@ -25,6 +25,7 @@ import {
   TERMINAL_LOG_READ,
   TERMINAL_SCROLLBACK_SAVE,
   TERMINAL_SET_VISIBILITY,
+  TERMINAL_CLIPBOARD_WRITE,
 } from '../../shared/ipc-channels'
 import { getOrCreateLogger, removeLogger, flushAll as flushAllLoggers, disposeAll as disposeAllLoggers } from './terminalLogger'
 import log from '../logger'
@@ -311,6 +312,14 @@ export function registerHandlers(): void {
 
   ipcMain.handle(TERMINAL_SET_VISIBILITY, async (_event, terminalId: string, visible: boolean) => {
     runtimeForTerminal(terminalId)?.process.setVisibility(terminalId, visible)
+  })
+
+  ipcMain.handle(TERMINAL_CLIPBOARD_WRITE, async (_event, text: string): Promise<void> => {
+    if (typeof text !== 'string') {
+      log.warn('[terminal] rejected non-string clipboard write payload')
+      return
+    }
+    clipboard.writeText(text)
   })
 
   ipcMain.handle(TERMINAL_GET_CWD, async (_event, ptyId: string): Promise<string | null> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,7 @@ import {
   TERMINAL_LOG_READ,
   TERMINAL_SCROLLBACK_SAVE,
   TERMINAL_SET_VISIBILITY,
+  TERMINAL_CLIPBOARD_WRITE,
   FS_READ_FILE,
   FS_READ_BINARY,
   FS_WRITE_FILE,
@@ -310,6 +311,7 @@ const invokeForwarders = {
   terminalLogRead: makeInvoker<'terminalLogRead'>(TERMINAL_LOG_READ),
   terminalScrollbackSave: makeInvoker<'terminalScrollbackSave'>(TERMINAL_SCROLLBACK_SAVE),
   terminalSetVisibility: makeInvoker<'terminalSetVisibility'>(TERMINAL_SET_VISIBILITY),
+  terminalClipboardWrite: makeInvoker<'terminalClipboardWrite'>(TERMINAL_CLIPBOARD_WRITE),
 
   // Filesystem
   fsReadFile: makeInvoker<'fsReadFile'>(FS_READ_FILE),

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -33,6 +33,7 @@ import {
   effectiveCursorBlink,
 } from './terminalSettings'
 import { createTerminalLinkHandler, makeTerminalKeyEventHandler } from './terminalInput'
+import { registerOsc52ClipboardHandler } from './terminalOsc52Clipboard'
 import { createFileLinkProvider, resolveLinkRoot } from './terminalFileLinkProvider'
 import { getActiveTheme } from '../themeManager'
 import { useStatusStore } from '../../stores/statusStore'
@@ -115,6 +116,7 @@ export function createAndConfigureXtermTerminal(opts: CreateOpts): ConfiguredTer
     altClickMovesCursor: true,
     minimumContrastRatio: getContrastRatio(),
   })
+  cleanupListeners.push(registerOsc52ClipboardHandler(terminal))
 
   // FitAddon — load before opening so fit() is available immediately
   const fitAddon = new FitAddon()

--- a/src/renderer/lib/terminal/terminalOsc52Clipboard.test.ts
+++ b/src/renderer/lib/terminal/terminalOsc52Clipboard.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  decodeOsc52ClipboardData,
+  registerOsc52ClipboardHandler,
+  type ClipboardWriter,
+} from './terminalOsc52Clipboard'
+
+function encodeBase64(text: string): string {
+  return Buffer.from(text, 'utf8').toString('base64')
+}
+
+describe('decodeOsc52ClipboardData', () => {
+  it('decodes UTF-8 clipboard payloads when OSC 52 targets the clipboard', () => {
+    const encoded = encodeBase64('remote copy 한글')
+
+    const decoded = decodeOsc52ClipboardData(`c;${encoded}`)
+
+    expect(decoded).toBe('remote copy 한글')
+  })
+
+  it('decodes clipboard payloads when the selection target is empty', () => {
+    const encoded = encodeBase64('empty target')
+
+    const decoded = decodeOsc52ClipboardData(`;${encoded}`)
+
+    expect(decoded).toBe('empty target')
+  })
+
+  it('ignores non-clipboard targets and paste requests', () => {
+    expect(decodeOsc52ClipboardData(`p;${encodeBase64('primary')}`)).toBeNull()
+    expect(decodeOsc52ClipboardData('c;?')).toBeNull()
+  })
+})
+
+describe('registerOsc52ClipboardHandler', () => {
+  it('writes decoded OSC 52 clipboard payloads to the provided clipboard writer', async () => {
+    const handlers: Array<(data: string) => boolean | Promise<boolean>> = []
+    const dispose = vi.fn()
+    const registerOscHandler = vi.fn((ident: number, cb: (data: string) => boolean | Promise<boolean>) => {
+      handlers.push(cb)
+      return { dispose }
+    })
+    const writeText = vi.fn(async () => {})
+    const clipboard: ClipboardWriter = { writeText }
+
+    const cleanup = registerOsc52ClipboardHandler({ parser: { registerOscHandler } }, clipboard)
+    const registeredHandler = handlers[0]
+    if (!registeredHandler) throw new Error('OSC handler was not registered')
+    const handled = await registeredHandler(`c;${encodeBase64('from tmux')}`)
+    cleanup()
+
+    expect(registerOscHandler).toHaveBeenCalledWith(52, expect.any(Function))
+    expect(handled).toBe(true)
+    expect(writeText).toHaveBeenCalledWith('from tmux')
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/lib/terminal/terminalOsc52Clipboard.ts
+++ b/src/renderer/lib/terminal/terminalOsc52Clipboard.ts
@@ -1,0 +1,71 @@
+import type { IDisposable, IParser } from '@xterm/xterm'
+import log from '../logger'
+
+const OSC52_IDENT = 52
+
+export interface ClipboardWriter {
+  readonly writeText: (text: string) => Promise<void>
+}
+
+export interface Osc52Terminal {
+  readonly parser: Pick<IParser, 'registerOscHandler'>
+}
+
+function browserClipboardWriter(): ClipboardWriter | null {
+  if (typeof window === 'undefined') return null
+  return { writeText: (text: string) => window.electronAPI.terminalClipboardWrite(text) }
+}
+
+function isExpectedDecodeFailure(error: unknown): boolean {
+  if (error instanceof Error) return true
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) return true
+  return false
+}
+
+export function decodeOsc52ClipboardData(data: string): string | null {
+  const separator = data.indexOf(';')
+  if (separator === -1) return null
+
+  const selectionTarget = data.slice(0, separator)
+  if (selectionTarget !== '' && !selectionTarget.includes('c')) return null
+
+  const encoded = data.slice(separator + 1).trim()
+  if (encoded === '?') return null
+
+  try {
+    const binary = atob(encoded)
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+    return new TextDecoder().decode(bytes)
+  } catch (error: unknown) {
+    if (isExpectedDecodeFailure(error)) return null
+    throw error
+  }
+}
+
+function reportClipboardWriteFailure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  log.warn('[terminal] OSC 52 clipboard write failed:', message)
+  return true
+}
+
+export function registerOsc52ClipboardHandler(
+  terminal: Osc52Terminal,
+  clipboard?: ClipboardWriter,
+): () => void {
+  const registerOscHandler = terminal.parser?.registerOscHandler?.bind(terminal.parser)
+  if (!registerOscHandler) return () => {}
+
+  const disposable: IDisposable = registerOscHandler(OSC52_IDENT, (data) => {
+    const text = decodeOsc52ClipboardData(data)
+    if (text === null) return false
+
+    const writer = clipboard ?? browserClipboardWriter()
+    if (!writer) return false
+
+    return writer.writeText(text).then(
+      () => true,
+      (error: unknown) => reportClipboardWriteFailure(error),
+    )
+  })
+  return () => disposable.dispose()
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -80,6 +80,8 @@ export interface ElectronAPI {
    *  idle-suspend logic to SIGSTOP terminals that are offscreen and silent. */
   terminalSetVisibility(terminalId: string, visible: boolean): Promise<void>
 
+  terminalClipboardWrite(text: string): Promise<void>
+
   // ---------------------------------------------------------------------------
   // Filesystem
   // ---------------------------------------------------------------------------

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -13,6 +13,7 @@ export const TERMINAL_GET_CWD = 'terminal:getCwd'
 export const TERMINAL_LOG_READ = 'terminal:logRead'
 export const TERMINAL_SCROLLBACK_SAVE = 'terminal:scrollbackSave'
 export const TERMINAL_SET_VISIBILITY = 'terminal:setVisibility'
+export const TERMINAL_CLIPBOARD_WRITE = 'terminal:clipboardWrite'
 
 // Filesystem
 export const FS_READ_FILE = 'fs:readFile'


### PR DESCRIPTION
## Summary
- Register an xterm OSC 52 handler for terminal output.
- Decode clipboard-targeted OSC 52 payloads and write them through Electron main-process clipboard IPC.
- Add coverage for OSC 52 decoding/registration and the new clipboard IPC bridge.

Fixes #403

## Root cause
Cate used xterm.js for terminal rendering but did not handle OSC 52 sequences, so remote tmux/neovim clipboard writes were ignored. PTY-originated output cannot reliably use `navigator.clipboard` because browser clipboard writes may require user activation, so this patch routes accepted OSC 52 clipboard writes through Electron's main-process `clipboard.writeText`.

## Security note
OSC 52 lets terminal programs request system clipboard writes. This matches the behavior users expect when enabling tmux `set-clipboard`, but it means remote shells inside Cate can update the local clipboard.

## Validation
- `bunx vitest run src/renderer/lib/terminal/terminalOsc52Clipboard.test.ts src/main/ipc/terminal.test.ts src/main/ipc/ipcConformance.test.ts`
- `bun run typecheck`
- `bun run lint` (0 errors, existing warnings only)
- `bun run build`
- `bun run test` (181 passed, 1 skipped)