### PR TITLE
Inherit selected terminal/agent worktree on new-panel create

### DIFF
--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -26,6 +26,7 @@ import { useUIStateStore } from '../stores/uiStateStore'
 import { useShortcutStore } from '../stores/shortcutStore'
 import { displayString, PANEL_DEFAULT_SIZES } from '../../shared/types'
 import { useAppStore } from '../stores/appStore'
+import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
 import { Tooltip } from '../ui/Tooltip'
 
 // The minimap pill can be docked in any of the four canvas corners. The choice
@@ -112,10 +113,16 @@ const TerminalSpawnButton: React.FC<{ onClick: () => void; canvasPanelId: string
         .viewToCanvas({ x: ev.clientX - rect.left, y: ev.clientY - rect.top })
       const base = PANEL_DEFAULT_SIZES.terminal
       const pos = { x: center.x - base.width / 2, y: center.y - base.height / 2 }
-      const wsId = useAppStore.getState().selectedWorkspaceId
+      const app = useAppStore.getState()
+      const wsId = app.selectedWorkspaceId
       // Pin to this toolbar's canvas so the drop lands here, not on the
-      // workspace's primary canvas (matters on secondary/nested canvases).
-      if (wsId) useAppStore.getState().createTerminal(wsId, undefined, pos, { target: 'canvas', canvasPanelId })
+      // workspace's primary canvas (matters on secondary/nested canvases), and
+      // inherit the selected terminal/agent's worktree like the click path does.
+      if (wsId) {
+        const wt = inheritedWorktreeFromSelection(canvasApi.getState(), app.getWorkspace(wsId)?.panels)
+        const newId = app.createTerminal(wsId, undefined, pos, { target: 'canvas', canvasPanelId }, wt.cwd)
+        if (newId && wt.worktreeId) app.setPanelWorktreeId(wsId, newId, wt.worktreeId)
+      }
     }
     window.addEventListener('mousemove', onMove, true)
     window.addEventListener('mouseup', onUp, true)

--- a/src/renderer/lib/inheritWorktree.test.ts
+++ b/src/renderer/lib/inheritWorktree.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { inheritedWorktreeFromSelection } from './inheritWorktree'
+import type { PanelState } from '../../shared/types'
+import type { CanvasStoreState } from '../stores/canvas/storeTypes'
+
+// Minimal canvas-state shape the helper reads. `nodes` maps a node id to its
+// backing panel id; selection + selectionActive drive focusedNodeId.
+function canvasState(
+  selection: string[],
+  selectionActive: boolean,
+  nodes: Record<string, { panelId: string }>,
+): Pick<CanvasStoreState, 'selection' | 'selectionActive' | 'nodes'> {
+  return { selection, selectionActive, nodes } as any
+}
+
+const panels = (list: PanelState[]): Record<string, PanelState> =>
+  Object.fromEntries(list.map((p) => [p.id, p]))
+
+describe('inheritedWorktreeFromSelection', () => {
+  it('returns {} when nothing is selected', () => {
+    const state = canvasState([], false, {})
+    expect(inheritedWorktreeFromSelection(state, {})).toEqual({})
+  })
+
+  it('returns {} when the selection is not activated', () => {
+    const state = canvasState(['n1'], false, { n1: { panelId: 't1' } })
+    const ps = panels([{ id: 't1', type: 'terminal', title: 'Terminal 1', isDirty: false, worktreeId: 'wt-a' }])
+    expect(inheritedWorktreeFromSelection(state, ps)).toEqual({})
+  })
+
+  it('inherits worktreeId + cwd from a selected terminal', () => {
+    const state = canvasState(['n1'], true, { n1: { panelId: 't1' } })
+    const ps = panels([
+      { id: 't1', type: 'terminal', title: 'Terminal 1', isDirty: false, cwd: '/repo/wt', worktreeId: 'wt-a' },
+    ])
+    expect(inheritedWorktreeFromSelection(state, ps)).toEqual({ cwd: '/repo/wt', worktreeId: 'wt-a' })
+  })
+
+  it('inherits the worktreeId from a selected agent (agents carry no cwd)', () => {
+    const state = canvasState(['n1'], true, { n1: { panelId: 'a1' } })
+    const ps = panels([{ id: 'a1', type: 'agent', title: 'Agent 1', isDirty: false, worktreeId: 'wt-b' }])
+    expect(inheritedWorktreeFromSelection(state, ps)).toEqual({ cwd: undefined, worktreeId: 'wt-b' })
+  })
+
+  it('returns {} when the selected node is not a terminal or agent', () => {
+    const state = canvasState(['n1'], true, { n1: { panelId: 'e1' } })
+    const ps = panels([{ id: 'e1', type: 'editor', title: 'file.ts', isDirty: false, worktreeId: 'wt-c' }])
+    expect(inheritedWorktreeFromSelection(state, ps)).toEqual({})
+  })
+
+  it('uses the lead (last) selection entry as the focused node', () => {
+    const state = canvasState(['n1', 'n2'], true, {
+      n1: { panelId: 't1' },
+      n2: { panelId: 't2' },
+    })
+    const ps = panels([
+      { id: 't1', type: 'terminal', title: 'Terminal 1', isDirty: false, worktreeId: 'wt-a' },
+      { id: 't2', type: 'terminal', title: 'Terminal 2', isDirty: false, worktreeId: 'wt-b' },
+    ])
+    expect(inheritedWorktreeFromSelection(state, ps)).toEqual({ cwd: undefined, worktreeId: 'wt-b' })
+  })
+})

