### PR TITLE
fix(main): reveal window when renderer load completes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -355,14 +355,19 @@ app.whenReady().then(async () => {
   }
 
   // Check for a crash report from the previous session — shows an opt-in
-  // dialog if one exists. Deferred until after the window is ready so the
-  // dialog has a parent window and doesn't block startup.
-  mainWin.once('ready-to-show', () => {
+  // dialog if one exists. Deferred until the window is usable so the dialog has
+  // a parent window and doesn't block startup. did-finish-load is a fallback
+  // for hidden-window startup paths where ready-to-show never arrives.
+  let mainWindowReadyHandled = false
+  const markMainWindowReady = (reason: string): void => {
+    if (mainWindowReadyHandled || mainWin.isDestroyed()) return
+    mainWindowReadyHandled = true
+    log.info('Main window ready via %s', reason)
     setMainWindowReady(true)
     flushPendingOpenPaths()
     // Register deferred IPC handlers and start the auto-updater now that the
-    // first paint has landed. Anything not on the cold-launch critical path
-    // belongs here.
+    // first usable renderer load has landed. Anything not on the cold-launch
+    // critical path belongs here.
     registerDeferredHandlers()
     log.info('Deferred IPC handlers registered')
     initAutoUpdater()
@@ -377,7 +382,9 @@ app.whenReady().then(async () => {
           app.exit(1)
         })
     }
-  })
+  }
+  mainWin.once('ready-to-show', () => markMainWindowReady('ready-to-show'))
+  mainWin.webContents.once('did-finish-load', () => markMainWindowReady('did-finish-load'))
 })
 
 // Window lifecycle: window-all-closed, activate, and the before-quit / will-quit

--- a/src/main/lifecycle/shutdown.ts
+++ b/src/main/lifecycle/shutdown.ts
@@ -90,10 +90,16 @@ export function registerLifecycleHandlers(): void {
     if (BrowserWindow.getAllWindows().length === 0) {
       setMainWindowReady(false)
       const win = createWindow({ type: 'main' })
-      win.once('ready-to-show', () => {
+      let readyHandled = false
+      const markReady = (reason: string): void => {
+        if (readyHandled || win.isDestroyed()) return
+        readyHandled = true
+        log.info('Activated main window ready via %s', reason)
         setMainWindowReady(true)
         flushPendingOpenPaths()
-      })
+      }
+      win.once('ready-to-show', () => markReady('ready-to-show'))
+      win.webContents.once('did-finish-load', () => markReady('did-finish-load'))
     }
   })
 

