### PR TITLE
Bump pi packages to 0.80.6 for new model catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.4",
-        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
         "@parcel/watcher": "^2.5.1",
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/electron": "^5.11.0",
@@ -38,7 +38,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.75.4",
+        "@earendil-works/pi-coding-agent": "^0.80.6",
         "@electron/rebuild": "^4.0.3",
         "@eslint/js": "^9.39.0",
         "@playwright/test": "^1.60.0",
@@ -152,20 +152,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -241,17 +227,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
-      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -260,15 +246,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
-      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -276,41 +262,55 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
-      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
-      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/credential-provider-env": "^3.972.38",
-        "@aws-sdk/credential-provider-http": "^3.972.40",
-        "@aws-sdk/credential-provider-login": "^3.972.42",
-        "@aws-sdk/credential-provider-process": "^3.972.38",
-        "@aws-sdk/credential-provider-sso": "^3.972.42",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -318,16 +318,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
-      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -335,21 +335,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
-      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.38",
-        "@aws-sdk/credential-provider-http": "^3.972.40",
-        "@aws-sdk/credential-provider-ini": "^3.972.42",
-        "@aws-sdk/credential-provider-process": "^3.972.38",
-        "@aws-sdk/credential-provider-sso": "^3.972.42",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -357,15 +357,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
-      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -373,17 +373,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
-      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/token-providers": "3.1049.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -391,16 +391,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
-      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -408,16 +408,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
-      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -425,14 +425,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.26.tgz",
+      "integrity": "sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,14 +440,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.22.tgz",
+      "integrity": "sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -455,17 +455,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.20.tgz",
-      "integrity": "sha512-LM6P0i+Lu6pi25oNw2nqxjRxiEOtLgPB7xIvHfa+FxHTRLg8wcgqu3qg2COl4QaT7Es2yCxYdeRLVYazKAwL8g==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.39.tgz",
+      "integrity": "sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -473,36 +473,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
-      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -527,12 +538,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -540,9 +551,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -552,14 +563,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -567,9 +576,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -846,9 +855,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1074,12 +1083,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
-      "integrity": "sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "integrity": "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1089,15 +1098,16 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
-      "integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -1112,17 +1122,26 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.4.tgz",
-      "integrity": "sha512-Fb+FRo08b5H9pYKbQJ708/5OKL0+K/yclhfCMEhrBzSPTZZ4c85nY1YsBo4qwL20ohBMlBezHMRuHzcJ1ylEoQ==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.4",
-        "@earendil-works/pi-ai": "^0.75.4",
-        "@earendil-works/pi-tui": "^0.75.4",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-tui": "^0.80.6",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1134,8 +1153,9 @@
         "jiti": "2.7.0",
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -1145,7 +1165,7 @@
         "node": ">=22.19.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.6"
+        "@mariozechner/clipboard": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
@@ -1611,12 +1631,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1626,15 +1646,17 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
@@ -1649,19 +1671,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.4.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "koffi": "2.16.2"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
@@ -1690,9 +1709,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1700,22 +1719,22 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
-        "@mariozechner/clipboard-darwin-universal": "0.3.6",
-        "@mariozechner/clipboard-darwin-x64": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +1749,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1744,9 +1763,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
       "cpu": [
         "x64"
       ],
@@ -1761,9 +1780,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
       "cpu": [
         "arm64"
       ],
@@ -1778,9 +1797,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
       ],
@@ -1795,9 +1814,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
       "cpu": [
         "riscv64"
       ],
@@ -1812,9 +1831,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
       "cpu": [
         "x64"
       ],
@@ -1829,9 +1848,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
       ],
@@ -1846,9 +1865,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
       "cpu": [
         "arm64"
       ],
@@ -1863,9 +1882,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
       "cpu": [
         "x64"
       ],
