### PR TITLE
fix(cate-agent): tidy empty chat bar and block sends on observer feed

### DIFF
--- a/src/agent/extensions/cate-agent-tools/index.ts
+++ b/src/agent/extensions/cate-agent-tools/index.ts
@@ -48,6 +48,7 @@ function envelope(tool: string, params: Json): string {
 const OBSERVER_PROMPT = [
   "Observer for a coding workspace. You never act and never start work.",
   "Each turn: read a terminal or two if worthwhile, then remark with one short update. That's all.",
+  "When you spot something concrete the agent could do next (a failing test to fix, a feature to implement, a cleanup), you MAY additionally `suggest` it: write a complete, ready-to-run prompt for the coding agent and a short call-to-action label for its button (e.g. \"Fix\", \"Implement\", \"Investigate\"). Only suggest when the action is clear and useful; a plain remark is the default.",
 ].join(" ")
 
 const ORCHESTRATOR_PROMPT = [
@@ -145,6 +146,21 @@ export default function (pi: ExtensionAPI) {
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         return call(ctx, "remark", { text: params.text })
+      },
+    })
+
+    pi.registerTool({
+      name: "suggest",
+      label: "Suggest",
+      description:
+        "Offer the user a ready-to-run action for the coding agent, shown in the timeline as a one-click button. Use for a concrete next step you've spotted; a plain remark stays the default.",
+      parameters: Type.Object({
+        text: Type.String({ description: "One short sentence describing the suggestion, shown above the button." }),
+        label: Type.String({ description: "Call-to-action button text, your free choice — e.g. \"Fix\", \"Implement\", \"Investigate\". Keep it to one or two words." }),
+        prompt: Type.String({ description: "The complete, ready-to-run prompt sent to the coding agent when the user clicks the button." }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        return call(ctx, "suggest", { text: params.text, label: params.label, prompt: params.prompt })
       },
     })
   }

--- a/src/agent/renderer/AgentPanel.tsx
+++ b/src/agent/renderer/AgentPanel.tsx
@@ -45,7 +45,6 @@ import { ChatInput } from './AgentChatInput'
 import { ModelPickerDropdown } from './ModelPicker'
 import {
   ExtensionDialog,
-  ExtensionStatusBar,
   ExtensionWidget,
   QueueBadges,
   readFileAsImage,
@@ -1174,8 +1173,6 @@ export default function AgentPanel({ panelId, workspaceId }: PanelProps) {
                 />
               </>
             )}
-
-            <ExtensionStatusBar entries={extensionStatuses} />
           </div>
         )}
       </div>

--- a/src/agent/renderer/AgentPanelChrome.tsx
+++ b/src/agent/renderer/AgentPanelChrome.tsx
@@ -1,7 +1,6 @@
 // =============================================================================
 // AgentPanelChrome — extra UI surfaces for the agent panel:
 //   • QueueBadges      — small chips for pending steering / follow-up messages
-//   • ExtensionStatusBar — extension setStatus() text (footer)
 //   • ExtensionWidget   — extension setWidget() lines (above/below editor)
 
 //   • ExtensionDialog   — in-panel renderer for extension_ui_request select /
@@ -26,10 +25,7 @@ import type {
   AgentImageAttachment,
   AgentThinkingLevel,
 } from '../../shared/types'
-import type {
-  ExtensionStatusEntry,
-  ExtensionWidgetEntry,
-} from './agentStore'
+import type { ExtensionWidgetEntry } from './agentStore'
 
 // -----------------------------------------------------------------------------
 // Steering / follow-up queue chips
