### PR TITLE
Color minimap panels by worktree; scissor the territory shader

### DIFF
--- a/e2e/worktree-territory-perf.spec.ts
+++ b/e2e/worktree-territory-perf.spec.ts
@@ -1,0 +1,358 @@
+// =============================================================================
+// Worktree-terrace performance stress test — drives the WebGL "territory" layer
+// (and its screen-space scissor) under load and measures the cost.
+//
+// The terrace is a full-screen fragment-shader field (domain-warp + per-panel
+// SDF loop + per-worktree colour blend) that redraws on every pan / zoom / drag
+// frame while worktrees are present. These scenarios make it render (2+ live
+// worktrees, panels tagged into them) and then bracket pan / zoom / drag with
+// the shared perf harness, reporting:
+//   - renderer FPS + long tasks (>50ms main-thread blocks = visible jank)
+//   - peak per-process CPU (GPU = the shader cost; Tab = renderer)
+//   - territory draws/sec and the scissor's shaded-vs-full-canvas area ratio
+//     (territoryDraw / territoryScissorKpx / territoryFullKpx, instrumented in
+//     territoryGL.draw under CATE_PERF=1)
+//
+// Thresholds are deliberately GENEROUS — they only catch egregious regressions
+// (sub-20fps drags, multi-second freezes, the terrace silently not rendering).
+// The printed report is the point: it gives before/after numbers for the GL
+// shader cost and proves the scissor clips empty regions.
+//
+// GL is the primary path; if WebGL2 / fragment-highp is unavailable the layer
+// falls back to CPU and the GL-only scissor assertions are skipped (reported).
+//
+// Run:  npm run build && npx playwright test e2e/worktree-territory-perf.spec.ts
+// =============================================================================
+
+import { test, expect } from '@playwright/test'
+import { launchApp, closeApp } from './fixtures/electron-app'
+import type { ElectronApplication, Page } from 'playwright'
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeAll(async () => {
+  ;({ electronApp: app, mainWindow: page } = await launchApp({ perf: true }))
+  await page.waitForFunction(() => typeof window.__catePerf === 'object', { timeout: 15_000 })
+})
+
+test.afterAll(async () => closeApp(app))
+
+// Each scenario seeds its own world; clear the canvas first so node counts and
+// layout don't accumulate across tests (the app instance is shared via beforeAll).
+test.beforeEach(async () => {
+  await page.evaluate(() => { window.__cateE2E!.clearCanvas(); window.__cateE2E!.setZoom(1); window.__cateE2E!.resetViewport() })
+  await page.waitForTimeout(150)
+})
+
+// -----------------------------------------------------------------------------
+// Measurement harness (terrace-focused: adds territory draw/scissor counters and
+// peak GPU/renderer CPU to the FPS + long-task signals).
+// -----------------------------------------------------------------------------
+
+interface TerritoryMeasurement {
+  label: string
+  secs: number
+  fps: number
+  longTasks: { count: number; maxMs: number }
+  /** territoryGL.draw calls over the window. */
+  draws: number
+  drawsPerSec: number
+  /** Mean shaded-area fraction (scissor rect ÷ full canvas) across drawn frames;
+   *  null when nothing drew (CPU fallback / no coverage). 1 = no clipping. */
+  scissorRatio: number | null
+  perProcCpu: Record<string, number>
+  /** Panels actually feeding the terrace (tagged + mounted). The shader's
+   *  per-fragment primitive loop is O(this), NOT O(total seeded) — off-screen
+   *  nodes are culled out, so this is the real shader load. */
+  livePanels: number
+  /** Mounted canvas nodes (DOM) — what the viewport cull left on screen. */
+  mountedNodes: number
+}
+
+async function measureTerritory(
+  label: string,
+  durationMs: number,
+  action: () => Promise<void>,
+): Promise<TerritoryMeasurement> {
+  const before = await page.evaluate(() => ({
+    t: performance.now(),
+    rc: window.__catePerf!.renderCounts(),
+  }))
+  await page.evaluate(() => window.__catePerf!.resetWindow())
+
+  const perProcCpu: Record<string, number> = {}
+  const actionP = action()
+  const polls = Math.max(1, Math.round(durationMs / 400))
+  for (let i = 0; i < polls; i++) {
+    await page.waitForTimeout(400)
+    const snap = await page.evaluate(() => window.electronAPI!.perfGetSnapshot())
+    if (snap) for (const p of snap.procs) perProcCpu[p.type] = Math.max(perProcCpu[p.type] ?? 0, p.cpu)
+  }
+  await actionP
+
+  const after = await page.evaluate(() => ({
+    t: performance.now(),
+    rc: window.__catePerf!.renderCounts(),
+    fps: window.__catePerf!.fps(),
+    longTasks: window.__catePerf!.longTasks(),
+    livePanels: window.__cateE2E!.worktreeDebug().taggedNodes,
+    mountedNodes: document.querySelectorAll('[data-node-id]').length,
+  }))
+
+  const secs = Math.max(0.001, (after.t - before.t) / 1000)
+  const d = (k: string) => (after.rc[k] ?? 0) - (before.rc[k] ?? 0)
+  const draws = d('territoryDraw')
+  const scissorKpx = d('territoryScissorKpx')
+  const fullKpx = d('territoryFullKpx')
+  return {
+    label,
+    secs: Math.round(secs * 10) / 10,
+    fps: after.fps,
+    longTasks: after.longTasks,
+    draws,
+    drawsPerSec: Math.round(draws / secs),
+    scissorRatio: fullKpx > 0 ? Math.round((scissorKpx / fullKpx) * 100) / 100 : null,
+    perProcCpu,
+    livePanels: after.livePanels,
+    mountedNodes: after.mountedNodes,
+  }
+}
+
+function report(m: TerritoryMeasurement): void {
+  const procs = Object.entries(m.perProcCpu).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k} ${v}%`).join('  ')
+  const ratio = m.scissorRatio == null ? 'n/a (no GL draws)' : `${Math.round(m.scissorRatio * 100)}% of canvas`
+  // eslint-disable-next-line no-console
+  console.log([
+    '',
+    `──────── TERRACE PERF: ${m.label}  (${m.secs}s window) ────────`,
+    `  live panels in terrace: ${m.livePanels}    mounted nodes: ${m.mountedNodes}`,
+    `  fps: ${m.fps}    longtasks: ${m.longTasks.count} (max ${Math.round(m.longTasks.maxMs)}ms)`,
+    `  territory draws: ${m.draws} (${m.drawsPerSec}/s)    scissor shaded: ${ratio}`,
+    `  peak cpu by process:  ${procs || '(none)'}`,
+    '────────────────────────────────────────────',
+  ].join('\n'))
+}
+
+// -----------------------------------------------------------------------------
+// Seeding: a worktree "world" — terminals laid on a grid, split across N
+// worktrees, with the terrace engaged.
+// -----------------------------------------------------------------------------
+
+const COLORS = ['#e5484d', '#30a46c', '#0091ff', '#f5a623', '#8e4ec6']
+
+// Stress load: overflow the viewport so the cluster spans more than fits, then
+// zoom out to mount as many as the (small, windowless) e2e viewport allows. The
+// terrace shader only pays for VISIBLE panels — off-screen nodes are culled out
+// of membership — so this caps at whatever the viewport mounts (~10 here), and
+// piling on more seeded panels only adds PTY-spawn cost, not shader load.
+const LOAD = 20
+const GROUPS = 4
+
+/** Seed `count` terminals on a grid (tight `spread:false` cluster, or spread far
+ *  apart), split round-robin across `groups` worktrees with the terrace on. */
+async function seedWorktreeWorld(
+  count: number,
+  groups: number,
+  spread: boolean,
+): Promise<void> {
+  const step = spread ? { x: 900, y: 760 } : { x: 200, y: 170 }
+  const cols = spread ? 3 : 4
+  const ids: string[] = []
+  for (let i = 0; i < count; i++) {
+    const col = i % cols
+    const row = Math.floor(i / cols)
+    const id = await page.evaluate(
+      (p) => window.__cateE2E!.createTerminal(p),
+      { x: 60 + col * step.x, y: 60 + row * step.y },
+    )
+    ids.push(id)
+    await page.waitForSelector(`[data-node-id="${id}"]`, { timeout: 5000 })
+  }
+
+  const worktrees = await page.evaluate(
+    (specs) => window.__cateE2E!.seedWorktrees(specs),
+    Array.from({ length: groups }, (_, i) => ({ color: COLORS[i % COLORS.length], label: `wt-${i}` })),
+  )
+  // Tag each terminal into a worktree round-robin (index 0 = primary).
+  for (let i = 0; i < ids.length; i++) {
+    await page.evaluate(
+      ({ nodeId, wtId }) => window.__cateE2E!.tagNodeWorktree(nodeId, wtId),
+      { nodeId: ids[i], wtId: worktrees[i % worktrees.length].id },
+    )
+  }
+  // Wait for CanvasNode to publish the tags so membership forms 2+ groups.
+  await page.waitForFunction(
+    () => window.__cateE2E!.worktreeDebug().distinctGroups >= 2,
+    undefined,
+    { timeout: 5000 },
+  )
+  await page.waitForTimeout(300)
+}
+
+/** Clear seeded nodes between scenarios so counts/layout don't accumulate. */
+async function resetWorld(): Promise<void> {
+  await page.evaluate(() => {
+    const h = window.__cateE2E!
+    h.setZoom(1)
+    h.resetViewport()
+  })
+}
+
+/** Zoom out + settle so the whole seeded cluster clears the viewport cull and
+ *  mounts — otherwise off-screen panels are culled and never reach the shader,
+ *  so the terrace would only ever render the few panels visible at zoom 1. */
+async function zoomOut(zoom = 0.4): Promise<void> {
+  await page.evaluate((z) => { window.__cateE2E!.setZoom(z); window.__cateE2E!.resetViewport() }, zoom)
+  await page.waitForTimeout(500)
+}
+
+// -----------------------------------------------------------------------------
+// Scenarios
+// -----------------------------------------------------------------------------
+
+test('terrace engages (sanity: 2+ worktrees, many panels feed the shader)', async () => {
+  await seedWorktreeWorld(LOAD, GROUPS, false)
+  await zoomOut()
+  const dbg = await page.evaluate(() => window.__cateE2E!.worktreeDebug())
+  // eslint-disable-next-line no-console
+  console.log(`\n  worktree debug: ${JSON.stringify(dbg)}`)
+  expect(dbg.liveWorktrees).toBeGreaterThanOrEqual(2)
+  expect(dbg.distinctGroups).toBeGreaterThanOrEqual(2)
+  // The territory canvas must be mounted (GL or CPU backend).
+  const hasCanvas = await page.evaluate(
+    () => !!document.querySelector('[data-worktree-territory], [data-worktree-territory-cpu]'),
+  )
+  expect(hasCanvas).toBe(true)
+})
+
+test('terrace pan stress (rAF-driven viewport sweep — redraw every frame)', async () => {
+  await seedWorktreeWorld(LOAD, GROUPS, false)
+  await zoomOut()
+
+  // Drive the viewport offset at rAF cadence from inside the page. Each change
+  // flows canvasStore → the territory layer's onChange → paintGL → draw, so the
+  // shader redraws every pan frame (pan is just a uniform update + one quad).
+  // Programmatic (not wheel) so it's deterministic and faithful even in the
+  // windowless e2e harness, which doesn't reliably route wheel-pan to the canvas.
+  const m = await measureTerritory('terrace pan (90 frames)', 2000, async () => {
+    await page.evaluate(async () => {
+      const h = window.__cateE2E!
+      const raf = () => new Promise((r) => requestAnimationFrame(() => r(null)))
+      for (let i = 0; i < 90; i++) {
+        h.setViewport({ x: Math.round(220 * Math.sin(i / 6)), y: Math.round(160 * Math.cos(i / 9)) })
+        await raf()
+      }
+    })
+  })
+  report(m)
+  await resetWorld()
+  // The terrace must actually be loaded (panels visible), stay interactive, and
+  // keep the shader running.
+  expect(m.livePanels).toBeGreaterThanOrEqual(5)
+  expect(m.fps).toBeGreaterThan(20)
+  expect(m.longTasks.maxMs).toBeLessThan(2000)
+  if (m.draws > 0) expect(m.scissorRatio).not.toBeNull()
+})
+
+test('terrace zoom stress (rAF-driven zoom sweep — setView every frame)', async () => {
+  await seedWorktreeWorld(LOAD, GROUPS, false)
+  await zoomOut()
+
+  // Drive zoomLevel at rAF cadence from inside the page: each change flows
+  // through canvasStore → the territory layer's onChange → paintGL → draw, so
+  // the shader redraws every frame (the full pan/zoom-is-just-a-uniform path).
+  // Sweep in a zoomed-out band (0.2–0.6) so the seeded panels stay mounted and
+  // keep feeding the shader instead of being culled at zoom 1.
+  const m = await measureTerritory('terrace zoom (90 frames)', 2000, async () => {
+    await page.evaluate(async () => {
+      const h = window.__cateE2E!
+      const raf = () => new Promise((r) => requestAnimationFrame(() => r(null)))
+      for (let i = 0; i < 90; i++) {
+        h.setZoom(0.4 + 0.2 * Math.sin(i / 7))
+        await raf()
+      }
+    })
+  })
+  report(m)
+  await resetWorld()
+  expect(m.livePanels).toBeGreaterThanOrEqual(5)
+  expect(m.fps).toBeGreaterThan(20)
+  expect(m.longTasks.maxMs).toBeLessThan(2000)
+})
+
+test('terrace node-move stress (per-frame geometry rebuild + GL re-upload + redraw)', async () => {
+  await seedWorktreeWorld(LOAD, GROUPS, false)
+  await zoomOut()
+  const nodeId = await page.evaluate(() => window.__cateE2E!.nodes()[0]?.id)
+  const start = await page.evaluate((id) => window.__cateE2E!.nodes().find((n) => n.id === id)?.origin, nodeId)
+  if (!nodeId || !start) throw new Error('no seeded node')
+
+  // Moving a node's origin every frame is the hottest terrace path: the content
+  // signature changes each frame, so the layer rebuilds groups, re-uploads the
+  // primitive geometry texture, AND redraws — exactly what a live node-drag costs
+  // (minus the synthetic mouse, which the hidden e2e window doesn't route to the
+  // node). Drives the node in a circle at rAF cadence.
+  const m = await measureTerritory('terrace node-move (90 frames, circular)', 2000, async () => {
+    await page.evaluate(async ({ id, sx, sy }) => {
+      const h = window.__cateE2E!
+      const raf = () => new Promise((r) => requestAnimationFrame(() => r(null)))
+      for (let i = 0; i < 90; i++) {
+        const a = (i / 90) * Math.PI * 2
+        h.moveNode(id, { x: sx + Math.cos(a) * 160, y: sy + Math.sin(a) * 130 })
+        await raf()
+      }
+      h.moveNode(id, { x: sx, y: sy }) // restore
+    }, { id: nodeId, sx: start.x, sy: start.y })
+  })
+  report(m)
+  expect(m.livePanels).toBeGreaterThanOrEqual(5)
+  expect(m.fps).toBeGreaterThan(20)
+  expect(m.longTasks.maxMs).toBeLessThan(2500)
+  if (m.draws > 0) expect(m.scissorRatio).not.toBeNull()
+})
+
+test('scissor clips empty regions (a tiny cluster shades far less than a full-viewport one)', async () => {
+  await seedWorktreeWorld(6, 2, false)
+  await resetWorld()
+
+  // A small programmatic viewport jiggle that forces a handful of GL draws at a
+  // fixed zoom (each setViewport → onChange → paintGL → draw).
+  const jiggle = async () => {
+    await page.evaluate(async () => {
+      const h = window.__cateE2E!
+      const raf = () => new Promise((r) => requestAnimationFrame(() => r(null)))
+      for (let i = 0; i < 24; i++) { h.setViewport({ x: (i % 6) - 3, y: (i % 4) - 2 }); await raf() }
+    })
+  }
+
+  // Zoomed IN so the cluster's terrace spans the viewport → scissor ≈ full.
+  const zoomedIn = await measureTerritory('scissor · cluster fills viewport (zoom 1.6)', 1200, async () => {
+    await page.evaluate(() => { window.__cateE2E!.setZoom(1.6); window.__cateE2E!.resetViewport() })
+    await jiggle()
+  })
+  report(zoomedIn)
+
+  // Zoomed OUT so the same cluster is a small island → scissor clips the empty
+  // surround and shades far fewer pixels.
+  const zoomedOut = await measureTerritory('scissor · cluster is a small island (zoom 0.3)', 1200, async () => {
+    await page.evaluate(() => { window.__cateE2E!.setZoom(0.3); window.__cateE2E!.resetViewport() })
+    await jiggle()
+  })
+  report(zoomedOut)
+  await resetWorld()
+
+  // Only assert the scissor win when the GL backend actually drew (CPU fallback
+  // doesn't scissor and reports no ratio).
+  if (zoomedIn.scissorRatio != null && zoomedOut.scissorRatio != null) {
+    // eslint-disable-next-line no-console
+    console.log(`\n  scissor shaded-area: zoomed-in ${Math.round(zoomedIn.scissorRatio * 100)}%  vs  zoomed-out ${Math.round(zoomedOut.scissorRatio * 100)}%`)
+    // The small island must shade a strictly smaller fraction of the canvas than
+    // the viewport-filling one — that gap IS the fragment work the scissor saved.
+    expect(zoomedOut.scissorRatio).toBeLessThan(zoomedIn.scissorRatio)
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('\n  (CPU territory backend — GL scissor assertion skipped)')
+    test.skip(true, 'GL territory backend unavailable in this environment')
+  }
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   // perf-stress asserts FPS / spawn-rate thresholds that depend on the host's
   // raw speed, so it's a local regression tool, not a CI gate. CI sets
   // E2E_SKIP_PERF=1 to run only the functional (smoke/drag/dock) specs.
-  testIgnore: process.env.E2E_SKIP_PERF ? ['**/perf-stress.spec.ts'] : [],
+  testIgnore: process.env.E2E_SKIP_PERF
+    ? ['**/perf-stress.spec.ts', '**/worktree-territory-perf.spec.ts']
+    : [],
   // Generous per-test cap: the content-search specs do up to two cold-daemon
   // settles (ripgrep spawn) of up to 30s each, which can stack under full-suite
   // load on a busy CI runner.

--- a/src/renderer/canvas/Minimap.tsx
+++ b/src/renderer/canvas/Minimap.tsx
@@ -7,6 +7,7 @@ import { useCanvasStoreContext, useCanvasStoreApi, shallow } from '../stores/Can
 import { useWorkspacePanels, useAppStore } from '../stores/appStore'
 import { useAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
 import { useUIStateStore } from '../stores/uiStateStore'
+import { useWorktreeMembership } from './worktree/useWorktreeMembership'
 
 // Default minimap size lives in DEFAULT_UI_STATE (shared/types); the floating
 // size is restored from ui-state.json.
@@ -56,6 +57,16 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
   // scope `useWorkspacePanels()` reads from, so they line up with the nodes.
   const workspaceId = useAppStore((s) => s.selectedWorkspaceId)
   const agentInfoByPanel = useAgentInfoByPanel(workspaceId)
+  // Worktree membership: which nodes belong to which parallel branch, and in
+  // what color. Empty (no outlines drawn) unless the workspace has 2+ worktrees
+  // — same gate the canvas terrace uses, so the minimap never disagrees.
+  const { groups } = useWorktreeMembership()
+  // nodeId → worktree color, so each node rect can carry its branch color.
+  const nodeColorById = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const g of groups) for (const id of g.nodeIds) map[id] = g.color
+    return map
+  }, [groups])
   const canvasApi = useCanvasStoreApi()
   const minimapRef = useRef<HTMLDivElement>(null)
   // Ref to the viewport indicator div — updated imperatively on pan
@@ -304,6 +315,9 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
         // Show the agent logo when an agent is open in this panel's terminal.
         const agentLogo = agentInfoByPanel[node.panelId]?.logo ?? null
         const iconSize = Math.min(rectW, rectH) - 2
+        // Outline the rect in its worktree color (if any) so each panel reads
+        // as belonging to a branch.
+        const worktreeColor = nodeColorById[node.id]
         return (
           <div
             key={node.id}
@@ -319,6 +333,10 @@ const Minimap: React.FC<MinimapProps> = ({ mode = 'floating' }) => {
               width: rectW,
               height: rectH,
               backgroundColor: themedPanelColor(type),
+              // Worktree color as a 2px ring drawn outside the rect, so it stays
+              // visible without eating into the small panel fill.
+              boxShadow: worktreeColor ? `0 0 0 2px ${worktreeColor}` : undefined,
+              boxSizing: 'border-box',
               borderRadius: 1,
               opacity: 1,
               cursor: 'pointer',

--- a/src/renderer/canvas/worktree/territoryGL.ts
+++ b/src/renderer/canvas/worktree/territoryGL.ts
@@ -24,6 +24,7 @@ import {
 import { OUTER_REACH, INNER_RING, OUTER_A, INNER_EXTRA, buildPrimitives, type BuiltPrimitives } from './territoryGeometry'
 import { POCKET_FILL, type PocketMask } from './territoryPocketMask'
 import type { TerritoryGroup } from './territoryRenderer'
+import { perfCount } from '../../lib/perf/perfClient'
 
 /** GLSL float literal — guarantees a decimal point so ints aren't parsed as int. */
 function glf(n: number): string {
@@ -351,6 +352,12 @@ export function createTerritoryGL(canvas: HTMLCanvasElement): TerritoryGL | null
 
   let deviceW = 1, deviceH = 1
   let disposed = false
+  // Current view + coverage AABB, kept so draw() can scissor the shaded region
+  // to where the territory can actually appear (a full-screen field shader is
+  // otherwise charged for every empty pixel). Bounds are world-space; Infinity
+  // means "no geometry".
+  let vZoom = 1, vOffX = 0, vOffY = 0, vDpr = 1
+  let bMinX = Infinity, bMinY = Infinity, bMaxX = -Infinity, bMaxY = -Infinity
 
   return {
     resize(dw, dh) {
@@ -361,12 +368,15 @@ export function createTerritoryGL(canvas: HTMLCanvasElement): TerritoryGL | null
       gl.uniform2f(loc.viewport, deviceW, deviceH)
     },
     setView(zoom, offX, offY, dpr) {
+      vZoom = zoom; vOffX = offX; vOffY = offY; vDpr = dpr
       gl.useProgram(program)
       gl.uniform1f(loc.zoom, zoom)
       gl.uniform2f(loc.offset, offX, offY)
       gl.uniform1f(loc.dpr, dpr)
     },
     uploadGeometry(built) {
+      bMinX = built.boundsMinX; bMinY = built.boundsMinY
+      bMaxX = built.boundsMaxX; bMaxY = built.boundsMaxY
       gl.useProgram(program)
       gl.uniform1i(loc.primCount, built.count)
       gl.uniform1i(loc.groupCount, built.groupCount)
@@ -397,10 +407,40 @@ export function createTerritoryGL(canvas: HTMLCanvasElement): TerritoryGL | null
       gl.bindTexture(gl.TEXTURE_2D, primTex)
       gl.activeTexture(gl.TEXTURE1)
       gl.bindTexture(gl.TEXTURE_2D, maskTex)
+      // Full-canvas clear first (scissor off), so last frame's territory is erased
+      // everywhere even when this frame's coverage shrinks or moves.
+      gl.disable(gl.SCISSOR_TEST)
       gl.clear(gl.COLOR_BUFFER_BIT)
+      if (!isFinite(bMinX)) return // no geometry — cleared canvas is the result
+
+      // Project the world coverage AABB to device pixels (gl_FragCoord space:
+      // lower-left origin). Mirrors the shader's css→world mapping inverted:
+      //   fragX = (wx·zoom + offX)·dpr
+      //   fragY = deviceH − (wy·zoom + offY)·dpr   (note the y flip)
+      const PAD = 2 // device px — covers fwidth-AA bleed at the scissor edge
+      const x0 = (bMinX * vZoom + vOffX) * vDpr
+      const x1 = (bMaxX * vZoom + vOffX) * vDpr
+      // Larger world-y → smaller fragY, so bMaxY gives the lower scissor edge.
+      const yLo = deviceH - (bMaxY * vZoom + vOffY) * vDpr
+      const yHi = deviceH - (bMinY * vZoom + vOffY) * vDpr
+      const sx = Math.max(0, Math.min(deviceW, Math.floor(x0) - PAD))
+      const sy = Math.max(0, Math.min(deviceH, Math.floor(yLo) - PAD))
+      const sw = Math.max(0, Math.min(deviceW, Math.ceil(x1) + PAD)) - sx
+      const sh = Math.max(0, Math.min(deviceH, Math.ceil(yHi) + PAD)) - sy
+      if (sw <= 0 || sh <= 0) return // coverage is entirely off-screen
+
+      gl.enable(gl.SCISSOR_TEST)
+      gl.scissor(sx, sy, sw, sh)
       gl.bindVertexArray(vao)
       gl.drawArrays(gl.TRIANGLES, 0, 3)
       gl.bindVertexArray(null)
+      gl.disable(gl.SCISSOR_TEST)
+      // Perf instrumentation (no-op unless CATE_PERF=1): draw rate plus shaded
+      // vs full-canvas area in kilopixels, so the e2e perf harness can report
+      // how much fragment work the scissor saved.
+      perfCount('territoryDraw')
+      perfCount('territoryScissorKpx', Math.round((sw * sh) / 1000))
+      perfCount('territoryFullKpx', Math.round((deviceW * deviceH) / 1000))
     },
     dispose() {
       if (disposed) return

--- a/src/renderer/canvas/worktree/territoryGeometry.ts
+++ b/src/renderer/canvas/worktree/territoryGeometry.ts
@@ -119,6 +119,15 @@ export interface BuiltPrimitives {
   /** World origin all coords are relative to (panels' bounding-box min). */
   originX: number
   originY: number
+  /** World-space AABB of the territory's potential coverage — every primitive
+   *  expanded by the field reach (panels by OUTER_REACH+WARP_AMP+SMINK, bridges
+   *  by their cullR). Lets the renderer scissor the draw to where the territory
+   *  can actually appear instead of shading the whole screen. `Infinity` bounds
+   *  mean "no geometry" (nothing to draw). */
+  boundsMinX: number
+  boundsMinY: number
+  boundsMaxX: number
+  boundsMaxY: number
 }
 
 const _primData = new Float32Array(MAX_PRIMITIVES * 8)
@@ -142,6 +151,12 @@ export function buildPrimitives(groups: TerritoryGroup[]): BuiltPrimitives {
 
   const data = _primData
   let count = 0
+  // World-space coverage AABB, accumulated over every emitted primitive so the
+  // renderer can scissor to it. A panel's territory reaches OUTER_REACH past its
+  // rect, the domain warp can push the sampled point another WARP_AMP, and smin
+  // fusion lifts the field by up to SMINK near a junction — pad by their sum.
+  const PANEL_MARGIN = OUTER_REACH + WARP_AMP + SMINK
+  let bMinX = Infinity, bMinY = Infinity, bMaxX = -Infinity, bMaxY = -Infinity
   // Panels first (never dropped); bridges after (dropped first on overflow).
   for (let gi = 0; gi < groupCount; gi++) {
     const c = hexToRgb(groups[gi].color)
@@ -156,6 +171,10 @@ export function buildPrimitives(groups: TerritoryGroup[]): BuiltPrimitives {
       data[o + 2] = rc.x + rc.w - ox; data[o + 3] = rc.y + rc.h - oy
       data[o + 4] = CORNER; data[o + 5] = gi; data[o + 6] = 0; data[o + 7] = 0
       count++
+      if (rc.x - PANEL_MARGIN < bMinX) bMinX = rc.x - PANEL_MARGIN
+      if (rc.y - PANEL_MARGIN < bMinY) bMinY = rc.y - PANEL_MARGIN
+      if (rc.x + rc.w + PANEL_MARGIN > bMaxX) bMaxX = rc.x + rc.w + PANEL_MARGIN
+      if (rc.y + rc.h + PANEL_MARGIN > bMaxY) bMaxY = rc.y + rc.h + PANEL_MARGIN
     }
   }
   for (let gi = 0; gi < groupCount; gi++) {
@@ -168,8 +187,20 @@ export function buildPrimitives(groups: TerritoryGroup[]): BuiltPrimitives {
       data[o + 2] = br.bx - ox; data[o + 3] = br.by - oy
       data[o + 4] = br.radius; data[o + 5] = gi; data[o + 6] = 1; data[o + 7] = 0
       count++
+      // br.cullR already = radius + OUTER_REACH + SMINK + WARP_AMP.
+      const lx = Math.min(br.ax, br.bx) - br.cullR
+      const hx = Math.max(br.ax, br.bx) + br.cullR
+      const ly = Math.min(br.ay, br.by) - br.cullR
+      const hy = Math.max(br.ay, br.by) + br.cullR
+      if (lx < bMinX) bMinX = lx
+      if (ly < bMinY) bMinY = ly
+      if (hx > bMaxX) bMaxX = hx
+      if (hy > bMaxY) bMaxY = hy
     }
   }
 
-  return { data, count, colors: _colorData, dims: _dimData, groupCount, originX: ox, originY: oy }
+  return {
+    data, count, colors: _colorData, dims: _dimData, groupCount, originX: ox, originY: oy,
+    boundsMinX: bMinX, boundsMinY: bMinY, boundsMaxX: bMaxX, boundsMaxY: bMaxY,
+  }
 }

--- a/src/renderer/lib/e2eHarness.ts
+++ b/src/renderer/lib/e2eHarness.ts
@@ -8,13 +8,14 @@
 import { useAppStore } from '../stores/appStore'
 import { useUIStore, type SidebarView } from '../stores/uiStore'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
+import { gitStatusStore, type GitWorktreeEntry } from '../stores/gitStatusStore'
 import { useDragStore } from '../drag/store'
 import { useSearchStore } from '../stores/searchStore'
 import { getLastReveal } from './editor/editorReveal'
 import { applyTheme } from './themeManager'
 import { BUILT_IN_THEMES } from '../../shared/themes'
 import { terminalRegistry } from './terminal/terminalRegistry'
-import type { Point } from '../../shared/types'
+import type { Point, WorktreeMeta } from '../../shared/types'
 
 /** Serializable snapshot of the search store for e2e assertions. */
 export interface SearchSnapshot {
@@ -49,8 +50,38 @@ declare global {
       zoom(): number
       setZoom(z: number): void
       resetViewport(): void
+      /** Set the canvas viewport offset (canvas-space pan), for driving a pan
+       *  sweep deterministically from a test (the windowless e2e harness doesn't
+       *  reliably route wheel-pan to the canvas). */
+      setViewport(offset: Point): void
+      /** Move a node's origin in the canvas store — drives the same per-frame
+       *  geometry-rebuild + redraw path a live node-drag does, without depending
+       *  on synthetic mouse drag working in the hidden window. */
+      moveNode(nodeId: string, origin: Point): void
+      /** Close every panel in the selected workspace (clears the canvas between
+       *  perf scenarios so node counts/layout don't accumulate). */
+      clearCanvas(): void
       addWorkspace(name?: string, rootPath?: string, id?: string): string
       selectWorkspace(id: string): Promise<void>
+      /** Seed N worktrees on the selected workspace (index 0 = primary, keyed by
+       *  the workspace root) WITHOUT a real on-disk repo: writes UI metadata
+       *  (id/color/label) and injects a pinned live `git worktree list` so the
+       *  worktree terrace / minimap outlines render. Returns the seeded records. */
+      seedWorktrees(specs: { color: string; label?: string }[]): { id: string; path: string; color: string }[]
+      /** Tag a terminal/agent node's panel with a worktree id (the real path,
+       *  flowing through CanvasNode → setNodeActiveWorktree). Returns false if the
+       *  node has no resolvable panel. */
+      tagNodeWorktree(nodeId: string, worktreeId: string): boolean
+      /** Inspect the worktree-terrace pipeline for perf-test assertions: how many
+       *  live worktrees, how many nodes are tagged, how many distinct groups they
+       *  form, and whether the GL (vs CPU-fallback) territory backend is active. */
+      worktreeDebug(): {
+        liveWorktrees: number
+        metaWorktrees: number
+        taggedNodes: number
+        distinctGroups: number
+        glActive: boolean
+      }
       /** Resolve the PTY id backing a terminal node (null until the PTY spawns). */
       terminalPtyId(nodeId: string): string | null
       /** Write raw data to a terminal node's PTY (e.g. a flooding command). */
@@ -165,12 +196,90 @@ export function installE2EHarness(): void {
     activeCanvasStore()?.setState({ viewportOffset: { x: 0, y: 0 } })
   }
 
+  const setViewport = (offset: Point) => {
+    activeCanvasStore()?.getState().setViewportOffset(offset)
+  }
+
+  const moveNode = (nodeId: string, origin: Point) => {
+    activeCanvasStore()?.getState().moveNode(nodeId, origin)
+  }
+
+  const clearCanvas = () => {
+    const wsId = useAppStore.getState().selectedWorkspaceId
+    const ws = useAppStore.getState().workspaces.find((w) => w.id === wsId)
+    for (const panelId of Object.keys(ws?.panels ?? {})) {
+      useAppStore.getState().closePanel(wsId, panelId)
+    }
+  }
+
   const addWorkspace = (name?: string, rootPath?: string, id?: string): string => {
     return useAppStore.getState().addWorkspace(name, rootPath, id)
   }
 
   const selectWorkspace = async (id: string): Promise<void> => {
     await useAppStore.getState().selectWorkspace(id)
+  }
+
+  const seedWorktrees = (
+    specs: { color: string; label?: string }[],
+  ): { id: string; path: string; color: string }[] => {
+    const wsId = useAppStore.getState().selectedWorkspaceId
+    const ws = useAppStore.getState().workspaces.find((w) => w.id === wsId)
+    if (!ws) return []
+    // The primary worktree is keyed by the workspace root; synthesize a path if
+    // the e2e workspace has none so useWorktrees has a stable join key.
+    const rootPath = ws.rootPath || `/private/tmp/cate-e2e-wt-${wsId}`
+    const metas: WorktreeMeta[] = specs.map((s, i) => ({
+      id: `wt-e2e-${i}`,
+      path: i === 0 ? rootPath : `${rootPath}/.cate-wt/feature-${i}`,
+      color: s.color,
+      label: s.label,
+    }))
+    // Set the workspace root + worktree metadata in one go (deterministic — no
+    // dependence on ensurePrimaryWorktree / upsert ordering).
+    useAppStore.setState((state) => ({
+      workspaces: state.workspaces.map((w) =>
+        w.id === wsId ? { ...w, rootPath, worktrees: metas } : w,
+      ),
+    }))
+    // Inject the matching live worktree list so membership sees 2+ live (the
+    // metadata alone would all read as orphans and gate the terrace off).
+    const live: GitWorktreeEntry[] = metas.map((m, i) => ({
+      path: m.path,
+      branch: i === 0 ? 'main' : `feature-${i}`,
+      isPrimary: i === 0,
+      isCurrent: i === 0,
+    }))
+    gitStatusStore._seedWorktrees(rootPath, live)
+    return metas.map((m) => ({ id: m.id, path: m.path, color: m.color }))
+  }
+
+  const tagNodeWorktree = (nodeId: string, worktreeId: string): boolean => {
+    const wsId = useAppStore.getState().selectedWorkspaceId
+    const cs = activeCanvasStore()
+    const node = cs?.getState().nodes[nodeId]
+    const panelId = node?.panelId ?? nodeId
+    if (!panelId) return false
+    useAppStore.getState().setPanelWorktreeId(wsId, panelId, worktreeId)
+    return true
+  }
+
+  const worktreeDebug = () => {
+    const wsId = useAppStore.getState().selectedWorkspaceId
+    const ws = useAppStore.getState().workspaces.find((w) => w.id === wsId)
+    const rootPath = ws?.rootPath ?? ''
+    const cs = activeCanvasStore()
+    const tags = cs ? cs.getState().nodeActiveWorktreeId : {}
+    const values = Object.values(tags).filter((v): v is string => !!v)
+    const glCanvas = document.querySelector('[data-worktree-territory]') as HTMLElement | null
+    const glActive = !!glCanvas && getComputedStyle(glCanvas).display !== 'none'
+    return {
+      liveWorktrees: gitStatusStore.getSnapshot(rootPath).worktrees.length,
+      metaWorktrees: ws?.worktrees?.length ?? 0,
+      taggedNodes: values.length,
+      distinctGroups: new Set(values).size,
+      glActive,
+    }
   }
 
   const terminalPtyId = (nodeId: string): string | null => {
@@ -260,8 +369,14 @@ export function installE2EHarness(): void {
     zoom,
     setZoom,
     resetViewport,
+    setViewport,
+    moveNode,
+    clearCanvas,
     addWorkspace,
     selectWorkspace,
+    seedWorktrees,
+    tagNodeWorktree,
+    worktreeDebug,
     terminalPtyId,
     writeTerminal,
     setWorkspaceRoot,

--- a/src/renderer/stores/gitStatusStore.ts
+++ b/src/renderer/stores/gitStatusStore.ts
@@ -96,6 +96,9 @@ interface RootEntry {
   /** Generation guard so a stale in-flight refetch can't clobber a newer one. */
   fetchSeq: number
   disposed: boolean
+  /** Test-only: when set, the live git fetch is suppressed so an injected
+   *  snapshot (gitStatusStore._seedWorktrees) survives focus/fs refreshes. */
+  pinned: boolean
 }
 
 const roots = new Map<string, RootEntry>()
@@ -116,6 +119,7 @@ function getRoot(rootPath: string): RootEntry {
       teardown: null,
       fetchSeq: 0,
       disposed: false,
+      pinned: false,
     }
     roots.set(rootPath, entry)
   }
@@ -169,10 +173,11 @@ async function fetchSnapshot(rootPath: string): Promise<GitStatusSnapshot | null
 /** Refetch and apply a fresh snapshot for this root, guarding against stale
  *  in-flight responses landing after a newer refresh. */
 function refresh(entry: RootEntry): void {
+  if (entry.pinned) return // test-only injected snapshot owns this root
   const seq = ++entry.fetchSeq
   void fetchSnapshot(entry.rootPath)
     .then((snap) => {
-      if (entry.disposed || seq !== entry.fetchSeq || !snap) return
+      if (entry.disposed || entry.pinned || seq !== entry.fetchSeq || !snap) return
       entry.snapshot = { ...snap, revision: entry.snapshot.revision + 1 }
       notify(entry)
     })
@@ -257,6 +262,27 @@ export const gitStatusStore = {
   refresh(rootPath: string): void {
     const entry = roots.get(rootPath)
     if (entry) refresh(entry)
+  },
+
+  /** Test-only: inject a live worktree list for `rootPath` and pin it so the
+   *  real git fetch can't overwrite it. Lets the e2e perf harness make the
+   *  worktree terrace render without a real on-disk repo. Marks the root as a
+   *  repo and notifies subscribers (membership recomputes on the new snapshot). */
+  _seedWorktrees(rootPath: string, worktrees: GitWorktreeEntry[]): void {
+    if (!rootPath) return
+    const entry = getRoot(rootPath)
+    entry.pinned = true
+    entry.snapshot = {
+      isRepo: true,
+      tracked: new Set(),
+      statusFiles: [],
+      branch: worktrees.find((w) => w.isPrimary)?.branch ?? 'main',
+      ahead: 0,
+      behind: 0,
+      worktrees,
+      revision: entry.snapshot.revision + 1,
+    }
+    notify(entry)
   },
 
   /** Test-only: clear all roots and timers. */


### PR DESCRIPTION
## Minimap: color panels by worktree

Each panel rect in the minimap now gets a 2px outline in its worktree color, so you can read which parallel branch a panel belongs to at a glance. Dropped the earlier terrace boxes/labels approach, which was noisy and added an extra git subscription.

## Territory shader: scissor to coverage

The worktree "territory" layer is a full-screen fragment shader that redraws every pan/zoom/drag frame. It now tracks a world-space coverage AABB per geometry build and scissors the draw to it, so empty pixels aren't charged for the per-fragment SDF loop. When the cluster is a small island on screen, this clips most of the canvas.

Adds a `CATE_PERF` draw/scissor instrument and an e2e perf harness (`seedWorktrees` + pan/zoom/move drivers) that drives the shader under load, reports FPS / long tasks / CPU / scissor ratio, and asserts the scissor shades a smaller fraction when zoomed out. Gated out of CI via `E2E_SKIP_PERF` (local regression tool).

## Test

- `npx tsc --noEmit` clean
- `npm run build && npx playwright test e2e/worktree-territory-perf.spec.ts` (local, GL backend)