@@ -1880,15 +1899,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -1903,6 +1931,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1926,9 +1974,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1946,13 +1994,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2581,18 +2622,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -2611,16 +2640,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -2812,9 +2841,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -2822,15 +2851,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2866,6 +2894,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2932,9 +2973,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2975,9 +3016,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4858,14 +4899,23 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -5117,18 +5167,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6231,9 +6269,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -6251,12 +6289,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -6270,9 +6302,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6814,13 +6846,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6828,13 +6859,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6842,13 +6873,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6882,13 +6913,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6896,9 +6927,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -10504,43 +10535,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -10827,9 +10821,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -11046,9 +11040,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -13880,21 +13874,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -14448,19 +14427,18 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -15465,18 +15443,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/style-to-js": {
@@ -17216,9 +17182,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -17244,21 +17210,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "sharp"
   ],
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.75.4",
-    "@earendil-works/pi-ai": "^0.75.5",
+    "@earendil-works/pi-agent-core": "^0.80.6",
+    "@earendil-works/pi-ai": "^0.80.6",
     "@parcel/watcher": "^2.5.1",
     "@phosphor-icons/react": "^2.1.10",
     "@sentry/electron": "^5.11.0",
@@ -94,7 +94,7 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.75.4",
+    "@earendil-works/pi-coding-agent": "^0.80.6",
     "@electron/rebuild": "^4.0.3",
     "@eslint/js": "^9.39.0",
     "@playwright/test": "^1.60.0",

