### PR TITLE
fix(fs-watch): native recursive watch to stop EMFILE on large workspaces

### DIFF
--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -2,7 +2,6 @@
 // Filesystem IPC handlers — file read/write and directory watching
 // =============================================================================
 
-import { watch, FSWatcher } from 'chokidar'
 import { ipcMain } from 'electron'
 import log from '../logger'
 import { consumeScopedWriteAllowance, validatePathStrict } from './pathValidation'
@@ -55,7 +54,7 @@ interface SubscriberEntry {
 }
 
 interface SharedWatcher {
-  watcher: FSWatcher
+  watcher: RecursiveWatcher
   refCount: number
   /** Per-subscriber entries keyed by an opaque subscriber key. */
   subscribers: Map<string, SubscriberEntry>
@@ -113,6 +112,7 @@ import {
   importEntriesInto as capImportEntriesInto,
   createFsIgnoreMatcher,
 } from '../../runtime/capabilities/file'
+import { createRecursiveWatcher, type RecursiveWatcher } from '../../runtime/capabilities/recursiveWatch'
 export function readDir(dirPath: string): Promise<FileTreeNode[]> {
   return capReadDir(dirPath, currentExclusionSet())
 }
@@ -157,20 +157,23 @@ function encodeTreeNodes(runtimeId: string, nodes: FileTreeNode[]): FileTreeNode
 }
 
 /**
- * Create a chokidar watcher rooted at `dirPath` and wire its raw events to fan
+ * Create a recursive watcher rooted at `dirPath` and wire its raw events to fan
  * out to `subscribers`. The Map is captured by reference, so subscribers added
  * after creation (and across watcher recreation) are honored.
  */
