### PR TITLE
fix(terminal): diagnose shells that exit immediately on spawn (#401)

### DIFF
--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -58,7 +58,21 @@ vi.mock('../windowRegistry', () => {
 })
 vi.mock('../shellEnv', () => ({ getShellEnv: () => ({}) }))
 vi.mock('../shellResolver', () => ({ resolveShell: () => ({ path: '/bin/sh', fallback: false }) }))
-vi.mock('../logger', () => ({ default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} } }))
+
+// Hoisted spies shared with the module mocks below (vi.mock factories are
+// hoisted above all other code, so the spies they reference must be too).
+const diag = vi.hoisted(() => ({ warn: vi.fn(), ptyCreate: vi.fn() }))
+vi.mock('../logger', () => ({ default: { warn: diag.warn, info: () => {}, error: () => {}, debug: () => {} } }))
+
+// A fake runtime whose process.create is the hoisted spy, so the instant-exit
+// tests can drive onData/onExit deterministically through the real spawnTerminal.
+vi.mock('../runtime/runtimeManager', () => ({
+  runtimes: {
+    resolve: () => ({ validateCwd: (p: string) => p, process: { create: diag.ptyCreate } }),
+    disposeAll: () => Promise.resolve(),
+  },
+}))
+vi.mock('../runtime/locator', () => ({ parseLocator: (cwd: string) => ({ runtimeId: 'local', path: cwd }) }))
 
 // --- terminalLifecycle (renderer) deps, stubbed so getOrCreate/dispose run
 //     without a real xterm/DOM/store stack. registryState is left REAL so the
