### PR TITLE
Reload terminals/agents into the correct worktree

### DIFF
--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -64,6 +64,7 @@ import type {
 } from '../../shared/types'
 import type { AgentMessage as StoreMessage } from './agentStore'
 import { loadDefaultModel, clearModelPrefsForProvider } from './agentModelPrefs'
+import { resolveWorktree } from '../../shared/worktrees'
 
 // -----------------------------------------------------------------------------
 // Component
@@ -74,9 +75,7 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
   // If this panel is tagged with a worktree, prefer its path so pi spawns
   // inside that parallel checkout instead of the workspace's primary root.
   const panelState = workspace?.panels[panelId]
-  const taggedWorktree = panelState?.worktreeId
-    ? workspace?.worktrees?.find((w) => w.id === panelState.worktreeId)
-    : undefined
+  const taggedWorktree = resolveWorktree(panelState?.worktreeId, workspace?.worktrees)
   const cwd = taggedWorktree?.path ?? workspace?.rootPath ?? ''
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/canvas/WorktreePill.tsx
+++ b/src/renderer/canvas/WorktreePill.tsx
@@ -19,6 +19,7 @@ import { useAppStore } from '../stores/appStore'
 import { useUIStore } from '../stores/uiStore'
 import { useWorktrees } from '../stores/useWorktrees'
 import { confirmCloseRunningTerminals } from '../lib/confirmCloseTerminal'
