### PR TITLE
fix(updater): prompt once per version instead of every 15 minutes

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { DEFAULT_UPDATE_RECORD, type UpdateRecord } from './updateState'
+import { UPDATE_STATUS } from '../shared/ipc-channels'
 
 // ---------------------------------------------------------------------------
 // Mocks. electron-updater's autoUpdater is an EventEmitter with stubbed methods
@@ -377,5 +378,28 @@ describe('manual-reinstall fallback', () => {
     h.autoUpdater.emit('update-available', { version: '1.2.3' })
     await flushMicrotasks()
     expect(h.dialog.showMessageBox).toHaveBeenCalledTimes(2)
+  })
+
+  it('checkForUpdatesManually re-surfaces a staged update (forceShow) so a dismissed modal can re-open', async () => {
+    const { initAutoUpdater, checkForUpdatesManually } = await loadModule()
+    initAutoUpdater()
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+    h.broadcastToAll.mockClear()
+    checkForUpdatesManually()
+    expect(h.broadcastToAll).toHaveBeenCalledWith(
+      UPDATE_STATUS,
+      expect.objectContaining({ state: 'downloaded', version: '1.2.3', forceShow: true }),
+    )
+  })
+
+  it('checkForUpdatesManually does NOT force-broadcast when nothing is staged', async () => {
+    const { initAutoUpdater, checkForUpdatesManually } = await loadModule()
+    initAutoUpdater()
+    h.broadcastToAll.mockClear()
+    checkForUpdatesManually()
+    expect(h.broadcastToAll).not.toHaveBeenCalledWith(
+      UPDATE_STATUS,
+      expect.objectContaining({ forceShow: true }),
+    )
   })
 })

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -354,10 +354,19 @@ export function initAutoUpdater(): void {
 
 /** Wired to the "Check for Updates…" menu items. Re-arms the manual prompt since
  *  the user explicitly asked. No "you're up to date" dialog by design — a pending
- *  update surfaces via the OS notification / manual fallback. */
+ *  update surfaces via the OS notification / manual fallback.
+ *
+ *  If an update is already downloaded and staged, the in-app modal may have been
+ *  dismissed ("Install on next quit") and won't re-open on its own — the modal
+ *  only auto-shows once per version. An explicit check is the deliberate way back
+ *  to "Restart now", so re-broadcast the staged status with forceShow to re-open
+ *  it. Sent off lastStatus directly (not cached) so the flag stays a one-off. */
 export function checkForUpdatesManually(): void {
   if (!app.isPackaged) return
   manualPrompted = false
+  if (updatePendingInstall && lastStatus.state === 'downloaded') {
+    broadcastToAll(UPDATE_STATUS, { ...lastStatus, forceShow: true })
+  }
   void runCheck(canSelfUpdate())
 }
 

--- a/src/renderer/dialogs/UpdateReadyDialog.tsx
+++ b/src/renderer/dialogs/UpdateReadyDialog.tsx
@@ -14,7 +14,11 @@ import headerImg from '../assets/welcome-header.jpg'
 // Styled to match WelcomeDialog: header image, surface tokens, beveled icon.
 export function UpdateReadyDialog() {
   const [version, setVersion] = useState<string | null>(null)
-  const [dismissed, setDismissed] = useState(false)
+  // The version the user dismissed ("Install on next quit"), so the modal does
+  // NOT re-nag every time the 15-minute background check re-announces the same
+  // staged update. A genuinely newer version (or an explicit "Check for
+  // Updates…", which arrives with forceShow) re-opens it.
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null)
   const [restarting, setRestarting] = useState(false)
   const [entered, setEntered] = useState(false)
 
@@ -22,7 +26,8 @@ export function UpdateReadyDialog() {
     const apply = (status: UpdateStatus): void => {
       if (status.state === 'downloaded') {
         setVersion(status.version)
-        setDismissed(false) // a freshly downloaded update re-surfaces the modal
+        // Explicit user re-check: clear the dismissal so it opens again.
+        if (status.forceShow) setDismissedVersion(null)
       }
     }
     const unsubscribe = window.electronAPI.onUpdateStatus(apply)
@@ -31,7 +36,7 @@ export function UpdateReadyDialog() {
     return unsubscribe
   }, [])
 
-  const open = version !== null && !dismissed
+  const open = version !== null && version !== dismissedVersion
 
   // Soft fade + scale in on appear (matches the welcome card's transition).
   useEffect(() => {
@@ -40,7 +45,7 @@ export function UpdateReadyDialog() {
     return () => cancelAnimationFrame(id)
   }, [open])
 
-  const later = useCallback(() => setDismissed(true), [])
+  const later = useCallback(() => setDismissedVersion(version), [version])
 
   const restart = useCallback(async () => {
     setRestarting(true)

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -14,6 +14,11 @@ export interface UpdateStatus {
   version: string | null
   /** Download progress 0-100 (present while state === 'downloading'). */
   percent?: number
+  /** Transient flag on a re-broadcast of an already-staged 'downloaded' update,
+   *  set when the user explicitly asked ("Check for Updates…"). Tells the in-app
+   *  modal to re-open even for a version it was already dismissed for. Never
+   *  cached into lastStatus — it's a one-off, not part of the steady state. */
+  forceShow?: boolean
 }
 
 export interface NativeContextMenuItem {


### PR DESCRIPTION
## Problem

Declining an update ("Install on next quit") only hid the modal until the next background check re-announced the same staged update, so it popped back up ~15 minutes later. The re-prompt was tied to the check interval (which is 15 min, not 10).

Root cause: the renderer un-dismissed itself on every `'downloaded'` status, and each 15-min check re-emits that status for the same staged update.

## Fix

Decouple checking from prompting:

- **Per-version dismiss** (`UpdateReadyDialog.tsx`): track the dismissed version instead of a boolean. The modal auto-shows at most once per version. A genuinely newer version still re-opens it automatically.
- **Menu re-entry** (`auto-updater.ts`): "Check for Updates…" force-resurfaces an already-staged update (one-off `forceShow` flag) so the user can always get back to "Restart now" after dismissing.

Checking/downloading is unchanged: updates are still found and staged every 15 min, and still auto-install on next quit. Only the modal nag is removed.

## Tests

Added coverage for the force-resurface path; full updater suite green (28/28), typecheck clean.