### PR TITLE
fix(workspace): worktree cwd for terminals (restart) and agents (live switch)

### DIFF
--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -35,6 +35,7 @@ import { useAgentStore } from './agentStore'
 import {
   getAgentPanelSession,
   saveAgentPanelSession,
+  disposeAgentChats,
   type OpenChat,
 } from './agentSessionRegistry'
 import { buildFileMentions, type LineRef } from './agentDrop'
@@ -329,6 +330,47 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
     }
   }, [workspaceId, cwd, refreshCommands, markReady])
 
+  // Open the most-recent on-disk session for the current cwd as the panel's sole
+  // chat (or a fresh chat if the checkout has none). Shared by the mount effect
+  // and the worktree-switch reinit below; both pass a `signal` so they can abort
+  // the in-flight startup if the panel unmounts or the cwd changes again.
+  const openInitialChat = useCallback(async (signal: { cancelled: boolean }) => {
+    const myGen = ++openGenRef.current
+    let resume: AgentSessionListEntry | null = null
+    try {
+      if (cwd) {
+        const list = await window.electronAPI.agentListSessions(cwd)
+        if (signal.cancelled || myGen !== openGenRef.current) return
+        if (list.length > 0) resume = list[0]
+      }
+    } catch { /* ignore — list failures fall through to fresh session */ }
+
+    if (signal.cancelled || myGen !== openGenRef.current) return
+    const key = newAgentKey()
+    useAgentStore.getState().init(key)
+    // Resume: prefer the chat's last-used model recorded in the session.
+    // Fresh chat: prefer the user-configured default, else fall through to
+    // the availableModels effect below.
+    const initialModel: AgentModelRef | null = resume?.lastModel
+      ? { provider: resume.lastModel.provider, model: resume.lastModel.model }
+      : loadDefaultModel()
+    if (initialModel) useAgentStore.getState().setModel(key, initialModel)
+
+    if (resume) {
+      try {
+        const transcript = await window.electronAPI.agentLoadSessionMessages(resume.path)
+        if (signal.cancelled || myGen !== openGenRef.current) return
+        useAgentStore.getState().loadMessages(key, transcript as StoreMessage[])
+      } catch (err) { log.warn('[AgentPanel] load transcript failed', err) }
+    }
+    if (signal.cancelled || myGen !== openGenRef.current) return
+    // Set state BEFORE creating pi so this key is recorded in openChats (and
+    // mirrored to the session registry) before any teardown could run.
+    setOpenChats([{ agentKey: key, sessionFile: resume?.path ?? null }])
+    setActiveAgentKey(key)
+    await createAgent(key, initialModel, resume?.path)
+  }, [cwd, newAgentKey, createAgent])
+
   // Mount: re-adopt this panel's live chats if a prior mount left them in the
   // session registry (e.g. the panel was dragged between a canvas node and a
   // dock zone, which unmounts it here and remounts it in another subtree).
@@ -353,53 +395,48 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
       return
     }
 
