### PR TITLE
Detect git repos in workspace subfolders (multi-repo Source Control)

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -16,6 +16,7 @@ import { createVcsCapability } from '../../runtime/capabilities/vcs'
 import { getShellEnv } from '../shellEnv'
 import {
   GIT_IS_REPO,
+  GIT_FIND_REPOS,
   GIT_INIT,
   GIT_LS_FILES,
   GIT_STATUS,
@@ -134,6 +135,17 @@ export function registerHandlers(): void {
 
   // Hand-written: these re-encode/decode the locator (runtimeId + formatLocator
   // / worktreeTargetPath) and so are NOT exact pass-throughs.
+
+  // findRepos returns runtime-absolute repo paths; re-encode each as a locator
+  // on the same runtime so the renderer can hand them straight back to the git
+  // IPC (which parses a locator off every cwd argument), exactly like the
+  // worktree list below.
+  ipcMain.handle(GIT_FIND_REPOS, async (_event, cwd: string, maxDepth?: number) => {
+    const { vcs, path, runtimeId } = vcsFor(cwd)
+    const repos = await vcs.findRepos(path, maxDepth)
+    return repos.map((repoPath) => formatLocator({ runtimeId, path: repoPath }))
+  })
+
   ipcMain.handle(GIT_WORKTREE_LIST, async (_event, cwd: string) => {
     const { vcs, path, runtimeId } = vcsFor(cwd)
     const worktrees = await vcs.worktreeList(path)

--- a/src/main/runtime/DeferredRuntime.ts
+++ b/src/main/runtime/DeferredRuntime.ts
@@ -107,6 +107,7 @@ export class DeferredRuntime implements Runtime {
 
     this.vcs = {
       isRepo: (dir) => d((c) => c.vcs.isRepo(dir)),
+      findRepos: (dir, maxDepth) => d((c) => c.vcs.findRepos(dir, maxDepth)),
       init: (dir) => d((c) => c.vcs.init(dir)),
       lsFiles: (dir) => d((c) => c.vcs.lsFiles(dir)),
       status: (cwd) => d((c) => c.vcs.status(cwd)),

--- a/src/main/runtime/RemoteRuntime.ts
+++ b/src/main/runtime/RemoteRuntime.ts
@@ -187,6 +187,7 @@ export class RemoteRuntime implements Runtime {
 
     this.vcs = {
       isRepo: (dir) => call<boolean>(Methods.vcsIsRepo, [dir]),
+      findRepos: (dir, maxDepth) => call<string[]>(Methods.vcsFindRepos, [dir, maxDepth]),
       init: (dir) => call<void>(Methods.vcsInit, [dir]),
       lsFiles: (dir) => call<string[]>(Methods.vcsLsFiles, [dir]),
       status: (cwd) => call<GitStatusResult>(Methods.vcsStatus, [cwd]),

--- a/src/main/runtime/runtime-loopback.test.ts
+++ b/src/main/runtime/runtime-loopback.test.ts
@@ -137,6 +137,20 @@ describe('runtime loopback (real daemon capabilities over the wire)', () => {
     expect(status.files.some((f) => f.path === 'alpha.ts')).toBe(true)
   })
 
+  test('vcs.findRepos discovers sub-repos one level down over the wire', async () => {
+    const { remote } = loopback(daemonApi())
+    // rootDir itself is not a repo; two children are, one plain folder is not.
+    await fs.mkdir(path.join(rootDir, 'frontend'))
+    await fs.mkdir(path.join(rootDir, 'backend'))
+    await remote.vcs.init(path.join(rootDir, 'frontend'))
+    await remote.vcs.init(path.join(rootDir, 'backend'))
+    // `sub` (created in beforeEach) stays a non-repo folder.
+    const repos = await remote.vcs.findRepos(rootDir)
+    expect(repos.sort()).toEqual(
+      [path.join(rootDir, 'backend'), path.join(rootDir, 'frontend')].sort(),
+    )
+  })
+
   test('write through the wire then read it back', async () => {
     const { remote } = loopback(daemonApi())
     const target = path.join(rootDir, 'written.txt')

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -297,6 +297,9 @@ export interface PrSummary {
 // relocatable.
 export interface VcsHost {
   isRepo(dir: string): Promise<boolean>
+  /** Discover git repos at or below `dir`, scanning at most `maxDepth` levels
+   *  (default 1) and stopping at each repo it finds. Returns absolute paths. */
+  findRepos(dir: string, maxDepth?: number): Promise<string[]>
   init(dir: string): Promise<void>
   lsFiles(dir: string): Promise<string[]>
   status(cwd: string): Promise<GitStatusResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,6 +24,7 @@ import {
   FS_WATCH_EVENT,
   FS_STAT,
   GIT_IS_REPO,
+  GIT_FIND_REPOS,
   GIT_INIT,
   GIT_LS_FILES,
   GIT_BRANCH_UPDATE,
@@ -345,6 +346,7 @@ const invokeForwarders = {
 
   // Git
   gitIsRepo: makeInvoker<'gitIsRepo'>(GIT_IS_REPO),
+  gitFindRepos: makeInvoker<'gitFindRepos'>(GIT_FIND_REPOS),
   gitInit: makeInvoker<'gitInit'>(GIT_INIT),
   gitLsFiles: makeInvoker<'gitLsFiles'>(GIT_LS_FILES),
   gitStatus: makeInvoker<'gitStatus'>(GIT_STATUS),

--- a/src/renderer/sidebar/SourceControlView.tsx
+++ b/src/renderer/sidebar/SourceControlView.tsx
@@ -24,6 +24,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { useGitStatusSnapshot, gitStatusStore } from '../stores/gitStatusStore'
 import { useWorktrees } from '../stores/useWorktrees'
 import { errorMessage } from '../lib/errorMessage'
+import { parseLocator } from '../../main/runtime/locator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -71,6 +72,16 @@ function dirName(path: string): string {
   const parts = path.split('/')
   parts.pop()
   return parts.join('/')
+}
+
+/** Last path segment of a rootPath, for the nested-mode section header.
+ *  rootPath may be a locator (`cate-runtime://<id>/<path>`) for a remote
+ *  workspace, so decode it before taking the basename. */
+function repoDisplayName(rootPath: string): string {
+  let p = rootPath
+  try { p = parseLocator(rootPath).path } catch { /* already a plain path */ }
+  const segs = p.split(/[/\\]/).filter(Boolean)
+  return segs[segs.length - 1] || p
 }
 
 function statusColor(status: string): string {
@@ -382,14 +393,20 @@ const BranchPicker: React.FC<{
 }
 
 // ---------------------------------------------------------------------------
-// SourceControlView
+// RepoSourceControl — the full single-repo view (staged/changes/branches/log/
+// worktrees + commit box). Rendered standalone when the workspace root is
+// itself a repo, or once per discovered repo (nested) in a multi-repo
+// workspace. `nested` swaps the "Source Control" panel header for a
+// collapsible section headed by the repo's folder name.
 // ---------------------------------------------------------------------------
 
-interface SourceControlViewProps {
+interface RepoSourceControlProps {
   rootPath: string
+  nested?: boolean
 }
 
-export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }) => {
+const RepoSourceControl: React.FC<RepoSourceControlProps> = ({ rootPath, nested = false }) => {
+  const [sectionOpen, setSectionOpen] = useState(true)
   // status + worktrees come from the single per-workspace gitStatusStore (the
   // shared fsWatch + focus + branch-update loop). The Source Control list can
   // therefore no longer disagree with the Explorer / Search git tints. Only the
@@ -607,6 +624,8 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
     )
   }
 
+  const repoName = repoDisplayName(rootPath)
+
   const branchSubtitle = (
     <span className="flex items-center gap-1.5">
       <GitBranch size={11} className="text-muted flex-shrink-0" />
@@ -620,37 +639,59 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
     </span>
   )
 
-  return (
-    <div className="flex flex-col h-full overflow-hidden text-[12px]">
-      <SidebarSectionHeader
-        title="Source Control"
-        subtitle={branchSubtitle}
-        actions={
-          <>
-            <Tooltip label="Fetch from remote">
-              <SidebarHeaderButton onClick={fetch_} aria-label="Fetch from remote" disabled={fetching} spinning={fetching}>
-                <Download size={12} />
-              </SidebarHeaderButton>
-            </Tooltip>
-            <Tooltip label="Pull from remote">
-              <SidebarHeaderButton onClick={pull} aria-label="Pull from remote" disabled={pulling}>
-                <ArrowDown size={12} />
-              </SidebarHeaderButton>
-            </Tooltip>
-            <Tooltip label="Push to remote">
-              <SidebarHeaderButton onClick={push} aria-label="Push to remote" disabled={pushing}>
-                <ArrowUp size={12} />
-              </SidebarHeaderButton>
-            </Tooltip>
-            <Tooltip label="Refresh status">
-              <SidebarHeaderButton onClick={refresh} aria-label="Refresh status" spinning={loading}>
-                <ArrowClockwise size={12} />
-              </SidebarHeaderButton>
-            </Tooltip>
-          </>
-        }
-      />
+  const headerActions = (
+    <>
+      <Tooltip label="Fetch from remote">
+        <SidebarHeaderButton onClick={fetch_} aria-label="Fetch from remote" disabled={fetching} spinning={fetching}>
+          <Download size={12} />
+        </SidebarHeaderButton>
+      </Tooltip>
+      <Tooltip label="Pull from remote">
+        <SidebarHeaderButton onClick={pull} aria-label="Pull from remote" disabled={pulling}>
+          <ArrowDown size={12} />
+        </SidebarHeaderButton>
+      </Tooltip>
+      <Tooltip label="Push to remote">
+        <SidebarHeaderButton onClick={push} aria-label="Push to remote" disabled={pushing}>
+          <ArrowUp size={12} />
+        </SidebarHeaderButton>
+      </Tooltip>
+      <Tooltip label="Refresh status">
+        <SidebarHeaderButton onClick={refresh} aria-label="Refresh status" spinning={loading}>
+          <ArrowClockwise size={12} />
+        </SidebarHeaderButton>
+      </Tooltip>
+    </>
+  )
 
+  // In nested (multi-repo) mode the whole repo body collapses under a header
+  // labelled with the repo's folder name; standalone keeps the full panel.
+  const bodyVisible = !nested || sectionOpen
+
+  return (
+    <div className={nested ? 'flex flex-col text-[12px]' : 'flex flex-col h-full overflow-hidden text-[12px]'}>
+      {nested ? (
+        <div
+          className="flex items-center gap-1 px-2 py-1 text-[11px] font-medium text-muted cursor-pointer hover:bg-hover select-none"
+          onClick={() => setSectionOpen((v) => !v)}
+        >
+          {sectionOpen ? <CaretDown size={12} /> : <CaretRight size={12} />}
+          <span className="truncate text-secondary flex-shrink-0 max-w-[45%]">{repoName}</span>
+          <span className="flex-1 min-w-0 font-normal normal-case">{branchSubtitle}</span>
+          <div className="flex items-center gap-0.5 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+            {headerActions}
+          </div>
+        </div>
+      ) : (
+        <SidebarSectionHeader
+          title="Source Control"
+          subtitle={branchSubtitle}
+          actions={headerActions}
+        />
+      )}
+
+      {bodyVisible && (
+      <>
       {/* Error banner */}
       {actionError && (
         <div className="flex items-center gap-1 px-2 py-1 bg-red-500/[0.1] text-red-400/80 text-[11px] flex-shrink-0">
@@ -708,8 +749,9 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
         </div>
       </div>
 
-      {/* Scrollable file sections */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* File sections — the standalone panel scrolls here; nested repos flow
+          into the wrapper's shared scroll container instead. */}
+      <div className={nested ? '' : 'flex-1 min-h-0 overflow-y-auto'}>
         {/* Staged Changes */}
         <Section
           title="Staged Changes"
@@ -850,6 +892,78 @@ export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }
             No changes detected
           </div>
         )}
+      </div>
+      </>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SourceControlView — public entry. Discovers the git repos in the workspace
+// and renders the single-repo view directly when the root itself is a repo (or
+// exactly one repo lives under it, or none is found), or a stacked, collapsible
+// section per repo when the root is a multi-repo parent folder (issue #400).
+// ---------------------------------------------------------------------------
+
+interface SourceControlViewProps {
+  rootPath: string
+}
+
+export const SourceControlView: React.FC<SourceControlViewProps> = ({ rootPath }) => {
+  // null = discovery hasn't resolved yet; render the single view meanwhile so
+  // the common (root-is-a-repo) case never flashes an intermediate layout.
+  const [repos, setRepos] = useState<string[] | null>(null)
+
+  useEffect(() => {
+    if (!rootPath) {
+      setRepos(null)
+      return
+    }
+    let cancelled = false
+    const discover = (): void => {
+      window.electronAPI
+        .gitFindRepos(rootPath)
+        .then((found) => { if (!cancelled) setRepos(found) })
+        .catch(() => { if (!cancelled) setRepos([]) })
+    }
+    discover()
+    // Re-scan on focus so a repo created/removed in a subfolder while the app
+    // was backgrounded appears without reopening the workspace. The scan is a
+    // cheap depth-1 directory read.
+    window.addEventListener('focus', discover)
+    return () => {
+      cancelled = true
+      window.removeEventListener('focus', discover)
+    }
+  }, [rootPath])
+
+  if (!rootPath) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted text-xs p-4">
+        No folder open
+      </div>
+    )
+  }
+
+  // Single-repo — the common case: root is the repo, one repo sits below it, or
+  // nothing was discovered (yet / at all). Render the full panel as before,
+  // targeting the discovered repo when it differs from the workspace root.
+  if (repos === null || repos.length <= 1) {
+    return <RepoSourceControl rootPath={repos && repos.length === 1 ? repos[0] : rootPath} />
+  }
+
+  // Multi-repo parent folder: one collapsible section per repo.
+  return (
+    <div className="flex flex-col h-full overflow-hidden text-[12px]">
+      <SidebarSectionHeader
+        title="Source Control"
+        subtitle={<span className="text-muted">{repos.length} repositories</span>}
+      />
+      <div className="flex-1 min-h-0 overflow-y-auto divide-y divide-subtle">
+        {repos.map((repo) => (
+          <RepoSourceControl key={repo} rootPath={repo} nested />
+        ))}
       </div>
     </div>
   )

--- a/src/runtime/capabilities/vcs.findRepos.test.ts
+++ b/src/runtime/capabilities/vcs.findRepos.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { createVcsCapability } from './vcs'
+
+// findRepos scans a directory a bounded depth down and returns the paths that
+// are git repos, without descending into the repos it finds (or into
+// node_modules and similar heavy dirs). Temp dirs live under os.tmpdir(), which
+// pathValidation always allows, so no allowed-root wiring is needed here.
+
+const vcs = createVcsCapability({ env: () => process.env })
+
+async function mkGitRepo(dir: string): Promise<void> {
+  await fs.mkdir(path.join(dir, '.git'), { recursive: true })
+}
+
+describe('vcs.findRepos', () => {
+  let root: string
+
+  beforeEach(async () => {
+    // Use the mkdtemp path as-is (not realpath'd): pathValidation allows paths
+    // under path.resolve(os.tmpdir()), and on macOS realpath would rewrite the
+    // /var → /private/var symlink and fall outside that allowed prefix.
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-findrepos-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  test('returns the root itself when it is a repo, without scanning children', async () => {
+    await mkGitRepo(root)
+    await mkGitRepo(path.join(root, 'nested'))
+    const repos = await vcs.findRepos(root)
+    expect(repos).toEqual([root])
+  })
+
+  test('finds repos one level down and skips non-repo folders', async () => {
+    await mkGitRepo(path.join(root, 'frontend'))
+    await mkGitRepo(path.join(root, 'backend'))
+    await fs.mkdir(path.join(root, 'docs'), { recursive: true })
+    const repos = await vcs.findRepos(root)
+    expect(repos.sort()).toEqual(
+      [path.join(root, 'backend'), path.join(root, 'frontend')].sort(),
+    )
+  })
+
+  test('does not descend into a found repo (nested repos are ignored at default depth)', async () => {
+    await mkGitRepo(path.join(root, 'frontend'))
+    await mkGitRepo(path.join(root, 'frontend', 'vendor'))
+    const repos = await vcs.findRepos(root)
+    expect(repos).toEqual([path.join(root, 'frontend')])
+  })
+
+  test('skips node_modules and dot-directories', async () => {
+    await mkGitRepo(path.join(root, 'node_modules', 'somepkg'))
+    await mkGitRepo(path.join(root, '.cache', 'thing'))
+    const repos = await vcs.findRepos(root)
+    expect(repos).toEqual([])
+  })
+
+  test('returns an empty list when nothing is a repo', async () => {
+    await fs.mkdir(path.join(root, 'docs'), { recursive: true })
+    await fs.mkdir(path.join(root, 'assets'), { recursive: true })
+    expect(await vcs.findRepos(root)).toEqual([])
+  })
+
+  test('respects a deeper maxDepth', async () => {
+    await mkGitRepo(path.join(root, 'group', 'app'))
+    expect(await vcs.findRepos(root, 1)).toEqual([])
+    expect(await vcs.findRepos(root, 2)).toEqual([path.join(root, 'group', 'app')])
+  })
+})

--- a/src/runtime/capabilities/vcs.ts
+++ b/src/runtime/capabilities/vcs.ts
@@ -76,6 +76,37 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
     }
   }
 
+  // Directory names we never descend into while scanning for sub-repos: heavy
+  // build/vendor output that can't itself be a workspace repo we'd surface.
+  // (Repos we DO find are never descended into either — see findReposFrom.)
+  const SCAN_SKIP_DIRS = new Set([
+    'node_modules', 'dist', 'build', 'out', 'target', 'vendor',
+    '.git', '.cache', '.next', '.turbo', '.venv', 'venv', '__pycache__',
+  ])
+
+  /** Recursively collect git-repo directories at or below `dir`, descending at
+   *  most `maxDepth` levels and stopping at each repo (so we never walk into a
+   *  found repo's own tree, node_modules, or dot-directories). `depth` is how
+   *  many levels below the original root `dir` sits. */
+  async function findReposFrom(dir: string, depth: number, maxDepth: number, out: string[]): Promise<void> {
+    if (await isGitRepo(dir)) {
+      out.push(dir)
+      return // a repo is a leaf for discovery — don't descend into it
+    }
+    if (depth >= maxDepth) return
+    let entries: import('fs').Dirent[]
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true })
+    } catch {
+      return // unreadable dir — skip silently
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (entry.name.startsWith('.') || SCAN_SKIP_DIRS.has(entry.name)) continue
+      await findReposFrom(path.join(dir, entry.name), depth + 1, maxDepth, out)
+    }
+  }
+
   async function ghAvailable(cwd: string): Promise<boolean> {
     try {
       await execFileP('gh', ['--version'], { cwd, timeout: 5000, env: env() })
@@ -105,6 +136,11 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
   return {
     async isRepo(dir) {
       return isGitRepo(validateCwd(dir))
+    },
+    async findRepos(dir, maxDepth) {
+      const out: string[] = []
+      await findReposFrom(validateCwd(dir), 0, Math.max(1, maxDepth ?? 1), out)
+      return out
     },
     async init(dir) {
       await simpleGit(validateCwd(dir)).init()

--- a/src/runtime/protocol.ts
+++ b/src/runtime/protocol.ts
@@ -103,6 +103,7 @@ export const Methods = {
   ptyScanPorts: 'pty.scanPorts',
 
   vcsIsRepo: 'vcs.isRepo',
+  vcsFindRepos: 'vcs.findRepos',
   vcsInit: 'vcs.init',
   vcsLsFiles: 'vcs.lsFiles',
   vcsStatus: 'vcs.status',

--- a/src/runtime/rpcServer.ts
+++ b/src/runtime/rpcServer.ts
@@ -174,6 +174,7 @@ export class RpcServer {
 
       // --- vcs ---
       case Methods.vcsIsRepo: return api.vcs.isRepo(s(0))
+      case Methods.vcsFindRepos: return api.vcs.findRepos(s(0), n(1))
       case Methods.vcsInit: return api.vcs.init(s(0))
       case Methods.vcsLsFiles: return api.vcs.lsFiles(s(0))
       case Methods.vcsStatus: return api.vcs.status(s(0))

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -146,6 +146,11 @@ export interface ElectronAPI {
   /** Check if a path is inside a git repository. */
   gitIsRepo(dirPath: string): Promise<boolean>
 
+  /** Discover git repos at or below `dirPath`, scanning at most `maxDepth`
+   *  levels (default 1) and stopping at each repo found. Returns locators (one
+   *  per repo) ready to hand back to the other git APIs as their cwd. */
+  gitFindRepos(dirPath: string, maxDepth?: number): Promise<string[]>
+
   /** Initialize a new git repository at the given directory. */
   gitInit(dirPath: string): Promise<void>
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -42,6 +42,7 @@ export const SHELL_SHOW_IN_FOLDER = 'shell:showInFolder'
 
 // Git
 export const GIT_IS_REPO = 'git:isRepo'
+export const GIT_FIND_REPOS = 'git:findRepos'
 export const GIT_INIT = 'git:init'
 export const GIT_LS_FILES = 'git:lsFiles'
 export const GIT_BRANCH_UPDATE = 'git:branch-update'         // main -> renderer


### PR DESCRIPTION
Closes #400.

## Problem

Source Control only picked up git when the workspace **root** itself was a repo. Opening a parent folder that holds several repos one level down showed nothing:

```
workspace/
  frontend/.git/
  backend/.git/
  docs/
```

`isRepo()` only `fs.access`-checks `.git` at the path it's handed, and the rest of the stack was only ever handed the single workspace root.

## Approach

Follows the direction laid out in the issue thread — a VS Code style bounded scan, depth hardcoded to 1 for now (a `git.repositoryScanMaxDepth`-style setting can layer on later since the arg is already plumbed through).

**1. Discovery.** New `findRepos(dir, maxDepth = 1)` on the vcs capability scans a bounded depth down, returns the dirs containing a `.git`, stops descending once it finds a repo (so it never walks into a repo's own tree), and skips `node_modules`, dot-directories, and common build output. Wired end to end: `VcsHost` type → RPC protocol + `rpcServer` dispatch → Remote/Deferred runtimes → git IPC handler (re-encoding the returned paths as locators, exactly like `worktreeList`) → preload → `electron-api` typings.

**2. UI.** `SourceControlView` becomes a thin wrapper over the existing single-repo view:
- Root is itself a repo, or exactly one / zero repos discovered → renders the **existing panel unchanged** (no regression for the common case).
- Root is a multi-repo parent → renders one **collapsible section per repo**, each headed by the repo's folder name + branch, sharing one scroll container. Folders without a `.git` are left out entirely.

Re-scans on window focus so a repo created/removed in a subfolder shows up without reopening the workspace.

## Tests

- `vcs.findRepos.test.ts` — depth behaviour, stop-at-repo, skip node_modules/dot-dirs, empty case, deeper `maxDepth`.
- `runtime-loopback.test.ts` — `findRepos` over the real daemon RPC wire.
- Full suite (1753) + typecheck + production build all green locally.