### PR TITLE
fix(canvas): make undo restore deleted panels

### DIFF
--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -18,6 +18,7 @@ import { useSearchStore } from '../stores/searchStore'
 import type { MenuActionId, ShortcutAction } from '../../shared/types'
 import type { CanvasStore } from '../stores/canvasStore'
 import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
+import { provideAppStoreForHistory } from '../stores/canvas/historySlice'
 import { inheritedWorktreeFromSelection } from './inheritWorktree'
 import { closePanelWithConfirm } from './closePanelWithConfirm'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
@@ -243,7 +244,22 @@ export async function runAction(
       if (focusedId && canvas?.nodes[focusedId]) {
         const node = canvas.nodes[focusedId]
         const panelId = activeDockPanelId(node.dockLayout)
-        if (panelId) await closePanelWithConfirm(selectedWorkspaceId, panelId)
+        if (panelId) {
+          // Snapshot the record before the close so the history entry can
+          // carry it — Cmd+Z then restores the panel, not a ghost node.
+          const record = appStore().workspaces
+            .find((w) => w.id === selectedWorkspaceId)?.panels[panelId]
+          provideAppStoreForHistory(useAppStore)
+          canvas.beginHistoryTransaction()
+          let closed = false
+          try {
+            closed = await closePanelWithConfirm(selectedWorkspaceId, panelId)
+          } finally {
+            canvas.commitHistoryTransaction(
+              closed && record ? { workspaceId: selectedWorkspaceId, panels: [record] } : undefined,
+            )
+          }
+        }
       }
       break
     }

--- a/src/renderer/stores/canvas/historySlice.test.ts
+++ b/src/renderer/stores/canvas/historySlice.test.ts
@@ -7,8 +7,20 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 const closePanelWithConfirm = vi.fn().mockResolvedValue(true)
+const wsPanels: Record<string, { id: string; type: string; title: string; isDirty: boolean }> = {}
 vi.mock('../appStore', () => ({
-  useAppStore: { getState: () => ({ selectedWorkspaceId: 'ws-1' }) },
+  useAppStore: {
+    getState: () => ({
+      selectedWorkspaceId: 'ws-1',
+      workspaces: [{ id: 'ws-1', panels: wsPanels }],
+      addPanel: (_wsId: string, panel: { id: string }) => {
+        wsPanels[panel.id] = panel as (typeof wsPanels)[string]
+      },
+      closePanel: (_wsId: string, panelId: string) => {
+        delete wsPanels[panelId]
+      },
+    }),
+  },
 }))
 vi.mock('../../lib/closePanelWithConfirm', () => ({ closePanelWithConfirm }))
 
@@ -17,6 +29,8 @@ import { createCanvasStore } from '../canvasStore'
 beforeEach(() => {
   closePanelWithConfirm.mockReset()
   closePanelWithConfirm.mockResolvedValue(true)
+  for (const id of Object.keys(wsPanels)) delete wsPanels[id]
+  for (const id of ['a', 'b']) wsPanels[id] = { id, type: 'editor', title: id, isDirty: false }
 })
 
 // Invariant the whole feature exists to guarantee: every selected id is live.

--- a/src/renderer/stores/canvas/historySlice.ts
+++ b/src/renderer/stores/canvas/historySlice.ts
@@ -1,10 +1,61 @@
 // =============================================================================
 // History slice — undo/redo snapshots of {nodes, selection, selectionActive}.
+//
+// Delete recovery: a panel delete closes real panel records (appStore) besides
+// removing canvas nodes, so a plain node snapshot would undo into ghost nodes.
+// deleteSelection/deleteNode therefore run inside a history TRANSACTION whose
+// single entry carries the closed PanelState records: undo re-adds the records
+// (panels re-instantiate lazily on mount, exactly like session restore) before
+// restoring the nodes; redo restores the post-delete nodes and closes the
+// panels again.
 // =============================================================================
 
+import type { PanelState } from '../../../shared/types'
 import type { CanvasGet, CanvasSet, CanvasHistoryEntry, CanvasStoreActions } from './storeTypes'
 
