### PR TITLE
Optional toggle to disable GPU text rasterization

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -214,6 +214,20 @@ log.info('Cate v%s starting (electron %s, node %s, platform %s)', app.getVersion
 // them before the async electron-store finishes initializing.
 loadSettingsSyncFromDisk()
 
+// Optional GPU-rasterization workaround (off by default). Under this app's GPU
+// load — many live xterm WebGL contexts + the worktree-territory WebGL2 renderer
+// + the canvas's `will-change: transform` compositing churn — Chromium's shared
+// GPU glyph atlas can intermittently corrupt, repainting text with random
+// missing glyphs (most visible in the file tree). Moving rasterization to the
+// CPU removes the glyph atlas from the path; WebGL still renders and composites
+// on the GPU, so terminals/territory stay accelerated. Command-line switches
+// must be set before app-ready (this runs at module load), so the toggle only
+// takes effect after a restart.
+if (getSettingSync('disableGpuRasterization')) {
+  app.commandLine.appendSwitch('disable-gpu-rasterization')
+  log.info('[gpu] GPU rasterization disabled via setting (text rendered on CPU)')
+}
+
 // Scope the onboarding tour to genuine first installs. Anyone who has launched
 // Cate before is marked past it, so an update never replays the tour. The
 // telemetry notice (WelcomeDialog) intentionally has NO such clause — every

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -41,6 +41,7 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   editorFontSize: 'number',
   editorFontFamily: 'string',
   uiScale: 'number',
+  disableGpuRasterization: 'boolean',
   showMinimap: 'boolean',
   defaultPanelWidth: 'number',
   defaultPanelHeight: 'number',

--- a/src/renderer/settings/AppearanceSettings.tsx
+++ b/src/renderer/settings/AppearanceSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Check, Trash, Upload, DownloadSimple, Sparkle } from '@phosphor-icons/react'
 import { Tooltip } from '../ui/Tooltip'
 import { useSettingsStore } from '../stores/settingsStore'
-import { SettingRow, Select, NumberInput, TextInput, SearchableBlock, SecondaryButton } from './SettingsComponents'
+import { SettingRow, Select, NumberInput, TextInput, Toggle, SearchableBlock, SecondaryButton } from './SettingsComponents'
 import type { Theme } from '../../shared/types'
 import { validateTheme } from '../../shared/theme'
 import { BASE_DARK, BASE_LIGHT, BUILT_IN_THEMES } from '../../shared/themes'
@@ -193,6 +193,23 @@ export function AppearanceSettings() {
           placeholder="e.g., JetBrains Mono"
         />
       </SettingRow>
+
+      <SearchableBlock keywords="gpu rasterization rendering glyph text missing garbled corruption render acceleration restart">
+        <SettingRow
+          label="Disable GPU text rendering"
+          description="Fixes occasional missing or garbled glyphs by rasterizing text on the CPU. May slightly increase CPU use during canvas zoom. Takes effect after restarting Cate."
+          hint={
+            store.disableGpuRasterization ? (
+              <span className="text-[11px] text-amber-400">Restart Cate for this to take effect.</span>
+            ) : undefined
+          }
+        >
+          <Toggle
+            checked={store.disableGpuRasterization}
+            onChange={(v) => store.setSetting('disableGpuRasterization', v)}
+          />
+        </SettingRow>
+      </SearchableBlock>
     </div>
   )
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1190,6 +1190,14 @@ export interface AppSettings {
    *  affect web pages shown in browser panels (those keep their own zoom).
    *  Range 0.5–2.0. */
   uiScale: number
+  /** Disable Chromium's GPU rasterization (text glyphs included) while leaving
+   *  WebGL and GPU compositing on. A workaround for intermittent glyph dropout —
+   *  text repainting with random missing characters — caused by GPU glyph-atlas
+   *  corruption under this app's GPU load (many xterm WebGL contexts + the
+   *  worktree-territory renderer + canvas compositing churn). Off by default
+   *  (full GPU). Applied as a command-line switch at launch, so a change only
+   *  takes effect after restarting the app. */
+  disableGpuRasterization: boolean
 
   // Canvas
   showMinimap: boolean
@@ -1343,6 +1351,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   editorFontSize: 12,
   editorFontFamily: '',
   uiScale: 1.0,
+  disableGpuRasterization: false,
 
   // Canvas
   showMinimap: true,


### PR DESCRIPTION
## What

Adds a **Disable GPU text rendering** toggle under Settings → Appearance. When on, Cate launches Chromium with `--disable-gpu-rasterization`, moving text rasterization to the CPU while leaving WebGL and GPU compositing on.

## Why

Under this app's GPU load (many live xterm WebGL contexts + the worktree-territory WebGL2 renderer + the canvas's `will-change: transform` compositing churn), Chromium's shared GPU glyph atlas can intermittently corrupt, repainting text with random missing glyphs (most visible in the file tree). Removing the glyph atlas from the GPU path works around it; terminals and territory stay accelerated.

## Notes

- Off by default (full GPU).
- The switch is applied at launch, before `app-ready`, so it only takes effect after a restart. The settings row shows a restart hint while enabled.

## Changes

- `shared/types.ts` — `disableGpuRasterization` setting + default
- `main/settingsFile.ts` — schema entry
- `main/index.ts` — apply the switch at startup when enabled
- `renderer/settings/AppearanceSettings.tsx` — toggle UI