-    let cancelled = false
-    const myGen = ++openGenRef.current
-
-    void (async () => {
-      let resume: AgentSessionListEntry | null = null
-      try {
-        if (cwd) {
-          const list = await window.electronAPI.agentListSessions(cwd)
-          if (cancelled || myGen !== openGenRef.current) return
-          if (list.length > 0) resume = list[0]
-        }
-      } catch { /* ignore — list failures fall through to fresh session */ }
-
-      if (cancelled || myGen !== openGenRef.current) return
-      const key = newAgentKey()
-      useAgentStore.getState().init(key)
-      // Resume: prefer the chat's last-used model recorded in the session.
-      // Fresh chat: prefer the user-configured default, else fall through to
-      // the availableModels effect below.
-      const initialModel: AgentModelRef | null = resume?.lastModel
-        ? { provider: resume.lastModel.provider, model: resume.lastModel.model }
-        : loadDefaultModel()
-      if (initialModel) useAgentStore.getState().setModel(key, initialModel)
-
-      if (resume) {
-        try {
-          const transcript = await window.electronAPI.agentLoadSessionMessages(resume.path)
-          if (cancelled || myGen !== openGenRef.current) return
-          useAgentStore.getState().loadMessages(key, transcript as StoreMessage[])
-        } catch (err) { log.warn('[AgentPanel] load transcript failed', err) }
-      }
-      if (cancelled || myGen !== openGenRef.current) return
-      // Set state BEFORE creating pi so this key is recorded in openChats (and
-      // mirrored to the session registry) before any teardown could run.
-      setOpenChats([{ agentKey: key, sessionFile: resume?.path ?? null }])
-      setActiveAgentKey(key)
-      await createAgent(key, initialModel, resume?.path)
-    })()
+    const signal = { cancelled: false }
+    void openInitialChat(signal)
 
     return () => {
       // Cancel any in-flight startup; do NOT dispose pi/store here — the panel
       // may just be moving between canvas and dock. Teardown is centralized in
       // disposeAgentPanel(), called from the appStore close paths.
-      cancelled = true
+      signal.cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelId])
+
+  // Worktree switch: pi's cwd is fixed at spawn and its sessions are cwd-scoped
+  // on disk, so re-tagging the panel's worktree (via the WorktreePill) isn't
+  // enough — the live chats still run in the old checkout. When the derived cwd
+  // changes under a live mount, dispose the old checkout's chats and reopen in
+  // the new one so the running agent actually moves with the pill.
+  const chatsCwdRef = useRef<string | null>(null)
+  useEffect(() => {
+    // A transient empty derivation (workspace/worktree briefly unresolved) must
+    // never tear down a live agent — wait for a real path.
+    if (!cwd) return
+    // First run records the cwd the mount effect spawned/adopted at; only a
+    // later change (a worktree switch) triggers a reinit.
+    if (chatsCwdRef.current === null) {
+      chatsCwdRef.current = cwd
+      return
+    }
+    if (chatsCwdRef.current === cwd) return
+    chatsCwdRef.current = cwd
+
+    // Tear down every chat bound to the old checkout, then reopen for the new.
+    disposeAgentChats(openChatsRef.current)
+    readyByKey.current = {}
+    setOpenChats([])
+    setActiveAgentKey(null)
+    setReadyTick((n) => n + 1)
+
+    const signal = { cancelled: false }
+    void openInitialChat(signal)
+    return () => { signal.cancelled = true }
+  }, [cwd, openInitialChat])
 
   // Mirror the live chat bookkeeping into the session registry so a remount
   // (canvas<->dock move) can re-adopt the same chats. Synced on every change so

--- a/src/agent/renderer/agentSessionRegistry.test.ts
+++ b/src/agent/renderer/agentSessionRegistry.test.ts
@@ -10,6 +10,7 @@ import {
   saveAgentPanelSession,
   getAgentPanelSession,
   disposeAgentPanel,
+  disposeAgentChats,
 } from './agentSessionRegistry'
 import { useAgentStore } from './agentStore'
 
@@ -50,6 +51,38 @@ describe('disposeAgentPanel', () => {
 
   it('is a no-op for an unknown panel', () => {
     disposeAgentPanel('does-not-exist')
+    expect(agentDispose).not.toHaveBeenCalled()
+  })
+})
+
+describe('disposeAgentChats', () => {
+  // The worktree-switch reinit disposes the old checkout's chats (pi process +
+  // store slice) and reopens fresh ones under the SAME panelId, so it must NOT
+  // touch the registry entry the way disposeAgentPanel does.
+  it('disposes each chat\'s pi + store slice without deleting the registry entry', () => {
+    const storeDispose = vi.spyOn(useAgentStore.getState(), 'dispose')
+    saveAgentPanelSession('panel-switch', {
+      openChats: [{ agentKey: 'old-1', sessionFile: '/wt-x/s.jsonl' }],
+      activeAgentKey: 'old-1',
+      readyByKey: { 'old-1': true },
+    })
+
+    disposeAgentChats([
+      { agentKey: 'old-1', sessionFile: '/wt-x/s.jsonl' },
+      { agentKey: 'old-2', sessionFile: null },
+    ])
+
+    expect(agentDispose).toHaveBeenCalledTimes(2)
+    expect(agentDispose).toHaveBeenCalledWith('old-1')
+    expect(agentDispose).toHaveBeenCalledWith('old-2')
+    expect(storeDispose).toHaveBeenCalledWith('old-1')
+    expect(storeDispose).toHaveBeenCalledWith('old-2')
+    // Registry entry survives — the panel lives on and reopens in the new cwd.
+    expect(getAgentPanelSession('panel-switch')).toBeDefined()
+  })
+
+  it('is a no-op for an empty chat list', () => {
+    disposeAgentChats([])
     expect(agentDispose).not.toHaveBeenCalled()
   })
 })

--- a/src/agent/renderer/agentSessionRegistry.ts
+++ b/src/agent/renderer/agentSessionRegistry.ts
@@ -47,6 +47,17 @@ export function saveAgentPanelSession(panelId: string, session: AgentPanelSessio
   sessions.set(panelId, session)
 }
 