+import { resolveWorktree } from '../../shared/worktrees'
 import type { PanelState } from '../../shared/types'
 
 interface WorktreePillProps {
@@ -37,7 +38,7 @@ export const WorktreePill: React.FC<WorktreePillProps> = ({ panel, workspaceId }
   const focusWorktree = useUIStore((s) => s.focusWorktree)
   const focusedWorktreeId = useUIStore((s) => s.focusedWorktreeId)
 
-  const current = worktrees.find((w) => w.id === panel.worktreeId) ?? worktrees.find((w) => w.isPrimary)
+  const current = resolveWorktree(panel.worktreeId, worktrees) ?? worktrees.find((w) => w.isPrimary)
   const currentId = current?.id
 
   // Collapsed (icon-only) until hovered, so the overlay covers as little of the

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -22,6 +22,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { focusedNodeId } from '../stores/canvas/selectionModel'
 import { resolveTerminalFontSize } from '../lib/terminal/terminalSettings'
+import { resolveWorktree } from '../../shared/worktrees'
 
 // ---------------------------------------------------------------------------
 // Component
@@ -95,14 +96,24 @@ export default function TerminalPanel({
   const panelCwd = useAppStore(
     (state) => state.workspaces.find((w) => w.id === workspaceId)?.panels[panelId]?.cwd,
   )
+  // The worktree this terminal is tagged to (the title-bar pill), resolved to its
+  // checkout path. This is the AUTHORITATIVE cwd for a tagged terminal — same as
+  // AgentPanel — so a restart respawns it inside its worktree regardless of
+  // whether the live cwd was captured at save time (which is flaky: it depends on
+  // a live PTY query). Returns a stable string, so this selector is cheap.
+  const taggedWorktreePath = useAppStore((state) => {
+    const ws = state.workspaces.find((w) => w.id === workspaceId)
+    return resolveWorktree(ws?.panels[panelId]?.worktreeId, ws?.worktrees)?.path
+  })
   // Bumped by respawnPanelTerminal() to force a fresh PTY at a new cwd (worktree
   // switch). Folded into the lifecycle effect deps below so it re-creates.
   const ptyEpoch = useAppStore(
     (state) => state.workspaces.find((w) => w.id === workspaceId)?.panels[panelId]?.ptyEpoch ?? 0,
   )
   const workspaceRoot = workspaces.find((w) => w.id === workspaceId)?.rootPath
-  // Prefer an explicit per-panel cwd (drag-drop folder, worktree, etc.).
-  const rootPath = panelCwd || workspaceRoot
+  // Tagged worktree wins; else an explicit per-panel cwd (drag-drop folder); else
+  // the workspace root.
+  const rootPath = taggedWorktreePath || panelCwd || workspaceRoot
   const rootPathRef = useRef(rootPath)
   rootPathRef.current = rootPath
 

--- a/src/shared/worktrees.test.ts
+++ b/src/shared/worktrees.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { resolveWorktree } from './worktrees'
+import type { WorktreeMeta } from './types'
+
+const WT: WorktreeMeta = {
+  id: 'wt-x',
+  path: '/repo/.cate/worktrees/x',
+  color: '#11aa55',
+}
+
+describe('resolveWorktree', () => {
+  it('matches by stable id', () => {
+    expect(resolveWorktree('wt-x', [WT])?.path).toBe(WT.path)
+  })
+
+  it('matches by path when the tag is a raw path (useWorktrees id fallback)', () => {
+    // A panel tagged before metadata existed stores the path as its worktreeId.
+    expect(resolveWorktree(WT.path, [WT])?.id).toBe('wt-x')
+  })
+
+  it('matches a path tag across separator/case differences (Windows)', () => {
+    const win: WorktreeMeta = { id: 'wt-y', path: 'C:/repo/wt', color: '#000' }
+    expect(resolveWorktree('C:\\repo\\wt', [win])?.id).toBe('wt-y')
+  })
+
+  it('returns undefined for an unknown tag (orphan → caller falls back to root)', () => {
+    expect(resolveWorktree('wt-gone', [WT])).toBeUndefined()
+  })
+
+  it('returns undefined when nothing is tagged', () => {
+    expect(resolveWorktree(undefined, [WT])).toBeUndefined()
+  })
+})

--- a/src/shared/worktrees.ts
+++ b/src/shared/worktrees.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// Worktree tag resolution — shared by the terminal and agent panels so both
+// anchor a worktree-tagged panel to the SAME checkout deterministically.
+//
+// A panel's `worktreeId` is normally the registry record's stable id, but it can
+// also be a raw path (the useWorktrees `m?.id ?? g.path` fallback, taken when a
+// panel is tagged before a background sync assigns metadata). Match on either so
+// a path-valued tag still resolves to its record after a restart, instead of
+// silently falling back to the workspace root.
+// =============================================================================
+
+import { pathKey } from './pathUtils'
+
+/** Minimal shape both the persisted registry (WorktreeMeta) and the read-time
+ *  join (JoinedWorktree) satisfy, so one resolver serves every call site. */
+interface WorktreeLike {
+  id: string
+  path: string
+}
+
+export function resolveWorktree<W extends WorktreeLike>(
+  worktreeId: string | undefined,
+  worktrees: readonly W[] | undefined,
+): W | undefined {
+  if (!worktreeId || !worktrees) return undefined
+  const key = pathKey(worktreeId)
+  return worktrees.find((w) => w.id === worktreeId || pathKey(w.path) === key)
+}


### PR DESCRIPTION
Worktree-tagged terminals sometimes came back at the workspace root after a restart. The terminal resolved its cwd only from the live PTY cwd captured at save time, with no link to the worktree tag, so when that capture was missing (PTY not live yet, query failed, terminal just reopened) the shell fell back to the root while the pill still showed the worktree. Intermittent by nature.

## What changed
- Terminal cwd is now resolved from its worktree tag at render time, like AgentPanel already does, so the tag is authoritative and the flaky live-cwd capture no longer gates correctness. Covers every reload path at once: main restore, reload-from-disk, deferred/workspace-switch, detached windows.
- New shared `resolveWorktree(worktreeId, worktrees)` matches a tag by id or normalized path. A panel tagged before sync assigns metadata stores a raw path as its tag, which never matched a registry record before and dropped the agent/pill to the root. Now used by the terminal, agent, and the pill.

## Note
A tagged terminal you'd cd'd into a subdir now reopens at the worktree root, not the subdir. That subdir restore rode on the same flaky capture this replaces, and ptyEpoch re-creates only happen on a worktree switch (which already resets to the root), so no live regression.

## Tests
- tsc clean; worktreePersistence + agentSessionRegistry pass
- New shared/worktrees.test.ts covers id match, path match, Windows separator/case, orphan, untagged