--- a/src/renderer/lib/inheritWorktree.ts
+++ b/src/renderer/lib/inheritWorktree.ts
@@ -1,0 +1,40 @@
+// =============================================================================
+// inheritWorktree — when a new terminal / agent is created on a canvas via a
+// generic action (⌘T, ⇧⌘A, the toolbar's terminal/agent buttons), it should open
+// in the SAME worktree as the terminal/agent the user currently has selected on
+// that canvas. This keeps a "new terminal" fired from inside a worktree's
+// terminal in that worktree instead of snapping back to the workspace root.
+//
+// The worktree-aware create paths that already target a specific worktree (the
+// worktree drop-up, folder drops, per-worktree context menus) pass their own
+// cwd/worktreeId and don't go through here.
+// =============================================================================
+
+import type { PanelState } from '../../shared/types'
+import type { CanvasStoreState } from '../stores/canvas/storeTypes'
+import { focusedNodeId } from '../stores/canvas/selectionModel'
+
+export interface InheritedWorktree {
+  /** Explicit working directory of the selected terminal (a dropped folder or a
+   *  non-primary worktree checkout). Undefined for the workspace root. */
+  cwd?: string
+  /** Worktree the selected panel is bound to, authoritative over cwd. */
+  worktreeId?: string
+}
+
+/** The worktree/cwd a newly created terminal or agent should inherit from the
+ *  canvas's currently selected node — but only when that node is itself a
+ *  worktree-bearing panel (a terminal or agent). Returns empty ({}) when nothing
+ *  worktree-bearing is selected, so callers fall back to their default placement.
+ */
+export function inheritedWorktreeFromSelection(
+  canvasState: Pick<CanvasStoreState, 'selection' | 'selectionActive' | 'nodes'>,
+  panels: Record<string, PanelState> | undefined,
+): InheritedWorktree {
+  const nodeId = focusedNodeId(canvasState)
+  if (!nodeId || !panels) return {}
+  const panelId = canvasState.nodes[nodeId]?.panelId
+  const panel = panelId ? panels[panelId] : undefined
+  if (!panel || (panel.type !== 'terminal' && panel.type !== 'agent')) return {}
+  return { cwd: panel.cwd, worktreeId: panel.worktreeId }
+}

--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -18,6 +18,7 @@ import { useSearchStore } from '../stores/searchStore'
 import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import type { CanvasStore } from '../stores/canvasStore'
 import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