-function createWatcher(dirPath: string, subscribers: Map<string, SubscriberEntry>): FSWatcher {
+function createWatcher(dirPath: string, subscribers: Map<string, SubscriberEntry>): RecursiveWatcher {
   // Watch the full tree (no `depth` cap): every consumer of a root watch — the
   // editor's external-reload, the explorer tree refresh, the git status store —
   // assumes events arrive for nested paths too. Hidden dirs and the user's
   // exclusions (node_modules, caches, …) are pruned by the ignore matcher, so
-  // recursion stays affordable.
-  const watcher = watch(dirPath, {
-    ignoreInitial: true,
-    ignored: createFsIgnoreMatcher(dirPath, currentExclusionSet()),
-  })
+  // recursion stays affordable. On macOS/Windows this is ONE native recursive
+  // handle (FSEvents / ReadDirectoryChangesW) rather than chokidar's one
+  // fs.watch fd per directory, which exhausted descriptors (EMFILE) on large
+  // workspaces (issue #398); Linux still uses chokidar under the hood.
+  const watcher = createRecursiveWatcher(
+    dirPath,
+    createFsIgnoreMatcher(dirPath, currentExclusionSet()),
+  )
   const fanOut = (type: string, fp: string) => {
     for (const sub of subscribers.values()) {
       if (pathHasPrefix(fp, sub.prefix)) sub.dispatch(type, fp)
@@ -296,7 +299,7 @@ function watchStop(dirPath: string, ownerWindowId: number): void {
 export function refreshWatcherIgnores(): void {
   for (const [dirPath, shared] of sharedWatchers) {
     const old = shared.watcher
-    let next: FSWatcher
+    let next: RecursiveWatcher
     try {
       next = createWatcher(dirPath, shared.subscribers)
     } catch (err) {

--- a/src/main/ipc/fsWatch.test.ts
+++ b/src/main/ipc/fsWatch.test.ts
@@ -84,6 +84,13 @@ describe('fs watch events for nested paths', () => {
   // the workspace root never reported changes to files nested deeper than one
   // level — the editor's external-reload (and git status / explorer refresh)
   // silently missed edits to virtually every real source file.
+  //
+  // Accept either `update` or `create`: macOS's native recursive watcher
+  // (issue #398) reports a content modify of an existing file as a `rename`,
+  // which the adapter maps to `create`. Downstream that's identical to `update`
+  // (classifyExternalEvent treats create/update the same; the file tree just
+  // re-reads on-disk state), so the meaningful assertion is "a change event for
+  // this deep path is delivered at all".
   test('reports updates to a file nested several levels below the watch root', async () => {
     const nestedDir = path.join(root, 'src', 'renderer', 'panels')
     const nestedFile = path.join(nestedDir, 'deep.txt')
@@ -94,7 +101,8 @@ describe('fs watch events for nested paths', () => {
 
     let rev = 0
     const seen = await waitForWatchEvent(
-      (event) => event.type === 'update' && event.path === nestedFile,
+      (event) =>
+        (event.type === 'update' || event.type === 'create') && event.path === nestedFile,
       () => fs.writeFile(nestedFile, `v${++rev}`, 'utf8'),
     )
     expect(seen).toBe(true)

--- a/src/main/ipc/fsWatchError.test.ts
+++ b/src/main/ipc/fsWatchError.test.ts
@@ -46,7 +46,9 @@ vi.mock('electron', () => ({
   },
 }))
 
-vi.mock('chokidar', () => ({ watch: mockState.watch }))
+// The local pool's watcher backend is the recursive-watch adapter (native on
+// macOS/Windows, chokidar on Linux); mock that boundary to drive error events.
+vi.mock('../../runtime/capabilities/recursiveWatch', () => ({ createRecursiveWatcher: mockState.watch }))
 
 vi.mock('../windowRegistry', () => ({
   windowFromEvent: () => ({ id: 1 }),

--- a/src/runtime/capabilities/index.ts
+++ b/src/runtime/capabilities/index.ts
@@ -6,10 +6,10 @@
 // daemon registers its workspace root via addAllowedRoot at startup.
 // =============================================================================
 
-import { watch } from 'chokidar'
 import { existsSync } from 'fs'
 import path from 'path'
 import * as fileLeaf from './file'
+import { createRecursiveWatcher, type RecursiveWatcher } from './recursiveWatch'
 import { runRipgrepSearch } from '../search/engine'
 import { createVcsCapability } from './vcs'
 import { createProcessCapability, type ProcessCapability } from './process'
@@ -77,7 +77,7 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
 
   interface SharedWatch {
     root: string
-    watcher: ReturnType<typeof watch>
+    watcher: RecursiveWatcher
     subscribers: Set<WatchSubscriber>
   }
 
@@ -103,10 +103,13 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
 
   // Create a chokidar watcher for `prefix` with the CURRENT ignore list, wiring
   // its add/change/unlink to onChange. Used on first watch and on every rebuild.
-  const spawnWatcher = (shared: SharedWatch) => {
+  const spawnWatcher = (shared: SharedWatch): RecursiveWatcher => {
     // Full-tree watch (no `depth` cap) — clients assume events for nested
-    // paths; the ignore matcher prunes hidden/excluded subtrees.
-    const w = watch(shared.root, { ignoreInitial: true, ignored: buildIgnored(shared.root) })
+    // paths; the ignore matcher prunes hidden/excluded subtrees. On macOS/Windows
+    // this is ONE native recursive handle rather than one fs.watch fd per
+    // directory, which avoids the EMFILE storm on large workspaces (issue #398);
+    // Linux falls back to chokidar.
+    const w = createRecursiveWatcher(shared.root, buildIgnored(shared.root))
     const fanOut = (fp: string, type: FsChangeType) => {
       for (const sub of shared.subscribers) {
         if (pathHasPrefix(fp, sub.prefix)) sub.onChange(fp, type)

--- a/src/runtime/capabilities/recursiveWatch.integration.test.ts
+++ b/src/runtime/capabilities/recursiveWatch.integration.test.ts
@@ -1,0 +1,92 @@
+// Real-filesystem integration test for createRecursiveWatcher. Exercises the
+// actual native recursive watcher (FSEvents / ReadDirectoryChangesW), so it is
+// gated to platforms that support it — on Linux the code path is chokidar,
+// covered by the existing pool tests. Verifies a nested create/modify/delete
+// round-trips into add/change/unlink with correct absolute paths (issue #398).
+
+import { describe, it, expect } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { createRecursiveWatcher, type RecursiveWatcher } from './recursiveWatch'
+
+const NATIVE = process.platform === 'darwin' || process.platform === 'win32'
+
+/** Resolve once any of `types` fires for `wantPath`, or reject on timeout.
+ *  add-vs-change is deliberately NOT asserted: macOS reports a modify as
+ *  `rename` (→ add), so the meaningful contract is "a presence event arrives",
+ *  not which one. Existence (unlink) IS asserted on its own. */
+function waitForEvent(
+  w: RecursiveWatcher,
+  types: Array<'add' | 'change' | 'unlink'>,
+  wantPath: string,
+  ms = 5000,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for ${types.join('|')} ${wantPath}`)),
+      ms,
+    )
+    for (const type of types) {
+      w.on(type, ((p: string) => {
+        if (path.resolve(p) === path.resolve(wantPath)) {
+          clearTimeout(timer)
+          resolve()
+        }
+      }) as never)
+    }
+  })
+}
+
+describe.skipIf(!NATIVE)('createRecursiveWatcher (real native fs)', () => {
+  it('reports nested create and delete on a file deep below the root', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cate-rwatch-'))
+    const nested = path.join(root, 'a', 'b')
+    await mkdir(nested, { recursive: true })
+    const file = path.join(nested, 'note.txt')
+
+    const w = createRecursiveWatcher(root, () => false)
+    try {
+      // Give the native watcher a moment to arm before mutating.
+      await new Promise((r) => setTimeout(r, 200))
+
+      // Create → a presence event (add or change), never unlink.
+      const present = waitForEvent(w, ['add', 'change'], file)
+      await writeFile(file, 'hello')
+      await present
+
+      // Delete → unlink, with the correct absolute path (stat-disambiguated).
+      const removed = waitForEvent(w, ['unlink'], file)
+      await rm(file)
+      await removed
+    } finally {
+      w.close()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('never reports an event for a path inside an ignored subtree', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'cate-rwatch-ig-'))
+    const ignoredDir = path.join(root, 'node_modules')
+    await mkdir(ignoredDir, { recursive: true })
+
+    const w = createRecursiveWatcher(root, (fp) => fp.includes('node_modules'))
+    const seen: string[] = []
+    w.on('add', ((p: string) => seen.push(p)) as never)
+    w.on('change', ((p: string) => seen.push(p)) as never)
+    w.on('unlink', ((p: string) => seen.push(p)) as never)
+    try {
+      await new Promise((r) => setTimeout(r, 200))
+      await writeFile(path.join(ignoredDir, 'pkg.js'), 'x')
+      // A real file outside the ignored tree, to confirm the watcher is live.
+      const live = path.join(root, 'live.txt')
+      const present = waitForEvent(w, ['add', 'change'], live)
+      await writeFile(live, 'y')
+      await present
+    } finally {
+      w.close()
+      await rm(root, { recursive: true, force: true })
+    }
+    expect(seen.every((p) => !p.includes('node_modules'))).toBe(true)
+  })
+})

--- a/src/runtime/capabilities/recursiveWatch.test.ts
+++ b/src/runtime/capabilities/recursiveWatch.test.ts
@@ -1,0 +1,213 @@
+// Tests for createRecursiveWatcher — the native-recursive (FSEvents /
+// ReadDirectoryChangesW) drop-in that replaces chokidar's per-directory
+// fs.watch on macOS/Windows (fixing the EMFILE storm on large workspaces,
+// issue #398). All logic is exercised through injected deps so the suite is
+// deterministic on every CI OS, independent of the real platform watcher.
+
+import { describe, it, expect, vi } from 'vitest'
+import path from 'path'
+import { createRecursiveWatcher } from './recursiveWatch'
+
+const ROOT = path.resolve('/work/repo')
+const flush = () => new Promise((r) => setImmediate(r))
+
+/** A fake node fs.watch: captures the raw (eventType, filename) callback and the
+ *  'error' listener so a test can drive events synchronously. */
+function fakeNativeWatch() {
+  let rawCb: ((eventType: string, filename: string | Buffer | null) => void) | undefined
+  let errCb: ((err: unknown) => void) | undefined
+  const handle = {
+    on: (ev: string, cb: (e: unknown) => void) => {
+      if (ev === 'error') errCb = cb
+    },
+    close: vi.fn(),
+  }
+  const watch = vi.fn((_root: string, _opts: unknown, cb: typeof rawCb) => {
+    rawCb = cb
+    return handle
+  })
+  return {
+    watch: watch as unknown as typeof import('fs').watch,
+    handle,
+    fire: (type: string, name: string | null) => rawCb!(type, name),
+    fireError: (e: unknown) => errCb!(e),
+  }
+}
+
+/** Default deps that force the native branch with a file-returning stat and a
+ *  never-ignore predicate. Individual tests override pieces. */
+function nativeDeps(over: Partial<Parameters<typeof createRecursiveWatcher>[2]> = {}) {
+  return {
+    platform: 'darwin' as NodeJS.Platform,
+    stat: vi.fn(async () => ({ isDirectory: () => false })),
+    ...over,
+  }
+}
+
+describe('createRecursiveWatcher (native branch)', () => {
+  it("maps a 'change' on an existing file to a 'change' event with an absolute path", async () => {
+    const fake = fakeNativeWatch()
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch }))
+    const onChange = vi.fn()
+    w.on('change', onChange)
+
+    fake.fire('change', 'src/app.ts')
+    await flush()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(path.join(ROOT, 'src/app.ts'))
+  })
+
+  it("maps a 'rename' on an existing file to an 'add' event", async () => {
+    const fake = fakeNativeWatch()
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch }))
+    const onAdd = vi.fn()
+    w.on('add', onAdd)
+
+    fake.fire('rename', 'new.txt')
+    await flush()
+
+    expect(onAdd).toHaveBeenCalledWith(path.join(ROOT, 'new.txt'))
+  })
+
+  it("emits 'unlink' when the path no longer exists (stat rejects)", async () => {
+    const fake = fakeNativeWatch()
+    const stat = vi.fn(async () => {
+      throw Object.assign(new Error('gone'), { code: 'ENOENT' })
+    })
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch, stat }))
+    const onUnlink = vi.fn()
+    w.on('unlink', onUnlink)
+
+    fake.fire('rename', 'deleted.txt')
+    await flush()
+
+    expect(onUnlink).toHaveBeenCalledWith(path.join(ROOT, 'deleted.txt'))
+  })
+
+  it('suppresses directory events (call sites never wire addDir/unlinkDir)', async () => {
+    const fake = fakeNativeWatch()
+    const stat = vi.fn(async () => ({ isDirectory: () => true }))
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch, stat }))
+    const onAdd = vi.fn()
+    const onChange = vi.fn()
+    w.on('add', onAdd)
+    w.on('change', onChange)
+
+    fake.fire('rename', 'src/newdir')
+    fake.fire('change', 'src/newdir')
+    await flush()
+
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('cheap-prunes ignored paths WITHOUT calling stat (no stat storm in excluded trees)', async () => {
+    const fake = fakeNativeWatch()
+    const stat = vi.fn(async () => ({ isDirectory: () => false }))
+    // ignore anything under node_modules
+    const ignored = (fp: string) => fp.includes('node_modules')
+    const w = createRecursiveWatcher(ROOT, ignored, nativeDeps({ watch: fake.watch, stat }))
+    const onAny = vi.fn()
+    w.on('add', onAny)
+    w.on('change', onAny)
+    w.on('unlink', onAny)
+
+    fake.fire('change', 'node_modules/.bin/x')
+    await flush()
+
+    expect(stat).not.toHaveBeenCalled()
+    expect(onAny).not.toHaveBeenCalled()
+  })
+
+  it('ignores a null filename (no stat, no emit)', async () => {
+    const fake = fakeNativeWatch()
+    const stat = vi.fn(async () => ({ isDirectory: () => false }))
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch, stat }))
+    const onAny = vi.fn()
+    w.on('add', onAny)
+
+    fake.fire('rename', null)
+    await flush()
+
+    expect(stat).not.toHaveBeenCalled()
+    expect(onAny).not.toHaveBeenCalled()
+  })
+
+  it('dedupes concurrent events on the same path into a single stat', async () => {
+    const fake = fakeNativeWatch()
+    let resolveStat: (v: { isDirectory(): boolean }) => void
+    const stat = vi.fn(
+      () => new Promise<{ isDirectory(): boolean }>((res) => { resolveStat = res }),
+    )
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch, stat }))
+    w.on('change', () => {})
+
+    fake.fire('change', 'busy.txt')
+    fake.fire('change', 'busy.txt') // second event while first stat is in flight
+    resolveStat!({ isDirectory: () => false })
+    await flush()
+
+    expect(stat).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-emits the underlying watcher's error event without throwing", async () => {
+    const fake = fakeNativeWatch()
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch }))
+    const onError = vi.fn()
+    w.on('error', onError)
+
+    const boom = new Error('EMFILE')
+    fake.fireError(boom)
+
+    expect(onError).toHaveBeenCalledWith(boom)
+  })
+
+  it('surfaces a throwing fs.watch (e.g. EMFILE at creation) as an error event, not a throw', async () => {
+    const watch = vi.fn(() => {
+      throw Object.assign(new Error('too many open files'), { code: 'EMFILE' })
+    }) as unknown as typeof import('fs').watch
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch }))
+    const onError = vi.fn()
+    w.on('error', onError) // listener attached AFTER construction must still fire
+    await flush()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect((onError.mock.calls[0][0] as { code?: string }).code).toBe('EMFILE')
+  })
+
+  it('close() closes the underlying handle and stops emitting', async () => {
+    const fake = fakeNativeWatch()
+    const w = createRecursiveWatcher(ROOT, () => false, nativeDeps({ watch: fake.watch }))
+    const onChange = vi.fn()
+    w.on('change', onChange)
+
+    w.close()
+    fake.fire('change', 'late.txt')
+    await flush()
+
+    expect(fake.handle.close).toHaveBeenCalledTimes(1)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('createRecursiveWatcher (non-native fallback)', () => {
+  it('returns a chokidar watcher unchanged on Linux and never opens a native watch', () => {
+    const sentinel = { on: vi.fn(), removeAllListeners: vi.fn(), close: vi.fn() }
+    const chokidar = vi.fn((_root: string, _opts: { ignoreInitial: boolean; ignored: unknown }) => sentinel)
+    const nativeWatch = vi.fn()
+    const ignored = () => false
+    const result = createRecursiveWatcher(ROOT, ignored, {
+      platform: 'linux',
+      chokidar: chokidar as never,
+      watch: nativeWatch as never,
+    })
+
+    expect(nativeWatch).not.toHaveBeenCalled()
+    expect(chokidar).toHaveBeenCalledTimes(1)
+    // chokidar called with the root, ignoreInitial, and the same ignored predicate
+    expect(chokidar.mock.calls[0][0]).toBe(ROOT)
+    expect(chokidar.mock.calls[0][1]).toMatchObject({ ignoreInitial: true, ignored })
+    expect(result).toBe(sentinel)
+  })
+})

--- a/src/runtime/capabilities/recursiveWatch.ts
+++ b/src/runtime/capabilities/recursiveWatch.ts
@@ -1,0 +1,145 @@
+// =============================================================================
+// createRecursiveWatcher — a drop-in for chokidar's per-directory watch that
+// uses ONE native recursive handle on platforms that support it.
+//
+// Why (issue #398): chokidar v4 has no FSEvents backend, so a full-tree watch
+// opens one `fs.watch` handle PER DIRECTORY. On macOS each handle is a kqueue
+// file descriptor; Electron caps the process at ~8k fds, so a workspace with
+// >8k directories hits `EMFILE` and floods unhandled rejections, freezing the
+// UI. Node's `fs.watch(root, { recursive: true })` instead uses FSEvents
+// (macOS) / ReadDirectoryChangesW (Windows) — ONE OS handle for the whole
+// subtree, independent of directory count (the same model VS Code uses).
+//
+// Linux has no native recursive watch, so there we fall back to chokidar
+// unchanged. The surface exposed here is the subset both call sites already use
+// (`.on('add'|'change'|'unlink'|'error')`, `.removeAllListeners()`, `.close()`),
+// so swapping the import is the only change at the two sites.
+// =============================================================================
+
+import { watch as fsWatch } from 'fs'
+import { stat as fsStat } from 'fs/promises'
+import { watch as chokidarWatch, type FSWatcher } from 'chokidar'
+import path from 'path'
+import { EventEmitter } from 'events'
+
+/** The chokidar `ignored` predicate shape (also usable as a post-hoc filter). */
+export type IgnoredPredicate = (filePath: string, stats?: { isDirectory(): boolean }) => boolean
+
+/** The minimal watcher surface both call sites consume. `close()` always
+ *  returns a Promise so callers can uniformly `.catch()` / `await` it,
+ *  matching chokidar's async close. */
+export interface RecursiveWatcher {
+  on(event: 'add' | 'change' | 'unlink', listener: (filePath: string) => void): unknown
+  on(event: 'error', listener: (err: unknown) => void): unknown
+  removeAllListeners(): unknown
+  close(): Promise<void>
+}
+
+/** Injectable seams — defaulted to the real implementations; overridden in tests
+ *  so the event-mapping/filtering logic is exercised deterministically on every
+ *  OS (and so the platform branch can be forced). */
+export interface RecursiveWatcherDeps {
+  watch?: typeof fsWatch
+  stat?: (p: string) => Promise<{ isDirectory(): boolean }>
+  chokidar?: (root: string, opts: { ignoreInitial: boolean; ignored: IgnoredPredicate }) => FSWatcher
+  platform?: NodeJS.Platform
+}
+
+const supportsNativeRecursive = (platform: NodeJS.Platform): boolean =>
+  platform === 'darwin' || platform === 'win32'
+
+/**
+ * Watch `root` recursively, emitting file `add`/`change`/`unlink` events whose
+ * paths pass `ignored`. Directory events are suppressed (call sites never wire
+ * dir events). On Linux, returns a chokidar watcher with the same `ignored`
+ * predicate so behavior is identical to the pre-fix code there.
+ */
+export function createRecursiveWatcher(
+  root: string,
+  ignored: IgnoredPredicate,
+  deps: RecursiveWatcherDeps = {},
+): RecursiveWatcher {
+  const platform = deps.platform ?? process.platform
+
+  // Linux (and any future platform without native recursive watch): unchanged
+  // chokidar path. The per-directory fd cost remains, but inotify limits differ
+  // from macOS's fd ceiling and this preserves existing behavior.
+  if (!supportsNativeRecursive(platform)) {
+    const chokidar = deps.chokidar ?? chokidarWatch
+    return chokidar(root, { ignoreInitial: true, ignored }) as unknown as RecursiveWatcher
+  }
+
+  const watch = deps.watch ?? fsWatch
+  const stat = deps.stat ?? ((p: string) => fsStat(p))
+
+  const emitter = new EventEmitter()
+  // EMFILE etc. must never become an unhandled rejection (the original bug). A
+  // listener may be attached AFTER construction, so an error raised by the
+  // synchronous fs.watch() call is deferred to a microtask before emitting.
+  let handle: ReturnType<typeof fsWatch> | null = null
+  // Coalesce concurrent events for the same path so a burst on one file doesn't
+  // fan out into N stats. Cleared once the stat settles.
+  const inFlight = new Set<string>()
+
+  const onRaw = (eventType: string, filename: string | Buffer | null): void => {
+    if (!filename) return
+    const fp = path.resolve(root, filename.toString())
+
+    // Cheap, syscall-free prune FIRST: excluded basenames and hidden-ancestor
+    // trees (node_modules, .git/objects, …) are dropped before any stat, so
+    // churn inside an ignored subtree (npm install) can't trigger a stat storm.
+    if (ignored(fp)) return
+    if (inFlight.has(fp)) return
+    inFlight.add(fp)
+
+    void (async () => {
+      try {
+        let stats: { isDirectory(): boolean }
+        try {
+          stats = await stat(fp)
+        } catch {
+          // Path is gone → delete. (Harmless if it was a directory: no
+          // subscriber prefixes a non-watched dir path.)
+          emitter.emit('unlink', fp)
+          return
+        }
+        // Suppress directory events; also re-check the predicate WITH stats so a
+        // hidden-directory leaf (its name only known to be a dir after stat) is
+        // pruned like chokidar would.
+        if (stats.isDirectory()) return
+        if (ignored(fp, stats)) return
+        // The native eventType is only ADVISORY for add-vs-change: macOS reports
+        // even a content modify of an existing file as `rename`, so we cannot
+        // reliably tell a create from an update here. That's fine — the stat
+        // above is authoritative for the ONE distinction consumers depend on
+        // (existence → unlink, handled in the catch). For the rest, downstream
+        // collapses them anyway: classifyExternalEvent treats create/update
+        // identically and the file tree just re-reads on-disk state. So we map
+        // the advisory type through best-effort and let the existence check rule.
+        emitter.emit(eventType === 'change' ? 'change' : 'add', fp)
+      } catch (err) {
+        emitter.emit('error', err)
+      } finally {
+        inFlight.delete(fp)
+      }
+    })()
+  }
+
+  try {
+    handle = watch(root, { recursive: true }, onRaw)
+    handle.on('error', (err) => emitter.emit('error', err))
+  } catch (err) {
+    queueMicrotask(() => emitter.emit('error', err))
+  }
+
+  return {
+    on: (event: string, listener: (arg: never) => void) =>
+      emitter.on(event, listener as (arg: unknown) => void),
+    removeAllListeners: () => emitter.removeAllListeners(),
+    close: async () => {
+      handle?.close()
+      handle = null
+      emitter.removeAllListeners()
+    },
+  }
+}

--- a/src/runtime/capabilities/watchPool.test.ts
+++ b/src/runtime/capabilities/watchPool.test.ts
@@ -52,7 +52,10 @@ function createMockWatcher(root: string): MockWatcher {
   return watcher
 }
 
-vi.mock('chokidar', () => ({ watch: mockState.watch }))
+// The daemon's watch backend is the recursive-watch adapter (native on
+// macOS/Windows, chokidar on Linux). Mock that boundary so these pool tests
+// exercise dedup/refcount/rebuild logic without a real OS watcher.
+vi.mock('./recursiveWatch', () => ({ createRecursiveWatcher: mockState.watch }))
 
 describe('daemon runtime watch pool', () => {
   beforeEach(() => {


### PR DESCRIPTION
Closes #398.

## Problem

chokidar v4 has no FSEvents backend, so a full-tree watch opens **one `fs.watch` fd per directory**. On macOS, Electron caps the process descriptor table at ~8k, so a workspace with >8k directories (the reporter's was ~15.5k) hits `EMFILE`, floods unhandled rejections, and freezes the UI. This is a regression from removing the `depth: 1` cap; #395 only contained the symptom.

Verified the diagnosis against the tree: `chokidar@4.0.3` declares only `readdirp` (no fsevents); the `fsevents` in `node_modules` belongs to vite/rollup/tailwind's chokidar v3.

## Fix

New electron-free adapter `createRecursiveWatcher` (`src/runtime/capabilities/recursiveWatch.ts`), swapped in at both watcher call sites (local pool in `main/ipc/filesystem.ts`, daemon capability in `runtime/capabilities/index.ts`):

- **macOS / Windows** → **one** native recursive `fs.watch` handle (FSEvents / ReadDirectoryChangesW) for the whole subtree — descriptor cost independent of directory count (the model VS Code uses).
- **Linux** (no native recursive watch) → falls back to chokidar unchanged.

Details that matter:

- **macOS reports nearly everything as `rename`** (probed against the real watcher: even a content modify of an existing file arrives as `rename`). So eventType is advisory — a `stat()` disambiguates the only distinction consumers depend on: existence → `unlink`. `classifyExternalEvent`, the file tree, and git status all treat create/update identically, so mapping modify→`create` is safe.
- **Cheap prune before stat** — the ignore predicate runs before any `stat`, so churn inside excluded trees (`npm install` in `node_modules`) can't trigger a stat storm.
- **No resurfaced unhandled rejections** — the async stat and a throwing `fs.watch` (EMFILE at creation) are both caught and routed to an `error` event.

## Tests

- New unit tests (11) drive the adapter through injected `watch`/`stat`/`chokidar`/`platform` deps — deterministic on all 3 CI OSes.
- New real-fs integration tests (2, gated to native platforms) — nested create/delete round-trip; events never escape an ignored subtree.
- Updated 3 existing tests whose assumptions changed: `watchPool` / `fsWatchError` now mock the adapter seam instead of chokidar (same intent); the real-fs `fsWatch` regression test accepts `create` or `update` for the deep-nested case (macOS rename→add).

Full suite: **1639 passed, 1 skipped**. `tsc` clean. `eslint` 0 errors.

## Not covered here

End-to-end in-app validation against a real 15k-directory workspace (acceptance criterion 1) wasn't run — that needs a launched Electron build. The single-native-handle architecture is what structurally removes the exhaustion, and the integration tests prove the native path fires correctly. Suggest `@parcel/watcher` as a follow-up (fixes Linux too, no stat-to-disambiguate) — larger native-dependency change, not needed for this regression.