### PR TITLE
Stateful cate.agent conversation API

### DIFF
--- a/src/agent/main/agentManager.test.ts
+++ b/src/agent/main/agentManager.test.ts
@@ -78,3 +78,79 @@ describe('AgentManager.disposeForWebContents', () => {
     expect(disposed.sort()).toEqual(['b', 'c'])
   })
 })
+
+// runTurn is the non-streaming extension turn runner: it resolves with the final
+// assistant message read straight off the terminal `agent_end` event's `messages`.
+// The tricky case is pi's auto-retry: it emits an `agent_end` with willRetry:true
+// for the failed turn (whose last assistant message is an empty error) before the
+// real terminal one. Resolving on the first agent_end is what produced "(no text)".
+describe('AgentManager.runTurn', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  function fakeClient() {
+    let eventListener: ((ev: unknown) => void) | undefined
+    return {
+      emit: (ev: unknown) => eventListener?.(ev),
+      onEvent: (l: (ev: unknown) => void) => { eventListener = l; return () => {} },
+      onExit: () => () => {},
+      prompt: vi.fn(async () => {}),
+    }
+  }
+
+  const run = (client: unknown) =>
+    (new AgentManager(fakeAuthManager) as unknown as {
+      runTurn(s: unknown, t: string): Promise<{ text: string; message: unknown }>
+    }).runTurn({ client }, 'hi')
+
+  const assistant = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }] })
+  const toolOnly = { role: 'assistant', content: [{ type: 'toolCall', name: 'x' }] }
+
+  it('skips a willRetry agent_end and resolves on the terminal one', async () => {
+    const client = fakeClient()
+    const result = run(client)
+
+    // Failed turn: pi will retry, so this carries the empty error message.
+    client.emit({ type: 'agent_end', willRetry: true, messages: [assistant('')] })
+    // Retry succeeds.
+    const answer = assistant('the answer')
+    client.emit({ type: 'agent_end', willRetry: false, messages: [answer] })
+
+    expect(await result).toEqual({ text: 'the answer', message: answer })
+  })
+
+  it('returns the answer-bearing assistant message, scanning past a tool-only turn', async () => {
+    const client = fakeClient()
+    const result = run(client)
+
+    // Final turn is a tool call with no text — text and message both come from
+    // the real answer turn so they agree.
+    const answer = assistant('real answer')
+    client.emit({ type: 'agent_end', messages: [answer, toolOnly] })
+
+    expect(await result).toEqual({ text: 'real answer', message: answer })
+  })
+
+  it('returns empty text but still the raw message when no turn carries text', async () => {
+    const client = fakeClient()
+    const result = run(client)
+
+    client.emit({ type: 'agent_end', messages: [toolOnly] })
+
+    expect(await result).toEqual({ text: '', message: toolOnly })
+  })
+
+  it('rejects with the reason when the turn ends on stopReason error', async () => {
+    const client = fakeClient()
+    const result = run(client)
+
+    // pi surfaces an unsupported-model/auth failure as an empty assistant message
+    // with stopReason 'error' — must reject, not resolve to silent empty text.
+    client.emit({
+      type: 'agent_end',
+      willRetry: false,
+      messages: [{ role: 'assistant', content: [], stopReason: 'error', errorMessage: 'model not supported' }],
+    })
+
+    await expect(result).rejects.toThrow('model not supported')
+  })
+})

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -62,15 +62,64 @@ function toImageContent(images?: AgentImageAttachment[]): PiImageContent[] | und
   return images.map((img) => ({ type: 'image', data: img.data, mimeType: img.mimeType }))
 }
 