+import { inheritedWorktreeFromSelection } from './inheritWorktree'
 import { confirmClosePanels } from './confirmClosePanels'
 
 /**
@@ -86,7 +87,13 @@ export async function runAction(
     case 'newTerminal': {
       const placement = placementForActivePanel()
       const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
-      if (wsId) appStore().createTerminal(wsId, undefined, undefined, placement)
+      if (wsId) {
+        // Inherit the selected terminal/agent's worktree so ⌘T from inside a
+        // worktree opens the new terminal in that same worktree.
+        const wt = inheritedWorktreeFromSelection(canvasStore(), appStore().getWorkspace(wsId)?.panels)
+        const panelId = appStore().createTerminal(wsId, undefined, undefined, placement, wt.cwd)
+        if (panelId && wt.worktreeId) appStore().setPanelWorktreeId(wsId, panelId, wt.worktreeId)
+      }
       break
     }
     case 'newBrowser': {
@@ -105,7 +112,13 @@ export async function runAction(
     case 'newAgent': {
       const placement = placementForActivePanel()
       const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
-      if (wsId) appStore().createAgent(wsId, undefined, placement)
+      if (wsId) {
+        // Same worktree inheritance as newTerminal — an agent carries only a
+        // worktreeId (no cwd), so bind it when the selection has one.
+        const wt = inheritedWorktreeFromSelection(canvasStore(), appStore().getWorkspace(wsId)?.panels)
+        const panelId = appStore().createAgent(wsId, undefined, placement)
+        if (panelId && wt.worktreeId) appStore().setPanelWorktreeId(wsId, panelId, wt.worktreeId)
+      }
       break
     }
     case 'newCanvas': {

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -34,6 +34,7 @@ import {
   findNodeIdForDockStore,
 } from './nodeDockRegistry'
 import { getPanelDef } from '../panels/registry'
+import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
 
 // Re-export the lookup helpers so existing callers (drag dispatcher, drop
 // resolver) keep working through the same import path. New code should import
@@ -304,8 +305,14 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
 
   const onNewTerminal = useCallback(async () => {
     const wsId = await ensureWorkspaceFolder(workspaceId)
-    if (wsId) useAppStore.getState().createTerminal(wsId, undefined, undefined, here())
-  }, [workspaceId, here])
+    if (!wsId) return
+    // Open the new terminal in the same worktree as the terminal/agent selected
+    // on this canvas (see inheritedWorktreeFromSelection).
+    const app = useAppStore.getState()
+    const wt = inheritedWorktreeFromSelection(store.getState(), app.getWorkspace(wsId)?.panels)
+    const newId = app.createTerminal(wsId, undefined, undefined, here(), wt.cwd)
+    if (newId && wt.worktreeId) app.setPanelWorktreeId(wsId, newId, wt.worktreeId)
+  }, [workspaceId, here, store])
 
   const onNewBrowser = useCallback(async () => {
     const wsId = await ensureWorkspaceFolder(workspaceId)
@@ -319,8 +326,12 @@ export default function CanvasPanel({ panelId, workspaceId, nodeId, renderPanelC
 
   const onNewAgent = useCallback(async () => {
     const wsId = await ensureWorkspaceFolder(workspaceId)
-    if (wsId) useAppStore.getState().createAgent(wsId, undefined, here())
-  }, [workspaceId, here])
+    if (!wsId) return
+    const app = useAppStore.getState()
+    const wt = inheritedWorktreeFromSelection(store.getState(), app.getWorkspace(wsId)?.panels)
+    const newId = app.createAgent(wsId, undefined, here())
+    if (newId && wt.worktreeId) app.setPanelWorktreeId(wsId, newId, wt.worktreeId)
+  }, [workspaceId, here, store])
 
   const onZoomIn = useCallback(() => {
     store.getState().animateZoomTo(zoomLevel + 0.1)


### PR DESCRIPTION
## What

New terminals and agents created on a canvas now open in the **same worktree** as the terminal/agent you currently have selected, instead of always falling back to the workspace root.

Covers every generic create path:
- keybind (⌘T / ⇧⌘A), native menu, and command palette (`runAction`)
- the canvas toolbar's terminal + agent buttons (`CanvasPanel`)
- the terminal button's drag-to-place spawn (`CanvasToolbar`)

Paths that already target a specific worktree (worktree drop-up, folder drops, per-worktree context menus) are unchanged.

## How

New `inheritedWorktreeFromSelection` helper reads the focused canvas node and returns its `cwd`/`worktreeId`, but only when that node is a terminal or agent (the two types with real worktree semantics). Callers create the panel and then `setPanelWorktreeId` when a worktree was inherited, matching the existing `launchInWorktree` pattern.

Select nothing worktree-bearing (or an editor/browser) and behavior is unchanged.

## Test

Added `inheritWorktree.test.ts` (6 cases: empty/inactive selection, terminal, agent, editor, lead-node rule). Full typecheck clean.