+/** Dispose the pi process + store slice for each given chat, without touching
+ *  any panel's registry entry. Shared by disposeAgentPanel (full teardown) and
+ *  AgentPanel's worktree-switch reinit, which disposes the old checkout's chats
+ *  and reopens fresh ones in the new checkout under the same panelId. */
+export function disposeAgentChats(openChats: OpenChat[]): void {
+  for (const chat of openChats) {
+    window.electronAPI?.agentDispose(chat.agentKey).catch(() => { /* */ })
+    useAgentStore.getState().dispose(chat.agentKey)
+  }
+}
+
 /** Tear down every pi chat this panel ever spawned and drop its store slices.
  *  Called from the appStore close paths (closePanel / closeAllPanels /
  *  clearCanvas) and the cross-window detach handler — the same deterministic
@@ -56,8 +67,5 @@ export function disposeAgentPanel(panelId: string): void {
   const session = sessions.get(panelId)
   if (!session) return
   sessions.delete(panelId)
-  for (const chat of session.openChats) {
-    window.electronAPI?.agentDispose(chat.agentKey).catch(() => { /* */ })
-    useAgentStore.getState().dispose(chat.agentKey)
-  }
+  disposeAgentChats(session.openChats)
 }

--- a/src/renderer/canvas/WorktreePill.tsx
+++ b/src/renderer/canvas/WorktreePill.tsx
@@ -5,7 +5,9 @@
 //   • Hover  → highlights every node in that worktree (ring + sludge boost).
 //   • Click  → menu: focus the worktree on canvas, or switch this panel to
 //              another worktree. Switching a TERMINAL opens a fresh PTY in the
-//              new checkout (a terminal IS a checkout); agents are re-tagged.
+//              new checkout (a terminal IS a checkout); switching an AGENT
+//              re-tags it and respawns pi in the new checkout (AgentPanel
+//              reacts to the changed cwd).
 //
 // Hidden unless the workspace has 2+ worktrees — otherwise it's just chrome
 // noise on the common single-branch flow.
@@ -78,8 +80,9 @@ export const WorktreePill: React.FC<WorktreePillProps> = ({ panel, workspaceId }
       if (!ok) return
       useAppStore.getState().respawnPanelTerminal(workspaceId, panel.id, target.path, target.id)
     } else {
-      // Agent panels: re-tag only — pi's cwd is fixed at spawn. The sidebar's
-      // "open agent here" starts a fresh agent in a worktree.
+      // Agent panels: re-tag the panel. AgentPanel derives its cwd from the
+      // worktree tag and reacts to the change by disposing the old checkout's
+      // chats and reopening pi in the new one, so the agent moves with the pill.
       setPanelWorktreeId(workspaceId, panel.id, target.id)
     }
   }, [worktrees, current, focusedWorktreeId, panel, workspaceId, setPanelWorktreeId, focusWorktree])

--- a/src/renderer/lib/workspace/sessionSerialize.ts
+++ b/src/renderer/lib/workspace/sessionSerialize.ts
@@ -118,6 +118,10 @@ export function projectFilesToSnapshot(
         // Re-attach the machine-local facts kept out of the committed file.
         worktreeId: sp?.worktreeId,
         unsavedContent: sp?.unsavedContent,
+        // Restore the per-panel cwd (worktree path / dropped folder) so the
+        // terminal respawns there. TerminalPanel reads panel.cwd directly. The
+        // terminalCwds map below feeds the separate scrollback-restore path.
+        cwd: sp?.workingDirectory,
       }
       if (sp?.workingDirectory) terminalCwds[id] = sp.workingDirectory
     }

--- a/src/renderer/lib/workspace/worktreePersistence.test.ts
+++ b/src/renderer/lib/workspace/worktreePersistence.test.ts
@@ -185,4 +185,44 @@ describe('worktree session persistence', () => {
     // instead of its worktree even though the worktree tag survived.
     expect(snap.panels?.['t-1']?.cwd).toBe(WT_X.path)
   })