+/** Concatenate the text blocks of a single pi message (assistant turn). */
+function messageText(message: unknown): string {
+  const content = (message as { content?: unknown } | null)?.content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((c): c is { type: 'text'; text: string } =>
+      !!c && (c as { type?: string }).type === 'text' && typeof (c as { text?: unknown }).text === 'string',
+    )
+    .map((c) => c.text)
+    .join('')
+    .trim()
+}
+
+/** The assistant message that holds a turn's answer, from a pi `messages` array:
+ *  the most recent assistant turn that actually has text, else the last assistant
+ *  message at all (e.g. a tool-only turn), else null. Scans from the end so the
+ *  text and the returned message agree. Mirrors pi's own `getLastAssistantText`. */
+function answerMessage(messages: unknown): Record<string, unknown> | null {
+  if (!Array.isArray(messages)) return null
+  let lastAssistant: Record<string, unknown> | null = null
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as { role?: string } | null
+    if (m?.role !== 'assistant') continue
+    if (!lastAssistant) lastAssistant = m as Record<string, unknown>
+    if (messageText(m)) return m as Record<string, unknown>
+  }
+  return lastAssistant
+}
+
+/** Result of one extension agent turn: the flattened `text` for convenience plus
+ *  the raw assistant `message` (content blocks and all). */
+export interface AgentTurnResult {
+  text: string
+  message: Record<string, unknown> | null
+}
+
+interface ExtSession {
+  /** The handle returned to the extension — pi's own session file path, so the
+   *  conversation can be resumed later with no Cate-side persistence. */
+  handle: string
+  /** The live pi session's panelId in `sessions`. */
+  panelId: string
+  extensionId: string
+  /** A turn is in flight — one at a time per session. */
+  busy: boolean
+}
+
 export class AgentManager {
   private sessions = new Map<string, AgentSession>()
   private locks = new Map<string, Promise<unknown>>()
   // Used to resolve the default model for extension-initiated background runs
   // (see runForExtension) and for the auth-change mirror hook below.
   private authManager: AuthManager
-  // Extensions with an in-flight background run — one run per extension at a
-  // time, the simple cap against runaway loops (see runForExtension).
-  private readonly extRuns = new Set<string>()
+  // Live extension agent sessions, keyed by handle (pi's session file). pi owns
+  // all conversation state on disk; Cate keeps only this in-memory handle->client
+  // routing, exactly like a panel. One live session per extension is the cap
+  // against runaway loops (see openForExtension).
+  private readonly extSessions = new Map<string, ExtSession>()
   private extRunSeq = 0
 
   constructor(authManager: AuthManager) {
@@ -272,52 +321,122 @@ export class AgentManager {
   }
 
   // ---------------------------------------------------------------------------
-  // Extension-initiated background runs (cate.agent.run)
+  // Extension agent sessions (cate.agent.open / send / dispose, and run sugar)
   //
-  // An enabled extension can run ONE agent turn at a time. The run is a real
-  // session owned by the active window's WebContents — so its events flow to
-  // the renderer and its lifetime is tied to that window like any panel session
-  // — but it is driven from main: send the prompt, wait for pi's terminal
-  // `agent_end`, return the last assistant text, then dispose. One run per
-  // extension at a time is the whole anti-runaway-loop guard for v1.
+  // An enabled extension drives a real pi session the same way a panel does:
+  // Cate holds the live client in `sessions` and forwards its events to the
+  // active window; pi owns ALL conversation state on its session jsonl. The
+  // handle returned to the extension IS that jsonl path, so a conversation can
+  // be resumed later with nothing persisted on Cate's side. Turn-based: each
+  // `send` runs one turn and returns the final assistant message. One live
+  // session per extension, one in-flight turn per session — the anti-runaway cap.
   // ---------------------------------------------------------------------------
 
+  /** Open (or resume) a persistent agent session for an extension. Returns the
+   *  handle (pi's session file) to pass to `sendForExtension`. */
+  async openForExtension(opts: {
+    workspaceId: string
+    locator: string
+    extensionId: string
+    sender: WebContents
+    resume?: string
+  }): Promise<{ sessionId: string }> {
+    for (const s of this.extSessions.values()) {
+      if (s.extensionId === opts.extensionId) throw new Error('agent-busy')
+    }
+    const panelId = `ext-${opts.extensionId}-${++this.extRunSeq}`
+    const model = await this.resolveDefaultModel()
+    await this.create(
+      {
+        panelId,
+        workspaceId: opts.workspaceId,
+        cwd: opts.locator,
+        model: model ?? undefined,
+        sessionFile: opts.resume,
+      },
+      opts.sender,
+    )
+    const session = this.sessions.get(panelId)
+    if (!session) throw new Error('agent-failed')
+    // The handle is pi's session file: known up-front on resume, else read back
+    // from pi (it assigns one for a fresh session). Fall back to the panelId so
+    // the session is still routable this run even if the path can't be read.
+    let handle = opts.resume ?? ''
+    if (!handle) {
+      try {
+        const state = (await session.client.getState()) as { sessionFile?: string } | null
+        handle = state?.sessionFile ?? ''
+      } catch { /* fall through */ }
+    }
+    if (!handle) handle = panelId
+    this.extSessions.set(handle, { handle, panelId, extensionId: opts.extensionId, busy: false })
+    log.info('[agentManager] ext session open ext=%s handle=%s', opts.extensionId, handle)
+    return { sessionId: handle }
+  }
+
+  /** Run one turn on an open extension session and return the final assistant
+   *  message. The session must belong to `extensionId`. */
+  async sendForExtension(opts: {
+    extensionId: string
+    sessionId: string
+    text: string
+  }): Promise<AgentTurnResult> {
+    const ext = this.extSessions.get(opts.sessionId)
+    if (!ext || ext.extensionId !== opts.extensionId) throw new Error('no-session')
+    if (ext.busy) throw new Error('agent-busy')
+    const session = this.sessions.get(ext.panelId)
+    if (!session) { this.extSessions.delete(opts.sessionId); throw new Error('no-session') }
+    ext.busy = true
+    try {
+      const result = await this.runTurn(session, opts.text)
+      log.info('[agentManager] ext session turn ext=%s chars=%d', opts.extensionId, result.text.length)
+      return result
+    } finally {
+      ext.busy = false
+    }
+  }
+
+  /** Tear down an open extension session's live client. pi's jsonl stays on disk,
+   *  so the same handle can be re-opened later via `resume`. */
+  async disposeForExtension(opts: { extensionId: string; sessionId: string }): Promise<void> {
+    const ext = this.extSessions.get(opts.sessionId)
+    if (!ext || ext.extensionId !== opts.extensionId) return
+    this.extSessions.delete(opts.sessionId)
+    await this.dispose(ext.panelId)
+  }
+
+  /** One-shot sugar over open -> send -> dispose (cate.agent.run). */
   async runForExtension(
     text: string,
     opts: { workspaceId: string; locator: string; extensionId: string; sender: WebContents },
-  ): Promise<{ text: string }> {
-    if (this.extRuns.has(opts.extensionId)) throw new Error('agent-busy')
-    this.extRuns.add(opts.extensionId)
-    const panelId = `ext-${opts.extensionId}-${++this.extRunSeq}`
+  ): Promise<AgentTurnResult> {
+    const { sessionId } = await this.openForExtension(opts)
     try {
-      const model = await this.resolveDefaultModel()
-      await this.create(
-        { panelId, workspaceId: opts.workspaceId, cwd: opts.locator, model: model ?? undefined },
-        opts.sender,
-      )
-      const session = this.sessions.get(panelId)
-      if (!session) throw new Error('agent-failed')
-      const result = await this.awaitRun(session, text)
-      return { text: result ?? '' }
+      return await this.sendForExtension({ extensionId: opts.extensionId, sessionId, text })
     } finally {
-      this.extRuns.delete(opts.extensionId)
-      await this.dispose(panelId)
+      await this.disposeForExtension({ extensionId: opts.extensionId, sessionId })
     }
   }
 
-  /** Abort any in-flight extension run for this extension (best effort). */
+  /** Abort the in-flight turn of this extension's session (best effort). */
   async cancelForExtension(extensionId: string): Promise<void> {
-    const prefix = `ext-${extensionId}-`
-    for (const panelId of this.sessions.keys()) {
-      if (panelId.startsWith(prefix)) await this.interrupt(panelId)
+    for (const ext of this.extSessions.values()) {
+      if (ext.extensionId === extensionId) await this.interrupt(ext.panelId)
     }
   }
 
-  /** Send the prompt and resolve with the final assistant text once pi emits
-   *  its terminal `agent_end` (the last event of a run). Rejects on an agent
-   *  error event or an unexpected pi exit. */
-  private awaitRun(session: AgentSession, text: string): Promise<string | null> {
-    return new Promise<string | null>((resolve, reject) => {
+  /** The NON-streaming turn runner used by extension sessions: send the prompt
+   *  and resolve with the final assistant message once pi emits its terminal
+   *  `agent_end`. That event carries the full `messages` list, so the answer is
+   *  read straight off it — the panel's streaming path (events forwarded to the
+   *  renderer and accumulated there) is entirely separate and untouched.
+   *
+   *  pi also emits an `agent_end` flagged `willRetry: true` for a turn it is
+   *  about to auto-retry — its last assistant message is the empty error, so we
+   *  skip it and wait for the terminal one. Rejects on an agent error event or
+   *  an unexpected pi exit. */
+  private runTurn(session: AgentSession, text: string): Promise<AgentTurnResult> {
+    return new Promise<AgentTurnResult>((resolve, reject) => {
       let settled = false
       let offEvent = () => {}
       let offExit = () => {}
@@ -329,15 +448,22 @@ export class AgentManager {
         fn()
       }
       offEvent = session.client.onEvent((ev) => {
-        const type = (ev as { type?: string } | null)?.type
-        if (type === 'agent_end') {
-          session.client.getLastAssistantText().then(
-            (txt) => settle(() => resolve(txt)),
-            () => settle(() => resolve(null)),
-          )
-        } else if (type === 'error') {
-          const message = (ev as { message?: string }).message || 'agent error'
-          settle(() => reject(new Error(message)))
+        const e = ev as { type?: string; willRetry?: boolean; messages?: unknown; message?: string } | null
+        if (e?.type === 'agent_end') {
+          // A retry turn follows — not the terminal end of the run.
+          if (e.willRetry === true) return
+          const message = answerMessage(e.messages)
+          // A turn can end on a non-retryable error (unsupported model, auth, bad
+          // request): pi sets stopReason 'error' + an errorMessage on an empty
+          // assistant message. Surface it, don't hand back silent empty text.
+          if (message && message.stopReason === 'error') {
+            const reason = typeof message.errorMessage === 'string' ? message.errorMessage : 'agent error'
+            settle(() => reject(new Error(reason)))
+            return
+          }
+          settle(() => resolve({ text: message ? messageText(message) : '', message }))
+        } else if (e?.type === 'error') {
+          settle(() => reject(new Error(e.message || 'agent error')))
         }
       })
       offExit = session.client.onExit((code) => settle(() => reject(new Error(`agent exited (code ${code})`))))
@@ -369,6 +495,11 @@ export class AgentManager {
     try { session.client.rejectAllPending('Pi session disposed') } catch { /* noop */ }
     try { await session.client.stop() } catch { /* noop */ }
     this.sessions.delete(panelId)
+    // Drop any extension handle that routed to this session (e.g. the owning
+    // window went away) so a stale handle can't outlive its client.
+    for (const [handle, ext] of this.extSessions) {
+      if (ext.panelId === panelId) this.extSessions.delete(handle)
+    }
     log.info('[agentManager] disposed session panel=%s', panelId)
   }
 

--- a/src/agent/main/piRpcClient.ts
+++ b/src/agent/main/piRpcClient.ts
@@ -155,9 +155,6 @@ export class PiRpcClient {
   async getForkMessages(): Promise<Array<{ entryId: string; text: string }>> {
     return this.data<{ messages: Array<{ entryId: string; text: string }> }>(await this.send({ type: 'get_fork_messages' })).messages
   }
-  async getLastAssistantText(): Promise<string | null> {
-    return this.data<{ text: string | null }>(await this.send({ type: 'get_last_assistant_text' })).text
-  }
   async setSessionName(name: string): Promise<void> { await this.send({ type: 'set_session_name', name }) }
   async getMessages(): Promise<unknown[]> {
     return this.data<{ messages: unknown[] }>(await this.send({ type: 'get_messages' })).messages

--- a/src/main/extensions/cateApiHandlers.test.ts
+++ b/src/main/extensions/cateApiHandlers.test.ts
@@ -25,11 +25,17 @@ vi.mock('electron', () => ({
 
 // Agent runtime is a heavy singleton; stub it so importing cateApiHandlers
 // stays light and cate.agent.run dispatch is observable.
-const { runForExtension, cancelForExtension } = vi.hoisted(() => ({
-  runForExtension: vi.fn(async () => ({ text: 'done' })),
-  cancelForExtension: vi.fn(async () => {}),
+const { runForExtension, openForExtension, sendForExtension, disposeForExtension, cancelForExtension } =
+  vi.hoisted(() => ({
+    runForExtension: vi.fn(async () => ({ text: 'done', message: null })),
+    openForExtension: vi.fn(async () => ({ sessionId: 'sess-1' })),
+    sendForExtension: vi.fn(async () => ({ text: 'reply', message: { role: 'assistant' } })),
+    disposeForExtension: vi.fn(async () => {}),
+    cancelForExtension: vi.fn(async () => {}),
+  }))
+vi.mock('../../agent/main/agentManager', () => ({
+  agentManager: { runForExtension, openForExtension, sendForExtension, disposeForExtension, cancelForExtension },
 }))
-vi.mock('../../agent/main/agentManager', () => ({ agentManager: { runForExtension, cancelForExtension } }))
 
 // cate.ui.notify reuses the shared OS-notification path; spy on it + the setting.
 const { showOsNotification, settings } = vi.hoisted(() => ({
@@ -109,7 +115,12 @@ beforeEach(() => {
   showMessageBox.mockClear()
   showMessageBox.mockResolvedValue({ response: 0 })
   runForExtension.mockClear()
-  runForExtension.mockResolvedValue({ text: 'done' })
+  runForExtension.mockResolvedValue({ text: 'done', message: null })
+  openForExtension.mockClear()
+  openForExtension.mockResolvedValue({ sessionId: 'sess-1' })
+  sendForExtension.mockClear()
+  sendForExtension.mockResolvedValue({ text: 'reply', message: { role: 'assistant' } })
+  disposeForExtension.mockClear()
   cancelForExtension.mockClear()
 })
 
@@ -229,7 +240,7 @@ describe('dispatchCateInvoke — cate.agent.run', () => {
     activeWindow.value = fakeWin
     const s = agentScope()
     const res = await dispatchCateInvoke(s, 'cate.agent.run', { prompt: '  build it  ' })
-    expect(res).toEqual({ text: 'done' })
+    expect(res).toEqual({ text: 'done', message: null })
     expect(showMessageBox).toHaveBeenCalledTimes(1) // first-use consent
     expect(runForExtension).toHaveBeenCalledWith('build it', {
       workspaceId: WS,
@@ -269,5 +280,51 @@ describe('dispatchCateInvoke — cate.agent.run', () => {
     const s = agentScope()
     expect(await dispatchCateInvoke(s, 'cate.agent.cancel', undefined)).toEqual({ ok: true })
     expect(cancelForExtension).toHaveBeenCalledWith(s.extensionId)
+  })
+
+  it('opens a session after consent and returns its handle', async () => {
+    state.scopes = ['agent']
+    activeWindow.value = fakeWin
+    const s = agentScope()
+    const res = await dispatchCateInvoke(s, 'cate.agent.open', { resume: '/p/sess.jsonl' })
+    expect(res).toEqual({ sessionId: 'sess-1' })
+    expect(showMessageBox).toHaveBeenCalledTimes(1) // first-use consent
+    expect(openForExtension).toHaveBeenCalledWith({
+      workspaceId: WS,
+      locator: '/ws/root',
+      extensionId: s.extensionId,
+      sender: fakeWin.webContents,
+      resume: '/p/sess.jsonl',
+    })
+  })
+
+  it('sends a turn to an open session without re-prompting consent', async () => {
+    state.scopes = ['agent']
+    const s = agentScope()
+    const res = await dispatchCateInvoke(s, 'cate.agent.send', { sessionId: 'sess-1', prompt: '  hi  ' })
+    expect(res).toEqual({ text: 'reply', message: { role: 'assistant' } })
+    expect(sendForExtension).toHaveBeenCalledWith({ extensionId: s.extensionId, sessionId: 'sess-1', text: 'hi' })
+    expect(showMessageBox).not.toHaveBeenCalled() // no consent gate on send
+  })
+
+  it('rejects a send with no sessionId or prompt', async () => {
+    state.scopes = ['agent']
+    expect(await dispatchCateInvoke(agentScope(), 'cate.agent.send', { prompt: 'hi' }))
+      .toEqual({ error: 'bad-args', method: 'cate.agent.send' })
+    expect(sendForExtension).not.toHaveBeenCalled()
+  })
+
+  it('maps an unknown/foreign session to no-session', async () => {
+    state.scopes = ['agent']
+    sendForExtension.mockRejectedValueOnce(new Error('no-session'))
+    expect(await dispatchCateInvoke(agentScope(), 'cate.agent.send', { sessionId: 'x', prompt: 'hi' }))
+      .toEqual({ error: 'no-session', method: 'cate.agent.send' })
+  })
+
+  it('disposes an open session', async () => {
+    state.scopes = ['agent']
+    const s = agentScope()
+    expect(await dispatchCateInvoke(s, 'cate.agent.dispose', { sessionId: 'sess-1' })).toEqual({ ok: true })
+    expect(disposeForExtension).toHaveBeenCalledWith({ extensionId: s.extensionId, sessionId: 'sess-1' })
   })
 })

--- a/src/main/extensions/cateApiHandlers.ts
+++ b/src/main/extensions/cateApiHandlers.ts
@@ -204,6 +204,23 @@ function scopeGranted(declared: string[] | undefined, required: string): boolean
 // re-confirm of a powerful capability rather than a persisted grant).
 const agentConsent = new Set<string>()
 
+/** The active main window the agent run is attached to, or undefined if none. */
+function requireHostWindow(): ReturnType<typeof getActiveMainWindow> {
+  const win = getActiveMainWindow()
+  return win && !win.isDestroyed() ? win : undefined
+}
+
+/** Map an agentManager rejection to an InvokeResult error. Known lifecycle codes
+ *  pass through as-is; anything else is the agent's own failure reason (e.g. an
+ *  unsupported-model or auth message from pi), surfaced so the extension can show
+ *  it instead of a useless generic code. */
+function agentError(err: unknown, method: string): InvokeResult {
+  const message = err instanceof Error ? err.message : String(err)
+  if (message === 'agent-busy') return { error: 'agent-busy', method }
+  if (message === 'no-session') return { error: 'no-session', method }
+  return { error: message || 'agent-failed', method }
+}
+
 /** Ask the user (once per app session) whether `extensionId` may run the agent.
  *  Returns true if already granted or the user allows. */
 async function ensureAgentConsent(extensionId: string): Promise<boolean> {
@@ -298,29 +315,64 @@ export async function dispatchCateInvoke(
     case 'cate.storage.panel.set':
       return dispatchStorage(method, panelId ?? '', args, extensionId, workspaceId)
 
-    // --- Agent: run one background turn through the bundled pi ---------------
+    // --- Agent: drive a pi session through the bundled pi --------------------
+    // pi owns all conversation state on its session jsonl; Cate only holds the
+    // live client. `open` returns a handle (the jsonl path) the extension reuses
+    // for `send` and can persist to `resume` later. `run` is one-shot sugar.
     case 'cate.agent.run': {
       const a = (args ?? {}) as { prompt?: string }
       const promptText = typeof a.prompt === 'string' ? a.prompt.trim() : ''
       if (!promptText) return { error: 'bad-args', method }
-      const win = getActiveMainWindow()
-      if (!win || win.isDestroyed()) return { error: 'no-host-window', method }
       const info = getWorkspaceInfo(workspaceId)
       if (!info) return { error: 'no-workspace', method }
+      const win = requireHostWindow()
+      if (!win) return { error: 'no-host-window', method }
       if (!(await ensureAgentConsent(extensionId))) return { error: 'consent-denied', method }
       try {
-        // Resolves with the final assistant text when pi emits `agent_end` — a
-        // long-lived call (a turn takes minutes); no short timeout applies here.
+        // A turn can take minutes; no short timeout applies here.
         return await agentManager.runForExtension(promptText, {
-          workspaceId,
-          locator: info.rootPath,
-          extensionId,
-          sender: win.webContents,
+          workspaceId, locator: info.rootPath, extensionId, sender: win.webContents,
         })
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return { error: message === 'agent-busy' ? 'agent-busy' : 'agent-failed', method }
+        return agentError(err, method)
       }
+    }
+
+    case 'cate.agent.open': {
+      const a = (args ?? {}) as { resume?: unknown }
+      const resume = typeof a.resume === 'string' && a.resume ? a.resume : undefined
+      const info = getWorkspaceInfo(workspaceId)
+      if (!info) return { error: 'no-workspace', method }
+      const win = requireHostWindow()
+      if (!win) return { error: 'no-host-window', method }
+      if (!(await ensureAgentConsent(extensionId))) return { error: 'consent-denied', method }
+      try {
+        return await agentManager.openForExtension({
+          workspaceId, locator: info.rootPath, extensionId, sender: win.webContents, resume,
+        })
+      } catch (err) {
+        return agentError(err, method)
+      }
+    }
+
+    case 'cate.agent.send': {
+      const a = (args ?? {}) as { sessionId?: unknown; prompt?: unknown }
+      const sessionId = typeof a.sessionId === 'string' ? a.sessionId : ''
+      const promptText = typeof a.prompt === 'string' ? a.prompt.trim() : ''
+      if (!sessionId || !promptText) return { error: 'bad-args', method }
+      try {
+        return await agentManager.sendForExtension({ extensionId, sessionId, text: promptText })
+      } catch (err) {
+        return agentError(err, method)
+      }
+    }
+
+    case 'cate.agent.dispose': {
+      const a = (args ?? {}) as { sessionId?: unknown }
+      const sessionId = typeof a.sessionId === 'string' ? a.sessionId : ''
+      if (!sessionId) return { error: 'bad-args', method }
+      await agentManager.disposeForExtension({ extensionId, sessionId })
+      return { ok: true }
     }
 
     case 'cate.agent.cancel': {

--- a/src/preload/cateHost.ts
+++ b/src/preload/cateHost.ts
@@ -12,7 +12,7 @@
 // =============================================================================
 
 import { contextBridge, ipcRenderer } from 'electron'
-import type { CateHost, CateHostTheme, CateHostWorkspace } from '../shared/cate-host-api'
+import type { AgentTurnResult, CateHost, CateHostTheme, CateHostWorkspace } from '../shared/cate-host-api'
 
 // Channel names are inlined (NOT imported from ../shared/ipc-channels) on
 // purpose: this is a SECOND preload entry, and sharing a runtime module with
@@ -65,7 +65,12 @@ const api: CateHost = {
   },
 
   agent: {
-    run: (prompt: string) => invoke('cate.agent.run', { prompt }) as Promise<{ text: string } | { error: string }>,
+    open: (opts?: { resume?: string }) =>
+      invoke('cate.agent.open', { resume: opts?.resume }) as Promise<{ sessionId: string } | { error: string }>,
+    send: (sessionId: string, prompt: string) =>
+      invoke('cate.agent.send', { sessionId, prompt }) as Promise<AgentTurnResult | { error: string }>,
+    dispose: (sessionId: string) => invoke('cate.agent.dispose', { sessionId }),
+    run: (prompt: string) => invoke('cate.agent.run', { prompt }) as Promise<AgentTurnResult | { error: string }>,
     cancel: () => invoke('cate.agent.cancel'),
   },
 

--- a/src/shared/cate-host-api.d.ts
+++ b/src/shared/cate-host-api.d.ts
@@ -16,6 +16,14 @@ export interface CateHostTheme {
   terminal: Record<string, string>
 }
 
+/** Result of one agent turn (`cate.agent.send` / `cate.agent.run`): the flattened
+ *  `text` for convenience plus the raw final assistant `message` from pi (its role
+ *  and content blocks — text, tool calls, etc.), or null if the turn produced none. */
+export interface AgentTurnResult {
+  text: string
+  message: Record<string, unknown> | null
+}
+
 /** Workspace context handed to a guest by `cate.workspace.get()`. */
 export interface CateHostWorkspace {
   rootPath: string | null
@@ -65,11 +73,22 @@ export interface CateHost {
   ui: {
     notify(message: string, level?: 'info' | 'warn' | 'error'): Promise<unknown>
   }
-  /** Run one background turn through Cate's bundled agent (requires the `agent`
-   *  scope + first-use user consent). Resolves with the agent's final text.
-   *  Long-lived — a turn can take minutes. One run per extension at a time. */
+  /** Drive Cate's bundled agent (requires the `agent` scope + first-use user
+   *  consent). pi owns all conversation state on its session file; the handle
+   *  returned by `open` is that file's path, so a conversation can be resumed
+   *  later with nothing persisted on Cate's side. Turn-based: each `send`/`run`
+   *  resolves on the agent's terminal `agent_end` (a turn can take minutes). One
+   *  live session per extension; one turn in flight per session. */
   agent: {
-    run(prompt: string): Promise<{ text: string } | { error: string }>
+    /** Open (or `resume` a previous) session; returns its handle. */
+    open(opts?: { resume?: string }): Promise<{ sessionId: string } | { error: string }>
+    /** Run one turn on an open session; returns the final assistant message. */
+    send(sessionId: string, prompt: string): Promise<AgentTurnResult | { error: string }>
+    /** Tear down the live session (pi's jsonl stays; reopen via `resume`). */
+    dispose(sessionId: string): Promise<unknown>
+    /** One-shot sugar over open -> send -> dispose. */
+    run(prompt: string): Promise<AgentTurnResult | { error: string }>
+    /** Abort the in-flight turn of this extension's session. */
     cancel(): Promise<unknown>
   }
   storage: CateHostStorage


### PR DESCRIPTION
Stacked on #397.

Replaces the one-shot `cate.agent.run` with a turn-based session API so an extension can hold a real multi-turn conversation:

- `open({ resume? })` returns a handle (pi's session file path)
- `send(sessionId, prompt)` runs one turn, returns the full assistant message `{ text, message }`
- `dispose(sessionId)` tears down the live client; pi's jsonl stays, so the handle resumes later
- `run(prompt)` stays as open -> send -> dispose sugar

pi owns all conversation state on its session file; Cate only holds the in-memory client, exactly like a panel (same `create()`/`PiRpcClient`/`dispose()` path). One live session per extension, one turn in flight: the anti-runaway guard.

Also fixes the bug behind every "(no text)": a turn that ends on `stopReason: 'error'` (unsupported model, auth, bad request) was indistinguishable from an empty turn, so it returned silent empty text. It now rejects with pi's reason and the handler surfaces it to the extension as `failed: <reason>`.

Kitchen Sink demo that exercises this: 0-AI-UG/cate-extensions#6.

Tests: open/send/dispose dispatch + consent gating, turn runner (willRetry skip, answer extraction, error-turn rejection). All green.