### PR TITLE
fix: runtime daemon won't start (missing picomatch) + macOS update relaunch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.3.2-beta.1",
+  "version": "1.3.2-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.3.2-beta.1",
+      "version": "1.3.2-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.3.2-beta.1",
+  "version": "1.3.2-beta.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/scripts/build-runtime-tarball.mjs
+++ b/scripts/build-runtime-tarball.mjs
@@ -36,6 +36,7 @@
 import { existsSync, mkdirSync, cpSync, rmSync, chmodSync, readFileSync, renameSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import os from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -215,15 +216,44 @@ async function stageParcelWatcher(outRoot) {
   for (const f of ['index.js', 'wrapper.js', 'index.js.flow', 'index.d.ts', 'package.json']) {
     if (existsSync(path.join(src, f))) cpSync(path.join(src, f), path.join(dest, f))
   }
-  // @parcel/watcher's OWN node_modules pins picomatch@4 (wrapper.js resolves the
-  // nested copy, not the repo-hoisted picomatch@2) — copy it verbatim.
-  if (existsSync(path.join(src, 'node_modules'))) {
-    cpSync(path.join(src, 'node_modules'), path.join(dest, 'node_modules'), { recursive: true, dereference: true })
+  // Stage @parcel/watcher's JS dependency closure. wrapper.js requires
+  // picomatch + is-glob (→ is-extglob); index.js requires detect-libc on linux.
+  // Resolve EACH from @parcel/watcher's own resolution root rather than assuming
+  // a fixed location: npm may nest a dep under @parcel/watcher/node_modules (a
+  // version-pin conflict) OR hoist it to the top-level node_modules (no conflict)
+  // — and which one happens varies by the full install tree. A previous version
+  // copied the nested dir if present, else a hardcoded list that OMITTED
+  // picomatch; when npm hoisted picomatch the nested dir was absent AND it wasn't
+  // in the list, so it shipped missing and the daemon crashed at startup with
+  // `Cannot find module 'picomatch'` (require'd by wrapper.js). createRequire
+  // finds the exact copy node would load, at whatever depth, every time.
+  const requireFrom = createRequire(path.join(src, 'package.json'))
+  for (const dep of ['picomatch', 'is-glob', 'is-extglob', 'detect-libc']) {
+    let pkgDir
+    try {
+      pkgDir = path.dirname(requireFrom.resolve(`${dep}/package.json`))
+    } catch {
+      // detect-libc is only require'd on linux; on darwin/win it may be absent.
+      if (dep === 'detect-libc') continue
+      throw new Error(`@parcel/watcher dependency "${dep}" not resolvable from ${src} — run \`npm install\` first`)
+    }
+    // Stage into the SAME relative location node resolved it from (nested under
+    // @parcel/watcher or hoisted to the top level) so resolution matches at runtime.
+    const rel = path.relative(repoRoot, pkgDir)
+    cpSync(pkgDir, path.join(outRoot, rel), { recursive: true, dereference: true })
   }
-  // The rest of the runtime closure resolves from the top-level node_modules.
-  for (const dep of ['is-glob', 'is-extglob', 'detect-libc']) {
-    const from = path.join(repoRoot, 'node_modules', dep)
-    if (existsSync(from)) cpSync(from, path.join(nm, dep), { recursive: true, dereference: true })
+  // Fail loudly if the staged tree can't resolve wrapper.js's requires — the exact
+  // crash that shipped before. Mirrors the watcher.node assert below.
+  const stagedRequire = createRequire(path.join(dest, 'wrapper.js'))
+  for (const dep of ['picomatch', 'is-glob']) {
+    try {
+      stagedRequire.resolve(dep)
+    } catch {
+      throw new Error(
+        `staged @parcel/watcher cannot resolve "${dep}" from ${path.join(dest, 'wrapper.js')}. ` +
+          'The daemon would crash at startup (MODULE_NOT_FOUND) — aborting the build.',
+      )
+    }
   }
 
   // The target's prebuilt native package.

--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -147,6 +147,32 @@ describe('initAutoUpdater — config', () => {
     expect(h.autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled()
   })
 
+  it('stops re-checking once an update is downloaded and staged', async () => {
+    const { initAutoUpdater } = await loadModule()
+    initAutoUpdater()
+    vi.advanceTimersByTime(6000) // launch check fires
+    expect(h.autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1)
+
+    // Update finished downloading → staged for install on quit.
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+
+    // The 15-minute poll must NOT re-check: a redundant check resets the native
+    // macOS Squirrel "ready" flag, which would make a later "Restart now" install
+    // on quit without relaunching (the app never reopens).
+    vi.advanceTimersByTime(15 * 60 * 1000)
+    expect(h.autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1)
+  })
+
+  it('a manual check does not re-check when an update is already staged', async () => {
+    const { initAutoUpdater, checkForUpdatesManually } = await loadModule()
+    initAutoUpdater()
+    vi.advanceTimersByTime(6000)
+    h.autoUpdater.emit('update-downloaded', { version: '1.2.3' })
+    const before = h.autoUpdater.checkForUpdatesAndNotify.mock.calls.length
+    checkForUpdatesManually() // re-opens the modal, but must not perturb native state
+    expect(h.autoUpdater.checkForUpdatesAndNotify.mock.calls.length).toBe(before)
+  })
+
   it('dev-update mode: wires events, forces dev config, and treats as eligible', async () => {
     h.app.isPackaged = false
     process.env.CATE_DEV_UPDATE = '1'

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -177,8 +177,23 @@ async function promptManualReinstall(version: string, opts: { offerMove: boolean
 
 /** Run a check. When eligible, AndNotify downloads (autoDownload) and shows the
  *  native "ready to install" notification; when ineligible we only check so the
- *  update-available handler can offer the manual path. */
+ *  update-available handler can offer the manual path.
+ *
+ *  Skips entirely once an update is downloaded and staged. A redundant check —
+ *  the 15-minute poll, a manual "Check for Updates…", or a beta-toggle re-check —
+ *  re-enters electron-updater's macOS flow (MacUpdater.doDownloadUpdate →
+ *  setFeedURL + nativeUpdater.checkForUpdates), which re-arms the native
+ *  Squirrel.Mac install-on-quit (no relaunch) and resets its internal
+ *  `squirrelDownloadedUpdate` "ready" flag. With that flag false, a subsequent
+ *  quitAndInstall (the "Restart now" button) silently DOESN'T relaunch: the
+ *  update installs on quit but the app never reopens (ShipItState
+ *  launchAfterInstallation=false). We already hold the latest, staged — there's
+ *  nothing to find by re-checking, so don't perturb the native state. */
 function runCheck(eligible: boolean): Promise<unknown> {
+  if (updatePendingInstall) {
+    log.info('[auto-updater] skipping check — an update is already downloaded and staged for install')
+    return Promise.resolve(null)
+  }
   const p = eligible ? autoUpdater.checkForUpdatesAndNotify() : autoUpdater.checkForUpdates()
   return p.catch((err) => {
     log.warn('[auto-updater] check failed: %O', err)

--- a/src/main/runtime/connection.test.ts
+++ b/src/main/runtime/connection.test.ts
@@ -301,9 +301,41 @@ describe('RuntimeManager LOCAL auto-reconnect (FIX 4)', () => {
     expect(seen).not.toContain('connecting')
 
     // Let the backoff fire: ensureLocalRuntime re-runs once with the same opts.
+    // First retry assumes a transient failure → no forced re-extract.
     await vi.advanceTimersByTimeAsync(1100)
     expect(ensureSpy).toHaveBeenCalledTimes(1)
-    expect(ensureSpy).toHaveBeenCalledWith({ root: os.homedir() })
+    expect(ensureSpy).toHaveBeenCalledWith({ root: os.homedir() }, { force: false })
+  })
+
+  test('reconnect backs off, forces a re-extract, then gives up at the cap', () => {
+    vi.useFakeTimers()
+    const mgr = new RuntimeManager()
+    ;(mgr as unknown as { localOpts: unknown }).localOpts = { root: os.homedir() }
+    // Stub the relaunch so each scheduled reconnect is a no-op "failure" — the
+    // retry budget only resets on a real successful connect (which we never let
+    // happen here), so consecutive schedules escalate toward the cap.
+    const ensureSpy = vi.spyOn(mgr, 'ensureLocalRuntime').mockReturnValue(undefined)
+    const schedule = () => (mgr as unknown as { scheduleLocalReconnect(): void }).scheduleLocalReconnect()
+    const home = os.homedir()
+
+    // Attempt 1: ~1s backoff, no forced re-extract (transient-failure assumption).
+    schedule()
+    vi.advanceTimersByTime(1000)
+    expect(ensureSpy).toHaveBeenLastCalledWith({ root: home }, { force: false })
+
+    // Attempt 2+: force a clean re-extract to repair a corrupt/partial install.
+    schedule()
+    vi.advanceTimersByTime(2000)
+    expect(ensureSpy).toHaveBeenLastCalledWith({ root: home }, { force: true })
+
+    schedule(); vi.advanceTimersByTime(4000) // attempt 3
+    schedule(); vi.advanceTimersByTime(8000) // attempt 4 (cap)
+    expect(ensureSpy).toHaveBeenCalledTimes(4)
+
+    // Past LOCAL_MAX_RETRIES the auto-retry stops — no further relaunch scheduled.
+    schedule()
+    vi.advanceTimersByTime(8000)
+    expect(ensureSpy).toHaveBeenCalledTimes(4)
   })
 
   test('an intentional LOCAL teardown does NOT reconnect', async () => {

--- a/src/main/runtime/runtimeManager.ts
+++ b/src/main/runtime/runtimeManager.ts
@@ -42,6 +42,15 @@ export class RuntimeManager {
   /** Pending LOCAL auto-reconnect timer — guards against stacking reconnects on
    *  a crash loop (one backoff in flight at a time). */
   private localReconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** Consecutive failed LOCAL starts/crashes since the last successful connect.
+   *  Drives the reconnect backoff, the force-reextract escalation, and the
+   *  give-up cap so a permanently-broken daemon can't tight-loop forever. Reset
+   *  to 0 once LOCAL connects. */
+  private localRetryCount = 0
+  /** Stop auto-retrying LOCAL after this many consecutive failures. A daemon that
+   *  can never start (e.g. a corrupt runtime bundle) would otherwise loop forever;
+   *  past the cap we leave `unreachable` so the UI's Retry is the way forward. */
+  private static readonly LOCAL_MAX_RETRIES = 4
   /** Last status emitted for the LOCAL runtime, so a window that subscribes to
    *  RUNTIME_STATUS after the startup connect already finished can still seed
    *  its loading blocker. Defaults to `connecting` — ensureLocalRuntime runs at
@@ -70,7 +79,10 @@ export class RuntimeManager {
    * fails, connect() drops the deferred and this emits `unreachable`, so every
    * local op fails with a clear error until fixed.
    */
-  ensureLocalRuntime(opts: { root: string; exclusions?: string[]; env?: NodeJS.ProcessEnv; idleSuspend?: boolean }): void {
+  ensureLocalRuntime(
+    opts: { root: string; exclusions?: string[]; env?: NodeJS.ProcessEnv; idleSuspend?: boolean },
+    { force = false }: { force?: boolean } = {},
+  ): void {
     // Remember the launch opts so a crash can re-provision + relaunch identically
     // (see the LOCAL auto-reconnect in doConnect's onClose handler).
     this.localOpts = opts
@@ -102,13 +114,15 @@ export class RuntimeManager {
 
     // install:true — the local daemon self-installs (extracts the bundled tarball)
     // on first run; a remote host installs only on an explicit user action. That
-    // flag is the ONLY thing distinguishing this from a remote connect. Fire-and-
-    // forget: connect() already registered the deferred synchronously (so the
-    // window paints), so we just log the eventual outcome. connect() drops the
-    // deferred on failure, so resolve(LOCAL) then fails clearly until fixed.
-    void this.connect(LOCAL_RUNTIME_ID, transport, { install: true })
+    // flag is the ONLY thing distinguishing this from a remote connect. `force`
+    // (set by the retry escalation) re-extracts the bundle, repairing a corrupt /
+    // partial install. Fire-and-forget: connect() already registered the deferred
+    // synchronously (so the window paints), so we just log the eventual outcome.
+    // connect() drops the deferred on failure, so resolve(LOCAL) then fails clearly.
+    void this.connect(LOCAL_RUNTIME_ID, transport, { install: true, force })
       .then(() => {
         log.info('[runtime] local workspace running on the daemon tarball')
+        this.localRetryCount = 0 // a clean connect resets the retry budget
       })
       .catch((err) => {
         const detail = err instanceof Error ? err.message : String(err)
@@ -116,25 +130,55 @@ export class RuntimeManager {
         // doConnect already emitted a step-specific status (unreachable/missing);
         // re-emit unreachable with the local-specific hint for the UI.
         this.emitStatus(LOCAL_RUNTIME_ID, 'unreachable', `Local runtime failed to start: ${detail}${hint}`)
+        // A failed START (daemon died before the handshake) never armed the
+        // onClose crash-reconnect — that only fires after a successful connect.
+        // Schedule the retry here so a transient startup failure (or a corrupt
+        // extract, repaired by the forced re-extract) recovers without a manual
+        // Retry click. A permanently-broken bundle is bounded by LOCAL_MAX_RETRIES.
+        this.scheduleLocalReconnect()
       })
   }
 
   /**
-   * Re-provision + relaunch the LOCAL daemon after a crash, using the opts it was
-   * started with. Backs off briefly to avoid a tight crash loop and never stacks
-   * (one pending timer at a time; the `connecting` map dedupes the connect once it
-   * fires). Emits `connecting` so the UI reflects the in-flight retry.
+   * Re-provision + relaunch the LOCAL daemon after a crash OR a failed start,
+   * using the opts it was started with. Never stacks (one pending timer at a time;
+   * the `connecting` map dedupes the connect once it fires) and emits `connecting`
+   * so the UI reflects the in-flight retry. Three guards keep a permanently-broken
+   * daemon from tight-looping forever:
+   *   - exponential backoff (1s → 8s) scaled by the consecutive-failure count;
+   *   - a forced re-extract from the 2nd retry on, to repair a corrupt/partial
+   *     install (a genuinely broken bundle still fails, but a truncated extract
+   *     recovers);
+   *   - a hard cap (LOCAL_MAX_RETRIES); past it we stop and leave the last
+   *     `unreachable` status, so the UI's Retry button is the way forward.
+   * The retry count resets to 0 on any successful connect (see ensureLocalRuntime).
    */
   private scheduleLocalReconnect(): void {
     if (this.localReconnectTimer) return // a reconnect is already pending
     if (!this.localOpts) return // never came up; nothing to relaunch
-    this.emitStatus(LOCAL_RUNTIME_ID, 'connecting', 'Local runtime crashed, reconnecting…')
+    if (this.localRetryCount >= RuntimeManager.LOCAL_MAX_RETRIES) {
+      log.error(
+        '[runtime] local daemon failed %d consecutive times; stopping auto-retry (use Retry to try again)',
+        this.localRetryCount,
+      )
+      return // leave the prior `unreachable` status in place
+    }
+    this.localRetryCount++
+    // Re-extract from the 2nd attempt on — the first retry assumes a transient
+    // failure (don't churn a healthy install), later ones suspect a bad extract.
+    const force = this.localRetryCount >= 2
+    const delay = Math.min(8000, 500 * 2 ** this.localRetryCount)
+    this.emitStatus(
+      LOCAL_RUNTIME_ID,
+      'connecting',
+      `Local runtime restarting (attempt ${this.localRetryCount}/${RuntimeManager.LOCAL_MAX_RETRIES})…`,
+    )
     this.localReconnectTimer = setTimeout(() => {
       this.localReconnectTimer = null
       // ensureLocalRuntime short-circuits if LOCAL is already registered, never
       // throws, and re-emits its own status; localOpts is non-null here.
-      void this.ensureLocalRuntime(this.localOpts!)
-    }, 1000)
+      void this.ensureLocalRuntime(this.localOpts!, { force })
+    }, delay)
     if (this.localReconnectTimer.unref) this.localReconnectTimer.unref()
   }
 

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.3.1'
+export const RUNTIME_VERSION = '1.3.2-beta.1'

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.3.2-beta.1'
+export const RUNTIME_VERSION = '1.3.2-beta.2'


### PR DESCRIPTION
## What broke

On the 1.3.2-beta.1 beta, the runtime daemon crashed at startup so no terminal or workspace would come up, and the "Restart now" update prompt installed the update but never reopened the app.

Three distinct bugs, all fixed here.

### 1. Runtime daemon missing `picomatch` (the actual crash)
The shipped runtime tarball was missing `picomatch`, so the daemon died at startup:
```
Error: Cannot find module 'picomatch'
  at .../@parcel/watcher/wrapper.js:2
```
`stageParcelWatcher` copied `@parcel/watcher`'s nested `node_modules` if present, else a hardcoded dep list that omitted `picomatch`. On the release runner npm hoisted `picomatch` to the top level (no nested dir), so neither branch staged it.

Fix: resolve each of `@parcel/watcher`'s runtime deps from its own resolution root via `createRequire` and stage each where node would load it, so it works whether npm nested or hoisted them. Plus a post-stage assert that `wrapper.js`'s requires resolve in the staged tree, so this fails the build instead of shipping broken. Verified by building the tarball and loading `@parcel/watcher` under the bundled node.

### 2. No auto-retry on a failed daemon *start*
The crash-reconnect only armed after a successful handshake, so a startup crash had no recovery (just the static Retry screen). Now a failed start schedules a reconnect with backoff (1s to 8s), a forced re-extract from the 2nd attempt (repairs a corrupt/partial install), and a hard cap so a permanently-broken bundle can't tight-loop.

### 3. macOS "Restart now" installs but doesn't relaunch
Diagnosed from `ShipItState.plist` (`launchAfterInstallation => false`) and the ShipIt logs: the install went through the no-relaunch install-on-quit path instead of the relaunching `quitAndInstall`. Trigger: a redundant update check (the 15-min poll, or a manual "Check for Updates") re-enters electron-updater's macOS flow and resets the native Squirrel "ready" flag, so a later `quitAndInstall` skips the relaunch.

Fix: once an update is downloaded and staged, skip further checks. Nothing to find, and the manual path still re-opens the staged modal.

## Tests
- `connection.test.ts`: backoff/force-reextract/give-up-cap for the LOCAL retry.
- `auto-updater.test.ts`: no re-check once an update is staged (poll + manual).
- Full `src/main/runtime` suite passes, including the real-tarball provision+PTY+fs-watch test (exercises the picomatch fix end to end). Typecheck clean.

## Note
#3 only manifests with a real signed Squirrel update and can't be unit-tested end to end, so it needs a manual verification on a packaged beta build.