--- a/src/main/windows/windowFactory.reveal.test.ts
+++ b/src/main/windows/windowFactory.reveal.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Regression cover for the startup bug where a hidden window could stay
+// invisible forever: on some cold-launch paths 'ready-to-show' never fires, so
+// the reveal must also be driven by the renderer's 'did-finish-load' — exactly
+// once across both events.
+
+// Shared test state lives in a hoisted block so the vi.mock factories (hoisted
+// above imports) can reach it.
+const hooks = vi.hoisted(() => {
+  const revealWindow = vi.fn()
+  let nextId = 1
+  const created: Array<Record<string, unknown>> = []
+
+  function makeEmitter() {
+    const once: Record<string, Array<() => void>> = {}
+    const on: Record<string, Array<() => void>> = {}
+    return {
+      once(ev: string, cb: () => void) { (once[ev] ??= []).push(cb) },
+      on(ev: string, cb: () => void) { (on[ev] ??= []).push(cb) },
+      emit(ev: string) {
+        const fired = once[ev] ?? []
+        once[ev] = []
+        fired.forEach((f) => f())
+        ;(on[ev] ?? []).forEach((f) => f())
+      },
+    }
+  }
+
+  function makeWin() {
+    const webContents = { ...makeEmitter(), send() {} }
+    const win = {
+      ...makeEmitter(),
+      id: nextId++,
+      destroyed: false,
+      webContents,
+      loadURL() {},
+      loadFile() {},
+      show() {},
+      focus() {},
+      isDestroyed() { return win.destroyed },
+      getPosition() { return [0, 0] },
+      getSize() { return [800, 600] },
+      isMinimized() { return false },
+      isFullScreen() { return false },
+      isMaximized() { return false },
+    } as unknown as Record<string, unknown>
+    created.push(win)
+    return win
+  }
+
+  return { revealWindow, created, makeWin }
+})
+
+vi.mock('electron', () => {
+  const BrowserWindow = function () { return hooks.makeWin() } as unknown as {
+    (): unknown
+    getAllWindows: () => unknown[]
+  }
+  BrowserWindow.getAllWindows = () =>
+    hooks.created.filter((w) => !(w as { destroyed: boolean }).destroyed)
+  const electron = {
+    BrowserWindow,
+    nativeImage: { createFromPath: () => ({}) },
+    nativeTheme: { themeSource: 'system' },
+  }
+  return { ...electron, default: electron }
+})
+
+vi.mock('../logger', () => ({
+  default: { info() {}, warn() {}, debug() {}, error() {} },
+}))
+vi.mock('./reveal', () => ({ revealWindow: hooks.revealWindow, IS_E2E: false }))
+vi.mock('./crashRecovery', () => ({ installRendererCrashRecovery: () => {} }))
+vi.mock('./fullscreen', () => ({ anyWindowFullscreen: () => false }))
+vi.mock('../store', () => ({ readBootSnapshot: () => null, writeBootSnapshot: () => {} }))
+vi.mock('../windowRegistry', () => ({
+  registerWindow: () => {},
+  getWindowType: () => undefined,
+  getActiveMainWindow: () => null,
+}))
+vi.mock('../ipc/filesystem', () => ({ stopWatchersForWindow: () => {} }))
+vi.mock('../ipc/shell', () => ({ unregisterTerminalsForWindow: () => {} }))
+vi.mock('../ipc/git-monitor', () => ({ stopMonitorsForWindow: () => {} }))
+vi.mock('../ipc/search', () => ({ stopSearchesForWindow: () => {} }))
+vi.mock('../ipc/pathValidation', () => ({
+  clearFileGrantsForWindow: () => {},
+  clearScopedWriteAllowancesForWindow: () => {},
+  grantFileAccess: () => Promise.resolve(),
+}))
+vi.mock('../runtime/runtimeManager', () => ({
+  forwardFileGrant: () => {},
+  forwardClearFileGrantsForWindow: () => {},
+  forwardClearScopedWriteAllowancesForWindow: () => {},
+}))
+vi.mock('../grantedPathStore', () => ({ listPersistentGrants: () => Promise.resolve([]) }))
+vi.mock('../menu', () => ({ rebuildApplicationMenu: () => {} }))
+vi.mock('../featureFlags', () => ({ disableRendererSandbox: () => false }))
+
+const { createWindow } = await import('./windowFactory')
+
+interface FakeWin {
+  emit(ev: string): void
+  webContents: { emit(ev: string): void }
+}
+
+describe('createWindow reveal wiring', () => {
+  beforeEach(() => {
+    hooks.revealWindow.mockClear()
+    hooks.created.length = 0
+  })
+
+  it('reveals once on ready-to-show', () => {
+    const win = createWindow({ type: 'main' }) as unknown as FakeWin
+    expect(hooks.revealWindow).not.toHaveBeenCalled()
+    win.emit('ready-to-show')
+    expect(hooks.revealWindow).toHaveBeenCalledTimes(1)
+  })
+
+  // The actual regression: a startup path where ready-to-show never arrives.
+  // Before the fix the window stayed hidden forever; now did-finish-load
+  // reveals it as a fallback.
+  it('reveals via did-finish-load when ready-to-show never fires', () => {
+    const win = createWindow({ type: 'main' }) as unknown as FakeWin
+    win.webContents.emit('did-finish-load')
+    expect(hooks.revealWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals exactly once when both events fire', () => {
+    const win = createWindow({ type: 'main' }) as unknown as FakeWin
+    win.emit('ready-to-show')
+    win.webContents.emit('did-finish-load')
+    expect(hooks.revealWindow).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/windows/windowFactory.ts
+++ b/src/main/windows/windowFactory.ts
@@ -99,11 +99,22 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
     },
   })
 
-  // Show on ready-to-show so the first frame is fully painted before the
-  // window appears — eliminates the white flash from initial mount.
-  win.once('ready-to-show', () => {
+  // Capture ID before window is destroyed (win.id throws after 'closed')
+  const windowId = win.id
+  let windowRevealed = false
+  const revealOnce = (reason: string): void => {
+    if (windowRevealed || win.isDestroyed()) return
+    windowRevealed = true
+    log.info('Revealing window type=%s id=%d via %s', windowType, windowId, reason)
     revealWindow(win)
-  })
+  }
+
+  // Prefer ready-to-show so the first frame is painted before the window
+  // appears. did-finish-load is a safety net for startup paths where
+  // ready-to-show never arrives and the hidden window would otherwise stay
+  // invisible forever.
+  win.once('ready-to-show', () => revealOnce('ready-to-show'))
+  win.webContents.once('did-finish-load', () => revealOnce('did-finish-load'))
 
   // Persist main-window geometry to the boot snapshot so the next cold launch
   // restores bounds synchronously (no white flash). The store debounces, so
@@ -124,8 +135,6 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
   // Track this window in the registry with its type
   registerWindow(win, windowType, params?.workspaceId)
 
-  // Capture ID before window is destroyed (win.id throws after 'closed')
-  const windowId = win.id
   log.info('Creating window type=%s id=%d', windowType, windowId)
 
   // Recover from renderer crashes / hangs (OOM, GPU fault, native crash) that


### PR DESCRIPTION
## Summary
- reveal the BrowserWindow once either `ready-to-show` or `did-finish-load` fires
- run main-window startup readiness/deferred init through the same once-only fallback
- apply the same readiness fallback when macOS `activate` recreates the main window

## Testing
- npm run typecheck
- npm test -- src/main/lifecycle/shutdown.test.ts
- npm run build
- npm run test:smoke:electron