### PR TITLE
chore(release): 1.4.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.4.0-beta.1",
+      "version": "1.4.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.4.0-beta.1'
+export const RUNTIME_VERSION = '1.4.0-beta.2'


### PR DESCRIPTION
Bumps to 1.4.0-beta.2. Picks up the cate-agent toolbar/chat work merged since beta.1 (#436).