-type HistoryActions = Pick<CanvasStoreActions, 'pushHistory' | 'undo' | 'redo' | 'clearHistory'>
+type HistoryActions = Pick<
+  CanvasStoreActions,
+  'pushHistory' | 'undo' | 'redo' | 'clearHistory' | 'beginHistoryTransaction' | 'commitHistoryTransaction'
+>
+
+// The slice can't import appStore statically (panel/terminal import cycle —
+// same reason selectionSlice lazy-imports it), so the delete initiators, which
+// already hold the module, register it here before committing a transaction.
+// An annotated entry can therefore never be undone/redone without the ref.
+interface HistoryAppStore {
+  getState(): {
+    workspaces: Array<{ id: string; panels: Record<string, PanelState> }>
+    addPanel(workspaceId: string, panel: PanelState): void
+    closePanel(workspaceId: string, panelId: string): void
+  }
+}
+let historyAppStore: HistoryAppStore | null = null
+export function provideAppStoreForHistory(store: HistoryAppStore): void {
+  historyAppStore = store
+}
+
+/** Re-add the panel records a delete closed, before its nodes render again.
+ *  Skips ids that exist again (the user may have recreated one). */
+function reopenClosedPanels(closedPanels: NonNullable<CanvasHistoryEntry['closedPanels']>) {
+  const state = historyAppStore?.getState()
+  const ws = state?.workspaces.find((w) => w.id === closedPanels.workspaceId)
+  if (!state || !ws) return
+  for (const panel of closedPanels.panels) {
+    if (!ws.panels[panel.id]) state.addPanel(closedPanels.workspaceId, panel)
+  }
+}
+
+/** Close the delete's panels again on redo. Runs after the post-delete node
+ *  state is restored, so closePanel finds no canvas node and only tears down
+ *  the panel itself (PTY, records, active-panel pointer). */
+function recloseClosedPanels(closedPanels: NonNullable<CanvasHistoryEntry['closedPanels']>) {
+  const state = historyAppStore?.getState()
+  const ws = state?.workspaces.find((w) => w.id === closedPanels.workspaceId)
+  if (!state || !ws) return
+  for (const panel of closedPanels.panels) {
+    if (ws.panels[panel.id]) state.closePanel(closedPanels.workspaceId, panel.id)
+  }
+}
 
 // Build a snapshot of the current store state. The selection array is CLONED —
 // the live array is replaced (not mutated) later, but cloning keeps history
