### PR TITLE
chore(release): 1.3.2-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.3.1",
+  "version": "1.3.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.3.1",
+      "version": "1.3.2-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.3.1",
+  "version": "1.3.2-beta.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the 1.3.2-beta.1 pre-release.

Merge this, then push the v1.3.2-beta.1 tag to trigger the release build. Pre-release, so only beta-opted-in users are offered it.