--- a/src/agent/main/authManager.concurrent.test.ts
+++ b/src/agent/main/authManager.concurrent.test.ts
@@ -10,11 +10,13 @@ const h = vi.hoisted(() => ({
 vi.mock('electron', () => ({ shell: { openExternal: vi.fn(async () => {}) } }))
 vi.mock('./agentDir', () => ({ sharedAuthPath: () => '/virtual/auth.json' }))
 vi.mock('./customModels', () => ({ readCustomOpenAI: vi.fn(async () => null) }))
-vi.mock('@earendil-works/pi-ai', () => ({
+vi.mock('@earendil-works/pi-ai/compat', () => ({
   findEnvKeys: vi.fn(),
   getEnvApiKey: vi.fn(),
-  getModels: vi.fn(() => []),
-  getProviders: vi.fn(() => []),
+}))
+vi.mock('@earendil-works/pi-ai/providers/all', () => ({
+  getBuiltinModels: vi.fn(() => []),
+  getBuiltinProviders: vi.fn(() => []),
 }))
 vi.mock('@earendil-works/pi-ai/oauth', () => ({
   getOAuthApiKey: vi.fn(),

--- a/src/agent/main/authManager.ts
+++ b/src/agent/main/authManager.ts
@@ -15,15 +15,16 @@
 // =============================================================================
 
 import { shell, type WebContents } from 'electron'
-import {
-  findEnvKeys,
-  getEnvApiKey,
-  getModels,
-  getProviders,
-  type KnownProvider,
-  type OAuthCredentials,
-  type OAuthLoginCallbacks,
+import type {
+  KnownProvider,
+  OAuthCredentials,
+  OAuthLoginCallbacks,
 } from '@earendil-works/pi-ai'
+// findEnvKeys/getEnvApiKey are only exported via the compat entry in pi-ai
+// 0.80; the new-style replacement is per-provider auth.resolve(), which needs
+// a Models collection + CredentialStore — not worth it for presence checks.
+import { findEnvKeys, getEnvApiKey } from '@earendil-works/pi-ai/compat'
+import { getBuiltinModels, getBuiltinProviders } from '@earendil-works/pi-ai/providers/all'
 import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from '@earendil-works/pi-ai/oauth'
 import { sharedAuthPath } from './agentDir'
 import { readAgentConfigFile, updateAgentConfigFile } from './agentConfigLock'
@@ -103,7 +104,7 @@ const BUILTIN_API_KEY_PROVIDERS: Array<Pick<AuthProviderDescriptor, 'id' | 'name
  *  upgrade drops disappears instead of offering a provider the runtime can't
  *  use. */
 function apiKeyProviders(): AuthProviderDescriptor[] {
-  const known = new Set<string>(getProviders())
+  const known = new Set<string>(getBuiltinProviders())
   return BUILTIN_API_KEY_PROVIDERS
     .filter((p) => known.has(p.id))
     .map((p) => ({ ...p, kind: 'apiKey' as const }))
@@ -202,9 +203,9 @@ export class AuthManager {
 
     for (const providerId of connected) {
       if (providerId === 'custom-openai') continue
-      // getModels indexes a static catalog and returns [] for unknown ids, so
-      // the cast is safe even for providers pi doesn't recognise.
-      for (const m of getModels(providerId as KnownProvider)) {
+      // getBuiltinModels indexes a static catalog and returns [] for unknown
+      // ids, so the cast is safe even for providers pi doesn't recognise.
+      for (const m of getBuiltinModels(providerId as KnownProvider)) {
         const key = `${m.provider}:${m.id}`
         if (seen.has(key)) continue
         seen.add(key)

--- a/src/agent/main/authManager.verify.test.ts
+++ b/src/agent/main/authManager.verify.test.ts
@@ -27,11 +27,13 @@ const h = vi.hoisted(() => ({
 vi.mock('electron', () => ({ app: { getPath: () => h.userData }, shell: {} }))
 vi.mock('./agentDir', () => ({ sharedAuthPath: () => h.authJsonPath }))
 vi.mock('./customModels', () => ({ readCustomOpenAI: () => h.readCustomOpenAI() }))
-vi.mock('@earendil-works/pi-ai', () => ({
+vi.mock('@earendil-works/pi-ai/compat', () => ({
   findEnvKeys: (...args: unknown[]) => h.findEnvKeys(...args),
-  getModels: (...args: unknown[]) => h.getModels(...args),
-  getProviders: () => h.getProviders(),
   getEnvApiKey: () => undefined,
+}))
+vi.mock('@earendil-works/pi-ai/providers/all', () => ({
+  getBuiltinModels: (...args: unknown[]) => h.getModels(...args),
+  getBuiltinProviders: () => h.getProviders(),
 }))
 vi.mock('@earendil-works/pi-ai/oauth', () => ({
   getOAuthApiKey: (...args: unknown[]) => h.getOAuthApiKey(...args),

--- a/src/runtime/piVersion.ts
+++ b/src/runtime/piVersion.ts
@@ -4,4 +4,4 @@
 // cate-pi-<PI_VERSION>.tgz from the release. Do not edit by hand.
 // =============================================================================
 
-export const PI_VERSION = '0.75.4'
+export const PI_VERSION = '0.80.6'


### PR DESCRIPTION
The agent panel model picker is fed by pi-ai's static catalog, so new models only arrive with a package bump. This updates pi-agent-core, pi-ai and pi-coding-agent from 0.75.x to 0.80.6, adding gpt-5.6 (luna/sol/terra), claude-sonnet-5 and claude-opus-4-8.

pi-ai 0.80 reworked its API: the static catalog functions were replaced by a Models collection. Kept the migration surgical:

- catalog reads use getBuiltinModels/getBuiltinProviders from providers/all (non-deprecated)
- findEnvKeys/getEnvApiKey come from the compat entry, their only export point in 0.80; the new-style replacement needs the full CredentialStore/Models machinery, overkill for presence checks
- test mocks updated to the new import paths
- piVersion.ts regenerated to 0.80.6 via pi:tarball

No breaking RPC changes in pi's changelog for this range. The tarball build now warns about native prebuilds in pi-tui, checked the loader: lazy, platform-guarded, TUI-only, never runs in rpc mode.

Typecheck clean, full vitest suite passes (2327 tests), production build succeeds. Verified via node that the catalog returns the new model ids through the exact import path authManager uses.