@@ -32,22 +83,48 @@ function restore(entry: CanvasHistoryEntry) {
 }
 
 export function createHistorySlice(set: CanvasSet, get: CanvasGet): HistoryActions {
+  // Open transaction's begin-time snapshot (null when no transaction is
+  // active). Per store instance via this closure.
+  let txSnapshot: CanvasHistoryEntry | null = null
+
+  function appendEntry(entry: CanvasHistoryEntry) {
+    const state = get()
+    const MAX = 100
+    const history = state.history.length >= MAX
+      ? [...state.history.slice(1), entry]
+      : [...state.history, entry]
+    set({ history, future: [] })
+  }
+
   return {
     pushHistory() {
-      const state = get()
-      const entry = snapshot(state)
-      const MAX = 100
-      const history = state.history.length >= MAX
-        ? [...state.history.slice(1), entry]
-        : [...state.history, entry]
-      set({ history, future: [] })
+      // A delete transaction owns the single entry for everything it touches —
+      // the removeNode calls it triggers must not add their own steps.
+      if (txSnapshot) return
+      appendEntry(snapshot(get()))
+    },
+
+    beginHistoryTransaction() {
+      txSnapshot ??= snapshot(get())
+    },
+
+    commitHistoryTransaction(closedPanels) {
+      if (!txSnapshot) return
+      const entry = closedPanels ? { ...txSnapshot, closedPanels } : txSnapshot
+      const changed = get().nodes !== txSnapshot.nodes
+      txSnapshot = null
+      if (changed) appendEntry(entry)
     },
 
     undo() {
       const state = get()
       if (state.history.length === 0) return
       const prev = state.history[state.history.length - 1]
-      const current = snapshot(state)
+      // Panel records first, nodes second — a restored node must never render
+      // before its panel record exists.
+      if (prev.closedPanels) reopenClosedPanels(prev.closedPanels)
+      // Carry the annotation onto the future entry so redo knows what to close.
+      const current = { ...snapshot(state), closedPanels: prev.closedPanels }
       set({
         ...restore(prev),
         history: state.history.slice(0, -1),
@@ -59,12 +136,16 @@ export function createHistorySlice(set: CanvasSet, get: CanvasGet): HistoryActio
       const state = get()
       if (state.future.length === 0) return
       const next = state.future[state.future.length - 1]
-      const current = snapshot(state)
+      // Carry the annotation back onto the history entry for the next undo.
+      const current = { ...snapshot(state), closedPanels: next.closedPanels }
       set({
         ...restore(next),
         history: [...state.history, current],
         future: state.future.slice(0, -1),
       })
+      // Nodes first, panels second — closePanel then finds no canvas node and
+      // won't try to remove (and history-push) one.
+      if (next.closedPanels) recloseClosedPanels(next.closedPanels)
     },
 
     clearHistory() {

--- a/src/renderer/stores/canvas/selectionSlice.delete.test.ts
+++ b/src/renderer/stores/canvas/selectionSlice.delete.test.ts
@@ -9,9 +9,24 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 const closePanelWithConfirm = vi.fn()
 const SELECTED_WS = 'ws-1'
 
+// Live panel-record map so the history transaction can snapshot records and
+// undo can re-add them. Seeded per test with the panel ids the test uses.
+const wsPanels: Record<string, { id: string; type: string; title: string; isDirty: boolean }> = {}
+const addPanel = vi.fn((_wsId: string, panel: { id: string }) => {
+  wsPanels[panel.id] = panel as (typeof wsPanels)[string]
+})
+const closePanel = vi.fn((_wsId: string, panelId: string) => {
+  delete wsPanels[panelId]
+})
+
 vi.mock('../appStore', () => ({
   useAppStore: {
-    getState: () => ({ selectedWorkspaceId: SELECTED_WS }),
+    getState: () => ({
+      selectedWorkspaceId: SELECTED_WS,
+      workspaces: [{ id: SELECTED_WS, panels: wsPanels }],
+      addPanel,
+      closePanel,
+    }),
   },
 }))
 
@@ -24,10 +39,22 @@ function tabs(panelIds: string[]): DockLayoutNode {
   return { type: 'tabs', id: `stack-${panelIds.join('-')}`, panelIds, activeIndex: 0 }
 }
 
+function seedPanels(ids: string[]) {
+  for (const id of Object.keys(wsPanels)) delete wsPanels[id]
+  for (const id of ids) wsPanels[id] = { id, type: 'terminal', title: id, isDirty: false }
+}
+
 describe('deleteSelection routes panel-backed nodes through closePanelWithConfirm', () => {
   beforeEach(() => {
     closePanelWithConfirm.mockReset()
-    closePanelWithConfirm.mockResolvedValue(true)
+    // The real closePanelWithConfirm removes the panel record on success.
+    closePanelWithConfirm.mockImplementation(async (_wsId: string, panelId: string) => {
+      delete wsPanels[panelId]
+      return true
+    })
+    addPanel.mockClear()
+    closePanel.mockClear()
+    seedPanels(['term-a', 'term-b', 'p1', 'p2', 'p3'])
   })
 
   it('closes every selected single-panel node through the normal close path', async () => {

--- a/src/renderer/stores/canvas/selectionSlice.ts
+++ b/src/renderer/stores/canvas/selectionSlice.ts
@@ -5,6 +5,7 @@
 
 import { collectPanelIds } from '../../../shared/collectPanelIds'
 import type { CanvasGet, CanvasSet, CanvasStoreActions } from './storeTypes'
+import { provideAppStoreForHistory } from './historySlice'
 import { withLead } from './selectionModel'
 
 type SelectionActions = Pick<
@@ -86,7 +87,17 @@ export function createSelectionSlice(set: CanvasSet, get: CanvasGet): SelectionA
           import('../appStore'),
           import('../../lib/closePanelWithConfirm'),
         ])
+        provideAppStoreForHistory(useAppStore)
         const workspaceId = useAppStore.getState().selectedWorkspaceId
+        // Snapshot the panel records before closing so the history entry can
+        // carry them — undo re-adds the records and restores the nodes. Copied
+        // eagerly: the close loop below removes them from the workspace.
+        const livePanels = useAppStore.getState().workspaces
+          .find((w) => w.id === workspaceId)?.panels ?? {}
+        const panelRecords = new Map([...panelIds].flatMap((id) => {
+          const panel = livePanels[id]
+          return panel ? [[id, panel] as const] : []
+        }))
         const closedPanelIds = new Set<string>()
 
         const removeClosedNodes = () => {
@@ -97,7 +108,6 @@ export function createSelectionSlice(set: CanvasSet, get: CanvasGet): SelectionA
           if (nodeIdsToRemove.length === 0) return
 
           const state = get()
-          state.pushHistory()
           for (const nodeId of nodeIdsToRemove) state.removeNode(nodeId)
           set((current) => ({
             selection: current.selection.filter((nodeId) => !nodeIdsToRemove.includes(nodeId)),
@@ -105,15 +115,26 @@ export function createSelectionSlice(set: CanvasSet, get: CanvasGet): SelectionA
           }))
         }
 
-        for (const panelId of panelIds) {
-          if (!(await closePanelWithConfirm(workspaceId, panelId))) {
-            removeClosedNodes()
-            return
+        // One transaction around the whole delete: every node removal (both the
+        // ones closePanel triggers internally and removeClosedNodes below)
+        // collapses into a single undo step carrying the closed panel records.
+        get().beginHistoryTransaction()
+        try {
+          for (const panelId of panelIds) {
+            if (!(await closePanelWithConfirm(workspaceId, panelId))) {
+              removeClosedNodes()
+              return
+            }
+            closedPanelIds.add(panelId)
           }
-          closedPanelIds.add(panelId)
-        }
 
-        removeClosedNodes()
+          removeClosedNodes()
+        } finally {
+          const closed = [...closedPanelIds].flatMap((id) => panelRecords.get(id) ?? [])
+          get().commitHistoryTransaction(
+            closed.length > 0 ? { workspaceId, panels: closed } : undefined,
+          )
+        }
       } catch {
         // Closing is user-initiated; an unavailable confirmation path must not
         // remove the selected nodes behind the user's back.

--- a/src/renderer/stores/canvas/storeTypes.ts
+++ b/src/renderer/stores/canvas/storeTypes.ts
@@ -9,6 +9,7 @@ import type {
   CanvasNodeId,
   CanvasNodeState,
   DockLayoutNode,
+  PanelState,
   Point,
   Rect,
   Size,
@@ -88,6 +89,11 @@ export interface CanvasHistoryEntry {
   nodes: Record<CanvasNodeId, CanvasNodeState>
   selection: CanvasNodeId[]
   selectionActive: boolean
+  /** Panel records closed by the delete that followed this snapshot. Undo
+   *  re-adds them to the workspace (so the restored nodes aren't ghosts);
+   *  redo closes them again. Carried between the history and future stacks
+   *  as the entry bounces on undo/redo. */
+  closedPanels?: { workspaceId: string; panels: PanelState[] }
 }
 
 export interface CanvasStoreActions {
@@ -216,6 +222,14 @@ export interface CanvasStoreActions {
   undo: () => void
   redo: () => void
   clearHistory: () => void
+  /** Open a delete transaction: snapshots the current state and suppresses all
+   *  pushHistory calls until commit, so a multi-panel delete (which removes
+   *  nodes through several paths) lands as ONE undo step. */
+  beginHistoryTransaction: () => void
+  /** Close the transaction. Pushes the begin-time snapshot as a single history
+   *  entry when nodes actually changed, annotated with the panel records the
+   *  delete closed so undo can restore them. No-op without a begin. */
+  commitHistoryTransaction: (closedPanels?: { workspaceId: string; panels: PanelState[] }) => void
 
   // Bulk reset (used when switching workspaces)
   loadWorkspaceCanvas: (

--- a/src/renderer/stores/canvasStore.lifecycle.test.ts
+++ b/src/renderer/stores/canvasStore.lifecycle.test.ts
@@ -9,11 +9,25 @@
 
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 
-// deleteSelection routes panel closure through the normal close helper.
-const closePanelWithConfirm = vi.fn().mockResolvedValue(true)
+// deleteSelection routes panel closure through the normal close helper. The
+// appStore mock keeps a live panel-record map so undo/redo can exercise the
+// real recovery flow (records removed on close, re-added on undo).
+const closePanelWithConfirm = vi.fn()
+const wsPanels: Record<string, { id: string; type: string; title: string; isDirty: boolean }> = {}
+const addPanel = vi.fn((_wsId: string, panel: { id: string }) => {
+  wsPanels[panel.id] = panel as (typeof wsPanels)[string]
+})
+const closePanel = vi.fn((_wsId: string, panelId: string) => {
+  delete wsPanels[panelId]
+})
 vi.mock('./appStore', () => ({
   useAppStore: {
-    getState: () => ({ selectedWorkspaceId: 'ws-1' }),
+    getState: () => ({
+      selectedWorkspaceId: 'ws-1',
+      workspaces: [{ id: 'ws-1', panels: wsPanels }],
+      addPanel,
+      closePanel,
+    }),
   },
 }))
 vi.mock('../lib/closePanelWithConfirm', () => ({ closePanelWithConfirm }))
@@ -25,7 +39,17 @@ import type { CanvasNodeState } from '../../shared/types'
 
 beforeEach(() => {
   closePanelWithConfirm.mockReset()
-  closePanelWithConfirm.mockResolvedValue(true)
+  // The real closePanelWithConfirm removes the panel record via closePanel.
+  closePanelWithConfirm.mockImplementation(async (_wsId: string, panelId: string) => {
+    delete wsPanels[panelId]
+    return true
+  })
+  addPanel.mockClear()
+  closePanel.mockClear()
+  for (const id of Object.keys(wsPanels)) delete wsPanels[id]
+  for (const id of ['panel-a', 'panel-b', 'panel-c']) {
+    wsPanels[id] = { id, type: 'terminal', title: id, isDirty: false }
+  }
 })
 
 const SIZE = { width: 200, height: 200 }
@@ -234,7 +258,7 @@ describe('viewport math', () => {
 })
 
 describe('undo/redo across a bulk delete', () => {
-  it('undo restores deleted nodes + selection; redo reapplies the delete', async () => {
+  it('a bulk delete is ONE undo step: undo restores nodes + panel records, redo re-closes', async () => {
     const store = createCanvasStore()
     const { a, b } = addThree(store)
     store.getState().selectNodes([a, b])
@@ -245,19 +269,34 @@ describe('undo/redo across a bulk delete', () => {
     expect(store.getState().nodes[a].animationState).toBe('exiting')
     expect(store.getState().nodes[b].animationState).toBe('exiting')
     expect(store.getState().selection.length).toBe(0)
+    expect(wsPanels['panel-a']).toBeUndefined()
+    expect(wsPanels['panel-b']).toBeUndefined()
 
-    // deleteSelection pushes once + once per removeNode → two undos rewind it.
-    store.getState().undo()
+    // The whole delete (panel closes + node removals) is a single entry.
     store.getState().undo()
     expect(store.getState().nodes[a].animationState).not.toBe('exiting')
     expect(store.getState().nodes[b].animationState).not.toBe('exiting')
     expect([...store.getState().selection].sort()).toEqual([a, b].sort())
+    // Undo brought the closed panel records back, so the nodes aren't ghosts.
+    expect(wsPanels['panel-a']).toBeDefined()
+    expect(wsPanels['panel-b']).toBeDefined()
 
-    store.getState().redo()
     store.getState().redo()
     expect(store.getState().nodes[a].animationState).toBe('exiting')
     expect(store.getState().nodes[b].animationState).toBe('exiting')
     expect(store.getState().selection.length).toBe(0)
+    // Redo re-applied the delete for real: records closed again.
+    expect(closePanel).toHaveBeenCalledWith('ws-1', 'panel-a')
+    expect(closePanel).toHaveBeenCalledWith('ws-1', 'panel-b')
+    expect(wsPanels['panel-a']).toBeUndefined()
+    expect(wsPanels['panel-b']).toBeUndefined()
+
+    // And undo after redo restores everything again.
+    store.getState().undo()
+    expect(store.getState().nodes[a].animationState).not.toBe('exiting')
+    expect(store.getState().nodes[b].animationState).not.toBe('exiting')
+    expect(wsPanels['panel-a']).toBeDefined()
+    expect(wsPanels['panel-b']).toBeDefined()
   })
 
   it('a new mutation clears the redo stack', () => {


### PR DESCRIPTION
Fixes #439 (together with the per-panel close confirms from #440).

Undo after a panel delete used to bring back ghost nodes: history only snapshotted canvas geometry while the panel records were torn down for real. Bulk deletes also needed several Cmd+Z presses because every nested removeNode pushed its own entry.

Now a delete runs inside a history transaction:

- the whole delete lands as one undo step, its entry carries the closed panel records
- undo re-adds the records before restoring the nodes (panels re-instantiate lazily on mount, same mechanism as session restore), so editors reload from disk, browsers keep their tabs, terminals come back as a fresh shell
- redo restores the post-delete nodes first, then closes the panels again for real
- covers Cmd+A + Backspace and Cmd+Backspace on the focused panel; closing a tab of a multi-tab node is now undoable too

appStore is handed to the history slice by the delete initiators (provideAppStoreForHistory) instead of imported, keeping the canvas store out of the panel/terminal import cycle.

Typecheck, lint and the full renderer suite (1306 tests) pass; the lifecycle test now covers the full delete, undo, redo, undo cycle including panel records.