@@ -70,26 +66,6 @@ export function QueueBadges({
 // -----------------------------------------------------------------------------
 // Extension chrome
 // -----------------------------------------------------------------------------
-
-// Status keys hidden from the footer. `plan-mode` drives the toggle-button
-// highlight in ChatInput, so surfacing it here too is redundant chrome. `mcp` /
-// `mcp-auth` are the pi-mcp-adapter's connection status — the MCP feature stays
-// fully active; we just don't want its footer line.
-const HIDDEN_STATUS_KEYS = new Set(['plan-mode', 'mcp', 'mcp-auth'])
-
-export function ExtensionStatusBar({ entries }: { entries: ExtensionStatusEntry[] }) {
-  const visible = entries.filter((e) => !HIDDEN_STATUS_KEYS.has(e.key))
-  if (visible.length === 0) return null
-  return (
-    <div className="flex flex-wrap gap-2 px-3 py-1 border-t border-subtle bg-surface-0 text-[11px] text-muted">
-      {visible.map((e) => (
-        <span key={e.key} className="px-1.5 py-0.5 rounded bg-hover font-mono">
-          {e.text}
-        </span>
-      ))}
-    </div>
-  )
-}
 
 export function ExtensionWidget({
   widgets,

--- a/src/agent/renderer/AgentPanelChrome.tsx
+++ b/src/agent/renderer/AgentPanelChrome.tsx
@@ -71,10 +71,14 @@ export function QueueBadges({
 // Extension chrome
 // -----------------------------------------------------------------------------
 
+// Status keys hidden from the footer. `plan-mode` drives the toggle-button
+// highlight in ChatInput, so surfacing it here too is redundant chrome. `mcp` /
+// `mcp-auth` are the pi-mcp-adapter's connection status — the MCP feature stays
+// fully active; we just don't want its footer line.
+const HIDDEN_STATUS_KEYS = new Set(['plan-mode', 'mcp', 'mcp-auth'])
+
 export function ExtensionStatusBar({ entries }: { entries: ExtensionStatusEntry[] }) {
-  // `plan-mode` drives the toggle-button highlight in ChatInput — surfacing it
-  // here too would be redundant chrome, so we hide it from the footer.
-  const visible = entries.filter((e) => e.key !== 'plan-mode')
+  const visible = entries.filter((e) => !HIDDEN_STATUS_KEYS.has(e.key))
   if (visible.length === 0) return null
   return (
     <div className="flex flex-wrap gap-2 px-3 py-1 border-t border-subtle bg-surface-0 text-[11px] text-muted">

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -297,7 +297,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   useEffect(() => {
     if (!inputOpen) setAgentInputH(AGENT_ROW_H)
   }, [inputOpen])
-  const AGENT_INPUT_EXTRA = 210 // how much wider than the toolbar the input grows (picker + textarea)
+  const AGENT_INPUT_EXTRA = 120 // how much wider than the toolbar the input grows (picker + textarea)
   // Both width and height are explicit so opening, typing (as text wraps), and
   // closing all animate via the transition. Height tracks the live textarea
   // content (clamped to one toolbar row); the closed target is the fixed row

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -234,12 +234,18 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   // OAuth sign-in ('needsReauth') hides it too; the reconnect prompt lives in
   // Settings → Cate Agent. Returns when a usable provider connects.
   const hasProvider = useCateAgentReady() === 'ok'
-  const inputOpen = cateAgent.inputOpen
+  // Without a provider the agent button and input bar are both hidden, so a
+  // lingering open state (persisted per-workspace) must not keep the content zone
+  // expanded — otherwise the pill renders empty and wide. Force it closed so the
+  // normal tools row shows.
+  const inputOpen = cateAgent.inputOpen && hasProvider
   const toggleAgentInput = () => useCateAgentStore.getState().setInputOpen(workspaceId, !inputOpen)
   const closeAgentInput = () => useCateAgentStore.getState().setInputOpen(workspaceId, false)
   // Compose into the active chat, minting one (titled from the prompt) on the first
   // send. The chat's persistent agent decides how to respond.
   const sendAgentPrompt = (text: string) => {
+    // The observer timeline is a read-only FYI view; it never takes a reply.
+    if (cateAgent.observerView) return
     const store = useChatsStore.getState()
     let chatId = cateAgent.activeChatId
     if (!chatId || !store.getChat(rootPath, chatId)) {
@@ -377,7 +383,9 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
                 agentToolsRef); opening grows it wider for the input and taller as
                 text wraps. Width + height are explicit so every change animates. */}
             <div
-              className="relative flex items-stretch ml-1.5 overflow-hidden transition-[width,height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
+              className={`relative flex items-stretch overflow-hidden transition-[width,height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+                hasProvider ? 'ml-1.5' : ''
+              }`}
               style={agentZoneStyle}
             >
               <div
@@ -456,6 +464,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
                   <CateAgentInputBar
                     workspaceId={workspaceId}
                     multiline={agentMultiline}
+                    disabled={cateAgent.observerView}
                     onSend={sendAgentPrompt}
                     onClose={closeAgentInput}
                     onHeightChange={setAgentInputH}

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -31,6 +31,7 @@ import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
 import { Tooltip } from '../ui/Tooltip'
 import { CateAgentToolbarButton } from '../cateAgent/CateAgentToolbarButton'
 import { CateAgentInputBar } from '../cateAgent/CateAgentInputBar'
+import { CateAgentChatPicker } from '../cateAgent/CateAgentChatPicker'
 import { CateAgentChat } from '../cateAgent/CateAgentChat'
 import { useCateAgentWs, useCateAgentStore } from '../cateAgent/cateAgentStore'
 import { cateAgentController } from '../cateAgent/cateAgentController'
@@ -244,14 +245,16 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   // Compose into the active chat, minting one (titled from the prompt) on the first
   // send. The chat's persistent agent decides how to respond.
   const sendAgentPrompt = (text: string) => {
-    // The observer timeline is a read-only FYI view; it never takes a reply.
-    if (cateAgent.observerView) return
     const store = useChatsStore.getState()
-    let chatId = cateAgent.activeChatId
+    // From the observer front door, a message always starts a NEW chat (you don't
+    // reply to the observer). Otherwise it composes into the selected chat.
+    let chatId = cateAgent.observerView ? '' : cateAgent.activeChatId
     if (!chatId || !store.getChat(rootPath, chatId)) {
       chatId = store.createChat(rootPath, deriveTopic(text)).id
-      useCateAgentStore.getState().setActiveChat(workspaceId, chatId)
     }
+    // Always select the target chat: this clears the observer view and grows the
+    // window into the chat we're sending to.
+    useCateAgentStore.getState().setActiveChat(workspaceId, chatId)
     void cateAgentController.sendMessage(workspaceId, rootPath, chatId, text)
   }
   // The dot means "there's observer feed to check via the eye tab" — it's the exact
@@ -294,7 +297,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   useEffect(() => {
     if (!inputOpen) setAgentInputH(AGENT_ROW_H)
   }, [inputOpen])
-  const AGENT_INPUT_EXTRA = 96 // how much wider than the toolbar the input grows
+  const AGENT_INPUT_EXTRA = 210 // how much wider than the toolbar the input grows (picker + textarea)
   // Both width and height are explicit so opening, typing (as text wraps), and
   // closing all animate via the transition. Height tracks the live textarea
   // content (clamped to one toolbar row); the closed target is the fixed row
@@ -460,11 +463,14 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
             </ToolbarButton>
               </div>
               {hasProvider && inputOpen && (
-                <div className={`flex-1 min-w-0 flex ${agentAlign}`}>
+                <div className={`flex-1 min-w-0 flex gap-1.5 ${agentAlign}`}>
+                  {/* Chat picker replaces the old tab strip: choose the observer
+                      (default) or a chat; it names what the window shows. */}
+                  <CateAgentChatPicker workspaceId={workspaceId} rootPath={rootPath} />
                   <CateAgentInputBar
                     workspaceId={workspaceId}
                     multiline={agentMultiline}
-                    disabled={cateAgent.observerView}
+                    placeholder={cateAgent.observerView ? 'Ask Cate to do something…' : 'Message Cate…'}
                     onSend={sendAgentPrompt}
                     onClose={closeAgentInput}
                     onHeightChange={setAgentInputH}

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -666,7 +666,10 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   if (!wsId || !mounted) return null
 
   return (
-    <div className="absolute bottom-full left-0 right-0 mb-2">
+    // Fixed width, centered above the toolbar — NOT left-0/right-0. Tracking the
+    // toolbar's width would make the card reflow (and its measured height jump)
+    // while the toolbar's open animation is still widening it, which flickered.
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-[min(440px,calc(100vw-32px))]">
       <div
         className="overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]"
         style={{

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -35,12 +35,14 @@ import {
   ArrowsSplit,
   SquaresFour,
   Eye,
+  Check,
 } from '@phosphor-icons/react'
 import { useShallow } from 'zustand/react/shallow'
 import { useChatsStore } from '../stores/chatsStore'
 import { useAppStore } from '../stores/appStore'
 import { useCateAgentWs, useCateAgentStore, type CateAgentFeedItem, type CateAgentFeedKind } from './cateAgentStore'
 import { cateAgentController } from './cateAgentController'
+import { deriveTopic } from './cateAgentTools'
 import { mergeChat, openPrChat, discardChat, type ReviewResult } from './cateAgentReviewActions'
 import { revealPanel } from '../lib/workspace/panelReveal'
 import { useWorktrees, type JoinedWorktree } from '../stores/useWorktrees'
@@ -81,9 +83,9 @@ const wtTitle = (wt: JoinedWorktree): string => wt.label || wt.branch || wt.path
 const IterationStatusGlyph: React.FC<{ status: IterationStatus }> = ({ status }) => {
   switch (status) {
     case 'running':
-      return <CircleNotch size={12} className="flex-shrink-0 text-green-400 animate-spin" />
+      return <span className="flex-shrink-0 mt-[3px] w-2 h-2 rounded-full bg-green-400" />
     case 'verifying':
-      return <MagnifyingGlass size={12} className="flex-shrink-0 text-blue-400 animate-pulse" />
+      return <MagnifyingGlass size={12} className="flex-shrink-0 text-blue-400" />
     case 'passed':
       return <CheckCircle size={12} weight="fill" className="flex-shrink-0 text-green-400" />
     case 'failed':
@@ -122,7 +124,6 @@ const TerminalChip: React.FC<{ wsId: string; panelId: string }> = ({ wsId, panel
     }),
   )
   const info = useAgentInfoByPanel(ownerWsId)[panelId]
-  const isRunning = info?.state === 'running'
   if (!ownerWsId || !label) return null
   return (
     <button
@@ -134,8 +135,8 @@ const TerminalChip: React.FC<{ wsId: string; panelId: string }> = ({ wsId, panel
         <TabIcon type={type} size={11} logo={info?.logo} agentName={info?.name} />
       </span>
       <span
-        className={`text-[10px] font-mono text-secondary truncate max-w-[160px] ${isRunning ? 'cate-notif-pulse' : ''}`}
-        style={worktreeTitleStyle(color, isRunning)}
+        className="text-[10px] font-mono text-secondary truncate max-w-[160px]"
+        style={worktreeTitleStyle(color, false)}
       >
         {label}
       </span>
@@ -207,7 +208,7 @@ const IterationRow: React.FC<{ it: Iteration; index: number; multi: boolean; win
         {winner && multi && <Trophy size={11} weight="fill" className="flex-shrink-0 mt-[1px] text-green-400" />}
         <div className={`text-[11.5px] leading-snug break-words ${bad ? 'text-red-400/80' : 'text-secondary'}`}>
           {multi && <span className="text-muted">#{index + 1} · </span>}
-          {it.verify ? it.verify.reason : <span className="text-muted">Working…</span>}
+          {it.verify ? it.verify.reason : <span className={it.status === 'running' || it.status === 'verifying' ? 'cate-notif-pulse' : 'text-muted'}>Working</span>}
         </div>
       </div>
       {it.agents.length > 0 && (
@@ -269,7 +270,7 @@ const AttemptsBlock: React.FC<{ chat: Chat; msg: ChatAttemptsMessage; wsId: stri
           <IterationStatusGlyph status={it.status} />
         </div>
         <div className={`text-[12.5px] leading-snug break-words ${bad ? 'text-red-400/80' : 'text-secondary'}`}>
-          {it.verify ? it.verify.reason : <span className="text-muted">Working…</span>}
+          {it.verify ? it.verify.reason : <span className={it.status === 'running' || it.status === 'verifying' ? 'cate-notif-pulse' : 'text-muted'}>Working</span>}
         </div>
         {it.agents.length > 0 && (
           <div className="flex flex-wrap items-center gap-1.5">
@@ -369,11 +370,7 @@ const ResultBlock: React.FC<{ chat: Chat; msg: ChatResultMessage; wsId: string; 
 const CanvasBlock: React.FC<{ msg: ChatCanvasMessage; wsId: string }> = ({ msg, wsId }) => (
   <div className="flex flex-col gap-1.5">
     <div className="flex items-center gap-2">
-      {msg.working ? (
-        <CircleNotch size={13} className="flex-shrink-0 text-blue-400 animate-spin" />
-      ) : (
-        <SquaresFour size={13} weight="fill" className="flex-shrink-0 text-blue-400" />
-      )}
+      <SquaresFour size={13} weight="fill" className="flex-shrink-0 text-blue-400" />
       <div className={`${LBL} flex-1`}>Canvas</div>
       {msg.canvasPanelId && !msg.working && (
         <button
@@ -386,7 +383,7 @@ const CanvasBlock: React.FC<{ msg: ChatCanvasMessage; wsId: string }> = ({ msg, 
     </div>
     <div className="text-[12.5px] leading-snug text-secondary break-words">{msg.request}</div>
     {msg.working ? (
-      <div className="text-[11px] text-muted animate-pulse">Laying out the canvas…</div>
+      <div className="text-[11px] cate-notif-pulse">Laying out the canvas</div>
     ) : (
       msg.panels && msg.panels.length > 0 && <div className="text-[11px] text-muted">{msg.panels.length} panel{msg.panels.length === 1 ? '' : 's'} on the canvas</div>
     )}
@@ -433,8 +430,9 @@ const relAge = (ts: number, now: number): string => {
 // A transient FYI — never a chat: the observer never mints a chat, it just speaks here.
 // Hover a remark to dismiss it; "Clear" empties the log. When the observer is quiet the
 // body explains what will show up here.
-const ObserverTimeline: React.FC<{ wsId: string; items: CateAgentFeedItem[] }> = ({ wsId, items }) => {
+const ObserverTimeline: React.FC<{ wsId: string; items: CateAgentFeedItem[]; onRun: (prompt: string) => void }> = ({ wsId, items, onRun }) => {
   const dismissFeedItem = useCateAgentStore((s) => s.dismissFeedItem)
+  const resolveFeedAction = useCateAgentStore((s) => s.resolveFeedAction)
   const clearFeed = useCateAgentStore((s) => s.clearFeed)
   const [now, setNow] = React.useState(() => Date.now())
 
@@ -447,20 +445,19 @@ const ObserverTimeline: React.FC<{ wsId: string; items: CateAgentFeedItem[] }> =
 
   if (items.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 px-8 text-center">
-        <Eye size={22} weight="bold" className="opacity-70" style={{ color: 'rgb(var(--agent-rgb))' }} />
-        <span className="text-[12.5px] text-secondary">Nothing to report yet</span>
-        <span className="text-[11.5px] leading-snug text-muted">Cate drops a short note here as it watches your workspace.</span>
+      <div className="flex min-h-[96px] flex-col items-center justify-center gap-2 px-8 py-6 text-center">
+        <Eye size={20} weight="bold" className="opacity-60" style={{ color: 'rgb(var(--agent-rgb))' }} />
+        <span className="text-[12px] text-muted">Nothing to report yet</span>
       </div>
     )
   }
   return (
     <div className="flex flex-col gap-3 px-4 py-3">
       <div className="flex items-center gap-1.5">
-        <span className={LBL}>Observer</span>
+        <span className={LBL}>Feed</span>
         <button
           onClick={() => clearFeed(wsId)}
-          title="Clear observer log"
+          title="Clear feed"
           className="ml-auto text-[10px] text-muted hover:text-primary transition-colors"
         >
           Clear
@@ -483,14 +480,46 @@ const ObserverTimeline: React.FC<{ wsId: string; items: CateAgentFeedItem[] }> =
             <span className="flex-shrink-0 w-[30px] font-mono text-[10px] leading-snug text-muted tabular-nums">
               {relAge(item.ts, now)}
             </span>
-            <span className={`flex-1 text-[12.5px] leading-snug break-words ${FEED_KIND_CLASS[item.kind]}`}>{item.text}</span>
-            <button
-              onClick={() => dismissFeedItem(wsId, item.id)}
-              title="Dismiss"
-              className="flex-shrink-0 -mt-[1px] p-0.5 rounded text-muted opacity-0 group-hover/obs:opacity-100 hover:text-primary hover:bg-hover transition-opacity"
-            >
-              <X size={12} />
-            </button>
+            <div className="flex flex-1 flex-col gap-1.5 min-w-0">
+              <span className={`text-[12.5px] leading-snug break-words ${FEED_KIND_CLASS[item.kind]}`}>{item.text}</span>
+              {item.action &&
+                (item.resolved ? (
+                  // Acted on: a spent record, not a live control. It stays in the feed
+                  // but can't be run again.
+                  <span className="self-start flex items-center gap-1 px-2 py-0.5 rounded text-xs text-muted opacity-70">
+                    {item.resolved === 'approved' ? (
+                      <>
+                        <Check size={11} weight="bold" /> {item.action.label}
+                      </>
+                    ) : (
+                      <span className="line-through">{item.action.label}</span>
+                    )}
+                  </span>
+                ) : (
+                  <button
+                    onClick={() => {
+                      onRun(item.action!.prompt)
+                      resolveFeedAction(wsId, item.id, 'approved')
+                    }}
+                    title={item.action.prompt}
+                    className={`${btn} self-start text-white hover:brightness-110`}
+                    style={{ backgroundColor: 'rgb(var(--agent-rgb))' }}
+                  >
+                    <Play size={10} weight="fill" /> {item.action.label}
+                  </button>
+                ))}
+            </div>
+            {/* Suggestions resolve (and stay) instead of vanishing; once resolved the X
+                is gone so they can't be dismissed twice. Plain remarks still just clear. */}
+            {!(item.action && item.resolved) && (
+              <button
+                onClick={() => (item.action ? resolveFeedAction(wsId, item.id, 'dismissed') : dismissFeedItem(wsId, item.id))}
+                title="Dismiss"
+                className="flex-shrink-0 -mt-[1px] p-0.5 rounded text-muted opacity-0 group-hover/obs:opacity-100 hover:text-primary hover:bg-hover transition-opacity"
+              >
+                <X size={12} />
+              </button>
+            )}
           </div>
         ))}
       </div>
@@ -500,7 +529,7 @@ const ObserverTimeline: React.FC<{ wsId: string; items: CateAgentFeedItem[] }> =
 
 // --- run controls (Stop / Continue) ------------------------------------------
 
-const RunControls: React.FC<{ chat: Chat; wsId: string; rootPath: string; working: boolean }> = ({ chat, wsId, rootPath, working }) => {
+const RunControls: React.FC<{ chat: Chat; wsId: string; rootPath: string; working: boolean; activeWork: boolean }> = ({ chat, wsId, rootPath, working, activeWork }) => {
   const [busy, setBusy] = React.useState(false)
   const run = chat.run
   if (run?.interrupted) {
@@ -529,19 +558,19 @@ const RunControls: React.FC<{ chat: Chat; wsId: string; rootPath: string; workin
   if (run?.status === 'running') {
     return (
       <div className="flex items-center gap-1.5">
-        <CircleNotch size={12} className="text-green-400 animate-spin" />
-        <span className="text-[11px] text-muted flex-1">Working…</span>
+        {/* A live tool call already shimmers above; the status line then carries
+            only the Stop control. In the gap it shimmers "Working" itself. */}
+        {activeWork ? <span className="flex-1" /> : <span className="text-[13px] cate-notif-pulse flex-1">Working</span>}
         <button onClick={() => cateAgentController.stop(wsId, chat.id)} className={`${btn} text-secondary hover:text-red-400 hover:bg-hover`}>
           <Stop size={11} weight="fill" /> Stop
         </button>
       </div>
     )
   }
-  if (working) {
+  if (working && !activeWork) {
     return (
       <div className="flex items-center gap-1.5">
-        <CircleNotch size={12} className="text-blue-400 animate-spin" />
-        <span className="text-[11px] text-muted">Cate is thinking…</span>
+        <span className="text-[13px] cate-notif-pulse">Thinking</span>
       </div>
     )
   }
@@ -601,6 +630,26 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   const activeChat = cateAgent.activeChatId ? list.find((c) => c.id === cateAgent.activeChatId) : undefined
   const working = cateAgent.activity === 'working' && !!activeChat && !activeChat.run
 
+  // The shimmer rides the active work, like the agent panel. While a tool call is
+  // live — a running loop iteration (one, or several in parallel) or a canvas being
+  // laid out — that block shimmers, and the bottom status line drops its own
+  // shimmer (just the Stop control remains). Only in the gap, when nothing is live,
+  // does the status line itself shimmer ("Thinking"/"Working"). Never both at once.
+  const liveIters = activeChat?.run?.status === 'running' ? (activeChat.run.iterations ?? []) : []
+  const hasActiveWork =
+    liveIters.some((i) => i.status === 'running' || i.status === 'verifying') ||
+    (activeChat?.messages.some((m) => m.kind === 'canvas' && m.working) ?? false)
+
+  // Run an observer suggestion: like a first message from the front door, it always
+  // starts a NEW chat (titled from the prompt), which clears the observer view and
+  // grows the window into that chat's transcript.
+  const runPrompt = (prompt: string) => {
+    const store = useChatsStore.getState()
+    const chatId = store.createChat(rootPath, deriveTopic(prompt)).id
+    useCateAgentStore.getState().setActiveChat(wsId, chatId)
+    void cateAgentController.sendMessage(wsId, rootPath, chatId, prompt)
+  }
+
   // Observer feed tail: the latest turn (since the last user line), capped.
   const feed = cateAgent.feed
   const lastUserIdx = feed.map((f) => f.kind).lastIndexOf('user')
@@ -610,38 +659,51 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   // Which one is chosen from the picker in the toolbar bar, not a tab strip here.
   const observerView = cateAgent.observerView
 
-  // Open/close is a morph out of / into the Cate Agent button: mount, then flip
-  // `entered` on the next frame so the enter transition plays from the collapsed
-  // (scaled-into-button, height 0) state; on close flip it back and unmount after.
+  // The window is shown only while the input bar is open; it simply appears and
+  // disappears with it — no open/close fade or grow animation.
   const inputOpen = cateAgent.inputOpen
-  const [mounted, setMounted] = React.useState(inputOpen)
-  const [entered, setEntered] = React.useState(false)
-  React.useEffect(() => {
-    if (inputOpen) {
-      setMounted(true)
-      const r = requestAnimationFrame(() => setEntered(true))
-      return () => cancelAnimationFrame(r)
-    }
-    setEntered(false)
-    const id = window.setTimeout(() => setMounted(false), 300)
-    return () => window.clearTimeout(id)
-  }, [inputOpen])
 
-  // The card's height is driven by its content: compact for the observer, tall
-  // (capped, then scrolls) for a chat. Measuring the content and mirroring it onto
-  // the card's explicit height lets the height TRANSITION — so selecting a chat
-  // grows the window and returning to the observer shrinks it.
+  const msgCount = activeChat?.messages.length ?? 0
+  // Live iteration count also grows the transcript without a new message; track it so
+  // an active run stays pinned to the bottom.
+  const runTick = activeChat?.run?.iterations?.length ?? 0
+
+  // The card is only as tall as its content (each view clamps itself to a max and
+  // scrolls past that). We mirror the measured content height onto the card so that
+  // *switching* views (observer↔chat, chat↔chat) animates the grow/shrink. The
+  // transition is armed one frame after the first measurement, so the window still
+  // appears instantly at full size on open instead of growing from zero.
   const contentRef = React.useRef<HTMLDivElement | null>(null)
   const [naturalH, setNaturalH] = React.useState(0)
+  const [animate, setAnimate] = React.useState(false)
+  const measure = React.useCallback(() => {
+    const el = contentRef.current
+    if (el) setNaturalH(el.scrollHeight)
+  }, [])
+  // A signature of everything that changes the content's height. Measuring in a
+  // layout effect keyed on this applies the new height in the SAME commit as the
+  // content swap — so the grow/shrink always transitions, instead of waiting for
+  // the ResizeObserver to fire a frame later (which sometimes skipped the animation).
+  const contentSig = observerView
+    ? 'obs:' + visibleFeed.map((f) => `${f.id}${f.resolved ?? (f.action ? 'a' : '')}`).join('|')
+    : `chat:${cateAgent.activeChatId}:${msgCount}:${runTick}:${!!activeChat}`
+  React.useLayoutEffect(() => {
+    measure()
+  }, [measure, contentSig])
+  // Async settle (text wrap, images, late-loading data) that no state change captures.
   React.useLayoutEffect(() => {
     const el = contentRef.current
     if (!el) return
-    const measure = () => setNaturalH(el.scrollHeight)
-    measure()
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [mounted, observerView, activeChat?.id])
+  }, [measure])
+  React.useEffect(() => {
+    if (naturalH > 0 && !animate) {
+      const r = requestAnimationFrame(() => setAnimate(true))
+      return () => cancelAnimationFrame(r)
+    }
+  }, [naturalH, animate])
 
   // Stick to the bottom (newest, nearest the input) as the transcript grows, unless
   // the user has scrolled up to read.
@@ -653,48 +715,40 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
     if (!el) return
     atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24
   }
-
-  const msgCount = activeChat?.messages.length ?? 0
-  // Live iteration count also grows the transcript without a new message; track it so
-  // an active run stays pinned to the bottom.
-  const runTick = activeChat?.run?.iterations?.length ?? 0
   React.useLayoutEffect(() => {
     const el = scrollRef.current
     if (el && atBottomRef.current) el.scrollTop = el.scrollHeight
   }, [msgCount, runTick, visibleFeed.length, cateAgent.activeChatId, observerView])
 
-  if (!wsId || !mounted) return null
+  if (!wsId || !inputOpen) return null
 
   return (
-    // Fixed width, centered above the toolbar — NOT left-0/right-0. Tracking the
-    // toolbar's width would make the card reflow (and its measured height jump)
-    // while the toolbar's open animation is still widening it, which flickered.
-    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-[min(440px,calc(100vw-32px))]">
+    // Same width as the toolbar bar below it: the relative parent is sized by the
+    // pill, so inset-x-0 pins the card to exactly the bar's width.
+    <div className="absolute bottom-full inset-x-0 mb-2">
       <div
         className="overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]"
         style={{
-          // Grow only: the window opens, closes, and switches observer↔chat purely by
-          // animating its height — no fade, no scale-morph.
-          transition: 'height 280ms cubic-bezier(0.16,1,0.3,1)',
-          height: entered ? naturalH : 0,
+          height: naturalH || undefined,
+          transition: animate ? 'height 240ms cubic-bezier(0.16,1,0.3,1)' : undefined,
         }}
       >
         <div ref={contentRef}>
           {observerView ? (
             // Observer: only as tall as its content needs (a floor so the empty state
             // has room, a ceiling before it scrolls).
-            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar min-h-[120px] max-h-[min(420px,55vh)] overflow-y-auto">
-              <ObserverTimeline wsId={wsId} items={visibleFeed} />
+            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar max-h-[min(420px,55vh)] overflow-y-auto">
+              <ObserverTimeline wsId={wsId} items={visibleFeed} onRun={runPrompt} />
             </div>
           ) : (
-            // Chat: the full-height transcript, scrolling internally.
-            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar h-[min(420px,55vh)] overflow-y-auto">
+            // Chat: as tall as the transcript, capped before it scrolls internally.
+            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar max-h-[min(420px,55vh)] overflow-y-auto">
               {activeChat ? (
                 <div className="flex flex-col gap-3.5 px-3 py-3">
                   {activeChat.messages.map((msg) => (
                     <MessageBlock key={msg.id} chat={activeChat} msg={msg} wsId={wsId} rootPath={rootPath} worktrees={worktrees} />
                   ))}
-                  <RunControls chat={activeChat} wsId={wsId} rootPath={rootPath} working={working} />
+                  <RunControls chat={activeChat} wsId={wsId} rootPath={rootPath} working={working} activeWork={hasActiveWork} />
                 </div>
               ) : (
                 <EmptyState />

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -744,7 +744,7 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   // the observer timeline; picking a chat swaps it back.
   return (
     <div className="absolute bottom-full left-0 right-0 mb-2">
-      <div className="flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
+      <div className="cate-agent-window-in flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
         <div className="flex-none flex items-stretch bg-surface-0">
           <ChatTabs
             wsId={wsId}

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -442,6 +442,7 @@ const ChatTabs: React.FC<{
   // corners, and shared 1px seams (collapsed via -ml-px). A lone tab keeps its
   // rounded, standalone look.
   const multi = chats.length >= 2
+  const hasChats = chats.length > 0
   const pick = (chatId: string) => {
     onPickChat()
     setActiveChat(wsId, chatId)
@@ -450,6 +451,13 @@ const ChatTabs: React.FC<{
     // No padding: tabs sit flush and fill the bar edge-to-edge. The card's rounded
     // overflow clips the outer corners round while the seams between tabs stay square.
     <div className={`no-scrollbar flex flex-1 min-w-0 items-stretch overflow-x-auto ${multi ? 'gap-0' : 'gap-1'}`}>
+      {/* With no chats the row would collapse below a tab's height; an invisible
+          tab-shaped spacer keeps the bar exactly as tall as it is with tabs. */}
+      {!hasChats && (
+        <div aria-hidden className="flex-shrink-0 flex items-center px-2.5 py-1.5 text-[11.5px] invisible">
+          &nbsp;
+        </div>
+      )}
       {[...chats].reverse().map((chat) => {
         const active = !observerView && chat.id === activeChatId
         return (
@@ -473,15 +481,19 @@ const ChatTabs: React.FC<{
           </div>
         )
       })}
-      <button
-        onClick={() => pick('')}
-        title="New chat"
-        className={`flex-shrink-0 self-center ml-0.5 flex items-center justify-center w-6 h-6 rounded-md transition-colors ${
-          !observerView && activeChatId === '' ? 'bg-hover-strong text-primary' : 'text-muted hover:text-primary hover:bg-hover'
-        }`}
-      >
-        <Plus size={13} weight="bold" />
-      </button>
+      {/* No "+" until there's a chat to switch from — a fresh chat is already the
+          default, so a lone plus in the empty bar just reads as a stray chip. */}
+      {hasChats && (
+        <button
+          onClick={() => pick('')}
+          title="New chat"
+          className={`flex-shrink-0 self-center ml-0.5 flex items-center justify-center w-6 h-6 rounded-md transition-colors ${
+            !observerView && activeChatId === '' ? 'bg-hover-strong text-primary' : 'text-muted hover:text-primary hover:bg-hover'
+          }`}
+        >
+          <Plus size={13} weight="bold" />
+        </button>
+      )}
     </div>
   )
 }
@@ -696,8 +708,11 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   const lastUserIdx = feed.map((f) => f.kind).lastIndexOf('user')
   const visibleFeed = (lastUserIdx >= 0 ? feed.slice(lastUserIdx) : feed).slice(-MAX_VISIBLE_FEED)
 
-  // The eye tab swaps the body from the active chat to the full-height observer timeline.
-  const [observerView, setObserverView] = React.useState(false)
+  // The eye tab swaps the body from the active chat to the full-height observer
+  // timeline. Lifted into the store so the toolbar's input bar can disable sending
+  // while the (read-only) observer view owns the body.
+  const observerView = cateAgent.observerView
+  const setObserverView = useCateAgentStore((s) => s.setObserverView)
 
   // Stick to the bottom (newest, nearest the input) as the transcript grows, unless
   // the user has scrolled up to read.
@@ -737,10 +752,10 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
             chats={list}
             activeChatId={cateAgent.activeChatId}
             observerView={observerView}
-            onPickChat={() => setObserverView(false)}
+            onPickChat={() => setObserverView(wsId, false)}
           />
           {(visibleFeed.length > 0 || observerView) && (
-            <ObserverTab active={observerView} onClick={() => setObserverView((v) => !v)} />
+            <ObserverTab active={observerView} onClick={() => setObserverView(wsId, !observerView)} />
           )}
         </div>
         <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar h-[min(420px,55vh)] overflow-y-auto border-t border-subtle">

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -714,6 +714,28 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   const observerView = cateAgent.observerView
   const setObserverView = useCateAgentStore((s) => s.setObserverView)
 
+  // Keep the window mounted through its close animation: when the input closes we
+  // flip to `closing` (playing the fold-down) and only unmount once it finishes, so
+  // the panel animates out (vertically + tracking the toolbar's horizontal collapse)
+  // instead of vanishing.
+  const inputOpen = cateAgent.inputOpen
+  const [mounted, setMounted] = React.useState(inputOpen)
+  const [closing, setClosing] = React.useState(false)
+  React.useEffect(() => {
+    if (inputOpen) {
+      setMounted(true)
+      setClosing(false)
+      return
+    }
+    if (!mounted) return
+    setClosing(true)
+    const id = window.setTimeout(() => {
+      setMounted(false)
+      setClosing(false)
+    }, 180)
+    return () => window.clearTimeout(id)
+  }, [inputOpen, mounted])
+
   // Stick to the bottom (newest, nearest the input) as the transcript grows, unless
   // the user has scrolled up to read.
   const scrollRef = React.useRef<HTMLDivElement | null>(null)
@@ -734,7 +756,7 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
     if (el && atBottomRef.current) el.scrollTop = el.scrollHeight
   }, [msgCount, runTick, visibleFeed.length, cateAgent.activeChatId, observerView])
 
-  if (!wsId || !cateAgent.inputOpen) return null
+  if (!wsId || !mounted) return null
   const hasChats = list.length > 0
   if (!hasChats && visibleFeed.length === 0) return null
 
@@ -744,7 +766,7 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   // the observer timeline; picking a chat swaps it back.
   return (
     <div className="absolute bottom-full left-0 right-0 mb-2">
-      <div className="cate-agent-window-in flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
+      <div className={`${closing ? 'cate-agent-window-out' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
         <div className="flex-none flex items-stretch bg-surface-0">
           <ChatTabs
             wsId={wsId}

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -729,12 +729,11 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
     }
     if (!mounted) return
     setClosing(true)
-    // Match the toolbar's width transition (duration-300) so the window tracks the
-    // full horizontal collapse to min width before it unmounts.
+    // Hold the mount until the morph-into-button finishes (matches the out anim), then unmount.
     const id = window.setTimeout(() => {
       setMounted(false)
       setClosing(false)
-    }, 300)
+    }, 220)
     return () => window.clearTimeout(id)
   }, [inputOpen, mounted])
 
@@ -768,7 +767,7 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   // the observer timeline; picking a chat swaps it back.
   return (
     <div className="absolute bottom-full left-0 right-0 mb-2">
-      <div className={`${closing ? '' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
+      <div className={`${closing ? 'cate-agent-window-out' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
         <div className="flex-none flex items-stretch bg-surface-0">
           <ChatTabs
             wsId={wsId}

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -729,10 +729,12 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
     }
     if (!mounted) return
     setClosing(true)
+    // Match the toolbar's width transition (duration-300) so the window tracks the
+    // full horizontal collapse to min width before it unmounts.
     const id = window.setTimeout(() => {
       setMounted(false)
       setClosing(false)
-    }, 180)
+    }, 300)
     return () => window.clearTimeout(id)
   }, [inputOpen, mounted])
 
@@ -766,7 +768,7 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   // the observer timeline; picking a chat swaps it back.
   return (
     <div className="absolute bottom-full left-0 right-0 mb-2">
-      <div className={`${closing ? 'cate-agent-window-out' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
+      <div className={`${closing ? '' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
         <div className="flex-none flex items-stretch bg-surface-0">
           <ChatTabs
             wsId={wsId}

--- a/src/renderer/cateAgent/CateAgentChat.tsx
+++ b/src/renderer/cateAgent/CateAgentChat.tsx
@@ -1,25 +1,26 @@
 // =============================================================================
-// CateAgentChat — the Cate Agent's front door, docked above the toolbar.
+// CateAgentChat — the Cate Agent's floating window, docked above the toolbar.
 //
-// A CHAT: a persistent thread you type into. Chats are a browser-style TAB STRIP
-// (top); the running one spins, one awaiting a decision shows an amber dot. The
-// transcript below renders the active chat as a stream of TYPED blocks on one flat
-// surface — a markdown answer (`text`), a code task's plan (`plan`), its
-// parallel-attempts grid (`attempts`), its land actions (`result`), or a delegated
-// canvas task (`canvas`). Tool blocks are calm left-accent RAILS, not boxed cards,
-// so the thread reads as one conversation. Live blocks bind to the chat's `run`
-// while it goes, then freeze to a snapshot so the transcript survives a reload.
+// The FRONT DOOR is the OBSERVER: opening the agent shows a compact, read-only
+// timeline of what it has watched — a single accent rail, one dot + relative time
+// per remark, newest at the bottom. The window is only as tall as that content
+// needs. Which view is shown (observer, or a specific chat) is chosen from the
+// picker in the toolbar bar — there is no tab strip here.
 //
-// The observer's remarks (the feed tail) get their own OBSERVER view, opened from an eye
-// tab beside the chats: the window body swaps to a full-height timeline — a single accent
-// rail, one dot + relative time per remark, newest at the bottom. A transient FYI, NOT
-// chat — the observer never mints a chat, it just speaks there. Hover a remark to dismiss
-// it, or clear the whole log. The whole surface shows only while the panel is open.
+// Selecting a CHAT clears the observer view and GROWS the window into that chat's
+// transcript: a stream of TYPED blocks on one flat surface — a markdown answer
+// (`text`), a code task's plan (`plan`), its parallel-attempts grid (`attempts`),
+// its land actions (`result`), or a delegated canvas task (`canvas`). Tool blocks
+// are calm left-accent RAILS, not boxed cards, so the thread reads as one
+// conversation. Live blocks bind to the chat's `run` while it goes, then freeze to
+// a snapshot so the transcript survives a reload.
+//
+// The card's height is measured from its content, so opening, closing, and the
+// observer↔chat switch all animate purely as a grow/shrink (no fade or scale).
 // =============================================================================
 
 import React from 'react'
 import {
-  Plus,
   X,
   Stop,
   Play,
@@ -415,109 +416,6 @@ const MessageBlock: React.FC<{ chat: Chat; msg: ChatMessage; wsId: string; rootP
   }
 }
 
-// --- chat tabs ---------------------------------------------------------------
-
-const chatDot = (chat: Chat): React.ReactNode => {
-  if (chat.run?.status === 'running') return <CircleNotch size={10} className="flex-shrink-0 text-green-400 animate-spin" />
-  if (chat.run?.interrupted) return <WarningCircle size={10} weight="fill" className="flex-shrink-0 text-amber-400" />
-  if (chat.run?.status === 'review') return <GitMerge size={10} className="flex-shrink-0 text-amber-400" />
-  if (chat.run?.status === 'failed') return <X size={10} className="flex-shrink-0 text-red-400/70" />
-  return <span className="w-[6px] h-[6px] rounded-full bg-surface-5 flex-shrink-0" />
-}
-
-// Browser-style tab strip: one tab per chat (newest first), the active one pulled up
-// to merge with the transcript below, plus a trailing "+" to start a fresh chat.
-const ChatTabs: React.FC<{
-  wsId: string
-  rootPath: string
-  chats: Chat[]
-  activeChatId: string
-  /** True while the observer view owns the body, so no chat tab reads as active. */
-  observerView: boolean
-  /** Picking any chat (or the "+") leaves the observer view. */
-  onPickChat: () => void
-}> = ({ wsId, rootPath, chats, activeChatId, observerView, onPickChat }) => {
-  const setActiveChat = useCateAgentStore((s) => s.setActiveChat)
-  // With two or more chats the tabs join into a segmented strip: no gap, square
-  // corners, and shared 1px seams (collapsed via -ml-px). A lone tab keeps its
-  // rounded, standalone look.
-  const multi = chats.length >= 2
-  const hasChats = chats.length > 0
-  const pick = (chatId: string) => {
-    onPickChat()
-    setActiveChat(wsId, chatId)
-  }
-  return (
-    // No padding: tabs sit flush and fill the bar edge-to-edge. The card's rounded
-    // overflow clips the outer corners round while the seams between tabs stay square.
-    <div className={`no-scrollbar flex flex-1 min-w-0 items-stretch overflow-x-auto ${multi ? 'gap-0' : 'gap-1'}`}>
-      {/* With no chats the row would collapse below a tab's height; an invisible
-          tab-shaped spacer keeps the bar exactly as tall as it is with tabs. */}
-      {!hasChats && (
-        <div aria-hidden className="flex-shrink-0 flex items-center px-2.5 py-1.5 text-[11.5px] invisible">
-          &nbsp;
-        </div>
-      )}
-      {[...chats].reverse().map((chat) => {
-        const active = !observerView && chat.id === activeChatId
-        return (
-          <div
-            key={chat.id}
-            className={`group/tab flex-shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 -mb-px border border-b-0 transition-colors ${
-              active ? 'bg-surface-0 border-subtle' : 'border-transparent hover:bg-hover'
-            }`}
-          >
-            <button onClick={() => pick(chat.id)} className="flex items-center gap-1.5 min-w-0" title={chat.title}>
-              {chatDot(chat)}
-              <span className={`text-[11.5px] truncate max-w-[130px] ${active ? 'text-primary' : 'text-secondary'}`}>{chat.title}</span>
-            </button>
-            <button
-              onClick={() => void cateAgentController.closeChat(wsId, rootPath, chat.id)}
-              title="Delete chat"
-              className="flex-shrink-0 opacity-0 group-hover/tab:opacity-100 text-muted hover:text-red-400 transition-opacity"
-            >
-              <X size={10} />
-            </button>
-          </div>
-        )
-      })}
-      {/* No "+" until there's a chat to switch from — a fresh chat is already the
-          default, so a lone plus in the empty bar just reads as a stray chip. */}
-      {hasChats && (
-        <button
-          onClick={() => pick('')}
-          title="New chat"
-          className={`flex-shrink-0 self-center ml-0.5 flex items-center justify-center w-6 h-6 rounded-md transition-colors ${
-            !observerView && activeChatId === '' ? 'bg-hover-strong text-primary' : 'text-muted hover:text-primary hover:bg-hover'
-          }`}
-        >
-          <Plus size={13} weight="bold" />
-        </button>
-      )}
-    </div>
-  )
-}
-
-// The observer's own tab, pinned to the right of the chat tabs: a round accent dot. Toggles the
-// full-height timeline view into the window body. Only shown while the timeline has content.
-const ObserverTab: React.FC<{ active: boolean; onClick: () => void }> = ({ active, onClick }) => (
-  <button
-    onClick={onClick}
-    title="Observer"
-    aria-label="Observer"
-    aria-pressed={active}
-    className={`flex-shrink-0 flex items-center justify-center px-2.5 -mb-px border border-b-0 transition-colors ${
-      active ? 'bg-surface-0 border-subtle' : 'border-transparent hover:bg-hover'
-    }`}
-  >
-    <span
-      aria-hidden
-      className="w-2.5 h-2.5 rounded-full"
-      style={{ backgroundColor: 'rgb(var(--agent-rgb))' }}
-    />
-  </button>
-)
-
 // --- observer timeline -------------------------------------------------------
 
 // Relative age of a remark, coarsely (s / m / h). Recomputed on a slow tick so idle
@@ -708,34 +606,42 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   const lastUserIdx = feed.map((f) => f.kind).lastIndexOf('user')
   const visibleFeed = (lastUserIdx >= 0 ? feed.slice(lastUserIdx) : feed).slice(-MAX_VISIBLE_FEED)
 
-  // The eye tab swaps the body from the active chat to the full-height observer
-  // timeline. Lifted into the store so the toolbar's input bar can disable sending
-  // while the (read-only) observer view owns the body.
+  // The window shows the observer (the default front door) or the selected chat.
+  // Which one is chosen from the picker in the toolbar bar, not a tab strip here.
   const observerView = cateAgent.observerView
-  const setObserverView = useCateAgentStore((s) => s.setObserverView)
 
-  // Keep the window mounted through its close animation: when the input closes we
-  // flip to `closing` (playing the fold-down) and only unmount once it finishes, so
-  // the panel animates out (vertically + tracking the toolbar's horizontal collapse)
-  // instead of vanishing.
+  // Open/close is a morph out of / into the Cate Agent button: mount, then flip
+  // `entered` on the next frame so the enter transition plays from the collapsed
+  // (scaled-into-button, height 0) state; on close flip it back and unmount after.
   const inputOpen = cateAgent.inputOpen
   const [mounted, setMounted] = React.useState(inputOpen)
-  const [closing, setClosing] = React.useState(false)
+  const [entered, setEntered] = React.useState(false)
   React.useEffect(() => {
     if (inputOpen) {
       setMounted(true)
-      setClosing(false)
-      return
+      const r = requestAnimationFrame(() => setEntered(true))
+      return () => cancelAnimationFrame(r)
     }
-    if (!mounted) return
-    setClosing(true)
-    // Hold the mount until the morph-into-button finishes (matches the out anim), then unmount.
-    const id = window.setTimeout(() => {
-      setMounted(false)
-      setClosing(false)
-    }, 220)
+    setEntered(false)
+    const id = window.setTimeout(() => setMounted(false), 300)
     return () => window.clearTimeout(id)
-  }, [inputOpen, mounted])
+  }, [inputOpen])
+
+  // The card's height is driven by its content: compact for the observer, tall
+  // (capped, then scrolls) for a chat. Measuring the content and mirroring it onto
+  // the card's explicit height lets the height TRANSITION — so selecting a chat
+  // grows the window and returning to the observer shrinks it.
+  const contentRef = React.useRef<HTMLDivElement | null>(null)
+  const [naturalH, setNaturalH] = React.useState(0)
+  React.useLayoutEffect(() => {
+    const el = contentRef.current
+    if (!el) return
+    const measure = () => setNaturalH(el.scrollHeight)
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [mounted, observerView, activeChat?.id])
 
   // Stick to the bottom (newest, nearest the input) as the transcript grows, unless
   // the user has scrolled up to read.
@@ -758,41 +664,39 @@ export const CateAgentChat: React.FC<{ workspaceId: string; rootPath: string }> 
   }, [msgCount, runTick, visibleFeed.length, cateAgent.activeChatId, observerView])
 
   if (!wsId || !mounted) return null
-  const hasChats = list.length > 0
-  if (!hasChats && visibleFeed.length === 0) return null
 
-  // A tab bar (chats + the observer's eye tab) over a body of FIXED height, so the window
-  // stays the same size whichever tab is active — short chats have room to spare, long
-  // ones scroll — instead of jumping as you switch. The eye tab swaps that same body to
-  // the observer timeline; picking a chat swaps it back.
   return (
     <div className="absolute bottom-full left-0 right-0 mb-2">
-      <div className={`${closing ? 'cate-agent-window-out' : 'cate-agent-window-in'} flex flex-col overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]`}>
-        <div className="flex-none flex items-stretch bg-surface-0">
-          <ChatTabs
-            wsId={wsId}
-            rootPath={rootPath}
-            chats={list}
-            activeChatId={cateAgent.activeChatId}
-            observerView={observerView}
-            onPickChat={() => setObserverView(wsId, false)}
-          />
-          {(visibleFeed.length > 0 || observerView) && (
-            <ObserverTab active={observerView} onClick={() => setObserverView(wsId, !observerView)} />
-          )}
-        </div>
-        <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar h-[min(420px,55vh)] overflow-y-auto border-t border-subtle">
+      <div
+        className="overflow-hidden rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]"
+        style={{
+          // Grow only: the window opens, closes, and switches observer↔chat purely by
+          // animating its height — no fade, no scale-morph.
+          transition: 'height 280ms cubic-bezier(0.16,1,0.3,1)',
+          height: entered ? naturalH : 0,
+        }}
+      >
+        <div ref={contentRef}>
           {observerView ? (
-            <ObserverTimeline wsId={wsId} items={visibleFeed} />
-          ) : activeChat ? (
-            <div className="flex flex-col gap-3.5 px-3 py-3">
-              {activeChat.messages.map((msg) => (
-                <MessageBlock key={msg.id} chat={activeChat} msg={msg} wsId={wsId} rootPath={rootPath} worktrees={worktrees} />
-              ))}
-              <RunControls chat={activeChat} wsId={wsId} rootPath={rootPath} working={working} />
+            // Observer: only as tall as its content needs (a floor so the empty state
+            // has room, a ceiling before it scrolls).
+            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar min-h-[120px] max-h-[min(420px,55vh)] overflow-y-auto">
+              <ObserverTimeline wsId={wsId} items={visibleFeed} />
             </div>
           ) : (
-            <EmptyState />
+            // Chat: the full-height transcript, scrolling internally.
+            <div ref={scrollRef} onScroll={onScroll} className="no-scrollbar h-[min(420px,55vh)] overflow-y-auto">
+              {activeChat ? (
+                <div className="flex flex-col gap-3.5 px-3 py-3">
+                  {activeChat.messages.map((msg) => (
+                    <MessageBlock key={msg.id} chat={activeChat} msg={msg} wsId={wsId} rootPath={rootPath} worktrees={worktrees} />
+                  ))}
+                  <RunControls chat={activeChat} wsId={wsId} rootPath={rootPath} working={working} />
+                </div>
+              ) : (
+                <EmptyState />
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/renderer/cateAgent/CateAgentChatPicker.tsx
+++ b/src/renderer/cateAgent/CateAgentChatPicker.tsx
@@ -11,7 +11,7 @@
 
 import React from 'react'
 import { createPortal } from 'react-dom'
-import { CaretDown, Plus, X, CircleNotch } from '@phosphor-icons/react'
+import { CaretDown, Plus, X } from '@phosphor-icons/react'
 import { useChatsStore } from '../stores/chatsStore'
 import { useCateAgentStore, useCateAgentWs } from './cateAgentStore'
 import { cateAgentController } from './cateAgentController'
@@ -78,7 +78,7 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
   const activeChat = cateAgent.activeChatId ? chats.find((c) => c.id === cateAgent.activeChatId) : undefined
 
   // What the collapsed pill shows.
-  const label = observer ? 'Observer' : activeChat ? activeChat.title : 'New chat'
+  const label = observer ? 'Feed' : activeChat ? activeChat.title : 'New chat'
 
   const pickObserver = () => {
     setObserverView(wsId, true)
@@ -104,7 +104,6 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
         title="Choose chat"
         className="flex items-center gap-1.5 h-[30px] max-w-[168px] pl-2.5 pr-1.5 rounded-full border border-subtle bg-surface-1 hover:bg-surface-2 hover:border-strong transition-colors"
       >
-        <SelectionDot observer={observer} chat={activeChat} />
         <span className="min-w-0 truncate text-[12px] text-secondary">{label}</span>
         <CaretDown size={11} weight="bold" className={`flex-shrink-0 text-muted transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
@@ -117,11 +116,9 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
           className="fixed w-[236px] p-1.5 rounded-xl border border-strong bg-surface-0 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)]"
           style={{ left: pos.left, bottom: pos.bottom, zIndex: 60 }}
         >
-          <GroupLabel>Watching</GroupLabel>
           <Option selected={observer} onClick={pickObserver}>
             <span aria-hidden className="w-2 h-2 rounded-full flex-shrink-0" style={AGENT_DOT} />
-            <span className="flex-1 truncate">Observer</span>
-            <span className="font-mono text-[10px] text-muted">{cateAgent.feed.length > 0 ? 'live' : 'idle'}</span>
+            <span className="flex-1 truncate">Feed</span>
           </Option>
 
           {chats.length > 0 && (
@@ -130,11 +127,7 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
               <GroupLabel>Chats</GroupLabel>
               {[...chats].reverse().map((chat) => (
                 <Option key={chat.id} selected={!observer && chat.id === cateAgent.activeChatId} onClick={() => pickChat(chat.id)}>
-                  {chat.run?.status === 'running' ? (
-                    <CircleNotch size={10} className="flex-shrink-0 animate-spin" style={{ color: 'var(--green, #4ade80)' }} />
-                  ) : (
-                    <span aria-hidden className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: chatDotColor(chat) }} />
-                  )}
+                  <span aria-hidden className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: chatDotColor(chat) }} />
                   <span className="flex-1 truncate">{chat.title}</span>
                   <button
                     type="button"
@@ -163,18 +156,6 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
         document.body,
       )}
     </div>
-  )
-}
-
-// The collapsed pill's leading dot: accent for the observer, else the chat's status colour.
-const SelectionDot: React.FC<{ observer: boolean; chat?: Chat }> = ({ observer, chat }) => {
-  if (observer) return <span aria-hidden className="w-[7px] h-[7px] rounded-full flex-shrink-0" style={AGENT_DOT} />
-  return (
-    <span
-      aria-hidden
-      className="w-[7px] h-[7px] rounded-full flex-shrink-0"
-      style={{ backgroundColor: chat ? chatDotColor(chat) : 'rgb(var(--agent-rgb))' }}
-    />
   )
 }
 

--- a/src/renderer/cateAgent/CateAgentChatPicker.tsx
+++ b/src/renderer/cateAgent/CateAgentChatPicker.tsx
@@ -10,6 +10,7 @@
 // =============================================================================
 
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { CaretDown, Plus, X, CircleNotch } from '@phosphor-icons/react'
 import { useChatsStore } from '../stores/chatsStore'
 import { useCateAgentStore, useCateAgentWs } from './cateAgentStore'
@@ -38,12 +39,29 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
 
   const [open, setOpen] = React.useState(false)
   const rootRef = React.useRef<HTMLDivElement>(null)
+  const btnRef = React.useRef<HTMLButtonElement>(null)
+  const menuRef = React.useRef<HTMLDivElement>(null)
 
-  // Close on any click outside the picker, or on Escape.
+  // The popover is rendered in a PORTAL (fixed-positioned above the button), so it
+  // escapes the toolbar zone's overflow-hidden clip and stacks above the window.
+  const [pos, setPos] = React.useState<{ left: number; bottom: number } | null>(null)
+  React.useLayoutEffect(() => {
+    if (!open) return
+    const place = () => {
+      const r = btnRef.current?.getBoundingClientRect()
+      if (r) setPos({ left: r.left, bottom: window.innerHeight - r.top + 8 })
+    }
+    place()
+    window.addEventListener('resize', place)
+    return () => window.removeEventListener('resize', place)
+  }, [open])
+
+  // Close on any click outside the picker or its (portaled) menu, or on Escape.
   React.useEffect(() => {
     if (!open) return
     const onDown = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+      const t = e.target as Node
+      if (!rootRef.current?.contains(t) && !menuRef.current?.contains(t)) setOpen(false)
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false)
@@ -78,6 +96,7 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
   return (
     <div ref={rootRef} className="relative flex-shrink-0">
       <button
+        ref={btnRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="listbox"
@@ -90,11 +109,13 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
         <CaretDown size={11} weight="bold" className={`flex-shrink-0 text-muted transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
 
-      {open && (
+      {open && pos && createPortal(
         <div
+          ref={menuRef}
           role="listbox"
           aria-label="Chats"
-          className="absolute left-0 bottom-[calc(100%+8px)] w-[236px] p-1.5 rounded-xl border border-strong bg-surface-0 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)] z-10"
+          className="fixed w-[236px] p-1.5 rounded-xl border border-strong bg-surface-0 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)]"
+          style={{ left: pos.left, bottom: pos.bottom, zIndex: 60 }}
         >
           <GroupLabel>Watching</GroupLabel>
           <Option selected={observer} onClick={pickObserver}>
@@ -138,7 +159,8 @@ export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: stri
             </span>
             <span className="flex-1 truncate" style={{ color: 'rgb(var(--agent-rgb))' }}>New chat</span>
           </Option>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/src/renderer/cateAgent/CateAgentChatPicker.tsx
+++ b/src/renderer/cateAgent/CateAgentChatPicker.tsx
@@ -1,0 +1,176 @@
+// =============================================================================
+// CateAgentChatPicker — the chat selector that replaces the old tab strip. It
+// sits in the toolbar bar (left of the input) and names what the window is
+// showing: the Observer (the default front door), a specific chat, or a fresh
+// "New chat". Clicking it opens a drop-up list of all of those.
+//
+// Picking the Observer keeps the window compact (a read-only feed); picking a
+// chat clears the observer view and grows the window into that chat's transcript
+// (see cateAgentStore.observerView + CateAgentChat).
+// =============================================================================
+
+import React from 'react'
+import { CaretDown, Plus, X, CircleNotch } from '@phosphor-icons/react'
+import { useChatsStore } from '../stores/chatsStore'
+import { useCateAgentStore, useCateAgentWs } from './cateAgentStore'
+import { cateAgentController } from './cateAgentController'
+import type { Chat } from '../../shared/types'
+
+// The status colour a chat's dot carries in the list (mirrors the old tab dot).
+const chatDotColor = (chat: Chat): string => {
+  if (chat.run?.status === 'running') return 'var(--green, #4ade80)'
+  if (chat.run?.interrupted || chat.run?.status === 'review') return '#fbbf24'
+  if (chat.run?.status === 'failed') return '#f87171'
+  return 'var(--surface-5)'
+}
+
+const AGENT_DOT: React.CSSProperties = {
+  backgroundColor: 'rgb(var(--agent-rgb))',
+  boxShadow: '0 0 0 2.5px color-mix(in srgb, rgb(var(--agent-rgb)) 18%, transparent)',
+}
+
+export const CateAgentChatPicker: React.FC<{ workspaceId: string; rootPath: string }> = ({ workspaceId, rootPath }) => {
+  const wsId = workspaceId
+  const cateAgent = useCateAgentWs(wsId)
+  const chats = useChatsStore((s) => s.chatsByRoot[rootPath]) ?? []
+  const setObserverView = useCateAgentStore((s) => s.setObserverView)
+  const setActiveChat = useCateAgentStore((s) => s.setActiveChat)
+
+  const [open, setOpen] = React.useState(false)
+  const rootRef = React.useRef<HTMLDivElement>(null)
+
+  // Close on any click outside the picker, or on Escape.
+  React.useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', onDown)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('mousedown', onDown)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const observer = cateAgent.observerView
+  const activeChat = cateAgent.activeChatId ? chats.find((c) => c.id === cateAgent.activeChatId) : undefined
+
+  // What the collapsed pill shows.
+  const label = observer ? 'Observer' : activeChat ? activeChat.title : 'New chat'
+
+  const pickObserver = () => {
+    setObserverView(wsId, true)
+    setOpen(false)
+  }
+  const pickChat = (chatId: string) => {
+    setActiveChat(wsId, chatId) // clears observerView
+    setOpen(false)
+  }
+  const pickNew = () => {
+    setActiveChat(wsId, '') // clears observerView; composes a fresh chat
+    setOpen(false)
+  }
+
+  return (
+    <div ref={rootRef} className="relative flex-shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title="Choose chat"
+        className="flex items-center gap-1.5 h-[30px] max-w-[168px] pl-2.5 pr-1.5 rounded-full border border-subtle bg-surface-1 hover:bg-surface-2 hover:border-strong transition-colors"
+      >
+        <SelectionDot observer={observer} chat={activeChat} />
+        <span className="min-w-0 truncate text-[12px] text-secondary">{label}</span>
+        <CaretDown size={11} weight="bold" className={`flex-shrink-0 text-muted transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Chats"
+          className="absolute left-0 bottom-[calc(100%+8px)] w-[236px] p-1.5 rounded-xl border border-strong bg-surface-0 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.6)] z-10"
+        >
+          <GroupLabel>Watching</GroupLabel>
+          <Option selected={observer} onClick={pickObserver}>
+            <span aria-hidden className="w-2 h-2 rounded-full flex-shrink-0" style={AGENT_DOT} />
+            <span className="flex-1 truncate">Observer</span>
+            <span className="font-mono text-[10px] text-muted">{cateAgent.feed.length > 0 ? 'live' : 'idle'}</span>
+          </Option>
+
+          {chats.length > 0 && (
+            <>
+              <div className="h-px my-1.5 mx-1" style={{ backgroundColor: 'var(--border-subtle)' }} />
+              <GroupLabel>Chats</GroupLabel>
+              {[...chats].reverse().map((chat) => (
+                <Option key={chat.id} selected={!observer && chat.id === cateAgent.activeChatId} onClick={() => pickChat(chat.id)}>
+                  {chat.run?.status === 'running' ? (
+                    <CircleNotch size={10} className="flex-shrink-0 animate-spin" style={{ color: 'var(--green, #4ade80)' }} />
+                  ) : (
+                    <span aria-hidden className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: chatDotColor(chat) }} />
+                  )}
+                  <span className="flex-1 truncate">{chat.title}</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      void cateAgentController.closeChat(wsId, rootPath, chat.id)
+                    }}
+                    title="Delete chat"
+                    className="flex-shrink-0 -mr-0.5 p-0.5 rounded text-muted opacity-0 group-hover/opt:opacity-100 hover:text-red-400 hover:bg-hover transition-opacity"
+                  >
+                    <X size={11} />
+                  </button>
+                </Option>
+              ))}
+            </>
+          )}
+
+          <div className="h-px my-1.5 mx-1" style={{ backgroundColor: 'var(--border-subtle)' }} />
+          <Option onClick={pickNew}>
+            <span className="flex-shrink-0 flex items-center justify-center w-2 h-2" style={{ color: 'rgb(var(--agent-rgb))' }}>
+              <Plus size={12} weight="bold" />
+            </span>
+            <span className="flex-1 truncate" style={{ color: 'rgb(var(--agent-rgb))' }}>New chat</span>
+          </Option>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// The collapsed pill's leading dot: accent for the observer, else the chat's status colour.
+const SelectionDot: React.FC<{ observer: boolean; chat?: Chat }> = ({ observer, chat }) => {
+  if (observer) return <span aria-hidden className="w-[7px] h-[7px] rounded-full flex-shrink-0" style={AGENT_DOT} />
+  return (
+    <span
+      aria-hidden
+      className="w-[7px] h-[7px] rounded-full flex-shrink-0"
+      style={{ backgroundColor: chat ? chatDotColor(chat) : 'rgb(var(--agent-rgb))' }}
+    />
+  )
+}
+
+const GroupLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="px-2 pt-1.5 pb-1 font-mono text-[9.5px] tracking-[0.1em] uppercase text-muted">{children}</div>
+)
+
+const Option: React.FC<{ selected?: boolean; onClick: () => void; children: React.ReactNode }> = ({ selected, onClick, children }) => (
+  <button
+    type="button"
+    role="option"
+    aria-selected={selected}
+    onClick={onClick}
+    className={`group/opt flex items-center gap-2.5 w-full px-2 py-1.5 rounded-md text-left text-[12.5px] transition-colors ${
+      selected ? 'text-primary' : 'text-secondary hover:text-primary hover:bg-hover'
+    }`}
+    style={selected ? { backgroundColor: 'color-mix(in srgb, rgb(var(--agent-rgb)) 14%, transparent)' } : undefined}
+  >
+    {children}
+  </button>
+)

--- a/src/renderer/cateAgent/CateAgentInputBar.tsx
+++ b/src/renderer/cateAgent/CateAgentInputBar.tsx
@@ -38,11 +38,13 @@ export const CateAgentInputBar: React.FC<{
   workspaceId: string
   /** Bottom-anchor controls when the input has wrapped (else vertically center). */
   multiline: boolean
+  /** Read-only: the observer timeline owns the panel body, which takes no reply. */
+  disabled?: boolean
   onSend: (text: string) => void
   onClose: () => void
   /** Reports the textarea's current content height (px) so the toolbar resizes. */
   onHeightChange?: (px: number) => void
-}> = ({ workspaceId, multiline, onSend, onClose, onHeightChange }) => {
+}> = ({ workspaceId, multiline, disabled, onSend, onClose, onHeightChange }) => {
   // Seed from the persisted draft so a reopened bar (or a fresh app launch)
   // restores whatever was typed but not sent.
   const [text, setText] = React.useState(() => loadDraft(workspaceId))
@@ -102,6 +104,7 @@ export const CateAgentInputBar: React.FC<{
   }, [resize])
 
   const send = () => {
+    if (disabled) return
     const t = text.trim()
     if (!t) return
     onSend(t)
@@ -114,6 +117,7 @@ export const CateAgentInputBar: React.FC<{
         ref={ref}
         rows={1}
         value={text}
+        disabled={disabled}
         onChange={(e) => update(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
@@ -124,14 +128,14 @@ export const CateAgentInputBar: React.FC<{
             onClose()
           }
         }}
-        placeholder="Message Cate…"
-        className="flex-1 min-w-0 resize-none bg-transparent text-sm leading-snug text-primary px-2 py-1.5 outline-none placeholder:text-muted"
+        placeholder={disabled ? 'Viewing observer feed' : 'Message Cate…'}
+        className="flex-1 min-w-0 resize-none bg-transparent text-sm leading-snug text-primary px-2 py-1.5 outline-none placeholder:text-muted disabled:cursor-default"
         style={{ maxHeight: MAX_HEIGHT }}
       />
       <button
         type="button"
         onClick={send}
-        disabled={!text.trim()}
+        disabled={disabled || !text.trim()}
         aria-label="Send"
         title="Send"
         style={{ WebkitTapHighlightColor: 'transparent' }}

--- a/src/renderer/cateAgent/CateAgentInputBar.tsx
+++ b/src/renderer/cateAgent/CateAgentInputBar.tsx
@@ -38,13 +38,13 @@ export const CateAgentInputBar: React.FC<{
   workspaceId: string
   /** Bottom-anchor controls when the input has wrapped (else vertically center). */
   multiline: boolean
-  /** Read-only: the observer timeline owns the panel body, which takes no reply. */
-  disabled?: boolean
+  /** Placeholder text (varies with what the window is showing, e.g. the observer). */
+  placeholder?: string
   onSend: (text: string) => void
   onClose: () => void
   /** Reports the textarea's current content height (px) so the toolbar resizes. */
   onHeightChange?: (px: number) => void
-}> = ({ workspaceId, multiline, disabled, onSend, onClose, onHeightChange }) => {
+}> = ({ workspaceId, multiline, placeholder = 'Message Cate…', onSend, onClose, onHeightChange }) => {
   // Seed from the persisted draft so a reopened bar (or a fresh app launch)
   // restores whatever was typed but not sent.
   const [text, setText] = React.useState(() => loadDraft(workspaceId))
@@ -104,7 +104,6 @@ export const CateAgentInputBar: React.FC<{
   }, [resize])
 
   const send = () => {
-    if (disabled) return
     const t = text.trim()
     if (!t) return
     onSend(t)
@@ -117,7 +116,6 @@ export const CateAgentInputBar: React.FC<{
         ref={ref}
         rows={1}
         value={text}
-        disabled={disabled}
         onChange={(e) => update(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
@@ -128,14 +126,14 @@ export const CateAgentInputBar: React.FC<{
             onClose()
           }
         }}
-        placeholder={disabled ? 'Viewing observer feed' : 'Message Cate…'}
-        className="flex-1 min-w-0 resize-none bg-transparent text-sm leading-snug text-primary px-2 py-1.5 outline-none placeholder:text-muted disabled:cursor-default"
+        placeholder={placeholder}
+        className="flex-1 min-w-0 resize-none bg-transparent text-sm leading-snug text-primary px-2 py-1.5 outline-none placeholder:text-muted"
         style={{ maxHeight: MAX_HEIGHT }}
       />
       <button
         type="button"
         onClick={send}
-        disabled={disabled || !text.trim()}
+        disabled={!text.trim()}
         aria-label="Send"
         title="Send"
         style={{ WebkitTapHighlightColor: 'transparent' }}

--- a/src/renderer/cateAgent/CateAgentToolbarButton.tsx
+++ b/src/renderer/cateAgent/CateAgentToolbarButton.tsx
@@ -26,7 +26,7 @@ export const CateAgentToolbarButton: React.FC<{
   const color = COLOR[activity] ?? COLOR.resting
   const busy = activity === 'working' || activity === 'observing'
   return (
-    <Tooltip label={attention ? 'Cate Agent — new activity' : 'Cate Agent — ask it to do something'} placement="top">
+    <Tooltip label={attention ? 'Cate Agent: new activity' : 'Cate Agent'} placement="top">
       <button
         type="button"
         onClick={onClick}

--- a/src/renderer/cateAgent/cateAgentStore.test.ts
+++ b/src/renderer/cateAgent/cateAgentStore.test.ts
@@ -75,6 +75,42 @@ describe('cateAgentStore — appendFeed kinds', () => {
     s.appendFeed('w', 'error', 'boom')
     expect(useCateAgentStore.getState().get('w').feed.map((f) => f.kind)).toEqual(['user', 'agent', 'error'])
   })
+
+  it('carries an optional suggestion action; a plain remark has none', () => {
+    const s = useCateAgentStore.getState()
+    s.appendFeed('w', 'agent', 'a null token slips through', { label: 'Fix', prompt: 'Fix the null-token crash in auth.ts' })
+    s.appendFeed('w', 'agent', 'just watching')
+    const feed = useCateAgentStore.getState().get('w').feed
+    expect(feed[0].action).toEqual({ label: 'Fix', prompt: 'Fix the null-token crash in auth.ts' })
+    expect(feed[1].action).toBeUndefined()
+  })
+
+  it('resolveFeedAction marks a suggestion but keeps it in the feed', () => {
+    const s = useCateAgentStore.getState()
+    s.appendFeed('w', 'agent', 'fix it', { label: 'Fix', prompt: 'do the fix' })
+    const id = useCateAgentStore.getState().get('w').feed[0].id
+    s.resolveFeedAction('w', id, 'approved')
+    const feed = useCateAgentStore.getState().get('w').feed
+    expect(feed).toHaveLength(1)
+    expect(feed[0].resolved).toBe('approved')
+  })
+
+  it('resolveFeedAction is idempotent — a second resolve does not overwrite the first', () => {
+    const s = useCateAgentStore.getState()
+    s.appendFeed('w', 'agent', 'fix it', { label: 'Fix', prompt: 'do the fix' })
+    const id = useCateAgentStore.getState().get('w').feed[0].id
+    s.resolveFeedAction('w', id, 'approved')
+    s.resolveFeedAction('w', id, 'dismissed')
+    expect(useCateAgentStore.getState().get('w').feed[0].resolved).toBe('approved')
+  })
+
+  it('resolveFeedAction ignores plain remarks (no action to resolve)', () => {
+    const s = useCateAgentStore.getState()
+    s.appendFeed('w', 'agent', 'just watching')
+    const id = useCateAgentStore.getState().get('w').feed[0].id
+    s.resolveFeedAction('w', id, 'approved')
+    expect(useCateAgentStore.getState().get('w').feed[0].resolved).toBeUndefined()
+  })
 })
 
 describe('cateAgentStore — unseen activity indicator', () => {

--- a/src/renderer/cateAgent/cateAgentStore.ts
+++ b/src/renderer/cateAgent/cateAgentStore.ts
@@ -38,6 +38,10 @@ export interface CateAgentWsState {
   /** The chat the input composes into and the transcript shows. Empty string means
    *  "compose a new chat" (one is minted on the first send). */
   activeChatId: string
+  /** The observer timeline (eye tab) owns the panel body instead of a chat. A
+   *  read-only FYI view — the input bar is disabled while it's shown, since the
+   *  observer never takes a reply. */
+  observerView: boolean
   /** Persistent-per-session feedback log shown above the toolbar, newest last. */
   feed: CateAgentFeedItem[]
   /** Terminals the orchestrator is actively driving → their pulsing glow color, keyed
@@ -61,6 +65,7 @@ export const DEFAULT_CATE_AGENT_WS: CateAgentWsState = {
   status: '',
   inputOpen: false,
   activeChatId: '',
+  observerView: false,
   feed: [],
   controlledTerminals: {},
   runAnchors: {},
@@ -75,6 +80,8 @@ interface CateAgentStore {
   setInputOpen: (wsId: string, open: boolean) => void
   /** Select the active chat (empty string = compose a new one). */
   setActiveChat: (wsId: string, chatId: string) => void
+  /** Toggle the observer timeline view (eye tab) on/off. */
+  setObserverView: (wsId: string, value: boolean) => void
   appendFeed: (wsId: string, kind: CateAgentFeedKind, text: string) => void
   /** Remove a single feed line by id (the per-remark dismiss button). */
   dismissFeedItem: (wsId: string, id: number) => void
@@ -106,14 +113,28 @@ export const useCateAgentStore = create<CateAgentStore>((set, getStore) => ({
     set((s) => {
       const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
       // Opening the panel means the user has now seen any pending activity.
-      return { byWs: { ...s.byWs, [wsId]: { ...prev, inputOpen: open, unseen: open ? false : prev.unseen } } }
+      // Closing drops the observer view so a reopen always lands on the chat.
+      return {
+        byWs: {
+          ...s.byWs,
+          [wsId]: { ...prev, inputOpen: open, unseen: open ? false : prev.unseen, observerView: open ? prev.observerView : false },
+        },
+      }
     })
   },
 
   setActiveChat(wsId, chatId) {
     set((s) => {
       const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
-      return { byWs: { ...s.byWs, [wsId]: { ...prev, activeChatId: chatId } } }
+      // Picking a chat always leaves the observer timeline.
+      return { byWs: { ...s.byWs, [wsId]: { ...prev, activeChatId: chatId, observerView: false } } }
+    })
+  },
+
+  setObserverView(wsId, value) {
+    set((s) => {
+      const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
+      return { byWs: { ...s.byWs, [wsId]: { ...prev, observerView: value } } }
     })
   },
 

--- a/src/renderer/cateAgent/cateAgentStore.ts
+++ b/src/renderer/cateAgent/cateAgentStore.ts
@@ -15,11 +15,26 @@ import type { CateAgentActivity, Point } from '../../shared/types'
  *  cleared or rolls past the cap. */
 export type CateAgentFeedKind = 'user' | 'agent' | 'status' | 'error'
 
+/** An observer-authored, ready-to-run prompt for the Cate Agent. When a feed item
+ *  carries one, the timeline renders a call-to-action button labelled `label`
+ *  (the observer's free choice, e.g. "Fix", "Implement") that starts a new chat
+ *  with `prompt`. */
+export interface CateAgentFeedAction {
+  label: string
+  prompt: string
+}
+
 export interface CateAgentFeedItem {
   id: number
   kind: CateAgentFeedKind
   text: string
   ts: number
+  /** Present on a suggestion: a one-click prompt the user can run as a new chat. */
+  action?: CateAgentFeedAction
+  /** A suggestion, once acted on, stays in the feed as a record but can't be run or
+   *  dismissed again. Undefined = still pending; 'approved' = the user ran it;
+   *  'dismissed' = the user waved it off. */
+  resolved?: 'approved' | 'dismissed'
 }
 
 let feedSeq = 0
@@ -83,9 +98,12 @@ interface CateAgentStore {
   setActiveChat: (wsId: string, chatId: string) => void
   /** Toggle the observer timeline view (eye tab) on/off. */
   setObserverView: (wsId: string, value: boolean) => void
-  appendFeed: (wsId: string, kind: CateAgentFeedKind, text: string) => void
+  appendFeed: (wsId: string, kind: CateAgentFeedKind, text: string, action?: CateAgentFeedAction) => void
   /** Remove a single feed line by id (the per-remark dismiss button). */
   dismissFeedItem: (wsId: string, id: number) => void
+  /** Mark a suggestion acted-on (run or waved off). It stays in the feed as a record
+   *  but its button + dismiss are spent — idempotent, so it can't resolve twice. */
+  resolveFeedAction: (wsId: string, id: number, resolution: 'approved' | 'dismissed') => void
   clearFeed: (wsId: string) => void
   /** Flag/clear unseen agent activity (drives the toolbar attention indicator). */
   setUnseen: (wsId: string, value: boolean) => void
@@ -140,10 +158,10 @@ export const useCateAgentStore = create<CateAgentStore>((set, getStore) => ({
     })
   },
 
-  appendFeed(wsId, kind, text) {
+  appendFeed(wsId, kind, text, action) {
     set((s) => {
       const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
-      const item: CateAgentFeedItem = { id: ++feedSeq, kind, text, ts: Date.now() }
+      const item: CateAgentFeedItem = { id: ++feedSeq, kind, text, ts: Date.now(), action }
       // Agent output (anything but the user's own line) arriving while the panel
       // is closed becomes unseen activity → toolbar attention indicator.
       const unseen = prev.unseen || (kind !== 'user' && !prev.inputOpen)
@@ -156,6 +174,18 @@ export const useCateAgentStore = create<CateAgentStore>((set, getStore) => ({
       const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
       const feed = prev.feed.filter((f) => f.id !== id)
       if (feed.length === prev.feed.length) return s
+      return { byWs: { ...s.byWs, [wsId]: { ...prev, feed } } }
+    })
+  },
+
+  resolveFeedAction(wsId, id, resolution) {
+    set((s) => {
+      const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
+      // Only pending suggestions resolve; already-resolved (or plain) items are left
+      // untouched so a double-click can't re-run or re-dismiss.
+      const target = prev.feed.find((f) => f.id === id)
+      if (!target || !target.action || target.resolved) return s
+      const feed = prev.feed.map((f) => (f.id === id ? { ...f, resolved: resolution } : f))
       return { byWs: { ...s.byWs, [wsId]: { ...prev, feed } } }
     })
   },

--- a/src/renderer/cateAgent/cateAgentStore.ts
+++ b/src/renderer/cateAgent/cateAgentStore.ts
@@ -38,9 +38,10 @@ export interface CateAgentWsState {
   /** The chat the input composes into and the transcript shows. Empty string means
    *  "compose a new chat" (one is minted on the first send). */
   activeChatId: string
-  /** The observer timeline (eye tab) owns the panel body instead of a chat. A
-   *  read-only FYI view — the input bar is disabled while it's shown, since the
-   *  observer never takes a reply. */
+  /** The observer timeline owns the panel body instead of a chat. This is the
+   *  DEFAULT the panel opens onto (the front door): a compact, read-only view of
+   *  what the observer has watched. Picking a chat (or sending a first message)
+   *  turns it off and grows the window into that chat. */
   observerView: boolean
   /** Persistent-per-session feedback log shown above the toolbar, newest last. */
   feed: CateAgentFeedItem[]
@@ -112,12 +113,13 @@ export const useCateAgentStore = create<CateAgentStore>((set, getStore) => ({
   setInputOpen(wsId, open) {
     set((s) => {
       const prev = s.byWs[wsId] ?? DEFAULT_CATE_AGENT_WS
-      // Opening the panel means the user has now seen any pending activity.
-      // Closing drops the observer view so a reopen always lands on the chat.
+      // Opening the panel means the user has now seen any pending activity, and it
+      // opens onto the observer (the front door) by default — not a chat. Closing
+      // drops the observer view so the next open starts clean.
       return {
         byWs: {
           ...s.byWs,
-          [wsId]: { ...prev, inputOpen: open, unseen: open ? false : prev.unseen, observerView: open ? prev.observerView : false },
+          [wsId]: { ...prev, inputOpen: open, unseen: open ? false : prev.unseen, observerView: open },
         },
       }
     })

--- a/src/renderer/cateAgent/cateAgentTools.ts
+++ b/src/renderer/cateAgent/cateAgentTools.ts
@@ -214,6 +214,12 @@ function setRemark(wsId: string, text: string): void {
   useCateAgentStore.getState().appendFeed(wsId, 'agent', text)
 }
 
+/** Surface an observer suggestion: a feed line carrying a one-click, ready-to-run
+ *  prompt for the coding agent (button labelled by the observer). */
+function setSuggestion(wsId: string, text: string, label: string, prompt: string): void {
+  useCateAgentStore.getState().appendFeed(wsId, 'agent', text, { label, prompt })
+}
+
 // --- observe context --------------------------------------------------------
 
 /** Snapshot of the workspace the observer needs every turn. */
@@ -445,6 +451,15 @@ export async function runCateAgentTool(ctx: CateAgentContext, tool: string, para
       const text = String(params.text ?? '').trim()
       if (!text) return json({ ok: false, error: 'text is required' })
       setRemark(wsId, text.slice(0, 200))
+      return json({ ok: true })
+    }
+
+    case 'suggest': {
+      const text = String(params.text ?? '').trim()
+      const label = String(params.label ?? '').trim()
+      const prompt = String(params.prompt ?? '').trim()
+      if (!text || !prompt) return json({ ok: false, error: 'text and prompt are required' })
+      setSuggestion(wsId, text.slice(0, 200), (label || 'Run').slice(0, 24), prompt.slice(0, 4000))
       return json({ ok: true })
     }
 

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -253,6 +253,19 @@
   animation: cate-fade-in 0.35s ease-out both;
 }
 
+/* Cate Agent chat window entrance — the panel is anchored to the top of the
+   toolbar (bottom-full), so it grows UP out of it: a vertical unfold (scaleY
+   from the bottom edge) that pairs with the toolbar's horizontal width stretch,
+   so opening reads as one panel expanding rather than a card popping in. */
+@keyframes cate-agent-window-in {
+  from { opacity: 0; transform: translateY(6px) scaleY(0.9); }
+  to   { opacity: 1; transform: translateY(0) scaleY(1); }
+}
+.cate-agent-window-in {
+  transform-origin: bottom center;
+  animation: cate-agent-window-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 /* Skill install progress — an indeterminate left-to-right fill on an agent pill
    while a skill downloads/installs. The pill sets position:relative;overflow:hidden
    and renders <span class="skill-fill"> behind its label. Fills, fades, repeats

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -258,8 +258,8 @@
    from the bottom edge) that pairs with the toolbar's horizontal width stretch,
    so opening reads as one panel expanding rather than a card popping in. */
 @keyframes cate-agent-window-in {
-  from { opacity: 0; transform: translateY(6px) scaleY(0.9); }
-  to   { opacity: 1; transform: translateY(0) scaleY(1); }
+  from { transform: scaleY(0); }
+  to   { transform: scaleY(1); }
 }
 .cate-agent-window-in {
   transform-origin: bottom center;
@@ -267,11 +267,11 @@
 }
 /* ...and its reverse on close: the panel folds back DOWN into the toolbar while
    the toolbar collapses its width, so the window shrinks vertically (scaleY) and
-   horizontally (it tracks the shrinking toolbar) at once. Kept mounted for the
-   animation's duration, then unmounted. */
+   horizontally (it tracks the shrinking toolbar) at once — no fade, it just gets
+   smaller. Kept mounted for the animation's duration, then unmounted. */
 @keyframes cate-agent-window-out {
-  from { opacity: 1; transform: translateY(0) scaleY(1); }
-  to   { opacity: 0; transform: translateY(6px) scaleY(0.9); }
+  from { transform: scaleY(1); }
+  to   { transform: scaleY(0); }
 }
 .cate-agent-window-out {
   transform-origin: bottom center;

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -265,17 +265,9 @@
   transform-origin: bottom center;
   animation: cate-agent-window-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
-/* On close it collapses HORIZONTALLY only (scaleX toward the center), matching the
-   toolbar's width collapse — no vertical fold, no fade. Kept mounted for the
-   animation's duration, then unmounted. */
-@keyframes cate-agent-window-out {
-  from { transform: scaleX(1); }
-  to   { transform: scaleX(0); }
-}
-.cate-agent-window-out {
-  transform-origin: center;
-  animation: cate-agent-window-out 180ms cubic-bezier(0.4, 0, 0.2, 1) both;
-}
+/* On close there's no exit transform: the window is anchored left-0/right-0, so it
+   simply tracks the toolbar's collapsing width and shrinks horizontally to the
+   toolbar's min width (not to nothing), then unmounts. */
 
 /* Skill install progress — an indeterminate left-to-right fill on an agent pill
    while a skill downloads/installs. The pill sets position:relative;overflow:hidden

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -265,16 +265,15 @@
   transform-origin: bottom center;
   animation: cate-agent-window-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
-/* ...and its reverse on close: the panel folds back DOWN into the toolbar while
-   the toolbar collapses its width, so the window shrinks vertically (scaleY) and
-   horizontally (it tracks the shrinking toolbar) at once — no fade, it just gets
-   smaller. Kept mounted for the animation's duration, then unmounted. */
+/* On close it collapses HORIZONTALLY only (scaleX toward the center), matching the
+   toolbar's width collapse — no vertical fold, no fade. Kept mounted for the
+   animation's duration, then unmounted. */
 @keyframes cate-agent-window-out {
-  from { transform: scaleY(1); }
-  to   { transform: scaleY(0); }
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
 }
 .cate-agent-window-out {
-  transform-origin: bottom center;
+  transform-origin: center;
   animation: cate-agent-window-out 180ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -265,6 +265,18 @@
   transform-origin: bottom center;
   animation: cate-agent-window-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+/* ...and its reverse on close: the panel folds back DOWN into the toolbar while
+   the toolbar collapses its width, so the window shrinks vertically (scaleY) and
+   horizontally (it tracks the shrinking toolbar) at once. Kept mounted for the
+   animation's duration, then unmounted. */
+@keyframes cate-agent-window-out {
+  from { opacity: 1; transform: translateY(0) scaleY(1); }
+  to   { opacity: 0; transform: translateY(6px) scaleY(0.9); }
+}
+.cate-agent-window-out {
+  transform-origin: bottom center;
+  animation: cate-agent-window-out 180ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
 
 /* Skill install progress — an indeterminate left-to-right fill on an agent pill
    while a skill downloads/installs. The pill sets position:relative;overflow:hidden

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -253,21 +253,31 @@
   animation: cate-fade-in 0.35s ease-out both;
 }
 
-/* Cate Agent chat window entrance — the panel is anchored to the top of the
-   toolbar (bottom-full), so it grows UP out of it: a vertical unfold (scaleY
-   from the bottom edge) that pairs with the toolbar's horizontal width stretch,
-   so opening reads as one panel expanding rather than a card popping in. */
+/* Cate Agent chat window morph — the panel grows out of / collapses into the
+   Cate Agent toolbar button (its entry point). The scale origin is aimed at that
+   button's center: the button is w-9 (36px) inside the pill's px-1/py-1 (4px), so
+   its center is ~22px right of the pill's left edge and ~22px below the pill top;
+   the window sits left-0 above the pill with an 8px (mb-2) gap, putting the button
+   at (22px, 100% + 30px) in the card's own box. Opening scales up from there,
+   closing scales back into it. */
 @keyframes cate-agent-window-in {
-  from { transform: scaleY(0); }
-  to   { transform: scaleY(1); }
+  from { transform: scale(0.05); }
+  to   { transform: scale(1); }
+}
+@keyframes cate-agent-window-out {
+  from { transform: scale(1); }
+  to   { transform: scale(0.05); }
+}
+.cate-agent-window-in,
+.cate-agent-window-out {
+  transform-origin: 22px calc(100% + 30px);
 }
 .cate-agent-window-in {
-  transform-origin: bottom center;
-  animation: cate-agent-window-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: cate-agent-window-in 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
-/* On close there's no exit transform: the window is anchored left-0/right-0, so it
-   simply tracks the toolbar's collapsing width and shrinks horizontally to the
-   toolbar's min width (not to nothing), then unmounts. */
+.cate-agent-window-out {
+  animation: cate-agent-window-out 220ms cubic-bezier(0.4, 0, 0.2, 1) both;
+}
 
 /* Skill install progress — an indeterminate left-to-right fill on an agent pill
    while a skill downloads/installs. The pill sets position:relative;overflow:hidden

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -253,31 +253,6 @@
   animation: cate-fade-in 0.35s ease-out both;
 }
 
-/* Cate Agent chat window morph — the panel grows out of / collapses into the
-   Cate Agent toolbar button (its entry point). The scale origin is aimed at that
-   button's center: the button is w-9 (36px) inside the pill's px-1/py-1 (4px), so
-   its center is ~22px right of the pill's left edge and ~22px below the pill top;
-   the window sits left-0 above the pill with an 8px (mb-2) gap, putting the button
-   at (22px, 100% + 30px) in the card's own box. Opening scales up from there,
-   closing scales back into it. */
-@keyframes cate-agent-window-in {
-  from { transform: scale(0.05); }
-  to   { transform: scale(1); }
-}
-@keyframes cate-agent-window-out {
-  from { transform: scale(1); }
-  to   { transform: scale(0.05); }
-}
-.cate-agent-window-in,
-.cate-agent-window-out {
-  transform-origin: 22px calc(100% + 30px);
-}
-.cate-agent-window-in {
-  animation: cate-agent-window-in 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.cate-agent-window-out {
-  animation: cate-agent-window-out 220ms cubic-bezier(0.4, 0, 0.2, 1) both;
-}
 
 /* Skill install progress — an indeterminate left-to-right fill on an agent pill
    while a skill downloads/installs. The pill sets position:relative;overflow:hidden


### PR DESCRIPTION
When the Cate Agent panel has no chats yet, the toolbar rendered a stray floating "+" in an otherwise empty, collapsed bar. And while viewing the read-only observer feed you could still type and send a message.

- No chats: hide the new-chat "+", keep the tab bar at full tab height (invisible spacer), and show the empty chat screen in the body
- Observer view (eye tab) is lifted into the store so the toolbar knows about it; the input bar is disabled while it's shown and sends are blocked
- Removed em dashes from the toolbar button tooltip