+
+  it('restoring from on-disk files leaves the terminal panel cwd at its worktree, not the workspace root', async () => {
+    // End-to-end across both restore layers (files -> projectFilesToSnapshot ->
+    // restoreSession -> appStore), asserting the exact field TerminalPanel reads
+    // as panelCwd. Before the fix panel.cwd was dropped on restore, so this
+    // landed undefined and TerminalPanel fell back to the workspace root (ROOT)
+    // even though the worktree tag survived — the terminal opened in the primary
+    // checkout while the pill still claimed the worktree.
+    const wsFile: ProjectWorkspaceFile = {
+      version: 1,
+      name: 'WT',
+      color: '',
+      panels: { 't-1': { type: 'terminal', title: 'shell' } },
+      canvases: {
+        cv: {
+          id: 'cv',
+          canvasNodes: {
+            'node-t-1': { id: 'node-t-1', panelId: 't-1', origin: { x: 0, y: 0 }, size: { width: 200, height: 150 }, zOrder: 0, creationIndex: 0 },
+          },
+          zoomLevel: 1,
+          viewportOffset: { x: 0, y: 0 },
+        },
+      },
+    }
+    const sessFile: ProjectSessionFile = {
+      version: 1,
+      workspaceId: 'ws',
+      panels: { 't-1': { panelId: 't-1', workingDirectory: WT_X.path, worktreeId: 'wt-x' } },
+      worktrees: [WT_PRIMARY, WT_X],
+    }
+
+    const ws = useAppStore.getState().addWorkspace('WT', ROOT, 'ws')
+    await restoreSession(projectFilesToSnapshot(wsFile, sessFile, ROOT), ws)
+
+    const panel = useAppStore.getState().workspaces.find((w) => w.id === ws)!.panels['t-1']
+    expect(panel?.cwd).toBe(WT_X.path)
+    expect(panel?.cwd).not.toBe(ROOT)
+    // The worktree tag survives alongside it, so the pill and the shell agree.
+    expect(panel?.worktreeId).toBe('wt-x')
+  })
 })

--- a/src/renderer/lib/workspace/worktreePersistence.test.ts
+++ b/src/renderer/lib/workspace/worktreePersistence.test.ts
@@ -180,5 +180,9 @@ describe('worktree session persistence', () => {
     expect(snap.panels?.['dt-1']?.worktreeId).toBe('wt-x')
     // The terminal's working directory is carried for respawn.
     expect(snap.terminalCwds?.['t-1']).toBe(WT_X.path)
+    // The cwd is also re-attached to panel.cwd. TerminalPanel reads panel.cwd
+    // directly, so without this the terminal respawned at the workspace root
+    // instead of its worktree even though the worktree tag survived.
+    expect(snap.panels?.['t-1']?.cwd).toBe(WT_X.path)
   })
 })


### PR DESCRIPTION
Two related worktree-cwd fixes surfaced while checking worktree persistence in a multi-workspace setup.

## 1. Terminal: cwd not restored into its worktree on restart
A terminal spawned inside a git worktree came back at the workspace root after a restart. The worktree path was persisted (session.json `workingDirectory`) and seeded into `terminalRestoreData`, but `TerminalPanel` reads `panel.cwd` directly and falls back to `workspaceRoot` (`TerminalPanel.tsx:104`), and `projectFilesToSnapshot` never re-attached `panel.cwd`. So the fallback always won and shadowed the restore-data cwd in `terminalLifecycle` (`resolvedCwd = opts.cwd ?? terminalRestoreData...`): the shell opened in the primary checkout while the worktree pill still showed the worktree.

Fix: re-attach `panel.cwd` from the persisted `workingDirectory` in `projectFilesToSnapshot`, next to where `worktreeId` and `unsavedContent` are already restored.

Tests: the existing lifecycle test that "uses the session-restore cwd" called `getOrCreate` with no `cwd` opt, which `TerminalPanel` never does, so it masked the bug. Added a serialization assertion and an end-to-end test (files -> `projectFilesToSnapshot` -> `restoreSession` -> appStore) asserting the restored terminal panel's `cwd` is the worktree path, not the workspace root. Both fail without the fix.

## 2. Agent: switching worktree didn't move the running agent
Unlike terminals, the agent panel derives its cwd from the `worktreeId` tag, so persistence/restart was already correct. But switching an agent panel's worktree mid-session only re-tagged it; pi's cwd is fixed at spawn, so the running agent kept the old checkout until the next restart (pill said Y, pi was still in X).

Fix: `AgentPanel` now reacts to its derived cwd changing under a live mount by disposing the old checkout's chats and reopening pi in the new one (pi sessions are cwd-scoped on disk). Extracted `disposeAgentChats` from `disposeAgentPanel` for the teardown, and factored the mount effect's initial-open into a shared `openInitialChat`.

Test: added coverage for `disposeAgentChats` (disposes each chat's pi + store slice without dropping the panel's registry entry).