### PR TITLE
chore(release): 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.3.2-beta.2",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.3.2-beta.2",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.3.2-beta.2",
+  "version": "1.3.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.3.2-beta.2'
+export const RUNTIME_VERSION = '1.3.2'


### PR DESCRIPTION
Promotes the `1.3.2` beta line to a stable release.

- Bumps version `1.3.2-beta.2` → `1.3.2` (package.json, package-lock.json, src/runtime/version.ts).
- Cut from current `main`, so v1.3.2 stable includes everything shipped since `v1.3.2-beta.2`: worktree-reload cwd fix (#419), grow-to-fill panel sizing (#399), and the runtime/updater fixes from the beta line.

After this merges, tag `v1.3.2` on the merge commit and push it to trigger the release workflow (clean tag → published as the `Latest` stable release).