@@ -336,5 +350,56 @@ describe('terminalLifecycle dispose-during-creation', () => {
     await pending
 
     expect(terminalKill).toHaveBeenCalledWith('pty-freshly-created')
+  })
+})
+
+// ===========================================================================
+// Instant-exit diagnostics (#401): a fresh shell that exits 0 immediately with
+// no output never became a session. spawnTerminal logs it with the resolved
+// shell so the cause is captured for the next report.
+// ===========================================================================
+describe('instant-exit diagnostics (#401)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    diag.warn.mockClear()
+    diag.ptyCreate.mockReset()
+  })
+
+  // Spawn through the real TERMINAL_CREATE handler; return the captured PTY
+  // callbacks so the test fires data/exit deterministically (after create
+  // resolves, so the resolved shell is recorded).
+  async function spawn(shell = '/bin/zsh'): Promise<{
+    onData: (id: string, d: string) => void
+    onExit: (id: string, c: number) => void
+  }> {
+    let cbs!: { onData: (id: string, d: string) => void; onExit: (id: string, c: number) => void }
+    diag.ptyCreate.mockImplementation(async (_opts: unknown, onData: never, onExit: never) => {
+      cbs = { onData, onExit }
+      return { id: 'pty-x', pid: 123, shell }
+    })
+    const mod = await import('./terminal')
+    mod.registerHandlers()
+    await handlers.get('terminal:create')!({}, { cols: 80, rows: 24 })
+    return cbs
+  }
+
+  it('warns (with the resolved shell) when a fresh terminal exits 0 immediately with no output', async () => {
+    const { onExit } = await spawn('/bin/zsh')
+    onExit('pty-x', 0)
+    expect(diag.warn).toHaveBeenCalled()
+    expect(diag.warn.mock.calls[0].join(' ')).toContain('/bin/zsh')
+  })
+
+  it('does not warn when the shell produced output before exiting 0', async () => {
+    const { onData, onExit } = await spawn()
+    onData('pty-x', 'prompt$ ')
+    onExit('pty-x', 0)
+    expect(diag.warn).not.toHaveBeenCalled()
+  })
+
+  it('does not warn for a non-zero exit code', async () => {
+    const { onExit } = await spawn()
+    onExit('pty-x', 1)
+    expect(diag.warn).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -214,6 +214,16 @@ async function spawnTerminal(
   // validation to that workspace's roots when supplied.
   const cwd = options.cwd ? runtime.validateCwd(cwdPath, ownerWindowId, options.workspaceId) : ''
 
+  // Instant-exit diagnostics (#401): a shell that exits cleanly within this
+  // window without ever emitting a byte never became an interactive session
+  // (shell startup files exiting, or a PTY that couldn't be allocated). Log it
+  // with the resolved shell so the next report carries the cause; the renderer
+  // shows the user-facing hint.
+  const INSTANT_EXIT_THRESHOLD_MS = 1000
+  const spawnedAt = Date.now()
+  let sawData = false
+  let resolvedShell = ''
+
   // Per-terminal output coalescing (16ms) → owner window. Owner is read at flush
   // time so a cross-window transfer reroutes in-flight output. The PTY only ever
   // invokes onData with this terminal's own id, so the id captured on first data
@@ -229,6 +239,7 @@ async function spawnTerminal(
   const onData = (id: string, data: string): void => {
     if (shuttingDown) return
     terminalId = id
+    sawData = true
     countTerminalData(data.length)
     getOrCreateLogger(id).append(data)
 
@@ -248,6 +259,13 @@ async function spawnTerminal(
 
   const onExit = (id: string, exitCode: number): void => {
     if (shuttingDown) return
+    if (exitCode === 0 && !sawData && Date.now() - spawnedAt < INSTANT_EXIT_THRESHOLD_MS) {
+      log.warn(
+        '[terminal] %s exited immediately (code 0) with no output — shell %s likely exited from its startup files or no PTY could be allocated',
+        id,
+        resolvedShell || '(unknown)',
+      )
+    }
     const windowId = terminalOwners.get(id)
     cleanupTerminal(id)
     if (windowId != null) sendToWindow(windowId, TERMINAL_EXIT, id, exitCode)
@@ -258,6 +276,7 @@ async function spawnTerminal(
   // [requested, $SHELL, bash, sh]) — so a path that only exists on the client is
   // handled there, not branched on here.
   const handle = await runtime.process.create({ cols: options.cols, rows: options.rows, cwd, shell: options.shell }, onData, onExit)
+  resolvedShell = handle.shell ?? ''
 
   terminalRuntime.set(handle.id, runtimeId)
   terminalOwners.set(handle.id, ownerWindowId)

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -38,6 +38,10 @@ export interface PtyHandle {
   pid: number
   /** Optional notice to surface in the terminal (e.g. shell fallback warning). */
   notice?: string
+  /** The shell path the host actually spawned (after the host's own resolution).
+   *  Carried back purely for diagnostics — e.g. logging which shell a terminal
+   *  that exited immediately was running (#401). */
+  shell?: string
 }
 
 /** Per-pty process-tree-derived activity, for the shell process monitor.

--- a/src/renderer/lib/terminal/terminalLifecycle.test.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.test.ts
@@ -315,6 +315,40 @@ describe('spawn → wire → dispose happy path', () => {
     expect(exitLine).toBeTruthy()
     LC.dispose('panel-exits')
   })
+
+  it('prints the instant-exit hint when a fresh PTY exits 0 immediately with no output (#401)', async () => {
+    terminalCreate.mockResolvedValueOnce('pty-instant')
+    await LC.getOrCreate('panel-instant', { workspaceId: 'ws-1' })
+
+    fireExit('pty-instant', 0)
+
+    const hint = terminalInstances[0].writes.find((w) => w.includes('exited immediately'))
+    expect(hint).toBeTruthy()
+    LC.dispose('panel-instant')
+  })
+
+  it('does NOT print the instant-exit hint when the shell produced output before exiting 0', async () => {
+    terminalCreate.mockResolvedValueOnce('pty-had-output')
+    await LC.getOrCreate('panel-had-output', { workspaceId: 'ws-1' })
+
+    fireData('pty-had-output', 'welcome\r\n$ ')
+    fireExit('pty-had-output', 0)
+
+    const hint = terminalInstances[0].writes.find((w) => w.includes('exited immediately'))
+    expect(hint).toBeFalsy()
+    LC.dispose('panel-had-output')
+  })
+
+  it('does NOT print the instant-exit hint for a non-zero exit code', async () => {
+    terminalCreate.mockResolvedValueOnce('pty-nonzero')
+    await LC.getOrCreate('panel-nonzero', { workspaceId: 'ws-1' })
+
+    fireExit('pty-nonzero', 1)
+
+    const hint = terminalInstances[0].writes.find((w) => w.includes('exited immediately'))
+    expect(hint).toBeFalsy()
+    LC.dispose('panel-nonzero')
+  })
 })
 
 // ===========================================================================

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -49,6 +49,19 @@ interface CreateOpts {
   initialInput?: string
 }
 
+// A freshly-spawned shell that exits cleanly (code 0) within this window WITHOUT
+// ever producing output never became an interactive session — almost always the
+// user's shell startup files exiting, or a PTY that couldn't be allocated. A bare
+// "[Process exited with code 0]" leaves the user with nothing to act on (see #401),
+// so we print a hint pointing at the usual causes. Generous threshold: a real
+// interactive shell prints its prompt within a few ms, so anything sub-second with
+// zero bytes is the failure mode, not a session the user closed.
+const INSTANT_EXIT_THRESHOLD_MS = 1000
+const INSTANT_EXIT_HINT =
+  '\x1b[33mThe shell exited immediately without starting a session. This usually means your ' +
+  'shell startup files (~/.zshrc, ~/.zprofile, ~/.bashrc) are exiting, or a PTY could not be ' +
+  'allocated. Try a different shell in Settings, or check those files for an early "exit".\x1b[0m\r\n'
+
 /** Drive the panel tab title from an OSC 0/1/2 title — plain shells only.
  *  Agent terminals keep the detected agent name (set by useProcessMonitor and
  *  numbered for duplicates by updatePanelTitleFromAgent); their raw OSC title
@@ -162,13 +175,23 @@ export function wireTerminalListeners(args: {
   opts: CreateOpts
   terminal: Terminal
   cleanupListeners: Array<() => void>
+  /** True only for a fresh spawn (getOrCreate). Reconnects (cross-window
+   *  transfer) adopt an already-running PTY that has produced output, so the
+   *  instant-exit diagnostic below must not fire for them. */
+  freshSpawn?: boolean
 }): void {
-  const { panelId, ptyId, opts, terminal, cleanupListeners } = args
+  const { panelId, ptyId, opts, terminal, cleanupListeners, freshSpawn = false } = args
   const { electronAPI } = window
+
+  // Instant-exit diagnostic state — see INSTANT_EXIT_HINT. Wired roughly at
+  // spawn time; `sawOutput` flips on the first byte the PTY ever emits.
+  const spawnedAt = Date.now()
+  let sawOutput = false
 
   // PTY -> xterm: incoming data
   const removeDataListener = electronAPI.onTerminalData((id: string, data: string) => {
     if (id === ptyId) {
+      sawOutput = true
       terminal.write(data)
       if (outputShowsBodySpinner(data)) noteAgentSpinnerByte(ptyId)
     }
@@ -185,6 +208,9 @@ export function wireTerminalListeners(args: {
       terminal.write(
         `\r\n\x1b[90m[Process exited with code ${exitCode}]\x1b[0m\r\n`,
       )
+      if (freshSpawn && exitCode === 0 && !sawOutput && Date.now() - spawnedAt < INSTANT_EXIT_THRESHOLD_MS) {
+        terminal.write(INSTANT_EXIT_HINT)
+      }
     }
   })
   cleanupListeners.push(removeExitListener)
@@ -333,8 +359,9 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
     setPtyForPanel(panelId, ptyId)
 
     // 6. Wire PTY<->xterm listeners + shell registration (shared with
-    //    reconnectTerminal via wireTerminalListeners).
-    wireTerminalListeners({ panelId, ptyId, opts, terminal, cleanupListeners })
+    //    reconnectTerminal via wireTerminalListeners). freshSpawn: this is a
+    //    brand-new PTY, so the instant-exit diagnostic applies.
+    wireTerminalListeners({ panelId, ptyId, opts, terminal, cleanupListeners, freshSpawn: true })
 
     // 11. Write initialInput immediately — the PTY buffers writes until the
     //     shell is ready to consume them, so a fixed setTimeout was both

--- a/src/runtime/capabilities/process.ts
+++ b/src/runtime/capabilities/process.ts
@@ -254,7 +254,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
         idle.delete(id)
         onExit(id, exitCode)
       })
-      return { id, pid: pty.pid, notice: shell.notice }
+      return { id, pid: pty.pid, notice: shell.notice, shell: shell.path }
     },
 
     write(id: string, data: string): void {


### PR DESCRIPTION
## Problem

Issue #401: after the first terminal works, every new terminal shows a bare `[Process exited with code 0]`. That message means the shell really spawned and exited cleanly within a fraction of a second, but the user is given nothing to act on.

The spawn path is identical for every terminal (same shell, same cached env, same daemon), so an instant clean exit is environmental: the user's shell startup files (`~/.zshrc`, `~/.zprofile`, `~/.bashrc`) exiting early, or a PTY that could not be allocated. Today Cate surfaces none of that, and daemon stderr is not logged after the handshake, so reports like #401 are undebuggable.

## Change

Detect a fresh PTY that exits code 0 within ~1s without ever emitting output, and surface it:

- **Renderer** (`terminalLifecycle.ts`): after the exit line, print a hint pointing at startup files / PTY allocation. Gated to fresh spawns (cross-window reconnects adopt a live PTY) and written after the exit line so ordering is deterministic.
- **Main** (`terminal.ts`): `log.warn` the same condition with the host-resolved shell path, so the next report carries the cause in app logs.
- **Runtime** (`process.ts` / `types.ts`): carry the resolved shell path back on `PtyHandle` for that log.

No behavior change for normal terminals: the hint/log only fire on code 0 + no output + sub-second exit.

## Tests

- `terminalLifecycle.test.ts`: hint shown on instant clean exit; not shown when output was produced, or on a non-zero exit.
- `terminal.test.ts`: main-process warn fires (with resolved shell) on instant clean exit; not otherwise.
- Full suite: 1598 passing; typecheck clean.

Closes #401