### PR TITLE
fix: re-target placement recommendations when active panel changes

### DIFF
--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -343,10 +343,12 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
   const handleWorldClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const target = e.target as HTMLElement
-      // A click that misses every ghost cancels a pending ghost placement.
-      // (Ghosts stopPropagation on their own clicks, so this only fires on a miss.)
+      // During a pending placement: clicking a ghost commits (handled by the ghost
+      // itself), clicking another panel re-targets the recommendations to it (the
+      // node's focus change drives refreshPlacement), and a click on genuinely
+      // empty canvas — neither ghost nor node — cancels.
       if (canvasApi.getState().pendingPlacement) {
-        if (!target.closest('[data-ghost-candidate]')) {
+        if (!target.closest('[data-ghost-candidate]') && !target.closest('[data-node-id]')) {
           canvasApi.getState().cancelPlacement()
         }
         return

--- a/src/renderer/canvas/GhostPlacementLayer.tsx
+++ b/src/renderer/canvas/GhostPlacementLayer.tsx
@@ -14,6 +14,7 @@
 
 import React, { useEffect, useRef } from 'react'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
 
 // Theme accent — ghosts track the active theme's --focus-blue rather than a
 // hardcoded blue, so they recolor with the IDE theme. color-mix gives us a
@@ -35,12 +36,40 @@ function injectStyles() {
 
 const GhostPlacementLayer: React.FC = () => {
   const pending = useCanvasStoreContext((s) => s.pendingPlacement)
+  const focusedId = useCanvasStoreContext((s) => focusedNodeIdOf(s))
   const zoom = useCanvasStoreContext((s) => s.zoomLevel)
   const api = useCanvasStoreApi()
 
   const count = pending?.candidates.length ?? 0
 
   useEffect(injectStyles, [])
+
+  // Re-target the recommendations when the active panel changes mid-placement
+  // (the user clicked a different panel). The candidates were computed for the
+  // focus at beginPlacement; refreshPlacement re-ranks them around the new focus.
+  // We seed the ref with the begin-time focus so this skips that first render and
+  // only fires on an ACTUAL change — otherwise begin's own framing gets re-run.
+  const lastFocus = useRef<string | null>(null)
+  const wasPending = useRef(false)
+  useEffect(() => {
+    if (!pending) {
+      wasPending.current = false
+      return
+    }
+    if (!wasPending.current) {
+      // Placement just opened — candidates already match the current focus.
+      wasPending.current = true
+      lastFocus.current = focusedId
+      return
+    }
+    if (focusedId !== lastFocus.current) {
+      lastFocus.current = focusedId
+      // Clicking a panel briefly deselects (selectNodes clears the active flag)
+      // before focusNode re-activates it — skip that transient null so the camera
+      // doesn't jump to a viewport-ranked frame and straight back.
+      if (focusedId !== null) api.getState().refreshPlacement()
+    }
+  }, [pending, focusedId, api])
 
   // Keyboard: digits / Enter commit, F arms free placement, Esc cancels.
   useEffect(() => {

--- a/src/renderer/stores/canvas/placementSlice.test.ts
+++ b/src/renderer/stores/canvas/placementSlice.test.ts
@@ -135,6 +135,69 @@ describe('beginPlacement', () => {
   })
 })
 
+describe('refreshPlacement (re-target on focus change)', () => {
+  // Two panels both kept on-screen so the picker can cluster around whichever is
+  // focused. Mirrors the real bug: ghosts are pending around A, the user clicks B.
+  const ROOMY = { width: 2400, height: 1600 }
+  const VIEW = { zoom: 1, offset: { x: 600, y: 500 } } // A and B both visible
+  function storeWithTwo() {
+    const store = createCanvasStore()
+    store.getState().setContainerSize(ROOMY)
+    const a = store.getState().addNode('a', 'terminal', { x: 0, y: 0 }, SEED_SIZE)
+    const b = store.getState().addNode('b', 'terminal', { x: 900, y: 0 }, SEED_SIZE)
+    store.getState().setZoomAndOffset(VIEW.zoom, VIEW.offset)
+    return { store, a, b }
+  }
+  const distTo = (c: { point: { x: number; y: number }; size: { width: number; height: number } }, cx: number, cy: number) =>
+    Math.hypot(c.point.x + c.size.width / 2 - cx, c.point.y + c.size.height / 2 - cy)
+
+  it('recomputes candidates around the newly focused node, preserving the transaction', () => {
+    const { store, a, b } = storeWithTwo()
+    store.getState().focusNode(a)
+    store.getState().beginPlacement('p3', 'terminal')
+    const pendingA = store.getState().pendingPlacement!
+    const bestA = pendingA.candidates[0]
+
+    // Reproduce the click on B: restore the user's view (both panels visible),
+    // then focus B and let the focus-change refresh run.
+    store.getState().setZoomAndOffset(VIEW.zoom, VIEW.offset)
+    store.getState().focusNode(b)
+    store.getState().refreshPlacement()
+
+    const pendingB = store.getState().pendingPlacement!
+    // The transaction itself is preserved — only the candidates re-target.
+    expect(pendingB.panelId).toBe('p3')
+    expect(pendingB.prevZoom).toBe(pendingA.prevZoom)
+    expect(pendingB.prevOffset).toEqual(pendingA.prevOffset)
+    expect(pendingB.hoveredIndex).toBeNull()
+    // The best ghost now hugs B (center 1220,200), not A (center 320,200).
+    const bestB = pendingB.candidates[0]
+    expect(bestB.point).not.toEqual(bestA.point)
+    expect(distTo(bestB, 1220, 200)).toBeLessThan(distTo(bestA, 1220, 200))
+    // No node was created by the re-target.
+    expect(nodeCount(store)).toBe(2)
+  })
+
+  it('is a no-op when no placement is pending', () => {
+    const { store } = storeWithTwo()
+    store.getState().refreshPlacement()
+    expect(store.getState().pendingPlacement).toBeNull()
+    expect(nodeCount(store)).toBe(2)
+  })
+
+  it('does not disturb an armed free placement', () => {
+    const { store, a } = storeWithTwo()
+    store.getState().focusNode(a)
+    store.getState().beginPlacement('p3', 'terminal')
+    store.getState().setFreeArmed(true)
+    const before = store.getState().pendingPlacement!
+
+    store.getState().refreshPlacement()
+
+    expect(store.getState().pendingPlacement).toBe(before) // untouched while armed
+  })
+})
+
 describe('commitPlacement', () => {
   it('places the node exactly once at the chosen candidate, restores zoom, and recentres on the node', () => {
     const { store } = storeWithSeed(1.5, { x: 120, y: -40 })

--- a/src/renderer/stores/canvas/placementSlice.ts
+++ b/src/renderer/stores/canvas/placementSlice.ts
@@ -4,11 +4,11 @@
 // click-anywhere, or cancel). The latest pointer position lives on ctx.
 // =============================================================================
 
-import type { Rect } from '../../../shared/types'
+import type { Rect, Point, Size, PanelType } from '../../../shared/types'
 import { ZOOM_MIN, ZOOM_MAX, PANEL_DEFAULT_SIZES } from '../../../shared/types'
 import { viewToCanvas as viewToCanvasCoords } from '../../lib/canvas/coordinates'
-import { recommendPlacements, nudgeToFree, type PlacementTrace } from '../../canvas/placement'
-import type { CanvasGet, CanvasSet, CanvasStoreActions } from './storeTypes'
+import { recommendPlacements, nudgeToFree, type PlacementTrace, type PlacementCandidate } from '../../canvas/placement'
+import type { CanvasGet, CanvasSet, CanvasStoreActions, CanvasStoreState } from './storeTypes'
 import type { CanvasStoreCtx } from './storeCtx'
 import { focusedNodeId } from './selectionModel'
 
@@ -16,6 +16,7 @@ type PlacementActions = Pick<
   CanvasStoreActions,
   | 'setPlacementPointer'
   | 'beginPlacement'
+  | 'refreshPlacement'
   | 'commitPlacement'
   | 'setFreeArmed'
   | 'updatePlacementCursor'
@@ -23,6 +24,65 @@ type PlacementActions = Pick<
   | 'cancelPlacement'
   | 'setPlacementHover'
 >
+
+// Dev-only: a fresh trace object the placement algorithm fills in, so the viz
+// overlay (Cmd/Ctrl+Shift+G) can render the REAL spots. Undefined in prod, so no
+// allocation and the trace path costs nothing.
+function buildTrace(): PlacementTrace | undefined {
+  const isDev = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV
+  return isDev
+    ? { area: { origin: { x: 0, y: 0 }, size: { width: 0, height: 0 } }, rankAt: { x: 0, y: 0 }, inflated: [], guides: { xs: [], ys: [] }, steps: [] }
+    : undefined
+}
+
+// Recommend spots for the current focus + viewport. Shared by the initial
+// beginPlacement and the focus-change refreshPlacement so both rank identically.
+function computeCandidates(
+  state: CanvasStoreState,
+  ctx: CanvasStoreCtx,
+  panelType: PanelType,
+  nodeSize: Size,
+  trace: PlacementTrace | undefined,
+): PlacementCandidate[] {
+  return recommendPlacements(
+    state.nodes,
+    focusedNodeId(state),
+    panelType,
+    { offset: state.viewportOffset, zoom: state.zoomLevel, containerSize: state.containerSize },
+    ctx.lastPointerCanvasPos,
+    undefined,
+    nodeSize,
+    trace,
+  )
+}
+
+// Camera that frames every recommendation plus the focused node for context.
+// Only ever zooms OUT from the current zoom — never further in.
+function fitCamera(state: CanvasStoreState, candidates: PlacementCandidate[]): { zoom: number; offset: Point } {
+  let nextZoom = state.zoomLevel
+  let nextOffset = state.viewportOffset
+  const cs = state.containerSize
+  if (cs.width > 0 && cs.height > 0) {
+    const rects: Rect[] = candidates.map((c) => ({ origin: c.point, size: c.size }))
+    const focusedId = focusedNodeId(state)
+    const focused = focusedId ? state.nodes[focusedId] : null
+    if (focused) rects.push({ origin: focused.origin, size: focused.size })
+    const minX = Math.min(...rects.map((r) => r.origin.x))
+    const minY = Math.min(...rects.map((r) => r.origin.y))
+    const maxX = Math.max(...rects.map((r) => r.origin.x + r.size.width))
+    const maxY = Math.max(...rects.map((r) => r.origin.y + r.size.height))
+    const padding = 80
+    const contentW = maxX - minX + padding * 2
+    const contentH = maxY - minY + padding * 2
+    const fitZoom = Math.min(cs.width / contentW, cs.height / contentH)
+    nextZoom = Math.min(Math.max(Math.min(state.zoomLevel, fitZoom), ZOOM_MIN), ZOOM_MAX)
+    nextOffset = {
+      x: (cs.width - contentW * nextZoom) / 2 - (minX - padding) * nextZoom,
+      y: (cs.height - contentH * nextZoom) / 2 - (minY - padding) * nextZoom,
+    }
+  }
+  return { zoom: nextZoom, offset: nextOffset }
+}
 
 export function createPlacementSlice(set: CanvasSet, get: CanvasGet, ctx: CanvasStoreCtx): PlacementActions {
   return {
@@ -57,49 +117,13 @@ export function createPlacementSlice(set: CanvasSet, get: CanvasGet, ctx: Canvas
         get().focusAndCenter(nodeId)
         return true
       }
-      // Dev-only: capture the algorithm's reasoning so the placement-viz overlay
-      // (Cmd/Ctrl+Shift+G) can render the REAL spots. Stays undefined in prod, so
-      // no object is allocated and the trace path costs nothing.
-      const isDev = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV
-      const trace: PlacementTrace | undefined = isDev
-        ? { area: { origin: { x: 0, y: 0 }, size: { width: 0, height: 0 } }, rankAt: { x: 0, y: 0 }, inflated: [], guides: { xs: [], ys: [] }, steps: [] }
-        : undefined
-      const candidates = recommendPlacements(
-        state.nodes,
-        focusedNodeId(state),
-        panelType,
-        { offset: state.viewportOffset, zoom: state.zoomLevel, containerSize: state.containerSize },
-        ctx.lastPointerCanvasPos,
-        undefined,
-        nodeSize,
-        trace,
-      )
+      const trace = buildTrace()
+      const candidates = computeCandidates(state, ctx, panelType, nodeSize, trace)
       if (candidates.length === 0) return false
 
       // Zoom out so every recommendation (plus the focused node for context) is
       // visible at once. Only ever zoom OUT — never further in.
-      let nextZoom = state.zoomLevel
-      let nextOffset = state.viewportOffset
-      const cs = state.containerSize
-      if (cs.width > 0 && cs.height > 0) {
-        const rects: Rect[] = candidates.map((c) => ({ origin: c.point, size: c.size }))
-        const focusedId = focusedNodeId(state)
-        const focused = focusedId ? state.nodes[focusedId] : null
-        if (focused) rects.push({ origin: focused.origin, size: focused.size })
-        const minX = Math.min(...rects.map((r) => r.origin.x))
-        const minY = Math.min(...rects.map((r) => r.origin.y))
-        const maxX = Math.max(...rects.map((r) => r.origin.x + r.size.width))
-        const maxY = Math.max(...rects.map((r) => r.origin.y + r.size.height))
-        const padding = 80
-        const contentW = maxX - minX + padding * 2
-        const contentH = maxY - minY + padding * 2
-        const fitZoom = Math.min(cs.width / contentW, cs.height / contentH)
-        nextZoom = Math.min(Math.max(Math.min(state.zoomLevel, fitZoom), ZOOM_MIN), ZOOM_MAX)
-        nextOffset = {
-          x: (cs.width - contentW * nextZoom) / 2 - (minX - padding) * nextZoom,
-          y: (cs.height - contentH * nextZoom) / 2 - (minY - padding) * nextZoom,
-        }
-      }
+      const { zoom, offset } = fitCamera(state, candidates)
 
       set({
         pendingPlacement: {
@@ -115,10 +139,31 @@ export function createPlacementSlice(set: CanvasSet, get: CanvasGet, ctx: Canvas
           prevOffset: state.viewportOffset,
           onCancelled,
         },
-        zoomLevel: nextZoom,
-        viewportOffset: nextOffset,
+        zoomLevel: zoom,
+        viewportOffset: offset,
       })
       return true
+    },
+
+    refreshPlacement() {
+      const state = get()
+      const pending = state.pendingPlacement
+      if (!pending) return
+      // Free "place anywhere" mode owns the camera and the cursor ghost — leave it
+      // alone; re-ranking ghosts under the user mid-drag would be disorienting.
+      if (pending.freeArmed) return
+      // Re-rank around whatever is focused NOW (the user clicked another panel) and
+      // re-frame the camera, but keep the open transaction: same panel, same
+      // original-viewport snapshot to restore on cancel/commit.
+      const trace = buildTrace()
+      const candidates = computeCandidates(state, ctx, pending.panelType, pending.size, trace)
+      if (candidates.length === 0) return
+      const { zoom, offset } = fitCamera(state, candidates)
+      set({
+        pendingPlacement: { ...pending, candidates, hoveredIndex: null, trace },
+        zoomLevel: zoom,
+        viewportOffset: offset,
+      })
     },
 
     commitPlacement(index) {

--- a/src/renderer/stores/canvas/storeTypes.ts
+++ b/src/renderer/stores/canvas/storeTypes.ts
@@ -143,6 +143,10 @@ export interface CanvasStoreActions {
     onCancelled?: (panelId: string) => void,
     size?: Size,
   ) => boolean
+  /** Re-rank the pending placement's ghosts around whatever node is focused NOW
+   *  (the user clicked a different panel) and re-frame the camera, keeping the
+   *  open transaction. No-op when nothing is pending or free mode is armed. */
+  refreshPlacement: () => void
   /** Commit the pending placement at the given candidate index; returns the new node id. */
   commitPlacement: (index: number) => CanvasNodeId | null
   /** Arm/disarm free "place anywhere" mode (press F). Disarming clears the ghost. */


### PR DESCRIPTION
## Problem

The ghost placement picker recommends spots around the **active panel**, but clicking a different panel mid-placement didn't update the recommendations. Two issues:

1. The candidates were computed **once** in `beginPlacement` and frozen into `pendingPlacement` — nothing recomputed them on focus change.
2. Worse, a node's `onClick` doesn't `stopPropagation`, so clicking another panel bubbled to the canvas world-click handler, which **cancelled the whole placement** because the target wasn't a ghost.

## Fix

- **`placementSlice.ts`** — extracted candidate computation + camera fit into shared helpers (`buildTrace` / `computeCandidates` / `fitCamera`) and added a new **`refreshPlacement()`** action. It re-ranks the ghosts around the currently focused node and re-frames the camera while preserving the open transaction (panel id + original-viewport snapshot for cancel/commit). No-op while idle or while free "place anywhere" mode is armed.
- **`Canvas.tsx`** — `handleWorldClick` now only cancels a pending placement on a click that hits **neither a ghost nor an existing node**, so clicking another panel re-targets instead of cancelling.
- **`GhostPlacementLayer.tsx`** — calls `refreshPlacement()` on active-panel change, seeding the focus ref from begin time (so begin's own framing isn't re-run) and skipping the transient `null` focus that `selectNodes` emits before `focusNode` re-activates (avoids a camera jump).

## Tests

- Added 3 tests for `refreshPlacement` (re-targets to the newly focused node preserving the transaction; no-op when idle; doesn't disturb armed free mode), written test-first.
- Full suite: 1749 passed, 1 skipped. `tsc --noEmit` clean. ESLint clean (no new warnings).