### PR TITLE
Enable cate CLI by default and seed the cate-cli skill per workspace

### DIFF
--- a/skills/cate-cli/SKILL.md
+++ b/skills/cate-cli/SKILL.md
@@ -14,10 +14,10 @@ It talks to a per-workspace loopback endpoint Cate injects as `CATE_API` +
 `CATE_TOKEN`.
 
 **It only works inside a Cate terminal, and only when command-line control is
-enabled.** It is off by default; the user turns it on in Settings → Terminal
-("Command-line control"). Until then, and outside a Cate terminal, the env vars
-are unset and every command exits `3` with `not running inside a Cate terminal`.
-There is nothing to install.
+enabled.** It is on by default; the user can turn it off in Settings → Terminal
+("Command-line control"). While it is off — or outside a Cate terminal — the env
+vars are unset and every command exits `3` with a message explaining how to
+enable the setting. There is nothing to install.
 
 ## Browser control
 

--- a/src/agent/main/agentManager.test.ts
+++ b/src/agent/main/agentManager.test.ts
@@ -23,6 +23,9 @@ vi.mock('./agentDir', () => ({
   prepareAgentDir: vi.fn(),
   watchWorkspaceAuth: vi.fn(),
   pushSharedToWorkspace: vi.fn(),
+  // Pulled in transitively (workspaceManager → seedCateCliSkill → skills targets).
+  PI_AGENT_DIR: 'pi-agent',
+  hostJoin: vi.fn((_rt: string, ...segs: string[]) => segs.join('/')),
 }))
 vi.mock('./customModels', () => ({ mirrorModelsToWorkspace: vi.fn() }))
 

--- a/src/cli/cate.integration.test.ts
+++ b/src/cli/cate.integration.test.ts
@@ -222,10 +222,11 @@ describe('cate CLI — real binary over a real socket', () => {
     expect(r.stderr).toContain('unauthorized')
   }, 20_000)
 
-  it('6. env unset: exit 3 with the "not running inside a Cate terminal" message', async () => {
+  it('6. env unset: exit 3 with the how-to-enable message', async () => {
     const r = await runCli(['browser', 'current'], { PATH: process.env.PATH ?? '' })
     expect(r.code).toBe(3)
-    expect(r.stderr).toContain('not running inside a Cate terminal')
+    expect(r.stderr).toContain('CATE_API/CATE_TOKEN unset')
+    expect(r.stderr).toContain('Settings → Terminal')
     // Never reached the server.
     expect(lastRequest).toBeUndefined()
   }, 20_000)

--- a/src/cli/cate.test.ts
+++ b/src/cli/cate.test.ts
@@ -308,11 +308,13 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('run — exit codes', () => {
-  it('CATE_API unset -> exit 3 with a clear message', async () => {
+  it('CATE_API unset -> exit 3 with a how-to-enable message', async () => {
     const deps = makeDeps({ env: {} })
     const code = await run(['browser', 'current'], deps)
     expect(code).toBe(3)
-    expect(deps.err.join('\n')).toMatch(/not running inside a Cate terminal/)
+    const err = deps.err.join('\n')
+    expect(err).toMatch(/CATE_API\/CATE_TOKEN unset/)
+    expect(err).toMatch(/Settings → Terminal/)
   })
 
   it('happy path -> exit 0, url on stdout', async () => {
@@ -614,7 +616,7 @@ describe('defaultReadStdin — real binary', () => {
     )
     expect(r.timedOut).toBe(false)
     expect(r.code).toBe(3)
-    expect(r.stderr).toMatch(/not running inside a Cate terminal/)
+    expect(r.stderr).toMatch(/CATE_API\/CATE_TOKEN unset/)
   }, 15_000)
 
   posixIt('reads buffered pipe bytes even when the writer keeps the pipe open', async () => {

--- a/src/cli/cate.ts
+++ b/src/cli/cate.ts
@@ -43,7 +43,8 @@ export const DEFAULT_TIMEOUT_MS = 30_000
 
 /** Bad command-line usage → exit 2. */
 export class UsageError extends Error {}
-/** Missing CATE_API/CATE_TOKEN or a failed fetch → exit 3. */
+/** Missing CATE_API/CATE_TOKEN (endpoint disabled / not a Cate terminal) or a
+ *  failed fetch → exit 3. */
 export class EnvError extends Error {}
 /** A completed request that reported failure (top-level or in-band) → exit 1. */
 export class ApiError extends Error {
@@ -270,7 +271,13 @@ export async function send(method: string, args: Record<string, unknown>, deps: 
   const api = deps.env.CATE_API
   const token = deps.env.CATE_TOKEN
   if (!api || !token) {
-    throw new EnvError('not running inside a Cate terminal (CATE_API/CATE_TOKEN unset)')
+    // `cate` is on PATH in every Cate terminal, endpoint enabled or not — so a
+    // missing endpoint env almost always means the setting is off (or this
+    // terminal predates enabling it). Say how to fix it, not just what's wrong.
+    throw new EnvError(
+      'the cate CLI endpoint is not available in this shell (CATE_API/CATE_TOKEN unset).\n' +
+        'Enable "Command-line control (cate CLI)" in Cate Settings → Terminal, then open a new terminal.',
+    )
   }
 
   let res: Response
@@ -454,7 +461,8 @@ Flags:
   -h, --help       show this help
   --version        print the CLI version
 
-Requires CATE_API and CATE_TOKEN in the environment (Cate injects them).`
+Requires CATE_API and CATE_TOKEN in the environment. Cate injects them into new
+terminals while "Command-line control (cate CLI)" is enabled (Settings → Terminal).`
 
 export interface RunDeps {
   fetch: typeof fetch

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -343,11 +343,11 @@ app.whenReady().then(async () => {
   registerCriticalHandlers()
   log.info('Critical IPC handlers registered')
 
-  // Install our first-party skills into ~/.claude/skills (copy-if-missing) so
-  // Claude Code discovers them: cate-theme (theme authoring) and cate-cli
-  // (teaches an agent in a Cate terminal how to use the `cate` CLI).
+  // Install the cate-theme skill into ~/.claude/skills (copy-if-missing) so the
+  // LOCAL Claude Code discovers theme authoring anywhere. The cate-cli skill is
+  // NOT installed globally — it is seeded per-workspace for every supported
+  // agent at workspace open (seedCateCliSkill), where the CLI actually works.
   void installBundledSkill('cate-theme')
-  void installBundledSkill('cate-cli')
 
   const mainWin = createWindow({ type: 'main' })
   log.info('Main window created (id=%d)', mainWin.id)

--- a/src/main/ipc/dockWindows.test.ts
+++ b/src/main/ipc/dockWindows.test.ts
@@ -1,0 +1,347 @@
+// =============================================================================
+// Dock-window IPC handlers — integration seam between the renderer-facing
+// channels and the real windowRegistry / windowPanels modules.
+//
+// registerDockWindowHandlers wires five channels; these tests invoke the
+// captured handlers directly against REAL registry state (fake BrowserWindows
+// registered via registerWindow, panels reported via setWindowPanels) and pin:
+//   • DOCK_WINDOW_SYNC_STATE updates the persistence cache that
+//     DOCK_WINDOWS_LIST reads, keyed by the SENDER window — and can never
+//     change the window's creation-time workspaceId.
+//   • sync from an unknown/unregistered sender is observably ignored.
+//   • DOCK_WINDOW_RESTORE mints a window via the injected createWindow, applies
+//     snapshot bounds, defers DOCK_WINDOW_INIT + reveal-without-focus to
+//     did-finish-load, and returns the new window id — or null for a snapshot
+//     with no restorable first tab.
+//   • FOCUS_WINDOW_PANEL / CLOSE_WINDOW_PANEL route through the windowPanels
+//     union to the panel's owner window.
+// =============================================================================
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// Captured ipcMain.handle map so tests can invoke handlers directly, and a
+// sender -> fake-window map backing BrowserWindow.fromWebContents (which is how
+// windowFromEvent resolves the sync sender). Hoisted so the mock factory
+// (evaluated before imports) can reach them.
+const hoisted = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  senderToWin: new Map<unknown, unknown>(),
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      hoisted.handlers.set(channel, fn)
+    },
+  },
+  BrowserWindow: {
+    fromWebContents: (sender: unknown) => hoisted.senderToWin.get(sender),
+  },
+}))
+vi.mock('../perf/perfMonitor', () => ({ PERF_ENABLED: false, countIpc: vi.fn() }))
+
+import { registerWindow } from '../windowRegistry'
+import { setWindowPanels } from '../windowPanels'
+import { registerDockWindowHandlers } from './dockWindows'
+import {
+  DOCK_WINDOW_INIT,
+  DOCK_WINDOW_SYNC_STATE,
+  DOCK_WINDOWS_LIST,
+  DOCK_WINDOW_RESTORE,
+  FOCUS_WINDOW_PANEL,
+  CLOSE_WINDOW_PANEL,
+  REVEAL_PANEL_IN_WINDOW,
+  CLOSE_PANEL_IN_WINDOW,
+} from '../../shared/ipc-channels'
+import type {
+  DetachedDockWindowSnapshot,
+  DockWindowInitPayload,
+  DockWindowSyncState,
+  PanelState,
+  WindowDockState,
+} from '../../shared/types'
+
+// -----------------------------------------------------------------------------
+// Fake BrowserWindow — same shape as windowPanels.test.ts, extended with the
+// surfaces the restore path touches (setBounds, show, webContents.once).
+// -----------------------------------------------------------------------------
+
+interface FakeWin {
+  id: number
+  sent: Array<{ channel: string; args: unknown[] }>
+  focus: ReturnType<typeof vi.fn>
+  show: ReturnType<typeof vi.fn>
+  setBounds: ReturnType<typeof vi.fn>
+  fireClosed: () => void
+  fireDidFinishLoad: () => void
+  win: never
+}
+
+const liveWindows = new Set<FakeWin>()
+
+function makeWin(id: number): FakeWin {
+  const handlers: Record<string, () => void> = {}
+  const wcOnce: Record<string, Array<() => void>> = {}
+  const sent: FakeWin['sent'] = []
+  const fake: FakeWin = {
+    id,
+    sent,
+    focus: vi.fn(),
+    show: vi.fn(),
+    setBounds: vi.fn(),
+    fireClosed: () => handlers['closed']?.(),
+    fireDidFinishLoad: () => {
+      const fired = wcOnce['did-finish-load'] ?? []
+      wcOnce['did-finish-load'] = []
+      fired.forEach((f) => f())
+    },
+    win: {
+      id,
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      restore: vi.fn(),
+      focus: () => fake.focus(),
+      show: () => fake.show(),
+      setBounds: (b: unknown) => fake.setBounds(b),
+      isAlwaysOnTop: () => false,
+      setAlwaysOnTop: vi.fn(),
+      getBounds: () => ({ x: 5, y: 6, width: 800, height: 600 }),
+      on: (event: string, cb: () => void) => { handlers[event] = cb },
+      webContents: {
+        send: (channel: string, ...args: unknown[]) => sent.push({ channel, args }),
+        once: (event: string, cb: () => void) => { (wcOnce[event] ??= []).push(cb) },
+      },
+    } as never,
+  }
+  liveWindows.add(fake)
+  return fake
+}
+
+/** Register a window of `type` for `workspaceId` and track it for teardown. */
+function open(id: number, type: 'main' | 'dock', workspaceId?: string): FakeWin {
+  const fake = makeWin(id)
+  registerWindow(fake.win, type, workspaceId)
+  return fake
+}
+
+// Register the handlers ONCE with a swappable createWindow spy (real wiring
+// injects windowFactory.createWindow here).
+const createWindow = vi.fn()
+registerDockWindowHandlers({ createWindow: createWindow as never })
+
+const invoke = (channel: string, sender: unknown, ...args: unknown[]): unknown =>
+  hoisted.handlers.get(channel)!({ sender }, ...args)
+
+/** Register a sender object resolving to `win` (or to nothing when win is null). */
+function senderFor(win: FakeWin | null): object {
+  const sender = {}
+  if (win) hoisted.senderToWin.set(sender, win.win)
+  return sender
+}
+
+const emptyZone = (position: 'left' | 'right' | 'bottom' | 'center') =>
+  ({ position, visible: false, size: 0, layout: null })
+
+/** Zones with a single center tab stack hosting the given panelIds. */
+function zonesWith(panelIds: string[]): WindowDockState {
+  return {
+    left: emptyZone('left'),
+    right: emptyZone('right'),
+    bottom: emptyZone('bottom'),
+    center: {
+      position: 'center',
+      visible: true,
+      size: 0,
+      layout: { type: 'tabs', id: 'stack-1', panelIds, activeIndex: 0 },
+    },
+  }
+}
+
+const panel = (id: string): PanelState =>
+  ({ id, type: 'terminal', title: `Terminal ${id}`, isDirty: false }) as PanelState
+
+function syncState(panelIds: string[]): DockWindowSyncState {
+  return {
+    dockState: { zones: zonesWith(panelIds) },
+    panels: Object.fromEntries(panelIds.map((id) => [id, panel(id)])),
+    canvasStates: {},
+  }
+}
+
+function restoreSnapshot(
+  panelIds: string[],
+  panels: Record<string, PanelState>,
+): DetachedDockWindowSnapshot & { initPayload: DockWindowInitPayload } {
+  return {
+    dockState: { zones: zonesWith(panelIds) },
+    panels,
+    bounds: { x: 10, y: 20, width: 640, height: 480 },
+    workspaceId: 'ws-A',
+    canvasStates: {},
+    initPayload: {
+      panels,
+      dockState: zonesWith(panelIds),
+      workspaceId: 'ws-A',
+      restore: true,
+      canvasStates: {},
+    },
+  }
+}
+
+afterEach(() => {
+  // Close every window created in the test so the shared registry resets.
+  for (const w of [...liveWindows]) w.fireClosed()
+  liveWindows.clear()
+  hoisted.senderToWin.clear()
+  createWindow.mockReset()
+})
+
+describe('DOCK_WINDOW_SYNC_STATE / DOCK_WINDOWS_LIST', () => {
+  it('caches the sender window\'s state for the list, keyed by the sender', async () => {
+    const dock = open(201, 'dock', 'ws-A')
+    open(1, 'main', 'ws-A')
+
+    // A dock window that never synced has no persistable state yet.
+    expect(await invoke(DOCK_WINDOWS_LIST, senderFor(null))).toEqual([])
+
+    await invoke(DOCK_WINDOW_SYNC_STATE, senderFor(dock), syncState(['t1']))
+
+    const list = (await invoke(DOCK_WINDOWS_LIST, senderFor(null))) as Array<Record<string, unknown>>
+    expect(list).toHaveLength(1)
+    expect(list[0]).toMatchObject({
+      windowId: 201,
+      workspaceId: 'ws-A',
+      bounds: { x: 5, y: 6, width: 800, height: 600 }, // live window bounds, not synced
+    })
+    expect(Object.keys((list[0] as { panels: object }).panels)).toEqual(['t1'])
+
+    // A later sync replaces the cached state for that window.
+    await invoke(DOCK_WINDOW_SYNC_STATE, senderFor(dock), syncState(['t1', 't2']))
+    const relisted = (await invoke(DOCK_WINDOWS_LIST, senderFor(null))) as Array<{ panels: object }>
+    expect(Object.keys(relisted[0].panels)).toEqual(['t1', 't2'])
+  })
+
+  it('cannot change the window\'s creation-time workspaceId via a sync payload', async () => {
+    const dock = open(202, 'dock', 'ws-A')
+
+    // DockWindowSyncState deliberately carries no workspaceId; a hostile/stale
+    // extra field must not leak through either (main's creation-time value wins).
+    const poisoned = { ...syncState(['t1']), workspaceId: 'ws-EVIL' }
+    await invoke(DOCK_WINDOW_SYNC_STATE, senderFor(dock), poisoned)
+
+    const list = (await invoke(DOCK_WINDOWS_LIST, senderFor(null))) as Array<{ workspaceId: string }>
+    expect(list[0].workspaceId).toBe('ws-A')
+  })
+
+  it('ignores a sync whose sender resolves to no window', async () => {
+    open(203, 'dock', 'ws-A')
+    // fromWebContents finds nothing for this sender (e.g. window already gone).
+    await expect(
+      invoke(DOCK_WINDOW_SYNC_STATE, senderFor(null), syncState(['t1'])),
+    ).resolves.toBeUndefined()
+    expect(await invoke(DOCK_WINDOWS_LIST, senderFor(null))).toEqual([])
+  })
+
+  it('never lists a sync from a window the registry does not track', async () => {
+    // Electron knows the sender's window, but it was never registerWindow()ed.
+    // Current behavior: the state IS cached by window id, but the list is
+    // registry-driven so the entry is unobservable (harmless unless a window id
+    // were ever reused). Pinning the observable part: it is not listed.
+    const rogue = makeWin(999)
+    await invoke(DOCK_WINDOW_SYNC_STATE, senderFor(rogue), syncState(['t1']))
+    expect(await invoke(DOCK_WINDOWS_LIST, senderFor(null))).toEqual([])
+  })
+})
+
+describe('DOCK_WINDOW_RESTORE', () => {
+  it('mints a dock window, applies bounds, and defers init + reveal to did-finish-load', async () => {
+    const restored = makeWin(300)
+    createWindow.mockImplementation((params: { type: string; workspaceId?: string }) => {
+      // Mirror the production contract: windowFactory.createWindow registers the
+      // new window in the registry (sendToWindow silently drops otherwise).
+      registerWindow(restored.win, params.type as 'dock', params.workspaceId)
+      return restored.win
+    })
+
+    const payload = restoreSnapshot(['t1'], { t1: panel('t1') })
+    const result = await invoke(DOCK_WINDOW_RESTORE, senderFor(null), payload)
+
+    expect(result).toBe(300)
+    expect(createWindow).toHaveBeenCalledExactlyOnceWith({ type: 'dock', workspaceId: 'ws-A' })
+    expect(restored.setBounds).toHaveBeenCalledExactlyOnceWith(payload.bounds)
+
+    // Nothing is sent or shown until the renderer finishes loading.
+    expect(restored.sent).toEqual([])
+    expect(restored.show).not.toHaveBeenCalled()
+
+    restored.fireDidFinishLoad()
+
+    expect(restored.sent).toEqual([{ channel: DOCK_WINDOW_INIT, args: [payload.initPayload] }])
+    // Revealed without stealing focus from the main window mid-startup.
+    expect(restored.show).toHaveBeenCalledTimes(1)
+    expect(restored.focus).not.toHaveBeenCalled()
+  })
+
+  it('bails null when the dock state has no top-level panels', async () => {
+    const payload = restoreSnapshot([], {})
+    payload.dockState.zones.center.layout = null
+    payload.initPayload.dockState.center.layout = null
+
+    expect(await invoke(DOCK_WINDOW_RESTORE, senderFor(null), payload)).toBeNull()
+    expect(createWindow).not.toHaveBeenCalled()
+  })
+
+  it('bails null when the FIRST top-level panel record is missing, even if later tabs are restorable', async () => {
+    // Pins current behavior: only the first zone panel id is validated, so a
+    // ghost first tab (stale layout after an incomplete flush) drops the WHOLE
+    // window including the perfectly restorable 't1' behind it. Questionable
+    // but current — see the matching renderer-side `.fails` pin in
+    // session.restoreDockWindow.test.ts (ghost ids are not pruned upstream).
+    const payload = restoreSnapshot(['ghost', 't1'], { t1: panel('t1') })
+
+    expect(await invoke(DOCK_WINDOW_RESTORE, senderFor(null), payload)).toBeNull()
+    expect(createWindow).not.toHaveBeenCalled()
+  })
+})
+
+describe('FOCUS_WINDOW_PANEL / CLOSE_WINDOW_PANEL', () => {
+  it('reveals a panel by focusing its owner window and asking it to surface', async () => {
+    open(1, 'main', 'ws-A')
+    const dock = open(210, 'dock', 'ws-A')
+    setWindowPanels(210, [{ panelId: 't1', type: 'terminal', title: 'Terminal 1', workspaceId: 'ws-A' }])
+
+    await invoke(FOCUS_WINDOW_PANEL, senderFor(null), 't1')
+
+    expect(dock.focus).toHaveBeenCalled()
+    expect(dock.sent).toContainEqual({ channel: REVEAL_PANEL_IN_WINDOW, args: ['t1'] })
+  })
+
+  it('routes a close request to the owner window (which runs its own gates)', async () => {
+    open(1, 'main', 'ws-A')
+    const dock = open(211, 'dock', 'ws-A')
+    setWindowPanels(211, [{ panelId: 't1', type: 'terminal', title: 'Terminal 1', workspaceId: 'ws-A' }])
+
+    await invoke(CLOSE_WINDOW_PANEL, senderFor(null), 't1')
+
+    expect(dock.focus).toHaveBeenCalled()
+    expect(dock.sent).toContainEqual({ channel: CLOSE_PANEL_IN_WINDOW, args: ['t1'] })
+  })
+
+  it('is a silent no-op for an unknown panel (the not-found boolean is swallowed)', async () => {
+    const dock = open(212, 'dock', 'ws-A')
+    setWindowPanels(212, [{ panelId: 't1', type: 'terminal', title: 'Terminal 1', workspaceId: 'ws-A' }])
+
+    // Pins current behavior: the handlers discard reveal/close's boolean, so
+    // the invoking renderer resolves undefined either way (the declared API is
+    // Promise<void>) and nothing is sent anywhere for an unknown panel.
+    expect(await invoke(FOCUS_WINDOW_PANEL, senderFor(null), 'nope')).toBeUndefined()
+    expect(await invoke(CLOSE_WINDOW_PANEL, senderFor(null), 'nope')).toBeUndefined()
+    expect(dock.focus).not.toHaveBeenCalled()
+    // (The window still received the WINDOW_PANELS_CHANGED broadcast from
+    // setWindowPanels above; only the routed reveal/close sends must be absent.)
+    const routed = dock.sent.filter(
+      (m) => m.channel === REVEAL_PANEL_IN_WINDOW || m.channel === CLOSE_PANEL_IN_WINDOW,
+    )
+    expect(routed).toEqual([])
+  })
+})

--- a/src/main/ipc/dockWindows.ts
+++ b/src/main/ipc/dockWindows.ts
@@ -5,7 +5,7 @@ import {
   listDockWindows,
   windowFromEvent,
 } from '../windowRegistry'
-import { revealWindowPanel } from '../windowPanels'
+import { revealWindowPanel, closeWindowPanel } from '../windowPanels'
 import { collectTopLevelPanelIds } from '../windows/dockState'
 import { revealWindow } from '../windows/reveal'
 import type {
@@ -20,6 +20,7 @@ import {
   DOCK_WINDOWS_LIST,
   DOCK_WINDOW_RESTORE,
   FOCUS_WINDOW_PANEL,
+  CLOSE_WINDOW_PANEL,
 } from '../../shared/ipc-channels'
 
 interface DockWindowDeps {
@@ -43,6 +44,12 @@ export function registerDockWindowHandlers({ createWindow }: DockWindowDeps): vo
   // window, and ask it to bring the panel forward within itself.
   ipcMain.handle(FOCUS_WINDOW_PANEL, async (_event, panelId: string) => {
     revealWindowPanel(panelId)
+  })
+
+  // Close a panel that lives in another window: route the request to its owner,
+  // which runs its own dirty/running confirmation gates before closing.
+  ipcMain.handle(CLOSE_WINDOW_PANEL, async (_event, panelId: string) => {
+    closeWindowPanel(panelId)
   })
 
   // Session restore of a detached dock window — rebuilds the FULL window (every

--- a/src/main/ipc/git-monitor.ts
+++ b/src/main/ipc/git-monitor.ts
@@ -190,20 +190,17 @@ export function registerHandlers(): void {
   ipcMain.on(GIT_MONITOR_START, (event, workspaceId: string, rootPath: string) => {
     // `ipcMain.on` handlers have no promise boundary, so any throw inside
     // escapes as an uncaught exception and crashes the main process with a
-    // fatal Electron dialog. Path validation is legitimately expected to fail
-    // here during session restore (renderer requests monitoring before the
-    // workspace root has been registered as an allowed root), so treat a
-    // validation failure as "don't start monitoring" instead of a hard error.
-    // Resolve the target runtime off the locator, then validate. For the
-    // local runtime this is identical to the previous validateCwd(rootPath).
-    // The poll itself routes through runtime.vcs.monitorStatus, so a remote
-    // workspace's branch/dirty indicator reflects the remote repo.
+    // fatal Electron dialog. resolve() legitimately throws here during session
+    // restore (renderer requests monitoring before the workspace's runtime is
+    // registered), so treat that as "don't start monitoring" instead of a hard
+    // error. No client-side path validation: the daemon validates the root
+    // inside every monitorStatus poll / watch it serves, local and remote
+    // alike — so a remote workspace's branch/dirty indicator reflects the
+    // remote repo.
     const { runtimeId, path: rootP } = parseLocator(rootPath)
     let runtime: ReturnType<typeof runtimes.resolve>
-    let validRoot: string
     try {
       runtime = runtimes.resolve(runtimeId)
-      validRoot = runtime.validateCwd(rootP, undefined, workspaceId)
     } catch (err) {
       log.warn(
         '[git-monitor] skipping monitor for workspace %s: %s',
@@ -212,6 +209,7 @@ export function registerHandlers(): void {
       )
       return
     }
+    const validRoot = rootP
     const existing = activeMonitors.get(workspaceId)
     if (existing) {
       clearTimer(existing)

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -38,6 +38,10 @@ import type {
 } from '../../shared/types'
 import { broadcastToAll } from '../windowRegistry'
 import { formatLocator } from '../runtime/locator'
+// settingsFile, not ../store: getSettingSync is a re-export of this getSetting,
+// and store.ts's side-effect graph (analytics, menu, auto-updater) would bloat
+// every bundle of the buildTransport graph (see buildTransport.interop.test.ts).
+import { getSetting } from '../settingsFile'
 import type { RuntimeTransport } from '../runtime/transports/transport'
 import { SshTransport } from '../runtime/transports/sshTransport'
 import { WslTransport } from '../runtime/transports/wslTransport'
@@ -160,6 +164,11 @@ export async function buildTransport(runtimeId: string, spec: RemoteConnectSpec)
       distro: spec.distro,
       root: spec.distroPath,
       id: runtimeId,
+      // Same launch config the local daemon gets (main/index.ts) so a WSL host
+      // honors the exclusion + idle-suspend settings identically. Later live
+      // changes are forwarded to every connected runtime by the store.
+      exclusions: getSetting('fileExclusions'),
+      idleSuspend: getSetting('autoSuspendIdleTerminals'),
     })
   }
   // server (SSH): resolve stored secret + optional key file.
@@ -191,6 +200,11 @@ export async function buildTransport(runtimeId: string, spec: RemoteConnectSpec)
     privateKey,
     passphrase,
     agentSock: (spec.auth?.useAgent ?? secret?.useAgent) ? process.env.SSH_AUTH_SOCK : undefined,
+    // Same launch config the local daemon gets (main/index.ts) so an SSH host
+    // honors the exclusion + idle-suspend settings identically. Later live
+    // changes are forwarded to every connected runtime by the store.
+    exclusions: getSetting('fileExclusions'),
+    idleSuspend: getSetting('autoSuspendIdleTerminals'),
   })
 }
 

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -225,12 +225,11 @@ async function spawnTerminal(
   const { runtimeId, path: cwdPath } = parseLocator(options.cwd ?? '')
   const runtime = runtimes.resolve(runtimeId)
 
-  // Resolve the cwd through the runtime: the local one validates against its
-  // allowed roots, the remote one trusts the locator path (its daemon validates).
-  // An empty cwd is defaulted to the host's home dir inside the ProcessHost, so
-  // there's nothing host-specific to decide here. The owning workspace id scopes
-  // validation to that workspace's roots when supplied.
-  const cwd = options.cwd ? runtime.validateCwd(cwdPath, ownerWindowId, options.workspaceId) : ''
+  // No client-side validation: the authoritative allowed-root check runs on
+  // the daemon inside process.create (a bad cwd rejects the create). An empty
+  // cwd is defaulted to the host's home dir inside the ProcessHost, so there's
+  // nothing host-specific to decide here.
+  const cwd = options.cwd ? cwdPath : ''
 
   // First-party CATE_API endpoint: give this terminal CATE_API/CATE_TOKEN in its
   // env so a `cate` CLI run inside it can reach the dispatch core. ensureEndpoint

--- a/src/main/projectCateAgentStore.test.ts
+++ b/src/main/projectCateAgentStore.test.ts
@@ -7,7 +7,33 @@ vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
 vi.mock('./logger', () => ({
   default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
-vi.mock('./cateGitignore', () => ({ ensureCateGitignore: vi.fn(async () => {}) }))
+vi.mock('./cateGitignore', () => ({
+  ensureCateGitignore: vi.fn(async () => {}),
+  CATE_GITIGNORE_CONTENT: '*\n!workspace.json\n',
+}))
+
+// In-memory host fs behind runtime.file for the remote branch.
+const hostFiles = vi.hoisted(() => new Map<string, string>())
+vi.mock('./runtime/runtimeManager', () => ({
+  runtimes: {
+    resolve: () => ({
+      file: {
+        async readFile(p: string): Promise<string> {
+          const v = hostFiles.get(p)
+          if (v === undefined) throw new Error(`ENOENT: ${p}`)
+          return v
+        },
+        async writeFile(p: string, content: string): Promise<void> {
+          hostFiles.set(p, content)
+        },
+        async stat(p: string): Promise<{ isDirectory: boolean; isFile: boolean }> {
+          if (!hostFiles.has(p)) throw new Error(`ENOENT: ${p}`)
+          return { isDirectory: false, isFile: true }
+        },
+      },
+    }),
+  },
+}))
 
 import { loadCateAgentState, saveCateAgentState } from './projectCateAgentStore'
 
@@ -49,5 +75,35 @@ describe('projectCateAgentStore', () => {
     // The broken content is preserved aside for recovery, not silently swallowed.
     const files = await fs.readdir(path.join(root, '.cate'))
     expect(files.some((f) => f.startsWith('cateAgent.json.corrupt-'))).toBe(true)
+  })
+})
+
+describe('projectCateAgentStore — remote roots (through the runtime)', () => {
+  const REMOTE_ROOT = 'cate-runtime://srv_abc/home/dev/project'
+  const FILE = '/home/dev/project/.cate/cateAgent.json'
+  const GITIGNORE = '/home/dev/project/.cate/.gitignore'
+
+  beforeEach(() => hostFiles.clear())
+
+  it('defaults when the remote file is absent', async () => {
+    expect(await loadCateAgentState(REMOTE_ROOT)).toEqual({ version: 1, autoObserve: true })
+    expect(hostFiles.size).toBe(0) // load never writes
+  })
+
+  it('round-trips autoObserve on the runtime host and seeds .gitignore once', async () => {
+    await saveCateAgentState(REMOTE_ROOT, { version: 1, autoObserve: false })
+    expect(hostFiles.has(FILE)).toBe(true)
+    expect(hostFiles.has(GITIGNORE)).toBe(true)
+    expect(await loadCateAgentState(REMOTE_ROOT)).toEqual({ version: 1, autoObserve: false })
+
+    // A hand-edited .gitignore is not clobbered by the next save.
+    hostFiles.set(GITIGNORE, 'custom')
+    await saveCateAgentState(REMOTE_ROOT, { version: 1, autoObserve: true })
+    expect(hostFiles.get(GITIGNORE)).toBe('custom')
+  })
+
+  it('degrades a corrupt remote file to defaults', async () => {
+    hostFiles.set(FILE, 'nope')
+    expect(await loadCateAgentState(REMOTE_ROOT)).toEqual({ version: 1, autoObserve: true })
   })
 })

--- a/src/main/projectCateAgentStore.ts
+++ b/src/main/projectCateAgentStore.ts
@@ -2,9 +2,11 @@
 // projectCateAgentStore — per-workspace Cate Agent preferences at
 // `<project>/.cate/cateAgent.json`.
 //
-// Tiny machine-local file recording whether automatic observations are on for
+// Tiny per-workspace file recording whether automatic observations are on for
 // this workspace (the Cate Agent itself is always on), so the choice survives a
-// restart. Mirrors projectChatsStore's load/save contract. Gitignored like the
+// restart. Local roots write directly; remote roots write the same file through
+// the runtime, so the preference behaves identically wherever the workspace
+// lives. Mirrors projectChatsStore's load/save contract. Gitignored like the
 // rest of .cate/ (only workspace.json is shared).
 // =============================================================================
 
@@ -17,8 +19,9 @@ import type { ProjectCateAgentFile } from '../shared/types'
 import { writeJsonAtomic } from './writeJsonAtomic'
 import { quarantineCorruptFile } from './quarantineCorruptFile'
 import { isPlainObject } from './jsonUtils'
-import { ensureCateGitignore } from './cateGitignore'
-import { isLocalLocator } from './runtime/locator'
+import { ensureCateGitignore, CATE_GITIGNORE_CONTENT } from './cateGitignore'
+import { isLocalLocator, parseLocator } from './runtime/locator'
+import { runtimes } from './runtime/runtimeManager'
 
 const CATE_DIR = '.cate'
 const CATE_AGENT_FILE = 'cateAgent.json'
@@ -33,17 +36,62 @@ function cateAgentPath(rootPath: string): string {
   return path.join(rootPath, CATE_DIR, CATE_AGENT_FILE)
 }
 
+/** Per-field normalize: the file is hand-editable, so a missing or non-boolean
+ *  flag degrades to the default without rejecting the file. */
+function normalizeCateAgentFile(parsed: unknown): ProjectCateAgentFile {
+  const o = isPlainObject(parsed) ? parsed : {}
+  return {
+    version: 1,
+    autoObserve: typeof o.autoObserve === 'boolean' ? o.autoObserve : DEFAULTS.autoObserve,
+  }
+}
+
+// Remote workspaces persist the same `.cate/cateAgent.json` through the
+// runtime (remote paths are POSIX; runtime.file.writeFile is atomic tmp+rename
+// on the host, matching writeJsonAtomic locally). Corrupt files aren't
+// quarantined over RPC — a corrupt remote file just degrades to defaults, same
+// posture as projectWorkspaceStore's remote branch.
+function remoteTargets(rootPath: string) {
+  const { runtimeId, path: base } = parseLocator(rootPath)
+  const dir = path.posix.join(base, CATE_DIR)
+  return {
+    runtime: runtimes.resolve(runtimeId),
+    file: path.posix.join(dir, CATE_AGENT_FILE),
+    gitignoreFile: path.posix.join(dir, '.gitignore'),
+  }
+}
+
+async function loadCateAgentStateRemote(rootPath: string): Promise<ProjectCateAgentFile> {
+  const { runtime, file } = remoteTargets(rootPath)
+  const raw = await runtime.file.readFile(file).catch(() => null)
+  if (!raw) return { ...DEFAULTS } // absent (or runtime hiccup) — defaults
+  try {
+    return normalizeCateAgentFile(JSON.parse(raw))
+  } catch {
+    log.warn('[projectCateAgentStore] corrupt remote %s; using defaults', file)
+    return { ...DEFAULTS }
+  }
+}
+
+async function saveCateAgentStateRemote(rootPath: string, state: ProjectCateAgentFile): Promise<void> {
+  const { runtime, file, gitignoreFile } = remoteTargets(rootPath)
+  // Write-once .gitignore, mirroring ensureCateGitignore on the local branch.
+  await runtime.file
+    .stat(gitignoreFile)
+    .catch(() => runtime.file.writeFile(gitignoreFile, CATE_GITIGNORE_CONTENT))
+  await runtime.file.writeFile(file, `${JSON.stringify({ version: 1, autoObserve: state.autoObserve !== false }, null, 2)}\n`)
+}
+
 export async function loadCateAgentState(rootPath: string): Promise<ProjectCateAgentFile> {
-  if (!isLocalLocator(rootPath)) return { ...DEFAULTS }
+  if (!isLocalLocator(rootPath)) return loadCateAgentStateRemote(rootPath)
   let raw: string
   try {
     raw = await fs.readFile(cateAgentPath(rootPath), 'utf-8')
   } catch {
     return { ...DEFAULTS } // absent — this workspace has no saved preference yet
   }
-  let parsed: unknown
   try {
-    parsed = JSON.parse(raw)
+    return normalizeCateAgentFile(JSON.parse(raw))
   } catch {
     // Unparseable (bad hand-edit / crash mid-write): quarantine the broken file
     // so it survives for recovery instead of being silently overwritten by the
@@ -52,17 +100,10 @@ export async function loadCateAgentState(rootPath: string): Promise<ProjectCateA
     log.warn('[projectCateAgentStore] corrupt %s%s; using defaults', cateAgentPath(rootPath), backup ? `, backed up to ${backup}` : '')
     return { ...DEFAULTS }
   }
-  const o = isPlainObject(parsed) ? parsed : {}
-  return {
-    version: 1,
-    // Per-field normalize: the file is hand-editable, so a missing or
-    // non-boolean flag degrades to the default without rejecting the file.
-    autoObserve: typeof o.autoObserve === 'boolean' ? o.autoObserve : DEFAULTS.autoObserve,
-  }
 }
 
 export async function saveCateAgentState(rootPath: string, state: ProjectCateAgentFile): Promise<void> {
-  if (!isLocalLocator(rootPath)) return
+  if (!isLocalLocator(rootPath)) return saveCateAgentStateRemote(rootPath, state)
   await ensureCateGitignore(cateDir(rootPath))
   await writeJsonAtomic(cateAgentPath(rootPath), {
     version: 1,

--- a/src/main/projectChatsStore.test.ts
+++ b/src/main/projectChatsStore.test.ts
@@ -7,7 +7,33 @@ vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
 vi.mock('./logger', () => ({
   default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
-vi.mock('./cateGitignore', () => ({ ensureCateGitignore: vi.fn(async () => {}) }))
+vi.mock('./cateGitignore', () => ({
+  ensureCateGitignore: vi.fn(async () => {}),
+  CATE_GITIGNORE_CONTENT: '*\n!workspace.json\n',
+}))
+
+// In-memory host fs behind runtime.file for the remote branch.
+const hostFiles = vi.hoisted(() => new Map<string, string>())
+vi.mock('./runtime/runtimeManager', () => ({
+  runtimes: {
+    resolve: () => ({
+      file: {
+        async readFile(p: string): Promise<string> {
+          const v = hostFiles.get(p)
+          if (v === undefined) throw new Error(`ENOENT: ${p}`)
+          return v
+        },
+        async writeFile(p: string, content: string): Promise<void> {
+          hostFiles.set(p, content)
+        },
+        async stat(p: string): Promise<{ isDirectory: boolean; isFile: boolean }> {
+          if (!hostFiles.has(p)) throw new Error(`ENOENT: ${p}`)
+          return { isDirectory: false, isFile: true }
+        },
+      },
+    }),
+  },
+}))
 
 import { loadChats, saveChats } from './projectChatsStore'
 import type { Chat } from '../shared/types'
@@ -102,5 +128,43 @@ describe('projectChatsStore', () => {
     // The broken content is preserved aside for recovery, not silently swallowed.
     const files = await fs.readdir(path.join(root, '.cate'))
     expect(files.some((f) => f.startsWith('chats.json.corrupt-'))).toBe(true)
+  })
+})
+
+describe('projectChatsStore — remote roots (through the runtime)', () => {
+  const REMOTE_ROOT = 'cate-runtime://srv_abc/home/dev/project'
+  const FILE = '/home/dev/project/.cate/chats.json'
+  const GITIGNORE = '/home/dev/project/.cate/.gitignore'
+
+  const chat: Chat = {
+    id: 'c1',
+    title: 'remote chat',
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [{ id: 'm1', role: 'user', ts: 3, kind: 'text', text: 'hello from afar' }],
+  }
+
+  beforeEach(() => hostFiles.clear())
+
+  it('loads empty when the remote file is absent', async () => {
+    expect(await loadChats(REMOTE_ROOT)).toEqual([])
+    expect(hostFiles.size).toBe(0) // load never writes
+  })
+
+  it('round-trips chats on the runtime host and seeds .gitignore once', async () => {
+    await saveChats(REMOTE_ROOT, [chat])
+    expect(hostFiles.has(FILE)).toBe(true)
+    expect(hostFiles.has(GITIGNORE)).toBe(true)
+    expect(await loadChats(REMOTE_ROOT)).toEqual([chat])
+
+    // A hand-edited .gitignore is not clobbered by the next save.
+    hostFiles.set(GITIGNORE, 'custom')
+    await saveChats(REMOTE_ROOT, [chat])
+    expect(hostFiles.get(GITIGNORE)).toBe('custom')
+  })
+
+  it('degrades a corrupt remote file to an empty list', async () => {
+    hostFiles.set(FILE, '{ definitely not json')
+    expect(await loadChats(REMOTE_ROOT)).toEqual([])
   })
 })

--- a/src/main/projectChatsStore.ts
+++ b/src/main/projectChatsStore.ts
@@ -4,11 +4,12 @@
 // The Cate Agent's front door: each chat is a persistent thread of typed messages
 // (text / plan / attempts / result / canvas) plus the live/last `run` state for a
 // code task. The renderer holds the authoritative in-memory list and mirrors every
-// mutation here. Machine-local — `.cate/.gitignore` keeps it out of the user's VCS.
+// mutation here. Local roots write directly (atomic tmp+rename); remote roots
+// write the same file through the runtime, so chats survive a restart wherever
+// the workspace lives. `.cate/.gitignore` keeps it out of the user's VCS.
 //
-// Persistence mirrors projectTodosStore's contract (load/save IPC, atomic
-// tmp+rename writes). A hand-edited / partial file must degrade gracefully rather
-// than crash, so every record is coerced on load.
+// A hand-edited / partial file must degrade gracefully rather than crash, so
+// every record is coerced on load.
 // =============================================================================
 
 import { ipcMain } from 'electron'
@@ -28,8 +29,9 @@ import type {
 } from '../shared/types'
 import { writeJsonAtomic } from './writeJsonAtomic'
 import { quarantineCorruptFile } from './quarantineCorruptFile'
-import { ensureCateGitignore } from './cateGitignore'
-import { isLocalLocator } from './runtime/locator'
+import { ensureCateGitignore, CATE_GITIGNORE_CONTENT } from './cateGitignore'
+import { isLocalLocator, parseLocator } from './runtime/locator'
+import { runtimes } from './runtime/runtimeManager'
 
 const CATE_DIR = '.cate'
 const CHATS_FILE = 'chats.json'
@@ -178,19 +180,63 @@ function normalizeChat(raw: unknown): Chat | null {
   return chat
 }
 
-/** Read `.cate/chats.json` for a local project. Missing → []; unparseable →
- *  quarantined (kept for recovery) then []. */
+/** Coerce a parsed chats file into a clean Chat[] (shared local/remote). */
+function normalizeChatsFile(parsed: unknown): Chat[] {
+  const o = parsed as Partial<ProjectChatsFile> | null
+  if (!o || !Array.isArray(o.chats)) return []
+  return o.chats.map(normalizeChat).filter((c): c is Chat => c !== null)
+}
+
+// Remote workspaces persist the same `.cate/chats.json` through the runtime
+// (remote paths are POSIX; runtime.file.writeFile is atomic tmp+rename on the
+// host, matching writeJsonAtomic locally). A corrupt file isn't quarantined
+// over RPC — it degrades to an empty list, same posture as
+// projectWorkspaceStore's remote branch.
+function remoteTargets(rootPath: string) {
+  const { runtimeId, path: base } = parseLocator(rootPath)
+  const dir = path.posix.join(base, CATE_DIR)
+  return {
+    runtime: runtimes.resolve(runtimeId),
+    file: path.posix.join(dir, CHATS_FILE),
+    gitignoreFile: path.posix.join(dir, '.gitignore'),
+  }
+}
+
+async function loadChatsRemote(rootPath: string): Promise<Chat[]> {
+  const { runtime, file } = remoteTargets(rootPath)
+  const raw = await runtime.file.readFile(file).catch(() => null)
+  if (!raw) return [] // absent (or runtime hiccup) — no chats yet
+  try {
+    return normalizeChatsFile(JSON.parse(raw))
+  } catch {
+    log.warn('[projectChatsStore] corrupt remote %s; starting empty', file)
+    return []
+  }
+}
+
+async function saveChatsRemote(rootPath: string, chats: Chat[]): Promise<void> {
+  const { runtime, file, gitignoreFile } = remoteTargets(rootPath)
+  // Write-once .gitignore, mirroring ensureCateGitignore on the local branch.
+  await runtime.file
+    .stat(gitignoreFile)
+    .catch(() => runtime.file.writeFile(gitignoreFile, CATE_GITIGNORE_CONTENT))
+  const payload: ProjectChatsFile = { version: 1, chats }
+  await runtime.file.writeFile(file, `${JSON.stringify(payload, null, 2)}\n`)
+}
+
+/** Read `.cate/chats.json` for a project. Missing → []; unparseable →
+ *  quarantined locally (kept for recovery) then []. */
 export async function loadChats(rootPath: string): Promise<Chat[]> {
-  if (!isLocalLocator(rootPath)) return [] // remote chats unsupported in this phase
+  if (!isLocalLocator(rootPath)) return loadChatsRemote(rootPath)
   let raw: string
   try {
     raw = await fs.readFile(chatsPath(rootPath), 'utf-8')
   } catch {
     return [] // absent — no chats yet
   }
-  let parsed: Partial<ProjectChatsFile>
+  let parsed: unknown
   try {
-    parsed = JSON.parse(raw) as Partial<ProjectChatsFile>
+    parsed = JSON.parse(raw)
   } catch {
     // Unparseable (bad hand-edit / crash mid-write): quarantine the broken file
     // so it survives for recovery instead of being silently overwritten by the
@@ -199,13 +245,12 @@ export async function loadChats(rootPath: string): Promise<Chat[]> {
     log.warn('[projectChatsStore] corrupt %s%s; starting empty', chatsPath(rootPath), backup ? `, backed up to ${backup}` : '')
     return []
   }
-  if (!parsed || !Array.isArray(parsed.chats)) return []
-  return parsed.chats.map(normalizeChat).filter((c): c is Chat => c !== null)
+  return normalizeChatsFile(parsed)
 }
 
-/** Persist the whole chat list for a local project (atomic tmp+rename). */
+/** Persist the whole chat list for a project (atomic tmp+rename on both paths). */
 export async function saveChats(rootPath: string, chats: Chat[]): Promise<void> {
-  if (!isLocalLocator(rootPath)) return
+  if (!isLocalLocator(rootPath)) return saveChatsRemote(rootPath, chats)
   const file: ProjectChatsFile = { version: 1, chats }
   await ensureCateGitignore(cateDir(rootPath))
   await writeJsonAtomic(chatsPath(rootPath), file)

--- a/src/main/runtime/transports/localTransport.ts
+++ b/src/main/runtime/transports/localTransport.ts
@@ -18,6 +18,7 @@ import os from 'os'
 import path from 'path'
 import type { RuntimeChannel, RuntimeTransport } from './transport'
 import { RUNTIME_VERSION } from '../../../runtime/version'
+import { LOGIN_ENV_MARKER } from '../../../runtime/loginEnv'
 import { hostRuntimeTarget, localTarballIfPresent, shippedRuntimeTarball, tarballHash, type RuntimeTarget } from '../runtimeArtifacts'
 
 const execFileP = promisify(execFile)
@@ -125,7 +126,9 @@ export class LocalSubprocessTransport implements RuntimeTransport {
 
     const child = spawn(nodePath, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: this.opts.env ?? process.env,
+      // The env passed here is already the login-shell env (getShellEnv());
+      // the marker tells the daemon to skip its own login-env capture.
+      env: { ...(this.opts.env ?? process.env), [LOGIN_ENV_MARKER]: '1' },
     })
     child.stdin?.on('error', () => { /* EPIPE after daemon exit is reported via close */ })
     this.child = child

--- a/src/main/runtime/transports/sshTransport.ts
+++ b/src/main/runtime/transports/sshTransport.ts
@@ -37,6 +37,10 @@ export interface SshOptions {
   passphrase?: string
   agentSock?: string
   exclusions?: string[]
+  /** Idle-suspend of backgrounded terminals (the user's setting); appended as
+   *  `--idle-suspend` to the daemon launch args when true — same flag the
+   *  local transport passes, so an SSH host honors the setting identically. */
+  idleSuspend?: boolean
   /** Host-key policy (TOFU pin). Injected for tests; defaults to the on-disk
    *  known-hosts store keyed by host:port. Receives ssh2's sha256 fingerprint;
    *  must throw to reject the connection (host-key mismatch / MITM). */
@@ -236,7 +240,8 @@ export class SshTransport implements RuntimeTransport {
     await this.ensureConnected()
     const nodeBin = `${this.installDir}/runtime/bin/node`
     const args = `--root ${shq(this.opts.root)} --id ${shq(this.opts.id)}` +
-      (this.opts.exclusions?.length ? ` --exclude ${shq(this.opts.exclusions.join(','))}` : '')
+      (this.opts.exclusions?.length ? ` --exclude ${shq(this.opts.exclusions.join(','))}` : '') +
+      (this.opts.idleSuspend ? ' --idle-suspend' : '')
     const cmd = `${shq(nodeBin)} ${shq(`${this.installDir}/runtime.cjs`)} ${args}`
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/main/runtime/transports/wslTransport.ts
+++ b/src/main/runtime/transports/wslTransport.ts
@@ -27,6 +27,10 @@ export interface WslOptions {
   root: string
   id: string
   exclusions?: string[]
+  /** Idle-suspend of backgrounded terminals (the user's setting); appended as
+   *  `--idle-suspend` to the daemon launch args when true — same flag the
+   *  local transport passes, so a WSL host honors the setting identically. */
+  idleSuspend?: boolean
 }
 
 export class WslTransport implements RuntimeTransport {
@@ -150,6 +154,7 @@ export class WslTransport implements RuntimeTransport {
     const nodeBin = `${this.installDir}/runtime/bin/node`
     const args = ['-d', this.opts.distro, '-e', nodeBin, `${this.installDir}/runtime.cjs`, '--root', this.opts.root, '--id', this.opts.id]
     if (this.opts.exclusions?.length) args.push('--exclude', this.opts.exclusions.join(','))
+    if (this.opts.idleSuspend) args.push('--idle-suspend')
     const child = spawn('wsl.exe', args, { stdio: ['pipe', 'pipe', 'pipe'] })
     child.stdin?.on('error', () => { /* EPIPE after daemon exit is reported via close */ })
     this.child = child

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -445,13 +445,19 @@ export interface Runtime {
   readonly server: ServerHost
   readonly tunnel: TunnelHost
   /** Lexical + allowed-root check; returns the normalized path. When scopeId is
-   *  omitted, the runtime uses its own configured root scope. */
+   *  omitted, the runtime uses its own configured root scope.
+   *  NOTE: only the DAEMON's implementation validates (it alone can realpath
+   *  its filesystem). The client-side Runtime handles (RemoteRuntime /
+   *  DeferredRuntime) are sync pass-throughs that never throw — don't call
+   *  this client-side expecting a check; every leaf op re-validates on the
+   *  daemon anyway. Use validatePathStrict for a real client-side round-trip. */
   validatePath(filePath: string, ownerWindowId?: number, scopeId?: string): string
   /** Strict (symlink-resolving) read validation; returns the real path. */
   validatePathStrict(filePath: string, ownerWindowId?: number, scopeId?: string): Promise<string>
   /** Validate a target whose parent must exist; returns the safe path. */
   validatePathForCreation(filePath: string, ownerWindowId?: number, scopeId?: string): Promise<string>
-  /** Directory validation for cwd parameters. */
+  /** Directory validation for cwd parameters. Same caveat as validatePath:
+   *  a real check only on the daemon; a pass-through on client-side handles. */
   validateCwd(cwd: string, ownerWindowId?: number, scopeId?: string): string
   /** Add/remove a path from this runtime's allowed-roots set. For the local
    *  daemon (and remote daemons), workspace roots are forwarded here so the

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -60,6 +60,7 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   terminalOptionIsMeta: 'boolean',
   autoSuspendIdleTerminals: 'boolean',
   cliEnabled: 'boolean',
+  cliSkillInstallEnabled: 'boolean',
   browserHomepage: 'string',
   browserSearchEngine: 'string',
   browserShowBookmarksBar: 'boolean',

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -121,30 +121,29 @@ async function applySettingSideEffect(key: keyof AppSettings, value: unknown): P
   if (key === 'fileExclusions') {
     broadcastToAll(SETTINGS_CHANGED, key, value)
   }
-  // Push the new set to the LOCAL runtime daemon, which captured its exclusions once at
-  // launch — without this the daemon's file tree / file-name search wouldn't
-  // honor the change until a restart. Only LOCAL: remote daemons get their
-  // config at connect time (out of scope here). Imports are dynamic to avoid
-  // store<->filesystem and store<->runtime cycles.
+  // Push the new set to EVERY connected runtime daemon (local and remote alike
+  // — each captured its exclusions once at launch); without this a daemon's
+  // file tree / file-name search / watchers wouldn't honor the change until a
+  // reconnect. Imports are dynamic to avoid store<->filesystem and
+  // store<->runtime cycles.
   if (key === 'fileExclusions') {
     try {
       const { runtimes } = await import('./runtime/runtimeManager')
-      const { LOCAL_RUNTIME_ID } = await import('./runtime/locator')
-      if (runtimes.has(LOCAL_RUNTIME_ID)) {
-        runtimes.resolve(LOCAL_RUNTIME_ID).setExclusions(value as string[]).catch(() => {})
+      for (const id of runtimes.connectedIds()) {
+        runtimes.resolve(id).setExclusions(value as string[]).catch(() => {})
       }
     } catch (err) {
       log.warn('Runtime exclusions forward failed: %O', err)
     }
   }
-  // Push the idle-suspend toggle to the LOCAL runtime daemon, which gated its
-  // idle scanner once at launch — toggling otherwise needs a restart.
+  // Push the idle-suspend toggle to EVERY connected runtime daemon, each of
+  // which gated its idle scanner once at launch — toggling otherwise needs a
+  // reconnect. (POSIX-only inside the daemon; a win32 host ignores it.)
   if (key === 'autoSuspendIdleTerminals') {
     try {
       const { runtimes } = await import('./runtime/runtimeManager')
-      const { LOCAL_RUNTIME_ID } = await import('./runtime/locator')
-      if (runtimes.has(LOCAL_RUNTIME_ID)) {
-        runtimes.resolve(LOCAL_RUNTIME_ID).setIdleSuspend(value !== false).catch(() => {})
+      for (const id of runtimes.connectedIds()) {
+        runtimes.resolve(id).setIdleSuspend(value !== false).catch(() => {})
       }
     } catch (err) {
       log.warn('Runtime idle-suspend forward failed: %O', err)

--- a/src/main/windowPanels.test.ts
+++ b/src/main/windowPanels.test.ts
@@ -23,8 +23,9 @@ import {
   setWindowPanels,
   getWindowPanels,
   revealWindowPanel,
+  closeWindowPanel,
 } from './windowPanels'
-import { WINDOW_PANELS_CHANGED, REVEAL_PANEL_IN_WINDOW } from '../shared/ipc-channels'
+import { WINDOW_PANELS_CHANGED, REVEAL_PANEL_IN_WINDOW, CLOSE_PANEL_IN_WINDOW } from '../shared/ipc-channels'
 import type { WindowPanelInfo, WindowPanelReport, PanelState } from '../shared/types'
 
 // -----------------------------------------------------------------------------
@@ -39,6 +40,9 @@ interface FakeWin {
   focus: ReturnType<typeof vi.fn>
   restore: ReturnType<typeof vi.fn>
   fireClosed: () => void
+  /** Simulates a window that died WITHOUT a clean close: isDestroyed() flips
+   *  true while the union still holds its last report. */
+  destroyed: boolean
   win: never
 }
 
@@ -53,9 +57,10 @@ function makeWin(id: number): FakeWin {
     focus: vi.fn(),
     restore: vi.fn(),
     fireClosed: () => handlers['closed']?.(),
+    destroyed: false,
     win: {
       id,
-      isDestroyed: () => false,
+      isDestroyed: () => fake.destroyed,
       isMinimized: () => false,
       restore: () => fake.restore(),
       focus: () => fake.focus(),
@@ -203,6 +208,36 @@ describe('cross-window panel discovery (main)', () => {
 
     // Unknown panel → no-op, reported as not found.
     expect(revealWindowPanel('nope')).toBe(false)
+  })
+
+  it('closes a panel by focusing its owner window and asking IT to run the close (behind its gates)', () => {
+    open(1, 'main', 'ws-A')
+    const dock = open(160, 'dock', 'ws-A')
+    setWindowPanels(160, [report('t1', 'terminal', 'Terminal 1')])
+
+    expect(closeWindowPanel('t1')).toBe(true)
+    // Focused first so the owner's confirm dialogs are visible.
+    expect(dock.focus).toHaveBeenCalled()
+    const close = dock.sent.filter((m) => m.channel === CLOSE_PANEL_IN_WINDOW)
+    expect(close).toHaveLength(1)
+    expect(close[0].args[0]).toBe('t1')
+
+    // Unknown panel → not found, nothing sent anywhere.
+    expect(closeWindowPanel('nope')).toBe(false)
+  })
+
+  it('closeWindowPanel returns false when the owning window died without a clean close', () => {
+    const dock = open(161, 'dock', 'ws-A')
+    setWindowPanels(161, [report('t2', 'terminal', 'Terminal 2')])
+    expect(getWindowPanels()).toHaveLength(1)
+
+    // The window is destroyed but 'closed' never fired, so the union still
+    // holds its stale report — closeWindowPanel must not target a dead window.
+    dock.destroyed = true
+
+    expect(closeWindowPanel('t2')).toBe(false)
+    expect(dock.sent.filter((m) => m.channel === CLOSE_PANEL_IN_WINDOW)).toHaveLength(0)
+    expect(dock.focus).not.toHaveBeenCalled()
   })
 
   it('does NOT drive discovery from the dock session-persistence sync', () => {

--- a/src/main/windowPanels.ts
+++ b/src/main/windowPanels.ts
@@ -19,7 +19,7 @@
 // =============================================================================
 
 import type { WindowPanelInfo, WindowPanelReport } from '../shared/types'
-import { WINDOW_PANELS_CHANGED, REVEAL_PANEL_IN_WINDOW } from '../shared/ipc-channels'
+import { WINDOW_PANELS_CHANGED, REVEAL_PANEL_IN_WINDOW, CLOSE_PANEL_IN_WINDOW } from '../shared/ipc-channels'
 import { broadcastToAll, focusWindow, getWindow, getWindowType, onWindowClosed, sendToWindow } from './windowRegistry'
 
 /** The latest panel report from each window, keyed by Electron window id. */
@@ -93,6 +93,19 @@ export function revealWindowPanel(panelId: string): boolean {
   if (!win) return false
   focusWindow(win)
   sendToWindow(owner.ownerWindowId, REVEAL_PANEL_IN_WINDOW, panelId)
+  return true
+}
+
+/** Ask the window that owns `panelId` to close the panel (behind its own
+ *  dirty/running confirmation gates). Focuses the owner first so the gates'
+ *  dialogs are visible. Returns false if no live window owns it. */
+export function closeWindowPanel(panelId: string): boolean {
+  const owner = getWindowPanels().find((p) => p.panelId === panelId)
+  if (!owner) return false
+  const win = getWindow(owner.ownerWindowId)
+  if (!win) return false
+  focusWindow(win)
+  sendToWindow(owner.ownerWindowId, CLOSE_PANEL_IN_WINDOW, panelId)
   return true
 }
 

--- a/src/main/windows/windowFactory.flushOnClose.test.ts
+++ b/src/main/windows/windowFactory.flushOnClose.test.ts
@@ -1,0 +1,191 @@
+// =============================================================================
+// createWindow close wiring — a closing dock window must trigger an immediate
+// session save so session.json drops it: windowFactory's 'closed' handler sends
+// SESSION_FLUSH_SAVE to the active MAIN window for any non-main window. Driven
+// through the REAL createWindow + REAL windowRegistry (registration, active-main
+// lookup, sendToWindow, closeWindowsForWorkspace) with only the Electron shell
+// and window-scoped cleanup collaborators faked — the same harness shape as
+// windowFactory.reveal.test.ts.
+//
+// The fake BrowserWindow mirrors Electron's documented lifecycle: close() emits
+// 'close' then 'closed'; destroy() skips 'close' but still emits 'closed'.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const hooks = vi.hoisted(() => {
+  let nextId = 1
+  const created: FakeWin[] = []
+
+  interface FakeWin {
+    id: number
+    destroyed: boolean
+    sent: Array<{ channel: string; args: unknown[] }>
+    emit(ev: string): void
+    close(): void
+    destroy(): void
+    webContents: { emit(ev: string): void; send(channel: string, ...args: unknown[]): void }
+    [key: string]: unknown
+  }
+
+  function makeEmitter() {
+    const once: Record<string, Array<() => void>> = {}
+    const on: Record<string, Array<() => void>> = {}
+    return {
+      once(ev: string, cb: () => void) { (once[ev] ??= []).push(cb) },
+      on(ev: string, cb: () => void) { (on[ev] ??= []).push(cb) },
+      emit(ev: string) {
+        const fired = once[ev] ?? []
+        once[ev] = []
+        fired.forEach((f) => f())
+        ;(on[ev] ?? []).forEach((f) => f())
+      },
+    }
+  }
+
+  function makeWin(): FakeWin {
+    const sent: FakeWin['sent'] = []
+    const win: FakeWin = {
+      ...makeEmitter(),
+      id: nextId++,
+      destroyed: false,
+      sent,
+      webContents: {
+        ...makeEmitter(),
+        send(channel: string, ...args: unknown[]) { sent.push({ channel, args }) },
+      },
+      loadURL() {},
+      loadFile() {},
+      show() {},
+      focus() {},
+      isDestroyed() { return win.destroyed },
+      getPosition() { return [0, 0] },
+      getSize() { return [800, 600] },
+      isMinimized() { return false },
+      isFullScreen() { return false },
+      isMaximized() { return false },
+      // Electron: close() runs the 'close' gate, then tears down and emits 'closed'.
+      close() {
+        win.emit('close')
+        win.destroyed = true
+        win.emit('closed')
+      },
+      // Electron: destroy() skips 'close'/unload but GUARANTEES 'closed' fires.
+      destroy() {
+        win.destroyed = true
+        win.emit('closed')
+      },
+    }
+    created.push(win)
+    return win
+  }
+
+  return { created, makeWin }
+})
+
+vi.mock('electron', () => {
+  const BrowserWindow = function () { return hooks.makeWin() }
+  const electron = {
+    BrowserWindow,
+    nativeImage: { createFromPath: () => ({}) },
+    nativeTheme: { themeSource: 'system' },
+  }
+  return { ...electron, default: electron }
+})
+
+vi.mock('../logger', () => ({
+  default: { info() {}, warn() {}, debug() {}, error() {} },
+}))
+vi.mock('./reveal', () => ({ revealWindow: () => {}, IS_E2E: false }))
+vi.mock('./crashRecovery', () => ({ installRendererCrashRecovery: () => {} }))
+vi.mock('./fullscreen', () => ({ anyWindowFullscreen: () => false }))
+vi.mock('../store', () => ({ readBootSnapshot: () => null, writeBootSnapshot: () => {} }))
+vi.mock('../perf/perfMonitor', () => ({ PERF_ENABLED: false, countIpc: () => {} }))
+vi.mock('../ipc/filesystem', () => ({ stopWatchersForWindow: () => {} }))
+vi.mock('../ipc/git-monitor', () => ({ stopMonitorsForWindow: () => {} }))
+vi.mock('../ipc/search', () => ({ stopSearchesForWindow: () => {} }))
+vi.mock('../ipc/pathValidation', () => ({
+  clearFileGrantsForWindow: () => {},
+  clearScopedWriteAllowancesForWindow: () => {},
+  grantFileAccess: () => Promise.resolve(),
+}))
+vi.mock('../runtime/runtimeManager', () => ({
+  forwardFileGrant: () => {},
+  forwardClearFileGrantsForWindow: () => {},
+  forwardClearScopedWriteAllowancesForWindow: () => {},
+}))
+vi.mock('../grantedPathStore', () => ({ listPersistentGrants: () => Promise.resolve([]) }))
+vi.mock('../menu', () => ({ rebuildApplicationMenu: () => {} }))
+vi.mock('../featureFlags', () => ({ disableRendererSandbox: () => false }))
+
+const { createWindow } = await import('./windowFactory')
+const { closeWindowsForWorkspace } = await import('../windowRegistry')
+const { SESSION_FLUSH_SAVE } = await import('../../shared/ipc-channels')
+
+type FakeWin = ReturnType<typeof hooks.makeWin>
+
+const flushesTo = (win: FakeWin): number =>
+  win.sent.filter((m) => m.channel === SESSION_FLUSH_SAVE).length
+
+describe('createWindow close -> session flush wiring', () => {
+  beforeEach(() => {
+    // Close any window a previous test left registered so the shared registry
+    // (active-main tracking, workspace maps) starts clean.
+    for (const w of [...hooks.created]) { if (!w.destroyed) w.close() }
+    hooks.created.length = 0
+  })
+
+  it('closing a dock window sends SESSION_FLUSH_SAVE to the active main window', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+
+    expect(flushesTo(main)).toBe(0)
+    dock.close()
+
+    expect(flushesTo(main)).toBe(1)
+    expect(flushesTo(dock)).toBe(0)
+  })
+
+  it('closing the main window itself does not take the flush path', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    main.close()
+    expect(flushesTo(main)).toBe(0)
+  })
+
+  it('destroy() via closeWindowsForWorkspace still hits the flush (Electron emits closed on destroy)', () => {
+    // Pins current behavior: workspace teardown destroys dock windows to skip
+    // their 'close'-time save/re-integration gates, but Electron guarantees
+    // 'closed' fires even for destroy(), and windowFactory's 'closed' handler
+    // does not distinguish the two — so the main window is still asked to
+    // flush the session. Today that is redundant-but-harmless (the flush
+    // re-saves a session without the destroyed windows); if teardown ever must
+    // truly skip the save, the handler needs its own signal, not destroy().
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    createWindow({ type: 'dock', workspaceId: 'ws-A' })
+    const otherDock = createWindow({ type: 'dock', workspaceId: 'ws-B' }) as unknown as FakeWin
+
+    closeWindowsForWorkspace('ws-A')
+
+    expect(flushesTo(main)).toBe(1)
+    // Only ws-A's window was destroyed.
+    expect(otherDock.destroyed).toBe(false)
+  })
+
+  it('a dock window closing after the main window is gone flushes nowhere (no-op, no throw)', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+
+    // Real quit order: main's 'close' handler close()s the docks while main is
+    // still registered, so each dock flush targets the dying-but-live main.
+    // Pinned here: main.close() cascades into dock.close(), whose 'closed'
+    // flush is sent to main BEFORE main's own 'closed' unregisters it.
+    main.close()
+    expect(dock.destroyed).toBe(true)
+    expect(flushesTo(main)).toBe(1)
+
+    // A straggler dock closing with NO main window left must not throw.
+    const lateDock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+    expect(() => lateDock.close()).not.toThrow()
+    expect(flushesTo(main)).toBe(1)
+  })
+})

--- a/src/main/workspaceManager.remoteRoots.test.ts
+++ b/src/main/workspaceManager.remoteRoots.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest'
 type IpcHandler = (event: unknown, ...args: unknown[]) => unknown
 
 const handlers = new Map<string, IpcHandler>()
-let connectedListener: ((id: string, runtime: typeof remoteRuntime) => void) | undefined
+const connectedListeners: Array<(id: string, runtime: typeof remoteRuntime) => void> = []
+const fireConnected = (id: string): void => {
+  for (const listener of connectedListeners) listener(id, remoteRuntime)
+}
 let connected = false
 
 const remoteRuntime = {
@@ -34,18 +37,21 @@ vi.mock('./runtime/runtimeManager', () => ({
   runtimes: {
     has: vi.fn(() => connected),
     resolve: vi.fn(() => remoteRuntime),
-    onConnected: vi.fn((listener: typeof connectedListener) => {
-      connectedListener = listener
+    onConnected: vi.fn((listener: (typeof connectedListeners)[number]) => {
+      connectedListeners.push(listener)
       return () => {}
     }),
   },
 }))
+vi.mock('../skills/main/seedCateCliSkill', () => ({ seedCateCliSkill: vi.fn(async () => {}) }))
 
-const { WORKSPACE_CREATE } = await import('../shared/ipc-channels')
+const { WORKSPACE_CREATE, WORKSPACE_UPDATE } = await import('../shared/ipc-channels')
 const { registerWorkspaceHandlers } = await import('./workspaceManager')
+const { seedCateCliSkill } = await import('../skills/main/seedCateCliSkill')
 
 describe('remote workspace root scopes', () => {
   it('registers roots by workspace id and replays them after connection and reconnect', async () => {
+    connectedListeners.length = 0
     registerWorkspaceHandlers()
     const create = handlers.get(WORKSPACE_CREATE)
     expect(create).toBeDefined()
@@ -64,7 +70,7 @@ describe('remote workspace root scopes', () => {
     // the runtime id carried by the locator).
     expect(remoteRuntime.addAllowedRoot).not.toHaveBeenCalled()
     connected = true
-    connectedListener?.(runtimeId, remoteRuntime)
+    fireConnected(runtimeId)
     expect(remoteRuntime.addAllowedRoot).toHaveBeenLastCalledWith(root, workspaceId)
     expect(workspaceId).not.toBe(runtimeId)
 
@@ -81,10 +87,47 @@ describe('remote workspace root scopes', () => {
     // Reconnect creates a fresh daemon root registry; both workspace scopes are
     // replayed onto the replacement runtime.
     remoteRuntime.addAllowedRoot.mockClear()
-    connectedListener?.(runtimeId, remoteRuntime)
+    fireConnected(runtimeId)
     expect(remoteRuntime.addAllowedRoot.mock.calls).toEqual([
       [root, workspaceId],
       [secondRoot, secondId],
     ])
+  })
+
+  it('seeds the cate-cli skill at create, at rootPath attach, and on runtime connect', async () => {
+    connectedListeners.length = 0
+    registerWorkspaceHandlers()
+    const create = handlers.get(WORKSPACE_CREATE)!
+    const update = handlers.get(WORKSPACE_UPDATE)!
+    const seed = vi.mocked(seedCateCliSkill)
+    seed.mockClear()
+
+    const runtimeId = 'srv_seeding'
+    const locator = (p: string): string => `cate-runtime://${runtimeId}${p}`
+
+    // Open with a folder → seed attempt for that root.
+    await create({}, { id: 'workspace-seed-a', name: 'A', rootPath: locator('/home/dev/a') })
+    expect(seed).toHaveBeenLastCalledWith(locator('/home/dev/a'))
+
+    // A rootless workspace seeds nothing until a folder is attached (the local
+    // folder-pick / remote-attach path, which lands as an update).
+    await create({}, { id: 'workspace-seed-b', name: 'B' })
+    expect(seed).toHaveBeenCalledTimes(1)
+    await update({}, 'workspace-seed-b', { rootPath: locator('/home/dev/b') })
+    expect(seed).toHaveBeenLastCalledWith(locator('/home/dev/b'))
+
+    // Runtime (re)connect replays seeding for every workspace on that runtime —
+    // the moment a REMOTE workspace can actually seed.
+    seed.mockClear()
+    fireConnected(runtimeId)
+    expect(seed.mock.calls.map(([root]) => root).sort()).toEqual([
+      locator('/home/dev/a'),
+      locator('/home/dev/b'),
+    ])
+
+    // Other runtimes' connects don't touch these workspaces.
+    seed.mockClear()
+    fireConnected('srv_other')
+    expect(seed).not.toHaveBeenCalled()
   })
 })

--- a/src/main/workspaceManager.ts
+++ b/src/main/workspaceManager.ts
@@ -22,6 +22,7 @@ import { acquireProjectLock, releaseProjectLock } from './projectLock'
 import { isLocalLocator, parseLocator } from './runtime/locator'
 import { runtimes } from './runtime/runtimeManager'
 import { workspaceCateApi } from './extensions/workspaceCateApi'
+import { seedCateCliSkill } from '../skills/main/seedCateCliSkill'
 import type { RuntimeConnection } from '../shared/types'
 
 // In-memory workspace list — authoritative source of truth
@@ -106,6 +107,20 @@ function replayAllowedRoots(runtimeId: string, runtime: ReturnType<typeof runtim
   }
 }
 
+/** Seed the cate-cli skill for every workspace on a runtime once it actually
+ *  connects. createWorkspace/updateWorkspace seed too, but a REMOTE workspace's
+ *  runtime connects only AFTER those run (register → create/attach → ensure), so
+ *  their attempt finds no runtime and skips — this replay is what makes seeding
+ *  behave the same for local and remote. Re-runs on reconnect are cheap: seed
+ *  markers in .cate/skills.json short-circuit already-seeded targets. */
+function replaySkillSeeds(runtimeId: string): void {
+  for (const workspace of workspaces.values()) {
+    const locator = parseLocator(workspace.rootPath)
+    if (!locator.path || locator.runtimeId !== runtimeId) continue
+    void seedCateCliSkill(workspace.rootPath)
+  }
+}
+
 // -----------------------------------------------------------------------------
 // Public API (called by IPC handlers)
 // -----------------------------------------------------------------------------
@@ -165,6 +180,9 @@ async function createWorkspace(
     if (!remote) addAllowedRoot(info.rootPath, info.id)
     forwardAllowedRoot(info.rootPath, 'add', info.id)
     if (!remote) claimProjectLock(info.rootPath, info.name)
+    // Seed the bundled cate-cli skill for the agents used in this workspace
+    // (same install path as the skills modal). Best effort, never blocks open.
+    void seedCateCliSkill(info.rootPath)
   }
   return { ok: true, workspace: info }
 }
@@ -247,6 +265,9 @@ async function updateWorkspace(id: string, changes: Partial<Omit<WorkspaceInfo, 
     // Release the lock on the old root (local only) and claim the new one.
     if (existingLocal) dropProjectLock(existing.rootPath, id)
     if (nextLocal) claimProjectLock(updated.rootPath, updated.name)
+    // A workspace first gets its folder through here (local folder pick, remote
+    // attach) — seed exactly like createWorkspace. Best effort, never blocks.
+    if (updated.rootPath) void seedCateCliSkill(updated.rootPath)
   }
   return { ok: true, workspace: updated }
 }
@@ -287,6 +308,11 @@ export function registerWorkspaceHandlers(): void {
   // connection and reconnect; workspace ids deliberately differ from runtime
   // ids and are the scope carried by renderer fs/git requests.
   runtimes.onConnected(replayAllowedRoots)
+
+  // Skill seeding needs a live runtime; replay it on every (re)connect so remote
+  // workspaces — whose runtime connects after create/attach — seed exactly like
+  // local ones. Idempotent via seed markers.
+  runtimes.onConnected(replaySkillSeeds)
 
   // Create a new workspace
   ipcMain.handle(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,6 +158,8 @@ import {
   WINDOW_PANELS_CHANGED,
   FOCUS_WINDOW_PANEL,
   REVEAL_PANEL_IN_WINDOW,
+  CLOSE_WINDOW_PANEL,
+  CLOSE_PANEL_IN_WINDOW,
   WINDOW_PANELS_REPORT,
   CROSS_WINDOW_DRAG_START,
   CROSS_WINDOW_DRAG_UPDATE,
@@ -489,6 +491,7 @@ const invokeForwarders = {
 
   // Cross-window panel discovery
   focusWindowPanel: makeInvoker<'focusWindowPanel'>(FOCUS_WINDOW_PANEL),
+  closeWindowPanel: makeInvoker<'closeWindowPanel'>(CLOSE_WINDOW_PANEL),
   reportWindowPanels: makeInvoker<'reportWindowPanels'>(WINDOW_PANELS_REPORT),
 
   // Cross-window drag coordination
@@ -848,6 +851,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   onRevealPanelInWindow(callback: (panelId: string) => void): () => void {
     return createIpcListener(REVEAL_PANEL_IN_WINDOW, callback)
+  },
+
+  onClosePanelInWindow(callback: (panelId: string) => void): () => void {
+    return createIpcListener(CLOSE_PANEL_IN_WINDOW, callback)
   },
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/docking/useDockTabActions.rename.test.tsx
+++ b/src/renderer/docking/useDockTabActions.rename.test.tsx
@@ -1,0 +1,111 @@
+// =============================================================================
+// useDockTabActions rename-seed regression: commitRename must NOT write when
+// the submitted value equals the value beginRename seeded the input with.
+// renamePanelByUser sets titleUserOverridden, so committing an unchanged seed
+// (a live auto-title like "Agent · foo") would freeze it as a permanent user
+// title the user never actually typed. Only an actual edit may rename.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../lib/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: { entries: () => [], panelIdForPty: () => null, ptyIdForPanel: () => null, has: () => false, getEntry: () => undefined, dispose: vi.fn(), release: vi.fn(), disposeWorkspace: vi.fn() },
+}))
+vi.mock('../../agent/renderer/agentSessionRegistry', () => ({
+  disposeAgentPanel: vi.fn(),
+  getAgentPanelSession: vi.fn(),
+  saveAgentPanelSession: vi.fn(),
+}))
+
+import { useDockTabActions } from './useDockTabActions'
+import { CanvasStoreProvider } from '../stores/CanvasStoreContext'
+import { useAppStore } from '../stores/appStore'
+import { createDockStore } from '../stores/dockStore'
+import { getOrCreateCanvasStoreForPanel, releaseCanvasStoreForPanel } from '../stores/canvasStore'
+import type { DockTabStack } from '../../shared/types'
+
+const STACK: DockTabStack = { type: 'tabs', id: 'stack-1', panelIds: ['p1'], activeIndex: 0 }
+
+type Actions = ReturnType<typeof useDockTabActions>
+const api: { current: Actions | null } = { current: null }
+
+const dockStore = createDockStore()
+
+const Harness: React.FC = () => {
+  api.current = useDockTabActions({
+    stack: STACK,
+    zone: 'center',
+    dockStoreApi: dockStore,
+    workspaceId: 'ws-rename',
+  })
+  return null
+}
+
+let host: HTMLDivElement
+let root: Root
+const renamePanelByUser = vi.fn()
+const initialAppState = useAppStore.getState()
+
+beforeEach(() => {
+  renamePanelByUser.mockClear()
+  useAppStore.setState({ renamePanelByUser } as never)
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => {
+    root.render(
+      <CanvasStoreProvider store={getOrCreateCanvasStoreForPanel('rename-harness-cv')}>
+        <Harness />
+      </CanvasStoreProvider>,
+    )
+  })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  releaseCanvasStoreForPanel('rename-harness-cv')
+  useAppStore.setState(initialAppState, true)
+  api.current = null
+})
+
+describe('useDockTabActions — commitRename seed regression', () => {
+  it('committing the seeded value unchanged does NOT rename', () => {
+    act(() => { api.current!.beginRename('p1', 'Agent · foo') })
+    expect(api.current!.renameId).toBe('p1')
+    expect(api.current!.renameValue).toBe('Agent · foo')
+
+    act(() => { api.current!.commitRename('p1') })
+
+    expect(renamePanelByUser).not.toHaveBeenCalled()
+    expect(api.current!.renameId).toBeNull() // rename mode still exits
+  })
+
+  it('committing an edited value renames the panel', () => {
+    act(() => { api.current!.beginRename('p1', 'Agent · foo') })
+    act(() => { api.current!.setRenameValue('Build agent') })
+    act(() => { api.current!.commitRename('p1') })
+
+    expect(renamePanelByUser).toHaveBeenCalledTimes(1)
+    expect(renamePanelByUser).toHaveBeenCalledWith('ws-rename', 'p1', 'Build agent')
+  })
+
+  it('a fresh beginRename re-seeds: the previous seed does not leak into the next rename', () => {
+    // First rename: edit and commit.
+    act(() => { api.current!.beginRename('p1', 'Agent · foo') })
+    act(() => { api.current!.setRenameValue('Custom') })
+    act(() => { api.current!.commitRename('p1') })
+    renamePanelByUser.mockClear()
+
+    // Second rename seeds with the NEW title; committing it unchanged is a no-op.
+    act(() => { api.current!.beginRename('p1', 'Custom') })
+    act(() => { api.current!.commitRename('p1') })
+    expect(renamePanelByUser).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -70,6 +70,10 @@ export function useDockTabActions(params: DockTabActionsParams) {
   // --- Inline rename --------------------------------------------------------
   const [renameId, setRenameId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
+  // Seed value the input opened with — committing it unchanged must not write:
+  // renamePanelByUser sets titleUserOverridden, which would freeze a live
+  // auto-title (agent name) the user never actually edited.
+  const renameSeedRef = useRef('')
   const renameInputRef = useRef<HTMLInputElement | null>(null)
   useEffect(() => {
     if (renameId && renameInputRef.current) {
@@ -79,7 +83,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
   }, [renameId])
   const commitRename = (panelId: string) => {
     const trimmed = renameValue.trim()
-    if (trimmed) {
+    if (trimmed && trimmed !== renameSeedRef.current) {
       const wsId = workspaceId ?? useAppStore.getState().selectedWorkspaceId
       // renamePanelByUser sets titleUserOverridden so the agent-name tab title
       // (terminalRegistry) won't clobber a manual rename; onPanelRenamed keeps
@@ -90,6 +94,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
     setRenameId(null)
   }
   const beginRename = (panelId: string, currentTitle: string) => {
+    renameSeedRef.current = currentTitle
     setRenameValue(currentTitle)
     setRenameId(panelId)
   }

--- a/src/renderer/lib/closePanelWithConfirm.bulk.test.ts
+++ b/src/renderer/lib/closePanelWithConfirm.bulk.test.ts
@@ -1,0 +1,271 @@
+// =============================================================================
+// Bulk close/remove confirmation — regression tests for the two canonical
+// helpers in closePanelWithConfirm.ts:
+//
+//   • closeAllPanelsWithConfirm runs the dirty-editor + running-terminal gates
+//     over ALL of a workspace's panels before appStore.closeAllPanels — a
+//     cancel must close nothing.
+//   • removeWorkspacesWithConfirm aggregates panels across EVERY listed
+//     workspace and runs each gate ONCE (one dialog for the whole batch), then
+//     removes the workspaces — previously "Close Workspace" tore panels down
+//     unconditionally, skipping the gates entirely.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PanelState, WorkspaceState } from '../../shared/types'
+
+// ---------------------------------------------------------------------------
+// Hoisted fakes (vi.mock factories run before imports). The terminal registry
+// fake exposes the panelId→ptyId→workspaceId lookups the running-terminal gate
+// performs; dispose/release/disposeWorkspace are inert spies.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  ptyForPanel: new Map<string, string>(),
+  wsForPty: new Map<string, string>(),
+}))
+
+vi.mock('./logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+vi.mock('./terminal/terminalRegistry', () => ({
+  terminalRegistry: {
+    ptyIdForPanel: (panelId: string) => h.ptyForPanel.get(panelId) ?? null,
+    panelIdForPty: (ptyId: string) => {
+      for (const [panelId, pty] of h.ptyForPanel) if (pty === ptyId) return panelId
+      return null
+    },
+    workspaceIdForPty: (ptyId: string) => h.wsForPty.get(ptyId),
+    dispose: vi.fn(),
+    release: vi.fn(),
+    disposeWorkspace: vi.fn(),
+    has: () => false,
+    getEntry: () => undefined,
+    entries: () => [],
+  },
+}))
+
+// Agent pi sessions are out of scope; stub so the appStore graph stays light.
+vi.mock('../../agent/renderer/agentSessionRegistry', () => ({
+  disposeAgentPanel: vi.fn(),
+  getAgentPanelSession: vi.fn(),
+  saveAgentPanelSession: vi.fn(),
+}))
+
+import { useAppStore } from '../stores/appStore'
+import { useStatusStore } from '../stores/statusStore'
+import { releaseWorkspaceDockStore } from './workspace/dockRegistry'
+import { closeAllPanelsWithConfirm, removeWorkspacesWithConfirm } from './closePanelWithConfirm'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const confirmUnsavedChanges = vi.fn()
+const confirmCloseTerminal = vi.fn()
+
+function panel(id: string, type: PanelState['type'], extra: Partial<PanelState> = {}): PanelState {
+  return { id, type, title: id, isDirty: false, ...extra } as PanelState
+}
+
+function workspace(id: string, panels: PanelState[]): WorkspaceState {
+  return {
+    id,
+    name: `WS ${id}`,
+    color: '',
+    rootPath: `/tmp/${id}`,
+    rootPathError: null,
+    isRootPathPending: false,
+    worktrees: [],
+    panels: Object.fromEntries(panels.map((p) => [p.id, p])),
+  } as unknown as WorkspaceState
+}
+
+function panelsOf(wsId: string): Record<string, PanelState> {
+  return useAppStore.getState().workspaces.find((w) => w.id === wsId)?.panels ?? {}
+}
+
+/** Mark a terminal panel's PTY as running a foreground process. */
+function markRunning(wsId: string, panelId: string, processName: string): void {
+  const ptyId = `pty-${panelId}`
+  h.ptyForPanel.set(panelId, ptyId)
+  h.wsForPty.set(ptyId, wsId)
+  useStatusStore.setState((s) => ({
+    workspaces: {
+      ...s.workspaces,
+      [wsId]: {
+        terminals: {
+          ...(s.workspaces[wsId]?.terminals ?? {}),
+          [ptyId]: {
+            activity: { type: 'running', processName },
+            agentState: 'notRunning',
+            agentName: null,
+            agentPresent: false,
+            listeningPorts: [],
+            cwd: '',
+          },
+        },
+      },
+    },
+  }))
+}
+
+const initialAppState = useAppStore.getState()
+let usedWorkspaceIds: string[] = []
+
+function seed(...workspaces: WorkspaceState[]): void {
+  usedWorkspaceIds = workspaces.map((w) => w.id)
+  useAppStore.setState({ workspaces, selectedWorkspaceId: workspaces[0]?.id } as never)
+}
+
+beforeEach(() => {
+  for (const id of usedWorkspaceIds) releaseWorkspaceDockStore(id)
+  usedWorkspaceIds = []
+  useAppStore.setState(initialAppState, true)
+  useStatusStore.setState({ workspaces: {} })
+  h.ptyForPanel.clear()
+  h.wsForPty.clear()
+  confirmUnsavedChanges.mockReset()
+  confirmCloseTerminal.mockReset()
+  const g = globalThis as unknown as { window?: { electronAPI?: unknown } }
+  g.window = g.window ?? {}
+  g.window.electronAPI = {
+    confirmUnsavedChanges,
+    confirmCloseTerminal,
+    workspaceCreate: vi.fn(async () => ({ ok: true, workspace: {} })),
+    workspaceUpdate: vi.fn(async () => ({ ok: true, workspace: {} })),
+    workspaceRemove: vi.fn(async () => ({ ok: true })),
+    recentProjectsAdd: vi.fn(),
+    recentProjectsRemove: vi.fn(async () => undefined),
+    agentDispose: vi.fn(async () => undefined),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// closeAllPanelsWithConfirm
+// ---------------------------------------------------------------------------
+
+describe('closeAllPanelsWithConfirm', () => {
+  it('dirty editor + cancel → returns false and closes nothing', async () => {
+    seed(workspace('ws-a', [
+      panel('cv', 'canvas'),
+      panel('e1', 'editor', { isDirty: true, title: 'file.ts •', filePath: '/x/file.ts' }),
+      panel('t1', 'terminal'),
+    ]))
+    confirmUnsavedChanges.mockResolvedValue('cancel')
+
+    const before = panelsOf('ws-a')
+    const ok = await closeAllPanelsWithConfirm('ws-a')
+
+    expect(ok).toBe(false)
+    expect(confirmUnsavedChanges).toHaveBeenCalledTimes(1)
+    expect(panelsOf('ws-a')).toEqual(before) // untouched — nothing was closed
+  })
+
+  it('dirty editor + discard → panels are closed', async () => {
+    seed(workspace('ws-b', [
+      panel('e1', 'editor', { isDirty: true, title: 'file.ts •', filePath: '/x/file.ts' }),
+      panel('t1', 'terminal'),
+    ]))
+    confirmUnsavedChanges.mockResolvedValue('discard')
+
+    const ok = await closeAllPanelsWithConfirm('ws-b')
+
+    expect(ok).toBe(true)
+    expect(panelsOf('ws-b')['e1']).toBeUndefined()
+    expect(panelsOf('ws-b')['t1']).toBeUndefined()
+  })
+
+  it('running terminal + cancel → returns false, panels remain; close → closed', async () => {
+    seed(workspace('ws-c', [panel('t1', 'terminal'), panel('e1', 'editor')]))
+    markRunning('ws-c', 't1', 'vim')
+    confirmCloseTerminal.mockResolvedValueOnce('cancel')
+
+    expect(await closeAllPanelsWithConfirm('ws-c')).toBe(false)
+    expect(confirmCloseTerminal).toHaveBeenCalledWith({ count: 1, processName: 'vim' })
+    expect(panelsOf('ws-c')['t1']).toBeDefined()
+    expect(panelsOf('ws-c')['e1']).toBeDefined()
+
+    confirmCloseTerminal.mockResolvedValueOnce('close')
+    expect(await closeAllPanelsWithConfirm('ws-c')).toBe(true)
+    expect(panelsOf('ws-c')['t1']).toBeUndefined()
+    expect(panelsOf('ws-c')['e1']).toBeUndefined()
+  })
+
+  it('clean panels → closes without showing any dialog', async () => {
+    seed(workspace('ws-d', [panel('e1', 'editor'), panel('t1', 'terminal')]))
+
+    const ok = await closeAllPanelsWithConfirm('ws-d')
+
+    expect(ok).toBe(true)
+    expect(confirmUnsavedChanges).not.toHaveBeenCalled()
+    expect(confirmCloseTerminal).not.toHaveBeenCalled()
+    expect(panelsOf('ws-d')['e1']).toBeUndefined()
+    expect(panelsOf('ws-d')['t1']).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeWorkspacesWithConfirm
+// ---------------------------------------------------------------------------
+
+describe('removeWorkspacesWithConfirm', () => {
+  it('aggregates dirty editors across ALL workspaces into ONE dialog; cancel keeps both', async () => {
+    seed(
+      workspace('ws-1', [panel('e1', 'editor', { isDirty: true, title: 'a.ts •', filePath: '/x/a.ts' })]),
+      workspace('ws-2', [panel('e2', 'editor', { isDirty: true, title: 'b.ts •', filePath: '/x/b.ts' })]),
+    )
+    confirmUnsavedChanges.mockResolvedValue('cancel')
+
+    const ok = await removeWorkspacesWithConfirm(['ws-1', 'ws-2'])
+
+    expect(ok).toBe(false)
+    // ONE aggregate dialog covering both workspaces' dirty editors.
+    expect(confirmUnsavedChanges).toHaveBeenCalledTimes(1)
+    expect(confirmUnsavedChanges).toHaveBeenCalledWith(
+      expect.objectContaining({ multiple: true, fileName: '2 files' }),
+    )
+    // Both workspaces (and their panels) remain.
+    const ids = useAppStore.getState().workspaces.map((w) => w.id)
+    expect(ids).toContain('ws-1')
+    expect(ids).toContain('ws-2')
+    expect(panelsOf('ws-1')['e1']).toBeDefined()
+    expect(panelsOf('ws-2')['e2']).toBeDefined()
+  })
+
+  it('confirm → both workspaces are removed', async () => {
+    seed(
+      workspace('ws-1', [panel('e1', 'editor', { isDirty: true, title: 'a.ts •', filePath: '/x/a.ts' })]),
+      workspace('ws-2', [panel('e2', 'editor', { isDirty: true, title: 'b.ts •', filePath: '/x/b.ts' })]),
+    )
+    confirmUnsavedChanges.mockResolvedValue('discard')
+
+    const ok = await removeWorkspacesWithConfirm(['ws-1', 'ws-2'])
+
+    expect(ok).toBe(true)
+    expect(confirmUnsavedChanges).toHaveBeenCalledTimes(1)
+    const ids = useAppStore.getState().workspaces.map((w) => w.id)
+    expect(ids).not.toContain('ws-1')
+    expect(ids).not.toContain('ws-2')
+  })
+
+  it('runs the running-terminal gate once for the whole batch', async () => {
+    seed(
+      workspace('ws-1', [panel('t1', 'terminal')]),
+      workspace('ws-2', [panel('t2', 'terminal')]),
+    )
+    markRunning('ws-1', 't1', 'vim')
+    markRunning('ws-2', 't2', 'npm')
+    confirmCloseTerminal.mockResolvedValue('close')
+
+    const ok = await removeWorkspacesWithConfirm(['ws-1', 'ws-2'])
+
+    expect(ok).toBe(true)
+    expect(confirmCloseTerminal).toHaveBeenCalledTimes(1)
+    expect(confirmCloseTerminal).toHaveBeenCalledWith({ count: 2, processName: null })
+    const ids = useAppStore.getState().workspaces.map((w) => w.id)
+    expect(ids).not.toContain('ws-1')
+    expect(ids).not.toContain('ws-2')
+  })
+})

--- a/src/renderer/lib/closePanelWithConfirm.ts
+++ b/src/renderer/lib/closePanelWithConfirm.ts
@@ -11,6 +11,8 @@
 
 import { useAppStore } from '../stores/appStore'
 import { confirmClosePanels } from './confirmClosePanels'
+import { confirmCloseDirtyPanels } from './confirmCloseDirty'
+import { confirmCloseRunningTerminals } from './confirmCloseTerminal'
 import { confirmCloseCanvas } from './canvas/confirmCloseCanvas'
 
 /** Returns true when the panel was closed, false when the user cancelled. */
@@ -31,5 +33,34 @@ export async function closePanelWithConfirm(
 
   if (!(await confirmClosePanels(workspaceId, [panelId]))) return false
   useAppStore.getState().closePanel(workspaceId, panelId)
+  return true
+}
+
+/** Close every panel in a workspace behind the same dirty-editor /
+ *  running-terminal gates as a single close (one aggregate dialog per gate).
+ *  Returns true when the panels were closed, false when the user cancelled. */
+export async function closeAllPanelsWithConfirm(workspaceId: string): Promise<boolean> {
+  const ws = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
+  if (!ws) return true
+  if (!(await confirmClosePanels(workspaceId, Object.keys(ws.panels)))) return false
+  useAppStore.getState().closeAllPanels(workspaceId)
+  return true
+}
+
+/** Close whole workspaces (single close and bulk delete share this) behind ONE
+ *  aggregate confirmation covering every panel they host — removeWorkspace
+ *  itself tears panels down unconditionally, so the gates must run here first.
+ *  Forgets the workspaces' projects from recents (user-initiated close).
+ *  Returns true when the workspaces were removed, false when the user cancelled. */
+export async function removeWorkspacesWithConfirm(workspaceIds: string[]): Promise<boolean> {
+  const app = useAppStore.getState()
+  const panels = workspaceIds.flatMap((id) =>
+    Object.values(app.workspaces.find((w) => w.id === id)?.panels ?? {}),
+  )
+  if (!(await confirmCloseDirtyPanels(panels))) return false
+  if (!(await confirmCloseRunningTerminals(panels))) return false
+  for (const id of workspaceIds) {
+    useAppStore.getState().removeWorkspace(id, true)
+  }
   return true
 }

--- a/src/renderer/lib/editor/useFileSync.ts
+++ b/src/renderer/lib/editor/useFileSync.ts
@@ -32,6 +32,7 @@ import type * as monaco from 'monaco-editor'
 import log from '../logger'
 import { useAppStore } from '../../stores/appStore'
 import { watchFsRoot } from '../fs/fsWatchManager'
+import { pathDisplayName } from '../fs/displayPath'
 import { isLoadFailed, getBaseline, rememberBaseline } from './modelCache'
 import { classifyExternalEvent, shouldBlockOverwrite } from './externalConflict'
 import { threeWayMerge } from './threeWayMerge'
@@ -124,7 +125,7 @@ export function useFileSync({
     isDirtyRef.current = true
     useAppStore.getState().setPanelDirty(workspaceId, panelId, true)
     if (filePathRef.current) {
-      const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
+      const fileName = pathDisplayName(filePathRef.current) || 'Untitled'
       useAppStore.getState().updatePanelTitle(workspaceId, panelId, `${fileName} •`)
     }
   }, [workspaceId, panelId])
@@ -133,7 +134,7 @@ export function useFileSync({
     isDirtyRef.current = false
     useAppStore.getState().setPanelDirty(workspaceId, panelId, false)
     if (filePathRef.current) {
-      const fileName = filePathRef.current.split('/').pop() ?? 'Untitled'
+      const fileName = pathDisplayName(filePathRef.current) || 'Untitled'
       useAppStore.getState().updatePanelTitle(workspaceId, panelId, fileName)
     }
   }, [workspaceId, panelId])

--- a/src/renderer/lib/fs/displayPath.ts
+++ b/src/renderer/lib/fs/displayPath.ts
@@ -38,3 +38,21 @@ export function pathDisplayName(locator: string): string {
 }
 
 export const workspaceDisplayName = pathDisplayName
+
+/**
+ * Workspace-relative path for display / clipboard. Decodes both locators and
+ * returns the host-relative path when `locator` sits inside `rootLocator` on
+ * the same runtime; otherwise the decoded absolute host path. Local Windows
+ * paths are compared with normalized separators (mirrors shared/pathUtils).
+ */
+export function relativeDisplayPath(locator: string, rootLocator: string): string {
+  const file = parseLocator(locator)
+  const root = parseLocator(rootLocator)
+  if (file.runtimeId !== root.runtimeId) return file.path
+  const norm = (p: string): string =>
+    (file.runtimeId === LOCAL_RUNTIME_ID ? p.replace(/\\/g, '/') : p).replace(/\/+$/, '')
+  const normFile = norm(file.path)
+  const normRoot = norm(root.path)
+  if (normRoot && normFile.startsWith(normRoot + '/')) return normFile.slice(normRoot.length + 1)
+  return file.path
+}

--- a/src/renderer/lib/hooks/useWindowRuntime.ts
+++ b/src/renderer/lib/hooks/useWindowRuntime.ts
@@ -29,6 +29,7 @@ import {
 } from '../agent/agentScreenDetector'
 import { isExternalFileDrag } from '../fs/importExternalEntries'
 import { revealPanel } from '../workspace/panelReveal'
+import { closePanelWithConfirm } from '../closePanelWithConfirm'
 import { setupWindowPanelSync } from '../workspace/windowPanelSync'
 import { useOwnedTerminalTelemetry } from '../../hooks/useProcessMonitor'
 import type { AgentState } from '../../../shared/types'
@@ -132,6 +133,17 @@ export function useWindowRuntime(canvasStore?: StoreApi<CanvasStore>): void {
       const owner = app.workspaces.find((w) => panelId in w.panels)
       const wsId = owner?.id ?? app.selectedWorkspaceId
       void revealPanel(wsId, panelId, { retry: true })
+    })
+  }, [])
+
+  // Cross-window close: another window's overview asked to close a panel this
+  // window owns. Runs the same confirm gates as any local close affordance.
+  useEffect(() => {
+    return window.electronAPI.onClosePanelInWindow?.((panelId: string) => {
+      const app = useAppStore.getState()
+      const owner = app.workspaces.find((w) => panelId in w.panels)
+      if (!owner) return
+      void closePanelWithConfirm(owner.id, panelId)
     })
   }, [])
 }

--- a/src/renderer/lib/panelTitle.ts
+++ b/src/renderer/lib/panelTitle.ts
@@ -1,3 +1,17 @@
+import { browserPanelUrl, type PanelState } from '../../shared/types'
+import { pathDisplayName } from './fs/displayPath'
+
+/** Display label for a panel: explicit title, else the file basename, else the
+ *  active browser tab URL, else the panel type. Param is the minimal shape
+ *  shared by sidebar row props and a full PanelState. Used by the workspace
+ *  overview rows, the Cate agent chat, and the cross-window panel report — so
+ *  a panel reads the same everywhere. */
+export function panelRowLabel(
+  panel: Pick<PanelState, 'type' | 'title' | 'filePath' | 'tabs' | 'activeTabId'>,
+): string {
+  return panel.title || (panel.filePath ? pathDisplayName(panel.filePath) : '') || browserPanelUrl(panel) || panel.type
+}
+
 // Make an agent/shell-derived tab title unique within a workspace. Some agents
 // only surface their cwd (e.g. codex → the folder name), so two panels in the
 // same directory compute the identical title ("Codex · cate"). Append the lowest

--- a/src/renderer/lib/workspace/movePanelToNewWindow.test.ts
+++ b/src/renderer/lib/workspace/movePanelToNewWindow.test.ts
@@ -1,0 +1,232 @@
+// =============================================================================
+// movePanelToNewWindow — the location-agnostic detach used by the sidebar
+// workspace overview. Pins the removal matrix per source location:
+//
+//   • dock-located → undocked from the workspace dock store, record dropped;
+//     when main REFUSES the detach (dragDetach → null) the source must be
+//     completely untouched (detach-first, tear-down-after).
+//   • canvas-located, sole occupant of its node → the node is removed.
+//   • canvas-located but tabbed with siblings in the node's mini-dock → only
+//     the target tab is undocked; the node (and siblings) remain.
+//   • detaching the workspace's LAST canvas mints a fresh center canvas.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PanelState, WorkspaceState } from '../../../shared/types'
+
+const h = vi.hoisted(() => ({
+  releaseSpy: vi.fn(),
+  disposeSpy: vi.fn(),
+}))
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+vi.mock('../terminal/terminalRegistry', () => ({
+  terminalRegistry: {
+    ptyIdForPanel: () => null,
+    panelIdForPty: () => null,
+    workspaceIdForPty: () => undefined,
+    dispose: (panelId: string) => h.disposeSpy(panelId),
+    release: (panelId: string) => h.releaseSpy(panelId),
+    disposeWorkspace: vi.fn(),
+    has: () => false,
+    getEntry: () => undefined,
+    entries: () => [],
+  },
+}))
+
+vi.mock('../../../agent/renderer/agentSessionRegistry', () => ({
+  disposeAgentPanel: vi.fn(),
+  getAgentPanelSession: vi.fn(),
+  saveAgentPanelSession: vi.fn(),
+}))
+
+import { useAppStore } from '../../stores/appStore'
+import { getOrCreateCanvasStoreForPanel, releaseCanvasStoreForPanel } from '../../stores/canvasStore'
+import { createDockStore } from '../../stores/dockStore'
+import { registerWorkspaceDockStore, releaseWorkspaceDockStore, getWorkspaceDockStore } from './dockRegistry'
+import { registerNodeDockStore, unregisterNodeDockStore } from '../../panels/nodeDockRegistry'
+import { collectPanelIds } from '../../../shared/collectPanelIds'
+import { movePanelToNewWindow } from './movePanelToNewWindow'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dragDetach = vi.fn()
+
+function panel(id: string, type: PanelState['type']): PanelState {
+  return { id, type, title: id, isDirty: false } as PanelState
+}
+
+function seedWorkspace(wsId: string, panels: PanelState[]): void {
+  useAppStore.setState({
+    workspaces: [{
+      id: wsId,
+      name: 'W',
+      color: '',
+      rootPath: '/tmp/w',
+      rootPathError: null,
+      isRootPathPending: false,
+      worktrees: [],
+      panels: Object.fromEntries(panels.map((p) => [p.id, p])),
+    } as unknown as WorkspaceState],
+    selectedWorkspaceId: wsId,
+  } as never)
+}
+
+function panelsOf(wsId: string): Record<string, PanelState> {
+  return useAppStore.getState().workspaces.find((w) => w.id === wsId)?.panels ?? {}
+}
+
+const initialAppState = useAppStore.getState()
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  dragDetach.mockReset()
+  h.releaseSpy.mockClear()
+  h.disposeSpy.mockClear()
+  const g = globalThis as unknown as { window?: { electronAPI?: unknown } }
+  g.window = g.window ?? {}
+  g.window.electronAPI = { dragDetach }
+})
+
+// ---------------------------------------------------------------------------
+// Dock-located panel
+// ---------------------------------------------------------------------------
+
+describe('movePanelToNewWindow — dock-located panel', () => {
+  it('detach accepted → panel undocked and its record dropped', async () => {
+    const ws = 'ws-dock-ok'
+    seedWorkspace(ws, [panel('t1', 'terminal'), panel('t2', 'terminal')])
+    const dock = createDockStore()
+    dock.getState().dockPanel('t1', 'center')
+    dock.getState().dockPanel('t2', 'center')
+    registerWorkspaceDockStore(ws, dock)
+    dragDetach.mockResolvedValue(3)
+
+    const ok = await movePanelToNewWindow(ws, 't1')
+
+    expect(ok).toBe(true)
+    expect(dragDetach).toHaveBeenCalledTimes(1)
+    expect(dragDetach).toHaveBeenCalledWith(expect.anything(), ws)
+    const placed = collectPanelIds(dock.getState().zones.center.layout)
+    expect(placed).not.toContain('t1')
+    expect(placed).toContain('t2')
+    expect(panelsOf(ws)['t1']).toBeUndefined()
+    expect(panelsOf(ws)['t2']).toBeDefined()
+    // Transfer, not close: the xterm is released, the PTY survives.
+    expect(h.releaseSpy).toHaveBeenCalledWith('t1')
+    expect(h.disposeSpy).not.toHaveBeenCalled()
+
+    releaseWorkspaceDockStore(ws)
+  })
+
+  it('detach refused (dragDetach → null) → dock layout and record untouched', async () => {
+    const ws = 'ws-dock-refused'
+    seedWorkspace(ws, [panel('t1', 'terminal')])
+    const dock = createDockStore()
+    dock.getState().dockPanel('t1', 'center')
+    registerWorkspaceDockStore(ws, dock)
+    dragDetach.mockResolvedValue(null)
+
+    const ok = await movePanelToNewWindow(ws, 't1')
+
+    expect(ok).toBe(false)
+    expect(collectPanelIds(dock.getState().zones.center.layout)).toContain('t1')
+    expect(panelsOf(ws)['t1']).toBeDefined()
+    expect(h.releaseSpy).not.toHaveBeenCalled()
+
+    releaseWorkspaceDockStore(ws)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Canvas-located panel
+// ---------------------------------------------------------------------------
+
+describe('movePanelToNewWindow — canvas-located panel', () => {
+  it('sole occupant of its node → the node is removed from the canvas store', async () => {
+    const ws = 'ws-canvas-sole'
+    seedWorkspace(ws, [panel('cv', 'canvas'), panel('t1', 'terminal')])
+    const canvasStore = getOrCreateCanvasStoreForPanel('cv')
+    const nodeId = canvasStore.getState().addNode('t1', 'terminal', { x: 0, y: 0 })
+    dragDetach.mockResolvedValue(4)
+
+    const ok = await movePanelToNewWindow(ws, 't1')
+
+    expect(ok).toBe(true)
+    expect(canvasStore.getState().nodes[nodeId]).toBeUndefined() // node gone
+    expect(panelsOf(ws)['t1']).toBeUndefined()
+    expect(panelsOf(ws)['cv']).toBeDefined() // the canvas itself stays
+
+    releaseCanvasStoreForPanel('cv')
+  })
+
+  it('tabbed with a sibling in the node mini-dock → only the target tab is undocked, node remains', async () => {
+    const ws = 'ws-canvas-tabs'
+    seedWorkspace(ws, [panel('cv', 'canvas'), panel('t1', 'terminal'), panel('t2', 'terminal')])
+    const canvasStore = getOrCreateCanvasStoreForPanel('cv')
+    const nodeId = canvasStore.getState().addNode('t1', 'terminal', { x: 0, y: 0 })
+    // The node's LIVE mini-dock hosts two tabbed panels.
+    const nodeDock = createDockStore()
+    nodeDock.getState().dockPanel('t1', 'center')
+    nodeDock.getState().dockPanel('t2', 'center')
+    registerNodeDockStore('cv', nodeId, nodeDock)
+    dragDetach.mockResolvedValue(5)
+
+    const ok = await movePanelToNewWindow(ws, 't1')
+
+    expect(ok).toBe(true)
+    expect(canvasStore.getState().nodes[nodeId]).toBeDefined() // node survives
+    const placed = collectPanelIds(nodeDock.getState().zones.center.layout)
+    expect(placed).not.toContain('t1')
+    expect(placed).toContain('t2')
+    expect(panelsOf(ws)['t1']).toBeUndefined()
+    expect(panelsOf(ws)['t2']).toBeDefined()
+
+    unregisterNodeDockStore('cv', nodeId)
+    releaseCanvasStoreForPanel('cv')
+  })
+
+  it('canvas panel not placed anywhere → no detach, source untouched', async () => {
+    const ws = 'ws-unplaced'
+    seedWorkspace(ws, [panel('t1', 'terminal')]) // record only, no dock/canvas
+
+    const ok = await movePanelToNewWindow(ws, 't1')
+
+    expect(ok).toBe(false)
+    expect(dragDetach).not.toHaveBeenCalled()
+    expect(panelsOf(ws)['t1']).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Last canvas
+// ---------------------------------------------------------------------------
+
+describe('movePanelToNewWindow — last canvas', () => {
+  it('detaching the workspace\'s only canvas mints a fresh one', async () => {
+    const ws = 'ws-last-canvas'
+    seedWorkspace(ws, [panel('cv', 'canvas')])
+    const dock = createDockStore()
+    dock.getState().dockPanel('cv', 'center')
+    registerWorkspaceDockStore(ws, dock)
+    dragDetach.mockResolvedValue(6)
+
+    const ok = await movePanelToNewWindow(ws, 'cv')
+
+    expect(ok).toBe(true)
+    expect(panelsOf(ws)['cv']).toBeUndefined()
+    const canvases = Object.values(panelsOf(ws)).filter((p) => p.type === 'canvas')
+    expect(canvases).toHaveLength(1) // a NEW canvas was minted
+    expect(canvases[0].id).not.toBe('cv')
+    for (const c of canvases) releaseCanvasStoreForPanel(c.id)
+
+    releaseWorkspaceDockStore(ws)
+    // getWorkspaceDockStore may have been recreated by placement — release again defensively.
+    if (getWorkspaceDockStore(ws)) releaseWorkspaceDockStore(ws)
+  })
+})

--- a/src/renderer/lib/workspace/movePanelToNewWindow.ts
+++ b/src/renderer/lib/workspace/movePanelToNewWindow.ts
@@ -1,0 +1,101 @@
+// =============================================================================
+// movePanelToNewWindow — detach a panel into its own window from ANY location.
+//
+// The dock tab menu (useDockTabActions.moveTabToNewWindow) and the drag system
+// (drag/commit.ts 'detach') are stack-/drag-relative: they already know which
+// dock store or canvas node the panel is leaving. This helper is the
+// location-agnostic version for callers that only have a panel id (the sidebar
+// workspace overview, the command palette): it resolves the panel's location via
+// the canonical probe (resolvePanelLocation), builds the same transfer snapshot,
+// asks main to spawn the window, and only then removes the panel from its source
+// — mirroring the "detach first, tear down after" rule of both existing paths.
+// =============================================================================
+
+import type { PanelLocation } from '../../../shared/types'
+import { useAppStore } from '../../stores/appStore'
+import { getOrCreateCanvasStoreForPanel } from '../../stores/canvasStore'
+import { getNodeDockStore, getLiveNodeDockLayout } from '../../panels/nodeDockRegistry'
+import { collectPanelIds } from '../../../shared/collectPanelIds'
+import { createTransferSnapshot } from '../panelTransfer'
+import { removePanelFromWindow } from '../panels/removePanelFromWindow'
+import { getWorkspaceDockStore } from './dockRegistry'
+import { resolvePanelLocation } from './canvasAccess'
+
+/** Detach `panelId` into a new window. Returns true when the window was
+ *  created; false when the panel can't be located or main refused the detach
+ *  (e.g. macOS fullscreen) — in which case the source is left untouched. */
+export async function movePanelToNewWindow(
+  workspaceId: string,
+  panelId: string,
+): Promise<boolean> {
+  const ws = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
+  const panel = ws?.panels[panelId]
+  if (!ws || !panel) return false
+  if (!window.electronAPI?.dragDetach) return false
+
+  const location = resolvePanelLocation(workspaceId, panelId)
+  if (!location) return false
+
+  let sourceLocation: PanelLocation
+  let nodeId: string | null = null
+  if (location.kind === 'dock') {
+    sourceLocation = { type: 'dock', zone: location.zone, stackId: location.stackId }
+  } else {
+    const canvasStore = getOrCreateCanvasStoreForPanel(location.canvasPanelId)
+    nodeId = canvasStore.getState().nodeForPanel(panelId)
+    if (!nodeId) return false
+    sourceLocation = { type: 'canvas', canvasId: location.canvasPanelId, canvasNodeId: nodeId }
+  }
+
+  const snapshot = createTransferSnapshot(
+    panel,
+    sourceLocation,
+    { origin: { x: 100, y: 100 }, size: { width: 800, height: 600 } },
+    {
+      // A canvas panel carries its children; without this the new window
+      // renders them as generic "Panel" stubs (mirrors the dock tab path).
+      resolveChildPanel: (childId: string) => ws.panels[childId],
+      workspaceRootPath: ws.rootPath || undefined,
+      worktrees: ws.worktrees,
+    },
+  )
+
+  // Detach FIRST — only tear down the source once the new window actually
+  // exists (dragDetach returns null when main refuses).
+  const winId = await window.electronAPI.dragDetach(snapshot, workspaceId)
+  if (winId == null) return false
+
+  if (location.kind === 'dock') {
+    getWorkspaceDockStore(workspaceId)?.getState().undockPanel(panelId)
+  } else if (nodeId) {
+    // A canvas node may host several tabbed panels — only remove the whole
+    // node when this panel is its sole occupant; otherwise undock just its tab.
+    const canvasStore = getOrCreateCanvasStoreForPanel(location.canvasPanelId)
+    const layout =
+      getLiveNodeDockLayout(location.canvasPanelId, nodeId) ??
+      canvasStore.getState().nodes[nodeId]?.dockLayout ??
+      null
+    const nodeDock = getNodeDockStore(location.canvasPanelId, nodeId)
+    if (collectPanelIds(layout).length > 1 && nodeDock) {
+      nodeDock.getState().undockPanel(panelId)
+    } else {
+      canvasStore.getState().finalizeRemoveNode(nodeId)
+    }
+  }
+
+  // Release its content (PTYs keep running, mid-transfer) and drop its record
+  // (and a canvas's children) from this workspace so every system — overview,
+  // command palette, session, counts — agrees it's no longer here.
+  removePanelFromWindow(workspaceId, panelId, panel.type, 'transfer')
+
+  // Detaching the workspace's only canvas leaves an empty center dock — mint a
+  // fresh one, mirroring the drag-detach path (useDragOp.onRemovedFromCanvas).
+  if (panel.type === 'canvas') {
+    const app = useAppStore.getState()
+    const remaining = Object.values(
+      app.workspaces.find((w) => w.id === workspaceId)?.panels ?? {},
+    ).filter((p) => p.type === 'canvas')
+    if (remaining.length === 0) app.createCanvas(workspaceId)
+  }
+  return true
+}

--- a/src/renderer/lib/workspace/sessionStartup.dockWindows.test.ts
+++ b/src/renderer/lib/workspace/sessionStartup.dockWindows.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+// =============================================================================
+// restoreDetachedWindows — the startup driver that fans a session's persisted
+// dockWindows out to main. For each snapshot it runs the REAL reconstruction
+// (buildDockWindowRestoreInit), resolves the owning workspace's live
+// rootPath/worktrees from the app store, and calls
+// window.electronAPI.dockWindowRestore. These tests pin the orchestration:
+// which snapshots reach the IPC, with what payload, and that one degenerate or
+// failing window can never abort the rest of startup.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  DetachedDockWindowSnapshot,
+  MultiWorkspaceSession,
+  PanelState,
+  WindowDockState,
+  WorktreeMeta,
+} from '../../../shared/types'
+
+const hoisted = vi.hoisted(() => ({
+  // Live workspaces visible to sessionStartup via the mocked app store.
+  workspaces: [] as Array<{ id: string; rootPath?: string; worktrees?: WorktreeMeta[] }>,
+  warn: vi.fn(),
+}))
+
+vi.mock('../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: hoisted.warn, error: vi.fn(), log: vi.fn() },
+}))
+// Only .getState().workspaces is consulted on this path; the real store's
+// import chain (IPC sync, terminals, canvases) stays out of the test.
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: { getState: () => ({ workspaces: hoisted.workspaces }) },
+}))
+// Imported by sessionStartup for the multi-workspace restore path (not under
+// test here); mocked to cut its heavy store/terminal import chain.
+vi.mock('./sessionRestore', () => ({ restoreWorkspaceLayout: vi.fn() }))
+
+import { restoreDetachedWindows, buildDockWindowRestoreInit } from './sessionStartup'
+
+const dockWindowRestore = vi.fn<(payload: unknown) => Promise<number | null>>()
+
+beforeEach(() => {
+  hoisted.workspaces.length = 0
+  hoisted.warn.mockClear()
+  dockWindowRestore.mockReset()
+  dockWindowRestore.mockResolvedValue(301)
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = { dockWindowRestore }
+})
+
+const emptyZone = (position: 'left' | 'right' | 'bottom' | 'center') =>
+  ({ position, visible: false, size: 0, layout: null })
+
+function zonesWith(panelIds: string[]): WindowDockState {
+  return {
+    left: emptyZone('left'),
+    right: emptyZone('right'),
+    bottom: emptyZone('bottom'),
+    center: {
+      position: 'center',
+      visible: true,
+      size: 0,
+      layout: { type: 'tabs', id: 'stack-1', panelIds, activeIndex: 0 },
+    },
+  }
+}
+
+const panel = (id: string): PanelState =>
+  ({ id, type: 'terminal', title: `Terminal ${id}`, isDirty: false }) as PanelState
+
+function snapshot(panelIds: string[], overrides?: Partial<DetachedDockWindowSnapshot>): DetachedDockWindowSnapshot {
+  return {
+    dockState: { zones: zonesWith(panelIds) },
+    panels: Object.fromEntries(panelIds.map((id) => [id, panel(id)])),
+    bounds: { x: 10, y: 20, width: 640, height: 480 },
+    workspaceId: 'ws-9',
+    canvasStates: {},
+    ...overrides,
+  }
+}
+
+/** A window whose zones reference nothing — nothing restorable to show. */
+function emptySnapshot(): DetachedDockWindowSnapshot {
+  const dw = snapshot([])
+  dw.dockState.zones.center.layout = null
+  // An orphan record with no zone reference must not resurrect the window.
+  dw.panels = { orphan: panel('orphan') }
+  return dw
+}
+
+const session = (dockWindows?: DetachedDockWindowSnapshot[]): MultiWorkspaceSession =>
+  ({ version: 2, selectedWorkspaceIndex: 0, workspaces: [], dockWindows })
+
+describe('restoreDetachedWindows', () => {
+  it('restores each restorable snapshot once, skipping windows with no top-level panels', async () => {
+    const worktrees = [{ id: 'wt-1', path: '/live/root/.wt/feature', color: '#f00' } as unknown as WorktreeMeta]
+    hoisted.workspaces.push({ id: 'ws-9', rootPath: '/live/root', worktrees })
+    const valid = snapshot(['t1'], { terminalCwds: { t1: '/work/t1' } })
+
+    await restoreDetachedWindows(session([valid, emptySnapshot()]))
+
+    // The degenerate window never reaches the IPC; the valid one goes out with
+    // the snapshot verbatim plus the reconstructed initPayload, its
+    // rootPath/worktrees swapped for the LIVE workspace's values.
+    expect(dockWindowRestore).toHaveBeenCalledTimes(1)
+    expect(dockWindowRestore).toHaveBeenCalledWith({
+      ...valid,
+      initPayload: {
+        ...buildDockWindowRestoreInit(valid).initPayload,
+        rootPath: '/live/root',
+        worktrees,
+      },
+    })
+  })
+
+  it('leaves rootPath/worktrees unresolved when the owning workspace is not open', async () => {
+    await restoreDetachedWindows(session([snapshot(['t1'])]))
+
+    expect(dockWindowRestore).toHaveBeenCalledTimes(1)
+    const payload = dockWindowRestore.mock.calls[0][0] as { initPayload: { rootPath?: string; worktrees?: unknown } }
+    expect(payload.initPayload.rootPath).toBeUndefined()
+    expect(payload.initPayload.worktrees).toBeUndefined()
+  })
+
+  it('does nothing for a session with no dock windows', async () => {
+    await restoreDetachedWindows(session(undefined))
+    await restoreDetachedWindows(session([]))
+    expect(dockWindowRestore).not.toHaveBeenCalled()
+  })
+
+  it('tolerates main declining a restore (null) and continues with the rest', async () => {
+    dockWindowRestore.mockResolvedValueOnce(null)
+
+    await expect(
+      restoreDetachedWindows(session([snapshot(['a1']), snapshot(['b1'])])),
+    ).resolves.toBeUndefined()
+
+    expect(dockWindowRestore).toHaveBeenCalledTimes(2)
+    expect(hoisted.warn).not.toHaveBeenCalled()
+  })
+
+  it('isolates one snapshot\'s failure so the remaining windows still restore', async () => {
+    dockWindowRestore.mockRejectedValueOnce(new Error('ipc exploded'))
+
+    await restoreDetachedWindows(session([snapshot(['a1']), snapshot(['b1'])]))
+
+    expect(dockWindowRestore).toHaveBeenCalledTimes(2)
+    const second = dockWindowRestore.mock.calls[1][0] as DetachedDockWindowSnapshot
+    expect(Object.keys(second.panels)).toEqual(['b1'])
+    expect(hoisted.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('still issues the IPC for a ghost-first snapshot (main declines it with null)', async () => {
+    // Pins current behavior: buildDockWindowRestoreInit does NOT prune zone ids
+    // whose panel record is gone (see the `.fails` pin in
+    // session.restoreDockWindow.test.ts), so a stale layout whose FIRST tab is a
+    // ghost still goes out over IPC. Main's DOCK_WINDOW_RESTORE then bails null
+    // (first panel record missing) and this driver tolerates that, so the net
+    // effect is a wasted round-trip and a silently dropped window.
+    const ghostFirst = snapshot(['ghost', 't1'])
+    delete ghostFirst.panels.ghost
+    dockWindowRestore.mockResolvedValueOnce(null)
+
+    await restoreDetachedWindows(session([ghostFirst, snapshot(['b1'])]))
+
+    expect(dockWindowRestore).toHaveBeenCalledTimes(2)
+    expect(hoisted.warn).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/lib/workspace/windowPanelSync.test.tsx
+++ b/src/renderer/lib/workspace/windowPanelSync.test.tsx
@@ -13,6 +13,11 @@
 //    appStore-only subscription left the report stale and the moved terminal
 //    rendered at base level instead of nested ("only the first terminal on a
 //    canvas gets the indentation; the second is at root level").
+//
+// 3. The report contains only PLACED panels (same partition rules as the local
+//    tree) and stamps the DERIVED row label — ghost records used to surface in
+//    other windows as phantom rows, and titleless browser/editor panels
+//    reported an empty title that rendered as the bare panel type.
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -189,5 +194,74 @@ describe('windowPanelSync — canvas child parentCanvasId', () => {
     stop()
     releaseWorkspaceDockStore(ws)
     releaseCanvasStoreForPanel('cv')
+  })
+})
+
+describe('windowPanelSync — placed-only report + derived titles', () => {
+  it('omits ghost records (in ws.panels but placed in no dock/canvas) and keeps placed ones', async () => {
+    const reports: WindowPanelReport[][] = []
+    ;(window as any).electronAPI = {
+      reportWindowPanels: vi.fn(async (r: WindowPanelReport[]) => { reports.push(r) }),
+    }
+
+    const ws = 'ws-ghost'
+    useAppStore.setState({
+      workspaces: [{
+        id: ws, name: 'W', color: '', rootPath: '/x', rootPathError: null,
+        isRootPathPending: false, worktrees: [],
+        panels: { cv: panel('cv', 'canvas'), t1: panel('t1', 'terminal'), ghost: panel('ghost', 'terminal') },
+      } as any],
+      selectedWorkspaceId: ws,
+    } as any)
+
+    // The workspace's dock store places cv + t1; `ghost` is referenced nowhere.
+    const dock = createDockStore()
+    dock.getState().dockPanel('cv', 'center')
+    dock.getState().dockPanel('t1', 'center')
+    registerWorkspaceDockStore(ws, dock)
+
+    const stop = setupWindowPanelSync()
+    await tick()
+
+    const ids = reports[reports.length - 1].filter((r) => r.workspaceId === ws).map((r) => r.panelId)
+    expect(ids).toContain('cv')
+    expect(ids).toContain('t1')
+    expect(ids).not.toContain('ghost')
+
+    stop()
+    releaseWorkspaceDockStore(ws)
+  })
+
+  it('stamps the derived label: a titleless browser reports its URL, a titleless editor its basename', async () => {
+    const reports: WindowPanelReport[][] = []
+    ;(window as any).electronAPI = {
+      reportWindowPanels: vi.fn(async (r: WindowPanelReport[]) => { reports.push(r) }),
+    }
+
+    const ws = 'ws-titles'
+    useAppStore.setState({
+      workspaces: [{
+        id: ws, name: 'W', color: '', rootPath: '/x', rootPathError: null,
+        isRootPathPending: false, worktrees: [],
+        panels: {
+          b1: {
+            id: 'b1', type: 'browser', title: '', isDirty: false,
+            tabs: [{ id: 'tab1', url: 'https://example.com/docs', title: '' }],
+            activeTabId: 'tab1',
+          } as PanelState,
+          e1: { id: 'e1', type: 'editor', title: '', isDirty: false, filePath: '/x/src/main.ts' } as PanelState,
+        },
+      } as any],
+      selectedWorkspaceId: ws,
+    } as any)
+
+    const stop = setupWindowPanelSync()
+    await tick()
+
+    const byId = Object.fromEntries(reports[reports.length - 1].filter((r) => r.workspaceId === ws).map((r) => [r.panelId, r]))
+    expect(byId.b1?.title).toBe('https://example.com/docs')
+    expect(byId.e1?.title).toBe('main.ts')
+
+    stop()
   })
 })

--- a/src/renderer/lib/workspace/windowPanelSync.ts
+++ b/src/renderer/lib/workspace/windowPanelSync.ts
@@ -17,7 +17,10 @@ import { selectAgentInfoByPanel } from '../../hooks/useAgentPanelInfo'
 import { terminalRegistry } from '../terminal/terminalRegistry'
 import { peekCanvasStoreForPanel, getAllCanvasStores } from '../../stores/canvasStore'
 import { getLiveNodeDockLayout } from '../../panels/nodeDockRegistry'
-import { buildColdStartCanvasChildOwners } from '../../sidebar/partitionWorkspacePanels'
+import { buildColdStartCanvasChildOwners, partitionWorkspacePanels } from '../../sidebar/partitionWorkspacePanels'
+import { getWorkspaceDockSnapshot } from './canvasAccess'
+import { collectPanelIds } from '../../../shared/collectPanelIds'
+import { panelRowLabel } from '../panelTitle'
 import type { WindowPanelReport } from '../../../shared/types'
 
 let cleanup: (() => void) | null = null
@@ -97,11 +100,29 @@ export function setupWindowPanelSync(): () => void {
       // rows.
       const agentInfo = selectAgentInfoByPanel(status, ws.id)
       const withPorts = panelsWithPorts(ws.id)
-      for (const p of Object.values(ws.panels)) {
+      // Report only PLACED panels, using the same partition rules as the local
+      // tree (ghost records — in ws.panels but referenced by no canvas or dock —
+      // would otherwise surface in other windows as phantom rows). Placement
+      // unknown at cold start → nothing is filtered, same as the local tree.
+      const dockSnapshot = getWorkspaceDockSnapshot(ws.id)
+      const dockPlacedIds = dockSnapshot
+        ? new Set(Object.values(dockSnapshot.zones).flatMap((zone) => collectPanelIds(zone.layout)))
+        : null
+      const { canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels } =
+        partitionWorkspacePanels(Object.values(ws.panels), childToCanvas, dockPlacedIds)
+      const placed = [
+        ...canvasPanels,
+        ...Object.values(childrenByCanvas).flat(),
+        ...orphanCanvasChildren,
+        ...freePanels,
+      ]
+      for (const p of placed) {
         report.push({
           panelId: p.id,
           type: p.type,
-          title: p.title,
+          // The derived label (basename / URL / type when there's no explicit
+          // title), so a panel reads the same in other windows as it does here.
+          title: panelRowLabel(p),
           workspaceId: ws.id,
           parentCanvasId: childToCanvas.get(p.id),
           worktreeId: p.worktreeId,

--- a/src/renderer/panels/BrowserPanel.test.ts
+++ b/src/renderer/panels/BrowserPanel.test.ts
@@ -40,6 +40,10 @@ describe('isUrl', () => {
     expect(isUrl('how to use file://')).toBe(false)
   })
 
+  it('recognises remote-workspace locators (never leaked to a search engine)', () => {
+    expect(isUrl('cate-runtime://srv_x/%2Fhome%2Fdev%2Findex.html')).toBe(true)
+  })
+
   it('treats single bare words as search queries', () => {
     expect(isUrl('react')).toBe(false)
   })
@@ -54,6 +58,11 @@ describe('normalizeUrl', () => {
 
   it('passes file:// URLs through unchanged', () => {
     expect(normalizeUrl('file:///Users/foo/index.html')).toBe('file:///Users/foo/index.html')
+  })
+
+  it('passes remote-workspace locators through untouched (never rewritten to file:// or https://)', () => {
+    const locator = 'cate-runtime://srv_x/%2Fhome%2Fdev%2Findex.html'
+    expect(normalizeUrl(locator)).toBe(locator)
   })
 
   it('prepends file:// to POSIX absolute paths', () => {

--- a/src/renderer/panels/DocumentPanel.tsx
+++ b/src/renderer/panels/DocumentPanel.tsx
@@ -5,6 +5,8 @@ import { useAppStore } from '../stores/appStore'
 import { ArrowLeft, ArrowRight, Minus, Plus } from '@phosphor-icons/react'
 import { errorMessage } from '../lib/errorMessage'
 import { viewedArrayBuffer } from './documentBytes'
+import { pathDisplayName } from '../lib/fs/displayPath'
+import { isLocalLocator } from '../../main/runtime/locator'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
   'pdfjs-dist/build/pdf.worker.min.mjs',
@@ -310,7 +312,7 @@ export default function DocumentPanel({ panelId, workspaceId }: PanelProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const fileName = filePath?.split('/').pop() ?? 'Document'
+  const fileName = (filePath && pathDisplayName(filePath)) || 'Document'
 
   const detected = useMemo(() => {
     if (!data) return null
@@ -364,12 +366,15 @@ export default function DocumentPanel({ panelId, workspaceId }: PanelProps) {
     return (
       <div className="w-full h-full flex flex-col items-center justify-center bg-surface-4 gap-2">
         <span className="text-red-400 text-sm">{error ?? 'Failed to load file'}</span>
-        <button
-          onClick={openExternal}
-          className="text-xs text-neutral-400 hover:text-white underline"
-        >
-          Show in Finder
-        </button>
+        {/* Finder is local-only; a remote file has nothing to show there. */}
+        {filePath && isLocalLocator(filePath) && (
+          <button
+            onClick={openExternal}
+            className="text-xs text-neutral-400 hover:text-white underline"
+          >
+            Show in Finder
+          </button>
+        )}
       </div>
     )
   }

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -25,6 +25,7 @@ import { resolveTerminalFontSize } from '../lib/terminal/terminalSettings'
 import { useTerminalGlow } from '../cateAgent/cateAgentStore'
 import { resolveWorktree } from '../../shared/worktrees'
 import { CATE_FILE_MIME, readCateFileLocation, readCateFilePaths } from '../drag/fileDragPayload'
+import { parseLocator } from '../../main/runtime/locator'
 
 // ---------------------------------------------------------------------------
 // Component
@@ -658,7 +659,10 @@ export default function TerminalPanel({
       if (catePath) {
         const location = readCateFileLocation(e.dataTransfer)
         const line = location?.path === catePath ? location.line : undefined
-        refs.push({ path: catePath, line })
+        // Tree/search nodes carry locator-encoded paths (cate-runtime://… for a
+        // remote workspace). The shell runs ON that workspace's host, so paste
+        // the bare host path; for local paths parseLocator is a pass-through.
+        refs.push({ path: parseLocator(catePath).path, line })
       }
 
       // External OS file drop — use Electron's webUtils to get real paths

--- a/src/renderer/panels/browserUrl.ts
+++ b/src/renderer/panels/browserUrl.ts
@@ -16,6 +16,9 @@ export function isUrl(input: string): boolean {
   if (trimmed.startsWith('file://') || trimmed.startsWith('/') || /^[A-Za-z]:[\\/]/.test(trimmed)) {
     return true
   }
+  // A remote-workspace locator is URL-shaped, not a search query — treating it
+  // as a search would leak the path to the search engine.
+  if (trimmed.startsWith('cate-runtime://')) return true
   // Has spaces — definitely a search query
   if (trimmed.includes(' ')) {
     return false
@@ -58,6 +61,11 @@ export function normalizeUrl(input: string): string {
     return trimmed
   }
   if (trimmed.startsWith('file://')) return trimmed
+  // Remote-workspace locator: the embedded browser is a LOCAL Chromium and can
+  // never read a remote host's file. Pass it through untouched so the load
+  // fails visibly (unknown scheme) instead of being rewritten into a local
+  // file:// path or an https:// guess that points somewhere else entirely.
+  if (trimmed.startsWith('cate-runtime://')) return trimmed
   // Absolute POSIX path → file URL
   if (trimmed.startsWith('/')) return `file://${escapeFilePath(trimmed)}`
   // Absolute Windows path (e.g. C:\foo or C:/foo) → file URL with forward slashes

--- a/src/renderer/settings/TerminalSettings.tsx
+++ b/src/renderer/settings/TerminalSettings.tsx
@@ -87,11 +87,20 @@ export function TerminalSettings() {
       </SettingRow>
       <SettingRow
         label="Command-line control (cate CLI)"
-        description="Let agents and tools in your terminals drive Cate (browser, panels, editor) via the `cate` command. Off by default: turning it on puts a loopback endpoint and token in the env of every process in your terminals, so any of them can drive the browser on your live session. Off: the endpoint is never created."
+        description="Let agents and tools in your terminals drive Cate (browser, panels, editor) via the `cate` command. On puts a loopback endpoint and token in the env of every process in your terminals, so any of them can drive the browser on your live session. Off: the endpoint is never created; `cate` stays on PATH and explains how to re-enable it. New terminals pick up a change."
       >
         <Toggle
           checked={store.cliEnabled}
           onChange={(v) => store.setSetting('cliEnabled', v)}
+        />
+      </SettingRow>
+      <SettingRow
+        label="Install cate CLI skill"
+        description="Auto-install the cate-cli skill into each workspace so agents learn the `cate` command: Cate's agent always, plus Claude Code, Pi, OpenCode, Codex and Antigravity where their folder exists. Installs once, never overwrites edits; uninstalls stick. Off stops future installs."
+      >
+        <Toggle
+          checked={store.cliSkillInstallEnabled}
+          onChange={(v) => store.setSetting('cliSkillInstallEnabled', v)}
         />
       </SettingRow>
     </div>

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -18,10 +18,8 @@ import { terminalRegistry } from '../lib/terminal/terminalRegistry'
 import { getOrCreateCanvasStoreForPanel } from '../stores/canvasStore'
 import { ensurePanelsInAppStore } from '../lib/canvas/applyCanvasChildPanels'
 import { hydrateReceivedPanel, hydrateCanvasState } from '../lib/panelTransfer'
-import { removePanelFromWindow } from '../lib/panels/removePanelFromWindow'
 import { useAppStore } from '../stores/appStore'
-import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
-import { confirmCloseRunningTerminals } from '../lib/confirmCloseTerminal'
+import { closeDockWindowPanel } from './dockWindowClosePanel'
 import { isDockEmpty } from './dockEmpty'
 import { shouldCloseDockWindow } from './shouldCloseDockWindow'
 import WindowControls from './WindowControls'
@@ -306,22 +304,13 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
 
   const handleClosePanel = useCallback(
     async (panelId: string) => {
-      if (!(await confirmCloseDirtyPanels([panels[panelId]]))) return
-      if (!(await confirmCloseRunningTerminals([panels[panelId]]))) return
-      // Undock from THIS shell's own dock store first (removePanelFromWindow
-      // never touches layout stores — the workspace dock registry would be the
-      // wrong tree for this shell), then tear down content + records with
-      // 'close' semantics: PTYs killed (including a canvas tab's children),
-      // xterms and pi sessions disposed, records dropped.
-      dockStore.getState().undockPanel(panelId)
-      const panel = panels[panelId]
-      if (panel) removePanelFromWindow(wsId, panelId, panel.type, 'close')
+      if (!(await closeDockWindowPanel(wsId, panelId, dockStore))) return
 
       if (isDockEmpty(dockStore.getState())) {
         window.close()
       }
     },
-    [dockStore, panels, wsId],
+    [dockStore, wsId],
   )
 
   const handlePanelRenamed = useCallback(

--- a/src/renderer/shells/dockWindowClosePanel.test.ts
+++ b/src/renderer/shells/dockWindowClosePanel.test.ts
@@ -1,0 +1,191 @@
+// =============================================================================
+// closeDockWindowPanel — the detached shell's close-tab flow. Regression tests
+// for the confirmation matrix, in particular the canvas branch: closing a
+// canvas tab in a detached window MUST route through confirmCloseCanvas (the
+// move/delete/cancel child fan-out) exactly like closePanelWithConfirm does in
+// the main window. Before this helper existed the shell ran only the dirty /
+// running-terminal gates, so a canvas tab's children were torn down silently.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PanelState, WorkspaceState } from '../../shared/types'
+
+const h = vi.hoisted(() => ({
+  releaseSpy: vi.fn(),
+  disposeSpy: vi.fn(),
+}))
+
+vi.mock('../lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: {
+    ptyIdForPanel: () => null,
+    panelIdForPty: () => null,
+    workspaceIdForPty: () => undefined,
+    dispose: (panelId: string) => h.disposeSpy(panelId),
+    release: (panelId: string) => h.releaseSpy(panelId),
+    disposeWorkspace: vi.fn(),
+    has: () => false,
+    getEntry: () => undefined,
+    entries: () => [],
+  },
+}))
+
+vi.mock('../../agent/renderer/agentSessionRegistry', () => ({
+  disposeAgentPanel: vi.fn(),
+  getAgentPanelSession: vi.fn(),
+  saveAgentPanelSession: vi.fn(),
+}))
+
+import { useAppStore } from '../stores/appStore'
+import { getOrCreateCanvasStoreForPanel, releaseCanvasStoreForPanel } from '../stores/canvasStore'
+import { createDockStore } from '../stores/dockStore'
+import { collectPanelIds } from '../../shared/collectPanelIds'
+import { closeDockWindowPanel } from './dockWindowClosePanel'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const confirmCloseCanvasDialog = vi.fn()
+const confirmUnsavedChanges = vi.fn()
+
+function panel(id: string, type: PanelState['type'], extra?: Partial<PanelState>): PanelState {
+  return { id, type, title: id, isDirty: false, ...extra } as PanelState
+}
+
+function seedWorkspace(wsId: string, panels: PanelState[]): void {
+  useAppStore.setState({
+    workspaces: [{
+      id: wsId,
+      name: 'W',
+      color: '',
+      rootPath: '/tmp/w',
+      rootPathError: null,
+      isRootPathPending: false,
+      worktrees: [],
+      panels: Object.fromEntries(panels.map((p) => [p.id, p])),
+    } as unknown as WorkspaceState],
+    selectedWorkspaceId: wsId,
+  } as never)
+}
+
+function panelsOf(wsId: string): Record<string, PanelState> {
+  return useAppStore.getState().workspaces.find((w) => w.id === wsId)?.panels ?? {}
+}
+
+const initialAppState = useAppStore.getState()
+
+beforeEach(() => {
+  useAppStore.setState(initialAppState, true)
+  confirmCloseCanvasDialog.mockReset()
+  confirmUnsavedChanges.mockReset()
+  h.releaseSpy.mockClear()
+  h.disposeSpy.mockClear()
+  const g = globalThis as unknown as { window?: { electronAPI?: unknown } }
+  g.window = g.window ?? {}
+  g.window.electronAPI = {
+    confirmCloseCanvas: confirmCloseCanvasDialog,
+    confirmUnsavedChanges,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Canvas tab — the regression
+// ---------------------------------------------------------------------------
+
+describe('closeDockWindowPanel — canvas tab', () => {
+  it('routes through the confirmCloseCanvas dialog and cancel aborts everything', async () => {
+    const ws = 'dwc-canvas-cancel'
+    seedWorkspace(ws, [panel('cv', 'canvas'), panel('t1', 'terminal')])
+    const canvasStore = getOrCreateCanvasStoreForPanel('cv')
+    canvasStore.getState().addNode('t1', 'terminal', { x: 0, y: 0 })
+    const dock = createDockStore()
+    dock.getState().dockPanel('cv', 'center')
+    confirmCloseCanvasDialog.mockResolvedValue('cancel')
+
+    const ok = await closeDockWindowPanel(ws, 'cv', dock)
+
+    expect(ok).toBe(false)
+    // The dialog saw the child and the fact this is the only canvas here.
+    expect(confirmCloseCanvasDialog).toHaveBeenCalledWith({ panelCount: 1, isLast: true })
+    // Nothing torn down: canvas still docked, both records intact, PTY alive.
+    expect(collectPanelIds(dock.getState().zones.center.layout)).toContain('cv')
+    expect(panelsOf(ws)['cv']).toBeDefined()
+    expect(panelsOf(ws)['t1']).toBeDefined()
+    expect(h.disposeSpy).not.toHaveBeenCalled()
+
+    releaseCanvasStoreForPanel('cv')
+  })
+
+  it('close choice tears down the canvas AND its children (records dropped, PTYs killed)', async () => {
+    const ws = 'dwc-canvas-close'
+    seedWorkspace(ws, [panel('cv', 'canvas'), panel('t1', 'terminal')])
+    const canvasStore = getOrCreateCanvasStoreForPanel('cv')
+    canvasStore.getState().addNode('t1', 'terminal', { x: 0, y: 0 })
+    const dock = createDockStore()
+    dock.getState().dockPanel('cv', 'center')
+    confirmCloseCanvasDialog.mockResolvedValue('close')
+
+    const ok = await closeDockWindowPanel(ws, 'cv', dock)
+
+    expect(ok).toBe(true)
+    expect(collectPanelIds(dock.getState().zones.center.layout)).not.toContain('cv')
+    expect(panelsOf(ws)['cv']).toBeUndefined()
+    expect(panelsOf(ws)['t1']).toBeUndefined()
+    // Close semantics, not transfer: the child terminal's PTY is disposed.
+    expect(h.disposeSpy).toHaveBeenCalledWith('t1')
+    expect(h.releaseSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-canvas tabs — the pre-existing gates still apply
+// ---------------------------------------------------------------------------
+
+describe('closeDockWindowPanel — non-canvas tabs', () => {
+  it('dirty editor: cancel in the unsaved-changes dialog aborts the close', async () => {
+    const ws = 'dwc-dirty-cancel'
+    seedWorkspace(ws, [panel('e1', 'editor', { isDirty: true })])
+    const dock = createDockStore()
+    dock.getState().dockPanel('e1', 'center')
+    confirmUnsavedChanges.mockResolvedValue('cancel')
+
+    const ok = await closeDockWindowPanel(ws, 'e1', dock)
+
+    expect(ok).toBe(false)
+    expect(confirmUnsavedChanges).toHaveBeenCalledTimes(1)
+    expect(collectPanelIds(dock.getState().zones.center.layout)).toContain('e1')
+    expect(panelsOf(ws)['e1']).toBeDefined()
+  })
+
+  it('idle terminal closes without prompting: undocked, record dropped, PTY disposed', async () => {
+    const ws = 'dwc-terminal-close'
+    seedWorkspace(ws, [panel('t1', 'terminal')])
+    const dock = createDockStore()
+    dock.getState().dockPanel('t1', 'center')
+
+    const ok = await closeDockWindowPanel(ws, 't1', dock)
+
+    expect(ok).toBe(true)
+    expect(confirmCloseCanvasDialog).not.toHaveBeenCalled()
+    expect(collectPanelIds(dock.getState().zones.center.layout)).not.toContain('t1')
+    expect(panelsOf(ws)['t1']).toBeUndefined()
+    expect(h.disposeSpy).toHaveBeenCalledWith('t1')
+    expect(h.releaseSpy).not.toHaveBeenCalled()
+  })
+
+  it('ghost tab with no panel record: still undocks and reports closed', async () => {
+    const ws = 'dwc-ghost'
+    seedWorkspace(ws, [])
+    const dock = createDockStore()
+    dock.getState().dockPanel('ghost', 'center')
+
+    const ok = await closeDockWindowPanel(ws, 'ghost', dock)
+
+    expect(ok).toBe(true)
+    expect(collectPanelIds(dock.getState().zones.center.layout)).not.toContain('ghost')
+  })
+})

--- a/src/renderer/shells/dockWindowClosePanel.ts
+++ b/src/renderer/shells/dockWindowClosePanel.ts
@@ -1,0 +1,40 @@
+// =============================================================================
+// closeDockWindowPanel — the detached shell's close-tab flow. Mirrors
+// closePanelWithConfirm's confirmation matrix (canvas panels route through
+// confirmCloseCanvas so their children get the move/delete/cancel fan-out;
+// every other panel goes through the dirty-editor / running-terminal gates)
+// but keeps the shell's own teardown mechanics: the panel is undocked from
+// THIS shell's dock store — the workspace dock registry can point at another
+// window's tree when several dock windows share a workspace — and content is
+// torn down with 'close' semantics via removePanelFromWindow.
+//
+// Returns true when the panel was closed, false when the user cancelled; the
+// shell decides window.close() from its own dock-empty state afterwards.
+// =============================================================================
+
+import { useAppStore } from '../stores/appStore'
+import type { createDockStore } from '../stores/dockStore'
+import { confirmCloseDirtyPanels } from '../lib/confirmCloseDirty'
+import { confirmCloseRunningTerminals } from '../lib/confirmCloseTerminal'
+import { confirmCloseCanvas } from '../lib/canvas/confirmCloseCanvas'
+import { removePanelFromWindow } from '../lib/panels/removePanelFromWindow'
+
+export async function closeDockWindowPanel(
+  workspaceId: string,
+  panelId: string,
+  dockStore: ReturnType<typeof createDockStore>,
+): Promise<boolean> {
+  const ws = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
+  const panel = ws?.panels[panelId]
+
+  if (panel?.type === 'canvas') {
+    if (!(await confirmCloseCanvas(workspaceId, panelId))) return false
+  } else {
+    if (!(await confirmCloseDirtyPanels([panel]))) return false
+    if (!(await confirmCloseRunningTerminals([panel]))) return false
+  }
+
+  dockStore.getState().undockPanel(panelId)
+  if (panel) removePanelFromWindow(workspaceId, panelId, panel.type, 'close')
+  return true
+}

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -16,6 +16,7 @@ import { getClipboard, hasClipboard } from './fileClipboard'
 import { useAppStore } from '../stores/appStore'
 import { openFileAsPanel } from '../lib/fs/fileRouting'
 import { pathDisplayName, workspaceDisplayName } from '../lib/fs/displayPath'
+import { isLocalLocator } from '../../main/runtime/locator'
 import { isExternalFileDrag, importDroppedEntries } from '../lib/fs/importExternalEntries'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
 
@@ -570,7 +571,11 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath }) => {
       { id: 'new-file', label: 'New File…' },
       { id: 'new-folder', label: 'New Folder…' },
       { type: 'separator' },
-      { id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' },
+      // Reveal opens the LOCAL Finder — omitted for a remote workspace root
+      // instead of silently no-oping.
+      ...(isLocalLocator(rootPath)
+        ? [{ id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' }]
+        : []),
       { id: 'open-terminal', label: 'Open in Integrated Terminal' },
       { type: 'separator' },
       { id: 'paste', label: 'Paste', accelerator: 'Cmd+V', enabled: hasClipboard() },

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -21,7 +21,8 @@ import { isExternalFileDrag, importDroppedEntries } from '../lib/fs/importExtern
 import type { FileTreeNode as FileTreeNodeType } from '../../shared/types'
 import { folderColorClass, lookupNodeDecoration, type GitTree } from './gitStatusDecoration'
 import { getClipboard, hasClipboard, setClipboard } from './fileClipboard'
-import { parseLocator } from '../../main/runtime/locator'
+import { parseLocator, isLocalLocator } from '../../main/runtime/locator'
+import { relativeDisplayPath } from '../lib/fs/displayPath'
 import { InlineEditInput } from './InlineEditInput'
 import { CreateFileForm } from './CreateFileForm'
 import { CATE_FILE_MIME, readCateFilePaths, writeCateFileDrag } from '../drag/fileDragPayload'
@@ -223,9 +224,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       ? selectedFiles
       : [node.path]
 
-    const relPath = node.path.startsWith(rootPath + '/')
-      ? node.path.slice(rootPath.length + 1)
-      : node.path
+    const relPath = relativeDisplayPath(node.path, rootPath)
 
     const items: import('../../shared/electron-api').NativeContextMenuItem[] = []
     if (!node.isDirectory) {
@@ -243,8 +242,14 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       { id: 'new-file', label: 'New File…' },
       { id: 'new-folder', label: 'New Folder…' },
       { type: 'separator' },
-      { id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' },
-      { type: 'separator' },
+      // Reveal opens the LOCAL Finder; a remote file has nothing to reveal
+      // here, so the item is omitted instead of silently no-oping.
+      ...(isLocalLocator(node.path)
+        ? ([
+            { id: 'reveal', label: 'Reveal in Finder', accelerator: 'Alt+Cmd+R' },
+            { type: 'separator' },
+          ] as import('../../shared/electron-api').NativeContextMenuItem[])
+        : []),
       { id: 'copy', label: pathsToOpen.length > 1 ? `Copy ${pathsToOpen.length} Items` : 'Copy', accelerator: 'Cmd+C' },
       { id: 'paste', label: 'Paste', accelerator: 'Cmd+V', enabled: hasClipboard() },
       { type: 'separator' },

--- a/src/renderer/sidebar/ProjectList.tsx
+++ b/src/renderer/sidebar/ProjectList.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react'
 import { CaretDoubleDown, CaretDoubleUp, Plus } from '@phosphor-icons/react'
 import { useAppStore, useWorkspaceList } from '../stores/appStore'
+import { removeWorkspacesWithConfirm } from '../lib/closePanelWithConfirm'
 import { WorkspaceTab } from './WorkspaceTab'
 import { SidebarSectionHeader, SidebarHeaderButton } from './SidebarSectionHeader'
 import type { NativeContextMenuItem } from '../../shared/electron-api.d'
@@ -59,20 +60,20 @@ export const ProjectList: React.FC = () => {
     selectWorkspace(wsId)
   }, [workspaces, selectWorkspace])
 
-  const handleBulkDelete = useCallback(() => {
+  const handleBulkDelete = useCallback(async () => {
     if (multiSelected.size === 0) return
-    const idsToRemove = [...multiSelected]
+    // Same confirm-gated close as a single workspace / panel close — one
+    // aggregate dialog for dirty editors + running terminals across the
+    // selection. Keep the selection when the user cancels.
+    if (!(await removeWorkspacesWithConfirm([...multiSelected]))) return
     setMultiSelected(new Set())
     lastClickedIndexRef.current = null
-    for (const id of idsToRemove) {
-      useAppStore.getState().removeWorkspace(id, true)
-    }
   }, [multiSelected])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if ((e.key === 'Delete' || e.key === 'Backspace') && multiSelected.size > 0) {
       e.preventDefault()
-      handleBulkDelete()
+      void handleBulkDelete()
     }
     if (e.key === 'Escape' && multiSelected.size > 0) {
       e.preventDefault()
@@ -91,7 +92,7 @@ export const ProjectList: React.FC = () => {
     ]
     const id = await window.electronAPI.showContextMenu(items)
     if (id === 'delete-selected') {
-      handleBulkDelete()
+      void handleBulkDelete()
     }
     return true
   }, [multiSelected, handleBulkDelete])

--- a/src/renderer/sidebar/SourceControlView.tsx
+++ b/src/renderer/sidebar/SourceControlView.tsx
@@ -25,7 +25,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { useGitStatusSnapshot, gitStatusStore, workspaceIdForRoot } from '../stores/gitStatusStore'
 import { useWorktrees } from '../stores/useWorktrees'
 import { errorMessage } from '../lib/errorMessage'
-import { parseLocator } from '../../main/runtime/locator'
+import { parseLocator, formatLocator } from '../../main/runtime/locator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -468,8 +468,15 @@ const RepoSourceControl: React.FC<RepoSourceControlProps> = ({ rootPath, nested 
   // -------------------------------------------------------------------------
 
   const openFileDiff = useCallback((filePath: string, staged: boolean) => {
-    const fullPath = filePath.startsWith('/') ? filePath : `${rootPath}/${filePath}`
-    createDiffEditor(selectedWorkspaceId, fullPath, staged ? 'staged' : 'working')
+    // filePath is git-relative (POSIX). Join onto the DECODED host root and
+    // re-encode through formatLocator — concatenating onto the raw locator
+    // string corrupts remote filenames whose bytes collide with the percent
+    // encoding. For local roots formatLocator returns the bare path unchanged.
+    const { runtimeId, path: root } = parseLocator(rootPath)
+    const hostPath = filePath.startsWith('/')
+      ? filePath
+      : `${root.replace(/\/+$/, '')}/${filePath}`
+    createDiffEditor(selectedWorkspaceId, formatLocator({ runtimeId, path: hostPath }), staged ? 'staged' : 'working')
   }, [rootPath, selectedWorkspaceId, createDiffEditor])
 
   // -------------------------------------------------------------------------

--- a/src/renderer/sidebar/WorkspaceTab.menu.test.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.menu.test.tsx
@@ -1,0 +1,544 @@
+// =============================================================================
+// WorkspaceTab menus + detached rows — rendered component tests for the
+// workspace overview's interactions:
+//
+//   • workspace context menu: dispatch per item id, the live-panels enabled
+//     flag for "Close All Panels" (the workspace PROP's panels can be stale),
+//     its "…in This Window" label when detached panels exist, and the
+//     active-terminal-first "Copy Working Directory" (disabled with neither a
+//     rootPath nor a terminal).
+//   • panel-row context menu: exact items, close behind the running-terminal
+//     gate, and "Move into New Window" via movePanelToNewWindow.
+//   • panel-row rename seed: committing the DERIVED label unchanged must not
+//     freeze it as a user title (renamePanelByUser / titleUserOverridden).
+//   • "Other windows" section: nesting under detached canvases, the orphan
+//     child (parentCanvasId matching no canvas in the union) rendering
+//     top-level instead of being dropped, the detached-row context menu
+//     (Show in Window / Close) that does NOT bubble into the workspace menu.
+//   • collapsed badge counts rendered rows (ghost records excluded), not the
+//     raw ws.panels registry size.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// ---------------------------------------------------------------------------
+// Mocks for modules that explode under jsdom (xterm) or need controllable
+// panelId↔ptyId lookups for the cwd/running-terminal paths.
+// ---------------------------------------------------------------------------
+
+const h = vi.hoisted(() => ({
+  ptyForPanel: new Map<string, string>(),
+  wsForPty: new Map<string, string>(),
+}))
+
+vi.mock('../lib/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: {
+    entries: () => [],
+    ptyIdForPanel: (panelId: string) => h.ptyForPanel.get(panelId) ?? null,
+    panelIdForPty: (ptyId: string) => {
+      for (const [panelId, pty] of h.ptyForPanel) if (pty === ptyId) return panelId
+      return null
+    },
+    workspaceIdForPty: (ptyId: string) => h.wsForPty.get(ptyId),
+    dispose: vi.fn(),
+    release: vi.fn(),
+    disposeWorkspace: vi.fn(),
+    has: () => false,
+    getEntry: () => undefined,
+  },
+}))
+vi.mock('../../agent/renderer/agentSessionRegistry', () => ({
+  disposeAgentPanel: vi.fn(),
+  getAgentPanelSession: vi.fn(),
+  saveAgentPanelSession: vi.fn(),
+}))
+
+import { WorkspaceTab } from './WorkspaceTab'
+import { useAppStore } from '../stores/appStore'
+import { useStatusStore } from '../stores/statusStore'
+import { useWindowPanelStore } from '../stores/windowPanelStore'
+import { releaseCanvasStoreForPanel } from '../stores/canvasStore'
+import { createDockStore } from '../stores/dockStore'
+import { registerWorkspaceDockStore, releaseWorkspaceDockStore } from '../lib/workspace/dockRegistry'
+import { setActivePanel } from '../lib/activePanel'
+import type { NativeContextMenuItem } from '../../shared/electron-api'
+import type { PanelState, WindowPanelInfo, WorkspaceState } from '../../shared/types'
+
+// ---------------------------------------------------------------------------
+// Fixtures + helpers
+// ---------------------------------------------------------------------------
+
+const WS = 'ws-tab'
+
+const showContextMenu = vi.fn<(items: NativeContextMenuItem[]) => Promise<string | null>>()
+const confirmUnsavedChanges = vi.fn()
+const confirmCloseTerminal = vi.fn()
+const focusWindowPanel = vi.fn().mockResolvedValue(undefined)
+const closeWindowPanel = vi.fn().mockResolvedValue(undefined)
+const dragDetach = vi.fn()
+const clipboardWriteText = vi.fn()
+
+function panel(id: string, type: PanelState['type'], extra: Partial<PanelState> = {}): PanelState {
+  return { id, type, title: id, isDirty: false, ...extra } as PanelState
+}
+
+function makeWorkspace(panels: PanelState[], extra: Partial<WorkspaceState> = {}): WorkspaceState {
+  return {
+    id: WS,
+    name: 'Alpha',
+    color: '',
+    rootPath: '/tmp/proj',
+    rootPathError: null,
+    isRootPathPending: false,
+    worktrees: [],
+    panels: Object.fromEntries(panels.map((p) => [p.id, p])),
+    ...extra,
+  } as unknown as WorkspaceState
+}
+
+function seed(ws: WorkspaceState): WorkspaceState {
+  useAppStore.setState({ workspaces: [ws], selectedWorkspaceId: WS } as never)
+  return ws
+}
+
+function panelsOf(): Record<string, PanelState> {
+  return useAppStore.getState().workspaces.find((w) => w.id === WS)?.panels ?? {}
+}
+
+function detached(panelId: string, type: WindowPanelInfo['type'], extra: Partial<WindowPanelInfo> = {}): WindowPanelInfo {
+  return { panelId, type, title: panelId, workspaceId: WS, ownerWindowId: 7, ownerWindowType: 'dock', ...extra }
+}
+
+let host: HTMLDivElement
+let root: Root
+const initialAppState = useAppStore.getState()
+
+async function renderTab(ws: WorkspaceState, opts: { isSelected?: boolean; isExpanded?: boolean } = {}): Promise<void> {
+  await act(async () => {
+    root.render(
+      <WorkspaceTab
+        workspace={ws}
+        isSelected={opts.isSelected ?? true}
+        isExpanded={opts.isExpanded ?? true}
+        onToggleExpand={() => {}}
+        onClick={() => {}}
+      />,
+    )
+    // Flush WorkspaceSkillsTree's lazy manifest fetch inside act.
+    await new Promise((r) => setTimeout(r, 0))
+  })
+}
+
+/** Innermost element whose exact text is `text`. */
+function byText(text: string): HTMLElement {
+  const all = Array.from(host.querySelectorAll<HTMLElement>('*')).filter((el) => el.textContent === text)
+  const el = all[all.length - 1]
+  expect(el, `element with text "${text}"`).toBeTruthy()
+  return el
+}
+
+/** Right-click `el` and drain the async menu handler. */
+async function rightClick(el: HTMLElement): Promise<void> {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+  })
+}
+
+function lastMenuItems(): NativeContextMenuItem[] {
+  const calls = showContextMenu.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return calls[calls.length - 1][0]
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+  setter.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+beforeEach(() => {
+  showContextMenu.mockReset().mockResolvedValue(null)
+  confirmUnsavedChanges.mockReset()
+  confirmCloseTerminal.mockReset()
+  focusWindowPanel.mockClear()
+  closeWindowPanel.mockClear()
+  dragDetach.mockReset()
+  clipboardWriteText.mockClear()
+  h.ptyForPanel.clear()
+  h.wsForPty.clear()
+  setActivePanel(null)
+  useStatusStore.setState({ workspaces: {} })
+  useWindowPanelStore.setState({ panels: [] })
+
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    isE2E: false,
+    showContextMenu,
+    confirmUnsavedChanges,
+    confirmCloseTerminal,
+    focusWindowPanel,
+    closeWindowPanel,
+    dragDetach,
+    openFolderDialog: vi.fn().mockResolvedValue(null),
+    skillsListInstalled: vi.fn().mockResolvedValue([]),
+    workspaceCreate: vi.fn(async () => ({ ok: true, workspace: {} })),
+    workspaceUpdate: vi.fn(async () => ({ ok: true, workspace: {} })),
+    workspaceRemove: vi.fn(async () => ({ ok: true })),
+    recentProjectsAdd: vi.fn(),
+    recentProjectsRemove: vi.fn(async () => undefined),
+    agentDispose: vi.fn(async () => undefined),
+  }
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: { writeText: clipboardWriteText },
+    configurable: true,
+  })
+
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  releaseWorkspaceDockStore(WS)
+  releaseCanvasStoreForPanel('cv')
+  useAppStore.setState(initialAppState, true)
+})
+
+// ---------------------------------------------------------------------------
+// Workspace context menu
+// ---------------------------------------------------------------------------
+
+describe('workspace context menu', () => {
+  it("'select' calls selectWorkspace", async () => {
+    const selectWorkspace = vi.fn()
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    useAppStore.setState({ selectWorkspace } as never)
+    showContextMenu.mockResolvedValue('select')
+    await renderTab(ws, { isSelected: false })
+
+    await rightClick(byText('Alpha'))
+
+    expect(selectWorkspace).toHaveBeenCalledWith(WS)
+  })
+
+  it("'rename' shows the inline input seeded with the workspace name", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    showContextMenu.mockResolvedValue('rename')
+    await renderTab(ws)
+
+    expect(host.querySelector('input')).toBeNull()
+    await rightClick(byText('Alpha'))
+
+    const input = host.querySelector('input')
+    expect(input).not.toBeNull()
+    expect(input!.value).toBe('Alpha')
+  })
+
+  it("'color:<c>' sets the workspace color", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    showContextMenu.mockResolvedValue('color:blue')
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    expect(useAppStore.getState().workspaces.find((w) => w.id === WS)?.color).toBe('blue')
+  })
+
+  it("'copy-cwd' prefers the ACTIVE panel's terminal cwd over other terminals", async () => {
+    const ws = seed(makeWorkspace([panel('t-active', 'terminal'), panel('t-other', 'terminal')]))
+    h.ptyForPanel.set('t-active', 'pty-a')
+    h.ptyForPanel.set('t-other', 'pty-b')
+    useStatusStore.setState({
+      workspaces: {
+        [WS]: {
+          terminals: {
+            'pty-b': { activity: { type: 'idle' }, agentState: 'notRunning', agentName: null, agentPresent: false, listeningPorts: [], cwd: '/other' },
+            'pty-a': { activity: { type: 'idle' }, agentState: 'notRunning', agentName: null, agentPresent: false, listeningPorts: [], cwd: '/active' },
+          },
+        },
+      },
+    })
+    setActivePanel('t-active')
+    showContextMenu.mockResolvedValue('copy-cwd')
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('/active')
+  })
+
+  it("'copy-cwd' is disabled when there is neither a rootPath nor any terminal", async () => {
+    const ws = seed(makeWorkspace([], { rootPath: '' }))
+    await renderTab(ws)
+
+    // No rootPath renders the "Add Workspace" empty-state row; its context menu
+    // is still the workspace menu.
+    await rightClick(byText('Add Workspace'))
+
+    const item = lastMenuItems().find((i) => i.id === 'copy-cwd')
+    expect(item).toBeTruthy()
+    expect(item!.enabled).toBe(false)
+  })
+
+  it("'close-panels' is enabled from the LIVE panel registry even when the workspace prop is stale", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    // The prop carries a STALE panels snapshot (useWorkspaceList's equality fn
+    // ignores panels) — the enabled flag must come from the live registry.
+    await renderTab({ ...ws, panels: {} } as WorkspaceState)
+
+    await rightClick(byText('Alpha'))
+
+    const item = lastMenuItems().find((i) => i.id === 'close-panels')
+    expect(item).toBeTruthy()
+    expect(item!.enabled).toBe(true)
+    expect(item!.label).toBe('Close All Panels')
+  })
+
+  it("'close-panels' label switches to 'in This Window' when detached panels exist", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    useWindowPanelStore.setState({ panels: [detached('dt', 'terminal')] })
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    const item = lastMenuItems().find((i) => i.id === 'close-panels')
+    expect(item!.label).toBe('Close All Panels in This Window')
+  })
+
+  it("'close-panels' routes through the confirm gate — cancel keeps the panels", async () => {
+    const ws = seed(makeWorkspace([
+      panel('e1', 'editor', { isDirty: true, title: 'a.ts •', filePath: '/x/a.ts' }),
+      panel('t1', 'terminal'),
+    ]))
+    showContextMenu.mockResolvedValue('close-panels')
+    confirmUnsavedChanges.mockResolvedValue('cancel')
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    expect(confirmUnsavedChanges).toHaveBeenCalledTimes(1)
+    expect(panelsOf()['e1']).toBeDefined()
+    expect(panelsOf()['t1']).toBeDefined()
+  })
+
+  it("'remove' routes through removeWorkspacesWithConfirm and removes the workspace", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    showContextMenu.mockResolvedValue('remove')
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    expect(useAppStore.getState().workspaces.map((w) => w.id)).not.toContain(WS)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Panel-row context menu
+// ---------------------------------------------------------------------------
+
+describe('panel-row context menu', () => {
+  it('offers exactly Rename / Move into New Window / separator / Close', async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    await renderTab(ws)
+
+    await rightClick(byText('t1'))
+
+    expect(showContextMenu).toHaveBeenCalledTimes(1) // no bubbling into the workspace menu
+    const items = lastMenuItems()
+    expect(items).toEqual([
+      { id: 'rename', label: 'Rename' },
+      { id: 'move-window', label: 'Move into New Window' },
+      { type: 'separator' },
+      { id: 'close', label: 'Close' },
+    ])
+  })
+
+  it("'close' on a running terminal routes through the confirm flow", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    h.ptyForPanel.set('t1', 'pty-1')
+    h.wsForPty.set('pty-1', WS)
+    useStatusStore.setState({
+      workspaces: {
+        [WS]: {
+          terminals: {
+            'pty-1': { activity: { type: 'running', processName: 'vim' }, agentState: 'notRunning', agentName: null, agentPresent: false, listeningPorts: [], cwd: '' },
+          },
+        },
+      },
+    })
+    showContextMenu.mockResolvedValue('close')
+    await renderTab(ws)
+
+    // Cancel → the panel survives.
+    confirmCloseTerminal.mockResolvedValueOnce('cancel')
+    await rightClick(byText('t1'))
+    expect(confirmCloseTerminal).toHaveBeenCalledWith({ count: 1, processName: 'vim' })
+    expect(panelsOf()['t1']).toBeDefined()
+
+    // Confirm → the panel is closed.
+    confirmCloseTerminal.mockResolvedValueOnce('close')
+    await rightClick(byText('t1'))
+    expect(panelsOf()['t1']).toBeUndefined()
+  })
+
+  it("'move-window' detaches via dragDetach and drops the record", async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    const dock = createDockStore()
+    dock.getState().dockPanel('t1', 'center')
+    registerWorkspaceDockStore(WS, dock)
+    dragDetach.mockResolvedValue(3)
+    showContextMenu.mockResolvedValue('move-window')
+    await renderTab(ws)
+
+    await rightClick(byText('t1'))
+
+    expect(dragDetach).toHaveBeenCalledTimes(1)
+    expect(dragDetach).toHaveBeenCalledWith(expect.anything(), WS)
+    expect(panelsOf()['t1']).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Panel-row rename seed regression
+// ---------------------------------------------------------------------------
+
+describe('panel-row rename seed', () => {
+  it('committing the seeded DERIVED label unchanged does NOT rename', async () => {
+    const renamePanelByUser = vi.fn()
+    const ws = seed(makeWorkspace([panel('e1', 'editor', { title: '', filePath: '/x/notes.md' })]))
+    useAppStore.setState({ renamePanelByUser } as never)
+    await renderTab(ws)
+
+    // The row label is the DERIVED file basename.
+    const label = byText('notes.md')
+    act(() => { label.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })) })
+    const input = host.querySelector('input') as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('notes.md') // seeded with the derived label
+
+    act(() => { input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })) })
+
+    expect(renamePanelByUser).not.toHaveBeenCalled()
+    expect(panelsOf()['e1'].title).toBe('') // no frozen user title
+    expect(panelsOf()['e1'].titleUserOverridden).toBeUndefined()
+    expect(host.querySelector('input')).toBeNull() // rename mode exits
+  })
+
+  it('committing an edited value DOES rename', async () => {
+    const renamePanelByUser = vi.fn()
+    const ws = seed(makeWorkspace([panel('e1', 'editor', { title: '', filePath: '/x/notes.md' })]))
+    useAppStore.setState({ renamePanelByUser } as never)
+    await renderTab(ws)
+
+    const label = byText('notes.md')
+    act(() => { label.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })) })
+    const input = host.querySelector('input') as HTMLInputElement
+    act(() => { setInputValue(input, 'My Notes') })
+    act(() => { input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })) })
+
+    expect(renamePanelByUser).toHaveBeenCalledTimes(1)
+    expect(renamePanelByUser).toHaveBeenCalledWith(WS, 'e1', 'My Notes')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// "Other windows" (detached) section
+// ---------------------------------------------------------------------------
+
+describe('detached section', () => {
+  function seedDetachedUnion(): WorkspaceState {
+    const ws = seed(makeWorkspace([]))
+    useWindowPanelStore.setState({
+      panels: [
+        detached('dc', 'canvas', { title: 'Canvas' }),
+        detached('ct', 'terminal', { parentCanvasId: 'dc' }),
+        detached('oc', 'terminal', { parentCanvasId: 'missing-canvas' }),
+        detached('dt', 'browser'),
+      ],
+    })
+    return ws
+  }
+
+  it('renders the header, nests children under their canvas, and keeps the orphan top-level', async () => {
+    await renderTab(seedDetachedUnion())
+
+    expect(host.textContent).toContain('Other windows')
+    expect(host.textContent).toContain('Canvas')
+
+    // Child of the detached canvas is nested (indent = pl-10).
+    const child = byText('ct').closest('button')!
+    expect(child.className).toContain('pl-10')
+
+    // Regression: a child whose parentCanvasId matches NO canvas in the union
+    // still renders — top-level (pl-7), not silently dropped.
+    const orphan = byText('oc').closest('button')!
+    expect(orphan.className).toContain('pl-7')
+
+    // Plain top-level detached panel renders too.
+    const top = byText('dt').closest('button')!
+    expect(top.className).toContain('pl-7')
+  })
+
+  it('clicking a detached row focuses it in its owning window', async () => {
+    await renderTab(seedDetachedUnion())
+
+    act(() => { byText('dt').closest('button')!.click() })
+
+    expect(focusWindowPanel).toHaveBeenCalledWith('dt')
+  })
+
+  it('right-click opens the detached menu (Show in Window / Close), not the workspace menu', async () => {
+    await renderTab(seedDetachedUnion())
+    showContextMenu.mockResolvedValue('close')
+
+    await rightClick(byText('ct').closest('button')!)
+
+    // Exactly one menu — the event must not bubble into the workspace handler.
+    expect(showContextMenu).toHaveBeenCalledTimes(1)
+    const items = lastMenuItems()
+    expect(items).toEqual([
+      { id: 'show', label: 'Show in Window' },
+      { type: 'separator' },
+      { id: 'close', label: 'Close' },
+    ])
+    expect(closeWindowPanel).toHaveBeenCalledWith('ct')
+  })
+
+  it("'show' focuses the panel in its owning window", async () => {
+    await renderTab(seedDetachedUnion())
+    showContextMenu.mockResolvedValue('show')
+
+    await rightClick(byText('dt').closest('button')!)
+
+    expect(focusWindowPanel).toHaveBeenCalledWith('dt')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Collapsed badge — ghost exclusion
+// ---------------------------------------------------------------------------
+
+describe('collapsed badge', () => {
+  it('counts rendered rows (ghosts excluded), not the raw ws.panels size', async () => {
+    const ws = seed(makeWorkspace([panel('cv', 'canvas'), panel('t1', 'terminal'), panel('ghost', 'terminal')]))
+    // The dock store places cv + t1; `ghost` is in ws.panels but placed nowhere.
+    const dock = createDockStore()
+    dock.getState().dockPanel('cv', 'center')
+    dock.getState().dockPanel('t1', 'center')
+    registerWorkspaceDockStore(WS, dock)
+
+    await renderTab(ws, { isExpanded: false })
+
+    const badge = Array.from(host.querySelectorAll('span')).find((el) => el.className.includes('text-[10px]'))
+    expect(badge).toBeTruthy()
+    expect(badge!.textContent).toBe('2') // NOT 3 — the ghost is excluded
+  })
+})

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -11,13 +11,20 @@ import { useOtherWindowPanels } from '../stores/windowPanelStore'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import type { AgentState } from '../../shared/types'
 import { terminalRegistry } from '../lib/terminal/terminalRegistry'
-import { closePanelWithConfirm } from '../lib/closePanelWithConfirm'
+import {
+  closePanelWithConfirm,
+  closeAllPanelsWithConfirm,
+  removeWorkspacesWithConfirm,
+} from '../lib/closePanelWithConfirm'
+import { movePanelToNewWindow } from '../lib/workspace/movePanelToNewWindow'
+import { getActivePanelId } from '../lib/activePanel'
 import { worktreeTitleStyle } from '../lib/worktreeTitleStyle'
 import { isMiddleClick } from '../lib/mouse'
 import { PANEL_REGISTRY } from '../panels/registry'
+import { panelRowLabel } from '../lib/panelTitle'
 import { useAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
 import { getAgentLogo } from '../lib/agent/agentLogos'
-import { pathDisplayName, workspaceDisplayName } from '../lib/fs/displayPath'
+import { workspaceDisplayName } from '../lib/fs/displayPath'
 import { workspaceRuntime } from '../lib/workspace/workspaceRuntime'
 import { InlineEditInput } from './InlineEditInput'
 import { WorkspaceSkillsTree } from './WorkspaceSkillsTree'
@@ -85,14 +92,10 @@ export interface PanelRenameProps {
   onContextMenu: (e: React.MouseEvent) => void
 }
 
-/** Display label for a panel row: explicit title, else the file basename, else
- *  the active browser tab URL, else the panel type. Param is the minimal shape shared by the
- *  TerminalPanelRow prop and a full PanelState. */
-export function panelRowLabel(
-  panel: Pick<PanelState, 'type' | 'title' | 'filePath' | 'tabs' | 'activeTabId'>,
-): string {
-  return panel.title || (panel.filePath ? pathDisplayName(panel.filePath) : '') || browserPanelUrl(panel) || panel.type
-}
+// Canonical row-label logic lives in lib/panelTitle (shared with the cross-
+// window panel report and the Cate agent chat). Re-exported for existing
+// importers of this module.
+export { panelRowLabel }
 
 export interface TerminalPanelRowProps {
   panel: Pick<PanelState, 'id' | 'type' | 'title' | 'filePath' | 'tabs' | 'activeTabId'>
@@ -105,6 +108,9 @@ export interface TerminalPanelRowProps {
   /** Middle-click closes the row (mirrors the dock tab behavior). */
   onClose?: () => void
   rename?: PanelRenameProps
+  /** Context menu for rows without rename support (detached rows). Local rows
+   *  route their menu through rename.onContextMenu instead. */
+  onContextMenu?: (e: React.MouseEvent) => void
   /** Overrides the row's hover tooltip (used by detached rows to note the panel
    *  lives in another window). Falls back to the panel's path / url / label. */
   titleHint?: string
@@ -112,7 +118,7 @@ export interface TerminalPanelRowProps {
 
 const AWAIT_COLOR = '#c08a5a'
 
-export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, agentState, agentLogo: agentLogoProp, hasPorts, worktreeColor, onClick, onClose, rename, titleHint }) => {
+export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, indent, agentState, agentLogo: agentLogoProp, hasPorts, worktreeColor, onClick, onClose, rename, titleHint, onContextMenu }) => {
   const Icon = PANEL_ICONS[panel.type] ?? TerminalIcon
   const label = panelRowLabel(panel)
 
@@ -127,7 +133,7 @@ export const TerminalPanelRow: React.FC<TerminalPanelRowProps> = ({ panel, inden
         indent ? 'pl-10' : 'pl-7'
       } ${isAwaiting ? 'text-primary' : 'text-muted hover:text-primary'}`}
       onClick={onClick}
-      onContextMenu={rename?.onContextMenu}
+      onContextMenu={onContextMenu ?? rename?.onContextMenu}
       onMouseDown={(e) => { if (isMiddleClick(e)) e.preventDefault() }}
       onAuxClick={(e) => {
         if (isMiddleClick(e) && onClose) {
@@ -251,7 +257,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   // dock store, multi-canvas/dock-aware and ghost-filtered. The Cmd+K palette
   // reads the exact same source (see useWorkspacePanelTree), so the overview and
   // the palette can never disagree about which panels exist or where they live.
-  const { panels, canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels } =
+  const { panels, canvasPanels, childrenByCanvas, orphanCanvasChildren, freePanels, orderedPanels } =
     useWorkspacePanelTree(workspace.id)
 
   // Panels living in other (detached) windows for this workspace — they dropped
@@ -262,11 +268,15 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   const otherWindowPanels = useOtherWindowPanels(workspace.id, Object.keys(panels))
   const { detachedCanvases, detachedChildrenByCanvas, detachedTopLevel, detachedCount } = useMemo(() => {
     const canvases = otherWindowPanels.filter((p) => p.type === 'canvas')
+    const canvasIds = new Set(canvases.map((c) => c.panelId))
     const childrenByCanvas: Record<string, WindowPanelInfo[]> = {}
     const topLevel: WindowPanelInfo[] = []
     for (const p of otherWindowPanels) {
       if (p.type === 'canvas') continue
-      if (p.parentCanvasId) (childrenByCanvas[p.parentCanvasId] ??= []).push(p)
+      // A child whose parent canvas is missing from the union (transiently
+      // possible mid-transfer) renders top-level instead of being dropped —
+      // mirrors partitionWorkspacePanels' orphan fallback for local rows.
+      if (p.parentCanvasId && canvasIds.has(p.parentCanvasId)) (childrenByCanvas[p.parentCanvasId] ??= []).push(p)
       else topLevel.push(p)
     }
     return { detachedCanvases: canvases, detachedChildrenByCanvas: childrenByCanvas, detachedTopLevel: topLevel, detachedCount: otherWindowPanels.length }
@@ -303,6 +313,11 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   // the matching panel row renders an inline input in place of its label.
   const [renamingPanelId, setRenamingPanelId] = useState<string | null>(null)
   const [panelRenameValue, setPanelRenameValue] = useState('')
+  // The value the rename input was seeded with. The seed is the row's DERIVED
+  // label (file basename / browser URL / type when the panel has no title), so
+  // committing it unchanged would freeze that derived label as a permanent
+  // user title (titleUserOverridden) — only write when the user actually edited.
+  const panelRenameSeedRef = useRef('')
 
   // Per-canvas collapse state (canvas rows fold their children, like the
   // workspace row folds its tree). Absent = expanded; default is expanded.
@@ -342,16 +357,26 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         enabled: color !== workspace.color,
       })),
     ]
+    const hasCwd =
+      !!workspace.rootPath ||
+      Object.keys(useStatusStore.getState().workspaces[workspace.id]?.terminals ?? {}).length > 0
     const items: NativeContextMenuItem[] = [
       { id: 'select', label: 'Select Workspace', enabled: !isSelected },
       { id: 'rename', label: 'Rename Workspace' },
       { label: 'Change Color', submenu: colorSubmenu },
       { type: 'separator' },
       { id: 'select-folder', label: 'Select Project Folder' },
-      { id: 'copy-cwd', label: 'Copy Working Directory' },
+      { id: 'copy-cwd', label: 'Copy Working Directory', enabled: hasCwd },
       { type: 'separator' },
       { id: 'duplicate', label: 'Duplicate Workspace' },
-      { id: 'close-panels', label: 'Close All Panels', enabled: Object.keys(workspace.panels).length > 0 },
+      {
+        id: 'close-panels',
+        // Panels living in detached windows are NOT closed by this — say so.
+        label: detachedCount > 0 ? 'Close All Panels in This Window' : 'Close All Panels',
+        // `panels` is the live registry (the `workspace` prop's panels can be
+        // stale — useWorkspaceList's equality fn ignores them).
+        enabled: Object.keys(panels).length > 0,
+      },
       { type: 'separator' },
       { id: 'remove', label: 'Close Workspace' },
     ]
@@ -374,22 +399,22 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         break
       }
       case 'copy-cwd': {
-        const statusState = useStatusStore.getState()
-        const ws = statusState.workspaces[workspace.id]
-        let dir: string | undefined
-        if (ws) {
-          const cwds = Object.values(ws.terminals).map((terminal) => terminal.cwd).filter(Boolean)
-          dir = cwds[0]
-        }
+        const terminals = useStatusStore.getState().workspaces[workspace.id]?.terminals ?? {}
+        // Prefer the active panel's terminal — "first terminal in the status
+        // map" is an arbitrary pick when several run in different directories.
+        const activeId = getActivePanelId()
+        const activePty = activeId ? terminalRegistry.ptyIdForPanel(activeId) : null
+        let dir = (activePty && terminals[activePty]?.cwd) || undefined
+        if (!dir) dir = Object.values(terminals).map((terminal) => terminal.cwd).find(Boolean)
         if (!dir) dir = workspace.rootPath || undefined
         if (dir) navigator.clipboard.writeText(dir)
         break
       }
       case 'duplicate': app.duplicateWorkspace(workspace.id); break
-      case 'close-panels': app.closeAllPanels(workspace.id); break
-      case 'remove': app.removeWorkspace(workspace.id, true); break
+      case 'close-panels': void closeAllPanelsWithConfirm(workspace.id); break
+      case 'remove': void removeWorkspacesWithConfirm([workspace.id]); break
     }
-  }, [workspace.id, workspace.name, workspace.rootPath, workspace.color, workspace.panels, isSelected, onBulkContextMenu, beginRename])
+  }, [workspace.id, workspace.name, workspace.rootPath, workspace.color, panels, detachedCount, isSelected, onBulkContextMenu, beginRename])
 
   useEffect(() => {
     if (isRenaming && renameInputRef.current) {
@@ -407,13 +432,14 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
   }, [renameValue, workspace.id, workspace.name])
 
   const beginPanelRename = useCallback((panelId: string, currentTitle: string) => {
+    panelRenameSeedRef.current = currentTitle
     setPanelRenameValue(currentTitle)
     setRenamingPanelId(panelId)
   }, [])
 
   const handlePanelRenameSubmit = useCallback((panelId: string) => {
     const trimmed = panelRenameValue.trim()
-    if (trimmed) {
+    if (trimmed && trimmed !== panelRenameSeedRef.current) {
       useAppStore.getState().renamePanelByUser(workspace.id, panelId, trimmed)
     }
     setRenamingPanelId(null)
@@ -432,10 +458,11 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
     e.stopPropagation()
     if (!window.electronAPI) return
     // Mirror the dock tab menu, limited to actions that apply to a flat sidebar
-    // list (Split / Close-Others / Close-to-the-Right / Move-to-Window are
-    // dock-stack-relative and have no meaning here).
+    // list (Split / Close-Others / Close-to-the-Right are dock-stack-relative
+    // and have no meaning here).
     const id = await window.electronAPI.showContextMenu([
       { id: 'rename', label: 'Rename' },
+      { id: 'move-window', label: 'Move into New Window' },
       { type: 'separator' },
       { id: 'close', label: 'Close' },
     ])
@@ -443,15 +470,39 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       case 'rename':
         beginPanelRename(panelId, currentTitle)
         break
+      case 'move-window':
+        void movePanelToNewWindow(workspace.id, panelId)
+        break
       case 'close':
         handleClosePanel(panelId)
         break
     }
-  }, [beginPanelRename, handleClosePanel])
+  }, [beginPanelRename, handleClosePanel, workspace.id])
+
+  // Context menu for rows hosted in ANOTHER window: cross-window actions only
+  // (reveal there / close there, behind the owner's confirm gates). Without
+  // this the right-click bubbles into the workspace menu, which reads as a
+  // misfire on a specific panel row.
+  const handleDetachedContextMenu = useCallback(async (e: React.MouseEvent, panelId: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!window.electronAPI) return
+    const id = await window.electronAPI.showContextMenu([
+      { id: 'show', label: 'Show in Window' },
+      { type: 'separator' },
+      { id: 'close', label: 'Close' },
+    ])
+    switch (id) {
+      case 'show': void window.electronAPI.focusWindowPanel(panelId); break
+      case 'close': void window.electronAPI.closeWindowPanel?.(panelId); break
+    }
+  }, [])
 
   // Local panels plus panels in detached windows — drives the expand toggle and
   // the count badge so a workspace whose only panels are detached still expands.
-  const treeCount = Object.keys(panels).length + detachedCount
+  // Counts what the tree actually renders (orderedPanels excludes ghost records;
+  // the raw ws.panels registry can contain more).
+  const treeCount = orderedPanels.length + detachedCount
 
   const handlePanelClick = useCallback(async (e: React.MouseEvent, panelId: string) => {
     e.stopPropagation()
@@ -541,6 +592,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
           hasPorts={!!p.hasPorts}
           worktreeColor={worktreeColorForId(p.worktreeId)}
           onClick={onClick}
+          onContextMenu={(e) => handleDetachedContextMenu(e, p.panelId)}
           titleHint={titleHint}
         />
       )
@@ -553,6 +605,7 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
           indent ? 'pl-10' : 'pl-7'
         }`}
         onClick={onClick}
+        onContextMenu={(e) => handleDetachedContextMenu(e, p.panelId)}
         title={titleHint}
       >
         <Icon size={11} className="flex-shrink-0 opacity-60" />
@@ -576,6 +629,14 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         tabIndex={0}
         className="group/panel flex items-center gap-1.5 h-7 pl-3 pr-2 text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 cursor-pointer focus:outline-none"
         onClick={(e) => { e.stopPropagation(); void window.electronAPI.focusWindowPanel(p.panelId) }}
+        onContextMenu={(e) => handleDetachedContextMenu(e, p.panelId)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            void window.electronAPI.focusWindowPanel(p.panelId)
+          }
+        }}
         title={`${p.title} — in another window`}
       >
         {hasChildren ? (
@@ -685,6 +746,13 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         tabIndex={0}
         className="group/panel flex items-center gap-1.5 h-7 pl-3 pr-2 text-[13px] text-muted hover:text-primary hover:bg-hover text-left min-w-0 cursor-pointer focus:outline-none"
         onClick={(e) => handlePanelClick(e, cp.id)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            void focusWorkspacePanel(workspace.id, cp.id)
+          }
+        }}
         onContextMenu={rename.onContextMenu}
         onMouseDown={(e) => { if (isMiddleClick(e)) e.preventDefault() }}
         onAuxClick={(e) => {

--- a/src/renderer/stores/appStore/panelSlice.ts
+++ b/src/renderer/stores/appStore/panelSlice.ts
@@ -28,6 +28,7 @@ import {
   resolvePanelLocation,
 } from '../../lib/workspace/canvasAccess'
 import { clearActivePanelIfMatches } from '../../lib/activePanel'
+import { pathDisplayName } from '../../lib/fs/displayPath'
 import { recordRecentFile } from '../../lib/fs/recentFiles'
 
 type PanelSliceActions = Pick<
@@ -109,7 +110,7 @@ export function createPanelSlice(set: AppSet, get: AppGet): PanelSliceActions {
     createEditor(workspaceId, filePath?, position?, placement?) {
       const panelId = generateId()
       if (filePath) recordRecentFile(workspaceId, filePath)
-      const fileName = filePath ? filePath.split('/').pop() ?? 'Untitled' : 'Untitled'
+      const fileName = (filePath && pathDisplayName(filePath)) || 'Untitled'
       const panel: PanelState = {
         id: panelId,
         type: 'editor',
@@ -123,7 +124,7 @@ export function createPanelSlice(set: AppSet, get: AppGet): PanelSliceActions {
     createDocument(workspaceId, filePath?, documentType?, position?, placement?) {
       const panelId = generateId()
       if (filePath) recordRecentFile(workspaceId, filePath)
-      const fileName = filePath ? filePath.split('/').pop() ?? 'Document' : 'Document'
+      const fileName = (filePath && pathDisplayName(filePath)) || 'Document'
       const panel: PanelState = {
         id: panelId,
         type: 'document',
@@ -137,7 +138,7 @@ export function createPanelSlice(set: AppSet, get: AppGet): PanelSliceActions {
 
     createDiffEditor(workspaceId, filePath, diffMode, position?, placement?) {
       const panelId = generateId()
-      const fileName = filePath.split('/').pop() ?? 'Untitled'
+      const fileName = pathDisplayName(filePath) || 'Untitled'
       const label = diffMode === 'staged' ? 'Staged' : 'Working'
       const panel: PanelState = {
         id: panelId,

--- a/src/renderer/stores/useParallelWork.ts
+++ b/src/renderer/stores/useParallelWork.ts
@@ -18,6 +18,7 @@ import { useWorktreeActions } from './useWorktreeActions'
 import type { JoinedWorktree } from './useWorktrees'
 import type { PrListItem } from '../sidebar/CreateWorktreeForm'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
+import { isLocalLocator } from '../../main/runtime/locator'
 
 /** Apply a color/label change to a worktree's UI metadata, creating the metadata
  *  record when none exists yet (a worktree discovered only from git has its path
@@ -58,6 +59,9 @@ export interface CardCallbacks {
   onUpdateFromMain: () => void
   onMerge: () => void
   onDelete: () => void
+  /** Reveal opens the LOCAL Finder — false when the worktree lives on a remote
+   *  host, so menus omit the action instead of silently no-oping. */
+  canReveal: boolean
   onReveal: () => void
   onRename: (label: string | undefined) => void
   onRecolor: (color: string) => void
@@ -87,7 +91,7 @@ export async function runWorktreeContextMenu(opts: {
   items.push({ type: 'separator' })
   items.push({ id: 'rename', label: 'Rename…' })
   items.push({ id: 'color', label: 'Change color…' })
-  items.push({ id: 'reveal', label: 'Reveal in Finder' })
+  if (opts.cb.canReveal) items.push({ id: 'reveal', label: 'Reveal in Finder' })
   if (!opts.isPrimary) {
     items.push({ type: 'separator' })
     items.push({ id: 'delete', label: 'Discard this work…' })
@@ -331,6 +335,7 @@ export function useParallelWork(
       onUpdateFromMain: () => handleUpdateFromMain(wt),
       onMerge: () => handleMerge(wt),
       onDelete: () => handleDelete(wt),
+      canReveal: isLocalLocator(wt.path),
       onReveal: () => window.electronAPI.shellShowInFolder(wt.path, workspaceId ?? undefined),
       onRename: (label) => workspaceId && upsertWorktreeMeta(workspaceId, wt, { label: label?.trim() || undefined }),
       onRecolor: (color) => workspaceId && upsertWorktreeMeta(workspaceId, wt, { color }),

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -45,6 +45,7 @@ import { useWorkspacePanelTree } from '../lib/workspace/useWorkspacePanelTree'
 import { revealPanel } from '../lib/workspace/panelReveal'
 import { openFileAsPanel } from '../lib/fs/fileRouting'
 import { getRecentFiles } from '../lib/fs/recentFiles'
+import { pathDisplayName, relativeDisplayPath } from '../lib/fs/displayPath'
 import { cateAgentController } from '../cateAgent/cateAgentController'
 
 // -----------------------------------------------------------------------------
@@ -314,8 +315,8 @@ export const CommandPalette: React.FC = () => {
       .filter((p) => !openPaths.has(p))
       .map((p) => ({
         path: p,
-        name: p.split('/').pop() ?? p,
-        relativePath: rootPath && p.startsWith(rootPath) ? p.slice(rootPath.length).replace(/^\/+/, '') : p,
+        name: pathDisplayName(p) || p,
+        relativePath: relativeDisplayPath(p, rootPath ?? ''),
       }))
   }, [query, panels, selectedWorkspaceId, rootPath])
 

--- a/src/runtime/capabilities/file.test.ts
+++ b/src/runtime/capabilities/file.test.ts
@@ -1,0 +1,70 @@
+// Atomic write behavior of the daemon file capability: tmp+rename (no stray
+// tmp left behind), existing-mode preservation across the inode swap, symlink
+// refusal, and parent-dir creation. Same code serves local and remote hosts.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { writeFile, writeBinary, readFile } from './file'
+
+const posixIt = process.platform === 'win32' ? it.skip : it
+
+let dir: string
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(tmpdir(), 'cate-file-cap-'))
+})
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('writeFile (atomic)', () => {
+  it('writes content and leaves no tmp file behind', async () => {
+    const target = path.join(dir, 'a.json')
+    await writeFile(target, '{"ok":true}')
+    expect(await readFile(target)).toBe('{"ok":true}')
+    expect(await fs.readdir(dir)).toEqual(['a.json'])
+  })
+
+  it('creates missing parent directories', async () => {
+    const target = path.join(dir, 'nested', 'deep', 'b.txt')
+    await writeFile(target, 'x')
+    expect(await readFile(target)).toBe('x')
+  })
+
+  it('overwrites an existing file completely', async () => {
+    const target = path.join(dir, 'c.txt')
+    await writeFile(target, 'long original content')
+    await writeFile(target, 'short')
+    expect(await readFile(target)).toBe('short')
+    expect(await fs.readdir(dir)).toEqual(['c.txt'])
+  })
+
+  posixIt('preserves the existing file mode across the rename (executable bit survives a save)', async () => {
+    const target = path.join(dir, 'script.sh')
+    await writeFile(target, '#!/bin/sh\necho one\n')
+    await fs.chmod(target, 0o755)
+    await writeFile(target, '#!/bin/sh\necho two\n')
+    const mode = (await fs.stat(target)).mode & 0o7777
+    expect(mode).toBe(0o755)
+  })
+
+  posixIt('refuses to write through a symlink', async () => {
+    const real = path.join(dir, 'real.txt')
+    const link = path.join(dir, 'link.txt')
+    await fs.writeFile(real, 'original')
+    await fs.symlink(real, link)
+    await expect(writeFile(link, 'clobber')).rejects.toThrow(/symbolic link/)
+    expect(await fs.readFile(real, 'utf-8')).toBe('original')
+  })
+})
+
+describe('writeBinary (atomic)', () => {
+  it('round-trips bytes and leaves no tmp file behind', async () => {
+    const target = path.join(dir, 'blob.bin')
+    const bytes = Buffer.from([0, 1, 2, 255, 254, 128])
+    await writeBinary(target, bytes)
+    expect(await fs.readFile(target)).toEqual(bytes)
+    expect(await fs.readdir(dir)).toEqual(['blob.bin'])
+  })
+})

--- a/src/runtime/capabilities/file.ts
+++ b/src/runtime/capabilities/file.ts
@@ -30,18 +30,74 @@ async function assertNotSymlink(filePath: string): Promise<void> {
   }
 }
 
-export async function writeFile(filePath: string, content: string): Promise<void> {
+// ---------------------------------------------------------------------------
+// Atomic writes — every write through the runtime is tmp+rename, so a crash
+// mid-write can never leave a truncated file, on any host. This mirrors the
+// main process's writeJsonAtomic (src/main/writeJsonAtomic.ts): per-write
+// unique tmp in the same directory (rename is atomic on the same fs; unique so
+// concurrent writes can't consume each other's tmp), win32 rename retry for
+// the transient EPERM that MoveFileEx(REPLACE_EXISTING) hits when racing an
+// antivirus/indexer handle. The target's existing mode is copied onto the tmp
+// BEFORE the rename (a plain write preserves the inode's mode; a rename
+// replaces the inode — without this an editor save would strip a script's
+// executable bit).
+// ---------------------------------------------------------------------------
+
+let tmpSeq = 0
+function uniqueTmpPath(filePath: string): string {
+  tmpSeq = (tmpSeq + 1) & 0x7fffffff
+  return `${filePath}.${process.pid}.${tmpSeq}.tmp`
+}
+
+const RENAME_RETRY_CODES = new Set(['EPERM', 'EACCES', 'EBUSY'])
+const RENAME_MAX_RETRIES = 10
+const RENAME_RETRY_STEP_MS = 20
+
+async function renameWithRetry(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fs.rename(from, to)
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      const retryable =
+        process.platform === 'win32' &&
+        attempt < RENAME_MAX_RETRIES &&
+        code !== undefined &&
+        RENAME_RETRY_CODES.has(code)
+      if (!retryable) throw err
+      await new Promise((r) => setTimeout(r, RENAME_RETRY_STEP_MS * (attempt + 1)))
+    }
+  }
+}
+
+async function writeAtomic(filePath: string, data: string | Buffer): Promise<void> {
   await assertNotSymlink(filePath)
   await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, content, 'utf-8')
+  const existingMode = await fs
+    .stat(filePath)
+    .then((s) => s.mode & 0o7777)
+    .catch(() => null) // no existing file — the tmp's default mode applies
+  const tmp = uniqueTmpPath(filePath)
+  try {
+    await fs.writeFile(tmp, data, 'utf-8') // encoding ignored for Buffers
+    if (existingMode !== null) {
+      await fs.chmod(tmp, existingMode).catch(() => { /* no modes on this fs */ })
+    }
+    await renameWithRetry(tmp, filePath)
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => { /* never written */ })
+    throw err
+  }
+}
+
+export async function writeFile(filePath: string, content: string): Promise<void> {
+  await writeAtomic(filePath, content)
 }
 
 /** Write raw bytes (used by remote upload, where the source is read client-side
  *  and the contents are streamed in as a Buffer). Creates the parent directory. */
 export async function writeBinary(filePath: string, data: Buffer): Promise<void> {
-  await assertNotSymlink(filePath)
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, data)
+  await writeAtomic(filePath, data)
 }
 
 /** lstat + reject symlinks, returning the directory/file discriminator. */

--- a/src/runtime/capabilities/fileWatcher.ts
+++ b/src/runtime/capabilities/fileWatcher.ts
@@ -17,8 +17,10 @@
 // editor reload in one workspace share a single OS watcher), and events fan out
 // only to subscribers whose prefix actually covers the changed path.
 //
-// Both call sites delegate here: the local IPC pool (main/ipc/filesystem.ts)
-// and the daemon's watch capability (runtime/capabilities/index.ts).
+// The daemon's watch capability (runtime/capabilities/index.ts) is the ONLY
+// call site — main/ipc/filesystem.ts routes every watch (local and remote)
+// through runtime.file.watch, so all workspaces share these exact event
+// semantics.
 // =============================================================================
 
 import nativeWatcher from '@parcel/watcher'

--- a/src/runtime/capabilities/vcs.gitMissing.test.ts
+++ b/src/runtime/capabilities/vcs.gitMissing.test.ts
@@ -1,0 +1,48 @@
+// The git-missing guard: on a host without git, every VcsHost op that spawns
+// git must fail with the actionable GIT_MISSING message instead of a raw
+// `spawn git ENOENT`. Forced by pointing PATH at an empty temp dir (POSIX-only:
+// win32 binary resolution goes through PATHEXT and shells with different
+// failure shapes).
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { createVcsCapability } from './vcs'
+
+const posixTest = process.platform === 'win32' ? test.skip : test
+
+const access = { scopeId: 'vcs-test' }
+
+describe('vcs — git missing on host', () => {
+  let root: string
+  let oldPath: string | undefined
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-nogit-'))
+    oldPath = process.env.PATH
+  })
+
+  afterEach(async () => {
+    process.env.PATH = oldPath
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  posixTest('status fails with the clear install-git message, not a raw spawn error', async () => {
+    await fs.mkdir(path.join(root, '.git'), { recursive: true })
+    // simple-git resolves `git` off process.env at spawn time; the guard's
+    // probe uses the injected env. Point both at an empty dir.
+    process.env.PATH = root
+    const vcs = createVcsCapability({ env: () => ({ PATH: root }), scopeId: 'vcs-test' })
+    await expect(vcs.status(root, access)).rejects.toThrow(/git was not found on this host/)
+  })
+
+  posixTest('ops that never spawn git are unaffected', async () => {
+    process.env.PATH = root
+    const vcs = createVcsCapability({ env: () => ({ PATH: root }), scopeId: 'vcs-test' })
+    // isRepo is an fs check (.git presence), no git binary involved.
+    expect(await vcs.isRepo(root, access)).toBe(false)
+    await fs.mkdir(path.join(root, '.git'), { recursive: true })
+    expect(await vcs.isRepo(root, access)).toBe(true)
+  })
+})

--- a/src/runtime/capabilities/vcs.ts
+++ b/src/runtime/capabilities/vcs.ts
@@ -63,6 +63,47 @@ export interface VcsCapabilityDeps {
   scopeId: string
 }
 
+// Every git op fails with a raw `spawn git ENOENT` on a host without git — the
+// only runtime dependency that is NOT bundled into the tarball (node, rg, pi
+// are). Detect that case and replace it with an actionable message; a probe
+// failure is not cached, so installing git mid-session recovers on the next op.
+const GIT_MISSING_MESSAGE =
+  'git was not found on this host. Install git (and re-open the workspace if needed) to use source control.'
+
+function looksLikeMissingGit(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes('spawn git ENOENT') || /'git' is not recognized/i.test(msg)
+}
+
+/** Wrap every VcsHost method: when an op fails in the shape of a missing git
+ *  binary AND a `git --version` probe confirms it, throw the clear message
+ *  instead of the raw spawn error. Anything else rethrows untouched. */
+function guardGitMissing(host: VcsHost, env: () => NodeJS.ProcessEnv): VcsHost {
+  let probe: Promise<boolean> | null = null
+  const gitAvailable = (): Promise<boolean> =>
+    (probe ??= execFileP('git', ['--version'], { env: env() }).then(
+      () => true,
+      () => {
+        probe = null // re-probe next time: installing git recovers without a reconnect
+        return false
+      },
+    ))
+  const guarded = {} as Record<string, unknown>
+  for (const [key, method] of Object.entries(host)) {
+    guarded[key] = async (...args: unknown[]) => {
+      try {
+        return await (method as (...a: unknown[]) => Promise<unknown>)(...args)
+      } catch (err) {
+        if (looksLikeMissingGit(err) && !(await gitAvailable())) {
+          throw new Error(GIT_MISSING_MESSAGE)
+        }
+        throw err
+      }
+    }
+  }
+  return guarded as unknown as VcsHost
+}
+
 export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
   const env = () => deps.env()
   // Validate the cwd against the calling workspace's scope. No fallback to the
@@ -148,7 +189,7 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
     }
   }
 
-  return {
+  const host: VcsHost = {
     async isRepo(dir, access) {
       return isGitRepo(validateCwd(dir, access))
     },
@@ -443,4 +484,5 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
       }
     },
   }
+  return guardGitMissing(host, env)
 }

--- a/src/runtime/cateCli.test.ts
+++ b/src/runtime/cateCli.test.ts
@@ -1,18 +1,14 @@
-// catePathEnv gates on CATE_API and only prepends when the bundled CLI dir
-// actually exists (dev/direct mode has no extracted tarball). We can't force the
-// tarball layout in a unit test, so we assert the gate behaviour that does not
-// depend on the filesystem, plus that a present PATH is preserved when it no-ops.
+// catePathEnv prepends the bundled CLI dir whenever it exists — NOT gated on
+// CATE_API, so `cate` is callable (with a how-to-enable message) even while the
+// endpoint is disabled. We can't force the tarball layout in a unit test, so we
+// assert the behaviour that does not depend on the filesystem, plus that a
+// present PATH is preserved when it no-ops (dev/direct mode has no tarball).
 import { describe, it, expect } from 'vitest'
 import { catePathEnv, cateBinDir, cateCliPath } from './cateCli'
 import { existsSync } from 'fs'
 import path from 'path'
 
 describe('catePathEnv', () => {
-  it('no-ops when CATE_API is absent (CLI disabled / not injected)', () => {
-    const env = { PATH: '/usr/bin' }
-    expect(catePathEnv(env)).toEqual(env)
-  })
-
   it('returns env unchanged (never drops keys) regardless of the tarball state', () => {
     const env = { PATH: '/usr/bin', CATE_API: 'http://127.0.0.1:1', FOO: 'bar' }
     const out = catePathEnv(env)
@@ -23,8 +19,8 @@ describe('catePathEnv', () => {
     expect(out.PATH).toContain('/usr/bin')
   })
 
-  it('prepends cateBinDir() to PATH when the CLI dir exists and CATE_API is set', () => {
-    const env = { PATH: '/usr/bin', CATE_API: 'http://127.0.0.1:1' }
+  it('prepends cateBinDir() to PATH even without CATE_API (disabled endpoint keeps `cate` callable)', () => {
+    const env = { PATH: '/usr/bin' }
     const out = catePathEnv(env)
     if (existsSync(cateBinDir())) {
       expect(out.PATH).toBe(cateBinDir() + path.delimiter + '/usr/bin')

--- a/src/runtime/cateCli.ts
+++ b/src/runtime/cateCli.ts
@@ -22,15 +22,16 @@ export function cateCliPath(): string {
   return path.join(installRoot(), 'cate', 'dist', 'cli.cjs')
 }
 
-/** Put the bundled `cate` on a spawn env's PATH so agents can run it — but only
- *  when a CLI endpoint was injected (CATE_API present), keeping this consistent
- *  with the enable/disable gate (disabled ⇒ no endpoint AND no `cate`). Runs
- *  daemon-side (process.execPath == the tarball node), where cateBinDir() is
- *  correct for local and remote hosts. No-ops when the CLI dir is absent
+/** Put the bundled `cate` on a spawn env's PATH so agents and users can run it.
+ *  Unconditional (not gated on CATE_API): the endpoint env is the real on/off
+ *  switch, and keeping `cate` on PATH while the endpoint is disabled means
+ *  running it prints how to enable the setting (see the EnvError message in
+ *  src/cli/cate.ts) instead of a discoverability-killing "command not found".
+ *  Runs daemon-side (process.execPath == the tarball node), where cateBinDir()
+ *  is correct for local and remote hosts. No-ops when the CLI dir is absent
  *  (dev/direct mode runs the daemon from source, with no extracted tarball).
  *  Finds the PATH key case-insensitively (Windows uses `Path`). */
 export function catePathEnv(env: Record<string, string>): Record<string, string> {
-  if (!env.CATE_API) return env
   const binDir = presentBinDir()
   if (!binDir) return env
   const key = Object.keys(env).find((k) => k.toUpperCase() === 'PATH') ?? 'PATH'

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -13,6 +13,7 @@ import { RpcServer } from './rpcServer'
 import { buildDaemonRuntime } from './capabilities'
 import { hostExtensionsRoot } from './capabilities/extensions'
 import { reapOrphanServers } from './capabilities/server'
+import { applyLoginEnv } from './loginEnv'
 
 interface DaemonArgs {
   root: string
@@ -40,8 +41,13 @@ function parseArgs(argv: string[]): DaemonArgs {
   return { root, id, exclusions, idleSuspend }
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
+
+  // Merge the user's login-shell env over process.env (skipped when the
+  // launcher already resolved it — see loginEnv.ts). Awaited so the very first
+  // spawn sees the same PATH a local daemon gets from getShellEnv().
+  await applyLoginEnv()
 
   // The daemon's filesystem sandbox: its workspace root (plus the system temp
   // dir, which pathValidation always allows). Everything the client asks for is
@@ -89,4 +95,4 @@ function main(): void {
   server.start()
 }
 
-main()
+void main()

--- a/src/runtime/loginEnv.test.ts
+++ b/src/runtime/loginEnv.test.ts
@@ -1,0 +1,33 @@
+// applyLoginEnv: the launcher marker skips the capture (and never leaks to
+// children), and a real capture on POSIX merges the login-shell env over
+// process.env without dropping anything.
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyLoginEnv, LOGIN_ENV_MARKER } from './loginEnv'
+
+const posixIt = process.platform === 'win32' ? it.skip : it
+
+const savedShell = process.env.SHELL
+
+afterEach(() => {
+  delete process.env[LOGIN_ENV_MARKER]
+  if (savedShell === undefined) delete process.env.SHELL
+  else process.env.SHELL = savedShell
+})
+
+describe('applyLoginEnv', () => {
+  it('consumes the launcher marker and skips the capture', async () => {
+    process.env[LOGIN_ENV_MARKER] = '1'
+    const pathBefore = process.env.PATH
+    await applyLoginEnv()
+    expect(process.env[LOGIN_ENV_MARKER]).toBeUndefined() // never inherited by children
+    expect(process.env.PATH).toBe(pathBefore)
+  })
+
+  posixIt('captures the login-shell env and keeps PATH defined', async () => {
+    process.env.SHELL = '/bin/sh' // deterministic, always present on POSIX
+    await applyLoginEnv()
+    expect(process.env.PATH).toBeTruthy()
+    expect(process.env[LOGIN_ENV_MARKER]).toBeUndefined()
+  }, 15_000)
+})

--- a/src/runtime/loginEnv.ts
+++ b/src/runtime/loginEnv.ts
@@ -1,0 +1,85 @@
+// =============================================================================
+// loginEnv — give the daemon the user's LOGIN-SHELL environment on every host.
+//
+// The LOCAL daemon is spawned by Electron with getShellEnv() (the login env
+// captured in src/main/shellEnv.ts), but a remote daemon is launched over a
+// non-interactive SSH exec channel / `wsl.exe -e`, which inherits only the bare
+// system env. That env seeds every non-terminal child the daemon spawns (the
+// pi agent, extension servers, git/gh), so tools on ~/.local/bin, nvm, pyenv
+// were visible locally and missing remotely for the same setup.
+//
+// Fix: the daemon captures its own login env at startup (`$SHELL -ilc env -0`,
+// mirroring shellEnv.ts) and merges it over process.env, which every capability
+// reads live. Hosts whose launcher ALREADY resolved the login env (the local
+// transport) set CATE_LOGIN_ENV_RESOLVED=1 to skip the capture — the marker is
+// consumed (deleted) either way so children never inherit it. Windows has no
+// login-shell concept; skipped there, matching shellEnv.ts.
+// =============================================================================
+
+import { spawn } from 'child_process'
+import { resolveShell } from './capabilities/shellResolver'
+
+/** Set by launchers that already resolved the login env (localTransport). */
+export const LOGIN_ENV_MARKER = 'CATE_LOGIN_ENV_RESOLVED'
+
+/** Cap on the capture shell; a pathological rc file must not stall daemon
+ *  startup (the client's connect handshake is waiting on the hello frame). */
+const CAPTURE_TIMEOUT_MS = 8_000
+
+/** Parse NUL-delimited `env -0` output (mirrors shellEnv.ts parseEnv). */
+function parseEnvZ(raw: string): Record<string, string> | null {
+  if (!raw) return null
+  const env: Record<string, string> = {}
+  for (const entry of raw.split('\0')) {
+    const idx = entry.indexOf('=')
+    if (idx > 0) env[entry.slice(0, idx)] = entry.slice(idx + 1)
+  }
+  return env
+}
+
+function captureLoginEnv(shell: string): Promise<Record<string, string> | null> {
+  return new Promise((resolve) => {
+    let done = false
+    const finish = (v: Record<string, string> | null): void => {
+      if (!done) {
+        done = true
+        resolve(v)
+      }
+    }
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(shell, ['-ilc', 'env -0'], { stdio: ['ignore', 'pipe', 'ignore'] })
+    } catch {
+      return finish(null)
+    }
+    let out = ''
+    child.stdout?.on('data', (c: Buffer) => { out += c.toString() })
+    child.on('close', () => finish(parseEnvZ(out)))
+    child.on('error', () => finish(null))
+    const timer = setTimeout(() => {
+      try { child.kill() } catch { /* already exited */ }
+      finish(null)
+    }, CAPTURE_TIMEOUT_MS)
+    timer.unref()
+  })
+}
+
+/** Resolve the login-shell env and merge it over process.env. Best effort —
+ *  a failed/timed-out capture leaves the env untouched. Call once at daemon
+ *  startup, BEFORE serving requests, so the first spawn already sees it. */
+export async function applyLoginEnv(): Promise<void> {
+  const alreadyResolved = process.env[LOGIN_ENV_MARKER] === '1'
+  delete process.env[LOGIN_ENV_MARKER] // never leaks into spawned children
+  if (alreadyResolved || process.platform === 'win32') return
+
+  const shell = resolveShell(process.env.SHELL).path
+  const captured = await captureLoginEnv(shell)
+  // A capture without PATH is a failed capture — don't degrade the env.
+  if (!captured?.PATH) return
+  for (const [key, value] of Object.entries(captured)) {
+    // Same scrub as shellEnv.sanitizeEnv: never propagate Electron/npm
+    // lifecycle vars into everything the daemon spawns.
+    if (key.startsWith('ELECTRON_') || key.startsWith('npm_')) continue
+    process.env[key] = value
+  }
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -731,11 +731,18 @@ export interface ElectronAPI {
   /** Ask main to focus the window that owns `panelId` and reveal it. */
   focusWindowPanel(panelId: string): Promise<void>
 
+  /** Ask main to have the window that owns `panelId` close it (behind that
+   *  window's own dirty/running confirmation gates). */
+  closeWindowPanel(panelId: string): Promise<void>
+
   /** Report this window's panels (across its workspaces) for cross-window discovery. */
   reportWindowPanels(report: WindowPanelReport[]): Promise<void>
 
   /** This window owns `panelId` — bring it forward within this window. */
   onRevealPanelInWindow(callback: (panelId: string) => void): () => void
+
+  /** This window owns `panelId` — close it (with the usual confirmation gates). */
+  onClosePanelInWindow(callback: (panelId: string) => void): () => void
 
   // ---------------------------------------------------------------------------
   // Cross-window drag coordination

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -300,6 +300,8 @@ export const DOCK_WINDOW_FLUSH_SYNC_DONE = 'dock:windowFlushSyncDone' // rendere
 export const WINDOW_PANELS_CHANGED = 'window:panelsChanged'   // main -> renderer (broadcast)
 export const FOCUS_WINDOW_PANEL = 'window:focusPanel'         // renderer -> main
 export const REVEAL_PANEL_IN_WINDOW = 'detached:revealPanelInWindow' // main -> owning renderer
+export const CLOSE_WINDOW_PANEL = 'window:closePanel'         // renderer -> main
+export const CLOSE_PANEL_IN_WINDOW = 'detached:closePanelInWindow' // main -> owning renderer
 export const WINDOW_PANELS_REPORT = 'window:panelsReport'     // renderer -> main (this window's panels)
 
 // Cross-window drag coordination

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1370,12 +1370,24 @@ export interface AppSettings {
   autoSuspendIdleTerminals: boolean
   /** Enable the `cate` command-line control endpoint. When on, terminals and the
    *  pi agent get a per-workspace CATE_API loopback endpoint + bearer token in
-   *  their env so a `cate` CLI can drive Cate (browser, panels, editor, canvas).
+   *  their env so the `cate` CLI can drive Cate (browser, panels, editor, canvas).
    *  When OFF (fail closed): no endpoint is opened and no env is injected, so the
-   *  CLI is unreachable. Off by default (opt-in): the token lands in the env of
-   *  every process spawned in a terminal, so any of them (e.g. an npm postinstall)
-   *  could drive the browser on the user's live session. The user turns it on. */
+   *  CLI is unreachable — `cate` stays on PATH but only explains how to enable it.
+   *  On by default. The trade-off: the token lands in the env of every process
+   *  spawned in a terminal, so any of them (e.g. an npm postinstall) could drive
+   *  the browser on the user's live session — turn it off to close that.
+   *  Existing installs keep the value already written in their settings.json
+   *  (the file is seeded with full defaults on first run). */
   cliEnabled: boolean
+  /** Auto-install the bundled cate-cli skill so agents learn the `cate` command:
+   *  seeded into each opened workspace through the skills installer, the same
+   *  way for local and remote hosts — Cate's own agent always, other supported
+   *  agents (Claude Code, Pi, OpenCode, Codex, Antigravity) when their tool dir
+   *  exists there (see seedCateCliSkill).
+   *  Seeds at most once per workspace/target, never overwrites edits, and an
+   *  uninstall sticks. Turning this off stops future installs; it does not
+   *  remove an already-installed skill. */
+  cliSkillInstallEnabled: boolean
 
   // Browser
   browserHomepage: string
@@ -1505,7 +1517,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   terminalCursorBlink: false,
   terminalOptionIsMeta: true,
   autoSuspendIdleTerminals: true,
-  cliEnabled: false,
+  cliEnabled: true,
+  cliSkillInstallEnabled: true,
 
   // Browser
   browserHomepage: '',

--- a/src/skills/main/seedCateCliSkill.test.ts
+++ b/src/skills/main/seedCateCliSkill.test.ts
@@ -24,30 +24,34 @@ const CATE_AGENT_SKILL = `${WS}/.cate/pi-agent/skills/cate-cli/SKILL.md`
 const CLAUDE_SKILL = `${WS}/.claude/skills/cate-cli/SKILL.md`
 
 // In-memory host filesystem behind runtime.file. mkdir is lax about parents —
-// the installer's mkdirp walks level-by-level anyway.
+// the installer's mkdirp walks level-by-level anyway. Keys are normalized to
+// forward slashes: the local runtime builds paths with path.join, which uses
+// backslashes on Windows, while the test constants are POSIX.
 let files: Map<string, string>
 let dirs: Set<string>
+
+const norm = (p: string): string => p.replace(/\\/g, '/')
 
 function makeRuntime() {
   return {
     file: {
       readFile: async (p: string) => {
-        const v = files.get(p)
+        const v = files.get(norm(p))
         if (v === undefined) throw new Error(`ENOENT: ${p}`)
         return v
       },
       writeFile: async (p: string, content: string) => {
-        files.set(p, content)
+        files.set(norm(p), content)
       },
       writeBinary: async (p: string, buf: Buffer) => {
-        files.set(p, buf.toString('utf8'))
+        files.set(norm(p), buf.toString('utf8'))
       },
       mkdir: async (p: string) => {
-        dirs.add(p)
+        dirs.add(norm(p))
       },
       stat: async (p: string) => {
-        if (dirs.has(p)) return { isDirectory: true, isFile: false }
-        if (files.has(p)) return { isDirectory: false, isFile: true }
+        if (dirs.has(norm(p))) return { isDirectory: true, isFile: false }
+        if (files.has(norm(p))) return { isDirectory: false, isFile: true }
         throw new Error(`ENOENT: ${p}`)
       },
     },

--- a/src/skills/main/seedCateCliSkill.test.ts
+++ b/src/skills/main/seedCateCliSkill.test.ts
@@ -1,0 +1,136 @@
+// Coverage for seedCateCliSkill: the cliSkillInstallEnabled gate, cate-agent
+// always seeded, dir-presence gating for other targets, seed-once markers
+// (edits never clobbered, uninstalls stick), and marker-only handling of a
+// pre-existing manual install. Uses an in-memory fake runtime.file and the REAL
+// bundled skills/cate-cli dir (app.getAppPath() → repo root).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const settingsState = vi.hoisted(() => ({ cliSkillInstallEnabled: true as unknown }))
+const resolve = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({ app: { getAppPath: () => process.cwd() } }))
+vi.mock('../../main/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+vi.mock('../../main/settingsFile', () => ({
+  getSetting: (k: string) => (settingsState as Record<string, unknown>)[k],
+}))
+vi.mock('../../main/runtime/runtimeManager', () => ({ runtimes: { resolve } }))
+
+import { seedCateCliSkill } from './seedCateCliSkill'
+
+const WS = '/ws'
+const MANIFEST = `${WS}/.cate/skills.json`
+const CATE_AGENT_SKILL = `${WS}/.cate/pi-agent/skills/cate-cli/SKILL.md`
+const CLAUDE_SKILL = `${WS}/.claude/skills/cate-cli/SKILL.md`
+
+// In-memory host filesystem behind runtime.file. mkdir is lax about parents —
+// the installer's mkdirp walks level-by-level anyway.
+let files: Map<string, string>
+let dirs: Set<string>
+
+function makeRuntime() {
+  return {
+    file: {
+      readFile: async (p: string) => {
+        const v = files.get(p)
+        if (v === undefined) throw new Error(`ENOENT: ${p}`)
+        return v
+      },
+      writeFile: async (p: string, content: string) => {
+        files.set(p, content)
+      },
+      writeBinary: async (p: string, buf: Buffer) => {
+        files.set(p, buf.toString('utf8'))
+      },
+      mkdir: async (p: string) => {
+        dirs.add(p)
+      },
+      stat: async (p: string) => {
+        if (dirs.has(p)) return { isDirectory: true, isFile: false }
+        if (files.has(p)) return { isDirectory: false, isFile: true }
+        throw new Error(`ENOENT: ${p}`)
+      },
+    },
+  }
+}
+
+function manifest(): { skills: Array<{ skillId: string; targetId: string }>; seeded?: string[] } {
+  return JSON.parse(files.get(MANIFEST) ?? '{"skills":[]}')
+}
+
+beforeEach(() => {
+  settingsState.cliSkillInstallEnabled = true
+  files = new Map()
+  dirs = new Set([WS])
+  resolve.mockReset()
+  resolve.mockReturnValue(makeRuntime())
+})
+
+describe('seedCateCliSkill', () => {
+  it('does nothing when the setting is off', async () => {
+    settingsState.cliSkillInstallEnabled = false
+    await seedCateCliSkill(WS)
+    expect(files.size).toBe(0)
+  })
+
+  it('seeds cate-agent always, skips targets whose tool dir is absent', async () => {
+    await seedCateCliSkill(WS)
+    expect(files.get(CATE_AGENT_SKILL)).toContain('name: cate-cli')
+    expect(files.has(CLAUDE_SKILL)).toBe(false)
+    const m = manifest()
+    expect(m.skills).toEqual([expect.objectContaining({ skillId: 'cate/cate-cli', targetId: 'cate-agent' })])
+    expect(m.seeded).toEqual(['cate/cate-cli:cate-agent'])
+  })
+
+  it('seeds a target once its tool dir exists', async () => {
+    dirs.add(`${WS}/.claude`)
+    await seedCateCliSkill(WS)
+    expect(files.has(CLAUDE_SKILL)).toBe(true)
+    const m = manifest()
+    expect(m.seeded).toContain('cate/cate-cli:claude-code')
+    expect(m.seeded).toContain('cate/cate-cli:cate-agent')
+  })
+
+  it('a tool dir appearing later is picked up by the next open', async () => {
+    await seedCateCliSkill(WS)
+    expect(files.has(CLAUDE_SKILL)).toBe(false)
+    dirs.add(`${WS}/.claude`)
+    await seedCateCliSkill(WS)
+    expect(files.has(CLAUDE_SKILL)).toBe(true)
+  })
+
+  it('never rewrites a seeded copy (edits survive re-open)', async () => {
+    await seedCateCliSkill(WS)
+    files.set(CATE_AGENT_SKILL, 'user edited')
+    await seedCateCliSkill(WS)
+    expect(files.get(CATE_AGENT_SKILL)).toBe('user edited')
+  })
+
+  it('an uninstall sticks: marker present but skill gone -> not reinstalled', async () => {
+    await seedCateCliSkill(WS)
+    // Simulate the modal's uninstall: file and manifest entry removed, marker kept.
+    files.delete(CATE_AGENT_SKILL)
+    files.set(MANIFEST, JSON.stringify({ skills: [], seeded: ['cate/cate-cli:cate-agent'] }))
+    await seedCateCliSkill(WS)
+    expect(files.has(CATE_AGENT_SKILL)).toBe(false)
+  })
+
+  it('a pre-existing manual install just gets its marker, no overwrite', async () => {
+    files.set(CATE_AGENT_SKILL, 'manually installed, edited')
+    files.set(
+      MANIFEST,
+      JSON.stringify({ skills: [{ skillId: 'cate/cate-cli', name: 'cate-cli', targetId: 'cate-agent', path: CATE_AGENT_SKILL, origin: 'local' }] }),
+    )
+    await seedCateCliSkill(WS)
+    expect(files.get(CATE_AGENT_SKILL)).toBe('manually installed, edited')
+    expect(manifest().seeded).toContain('cate/cate-cli:cate-agent')
+  })
+
+  it('is a no-op when the runtime is not connected yet', async () => {
+    resolve.mockImplementation(() => {
+      throw new Error('not connected')
+    })
+    await expect(seedCateCliSkill(WS)).resolves.toBeUndefined()
+    expect(files.size).toBe(0)
+  })
+})

--- a/src/skills/main/seedCateCliSkill.ts
+++ b/src/skills/main/seedCateCliSkill.ts
@@ -1,0 +1,138 @@
+// =============================================================================
+// seedCateCliSkill — auto-install the bundled cate-cli skill into a workspace
+// through the SAME path the skills modal uses (writeSkillToWorkspace), so it is
+// per-target, runtime-aware (local AND remote hosts) and tracked in
+// <ws>/.cate/skills.json like any other install.
+//
+// Policy, evaluated whenever a workspace and its runtime are both present:
+// at workspace open (createWorkspace), when a folder is attached to a workspace
+// (updateWorkspace), and when a runtime (re)connects (replaySkillSeeds) — the
+// last one is what makes remote workspaces behave like local ones, since their
+// runtime connects only after create/attach.
+//   - gated by the cliSkillInstallEnabled setting (Settings → Terminal);
+//   - `cate-agent` is always seeded — it is Cate's own agent and `.cate/` is
+//     already Cate-managed;
+//   - every other target (claude-code, pi-native, opencode, codex, antigravity)
+//     is seeded only when its tool dir (`.claude`, `.agents`, …) already exists
+//     in the workspace, so repos don't grow dot-dirs for agents nobody uses
+//     there. A tool dir created later is picked up on a subsequent open.
+//   - each (skill, target) seeds AT MOST ONCE per workspace (a `seeded` marker
+//     in skills.json), so a user uninstall sticks and an edited copy is never
+//     overwritten. An already-installed copy just gets its marker.
+//
+// Files come from the app bundle (skills/cate-cli, shipped via extraResources)
+// — not GitHub — so seeding works offline and always matches the app version.
+// =============================================================================
+
+import fs from 'fs'
+import fsp from 'fs/promises'
+import path from 'path'
+import { app } from 'electron'
+import log from '../../main/logger'
+import { getSetting } from '../../main/settingsFile'
+import { parseLocator } from '../../main/runtime/locator'
+import { runtimes } from '../../main/runtime/runtimeManager'
+import { hostJoin } from '../../agent/main/agentDir'
+import type { Runtime } from '../../main/runtime/types'
+import { SKILL_TARGETS, type SkillTargetId } from '../../shared/skills'
+import { toolDirSegment } from './targets'
+import { readManifest, readSeededMarkers, addSeededMarker, writeSkillToWorkspace } from './skillsInstaller'
+import type { SkillFile } from './githubCrawl'
+
+// Matches the registry entry (registry/skills-index.json), so a modal install
+// and a seeded install are the same skill to the manifest.
+const SKILL_ID = 'cate/cate-cli'
+const SKILL_NAME = 'cate-cli'
+
+/** Source dir of the bundled skill: dev path (repo skills/ on disk) first, then
+ *  the packaged extraResources copy — same resolution as installBundledSkill. */
+function bundledSkillDir(): string | null {
+  const candidates = [
+    path.join(app.getAppPath(), 'skills', SKILL_NAME),
+    path.join(process.resourcesPath ?? '', 'skills', SKILL_NAME),
+  ]
+  for (const c of candidates) {
+    if (c && fs.existsSync(c)) return c
+  }
+  return null
+}
+
+/** Read the bundled skill's files as SkillFile[]. Skill bundles are text
+ *  (SKILL.md + optional companions) — read as UTF-8. */
+async function readBundledFiles(dir: string, base = ''): Promise<SkillFile[]> {
+  const out: SkillFile[] = []
+  for (const entry of await fsp.readdir(dir, { withFileTypes: true })) {
+    const rel = base ? `${base}/${entry.name}` : entry.name
+    const abs = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await readBundledFiles(abs, rel)))
+    } else if (entry.isFile()) {
+      out.push({ relPath: rel, text: await fsp.readFile(abs, 'utf8') })
+    }
+  }
+  return out
+}
+
+async function dirExists(runtime: Runtime, hostPath: string): Promise<boolean> {
+  try {
+    return (await runtime.file.stat(hostPath)).isDirectory
+  } catch {
+    return false
+  }
+}
+
+/** Seed the bundled cate-cli skill into a workspace. Best effort and NEVER
+ *  rejects (safe to call fire-and-forget at workspace open) — a failed target
+ *  is retried on the next open or runtime connect, since no marker is written
+ *  for it. */
+export async function seedCateCliSkill(cwd: string): Promise<void> {
+  try {
+    await seed(cwd)
+  } catch (err) {
+    log.warn('[skills-seed] seeding %s failed for %s: %O', SKILL_NAME, cwd, err)
+  }
+}
+
+async function seed(cwd: string): Promise<void> {
+  if (getSetting('cliSkillInstallEnabled') !== true) return
+  const { runtimeId, path: hostCwd } = parseLocator(cwd)
+  if (!hostCwd) return
+
+  let runtime: Runtime
+  try {
+    runtime = runtimes.resolve(runtimeId)
+  } catch {
+    return // runtime not registered yet — the runtime-connect replay retries
+  }
+
+  const srcDir = bundledSkillDir()
+  if (!srcDir) {
+    log.warn('[skills-seed] bundled %s dir not found — nothing seeded', SKILL_NAME)
+    return
+  }
+
+  const seeded = await readSeededMarkers(runtime, runtimeId, hostCwd)
+  const targets = SKILL_TARGETS.map((t) => t.id).filter(
+    (t: SkillTargetId) => !seeded.includes(`${SKILL_ID}:${t}`),
+  )
+  if (targets.length === 0) return
+
+  let files: SkillFile[] | null = null
+  const installed = await readManifest(runtime, runtimeId, hostCwd)
+  for (const targetId of targets) {
+    if (
+      targetId !== 'cate-agent' &&
+      !(await dirExists(runtime, hostJoin(runtimeId, hostCwd, toolDirSegment(targetId))))
+    ) {
+      continue
+    }
+    // Already installed (e.g. manually via the modal before seeding existed):
+    // don't rewrite over possible user edits — just record the marker.
+    if (!installed.some((m) => m.skillId === SKILL_ID && m.targetId === targetId)) {
+      files ??= await readBundledFiles(srcDir)
+      await writeSkillToWorkspace({ skillId: SKILL_ID, name: SKILL_NAME, targetId, cwd, files, origin: 'local' })
+      log.info('[skills-seed] seeded %s for %s in %s', SKILL_NAME, targetId, hostCwd)
+    }
+    await addSeededMarker(runtime, runtimeId, hostCwd, `${SKILL_ID}:${targetId}`)
+  }
+}

--- a/src/skills/main/skillsInstaller.ts
+++ b/src/skills/main/skillsInstaller.ts
@@ -30,26 +30,50 @@ import { fetchSkillFiles, type SkillFile } from './githubCrawl'
 
 interface SkillsManifest {
   skills: InstalledSkill[]
+  /** Auto-seed markers ("<skillId>:<targetId>"). A bundled skill is seeded at
+   *  most once per target per workspace, so a later user uninstall sticks and
+   *  an edited copy is never overwritten by the next workspace open. */
+  seeded?: string[]
 }
 
 function manifestPath(runtimeId: string, hostCwd: string): string {
   return hostJoin(runtimeId, hostCwd, '.cate', 'skills.json')
 }
 
-export async function readManifest(runtime: Runtime, runtimeId: string, hostCwd: string): Promise<InstalledSkill[]> {
+async function readManifestData(runtime: Runtime, runtimeId: string, hostCwd: string): Promise<SkillsManifest> {
   try {
     const raw = await runtime.file.readFile(manifestPath(runtimeId, hostCwd))
     const parsed = JSON.parse(raw) as SkillsManifest
-    return Array.isArray(parsed.skills) ? parsed.skills : []
+    return {
+      skills: Array.isArray(parsed.skills) ? parsed.skills : [],
+      seeded: Array.isArray(parsed.seeded) ? parsed.seeded.filter((s) => typeof s === 'string') : [],
+    }
   } catch {
-    return []
+    return { skills: [], seeded: [] }
   }
 }
 
-async function writeManifest(runtime: Runtime, runtimeId: string, hostCwd: string, skills: InstalledSkill[]): Promise<void> {
+export async function readManifest(runtime: Runtime, runtimeId: string, hostCwd: string): Promise<InstalledSkill[]> {
+  return (await readManifestData(runtime, runtimeId, hostCwd)).skills
+}
+
+async function writeManifest(runtime: Runtime, runtimeId: string, hostCwd: string, manifest: SkillsManifest): Promise<void> {
   await runtime.file.mkdir(hostJoin(runtimeId, hostCwd, '.cate'))
-  const manifest: SkillsManifest = { skills }
-  await runtime.file.writeFile(manifestPath(runtimeId, hostCwd), `${JSON.stringify(manifest, null, 2)}\n`)
+  // Omit an empty seeded list so pre-seeding manifests round-trip unchanged.
+  const out: SkillsManifest = manifest.seeded?.length ? manifest : { skills: manifest.skills }
+  await runtime.file.writeFile(manifestPath(runtimeId, hostCwd), `${JSON.stringify(out, null, 2)}\n`)
+}
+
+/** Seed markers for this workspace (see SkillsManifest.seeded). */
+export async function readSeededMarkers(runtime: Runtime, runtimeId: string, hostCwd: string): Promise<string[]> {
+  return (await readManifestData(runtime, runtimeId, hostCwd)).seeded ?? []
+}
+
+/** Record that a bundled skill was seeded for a target in this workspace. */
+export async function addSeededMarker(runtime: Runtime, runtimeId: string, hostCwd: string, marker: string): Promise<void> {
+  const manifest = await readManifestData(runtime, runtimeId, hostCwd)
+  if (manifest.seeded?.includes(marker)) return
+  await writeManifest(runtime, runtimeId, hostCwd, { ...manifest, seeded: [...(manifest.seeded ?? []), marker] })
 }
 
 // ---------------------------------------------------------------------------
@@ -141,10 +165,10 @@ export async function writeSkillToWorkspace(args: WriteSkillArgs): Promise<Write
     origin,
   }
 
-  const manifest = await readManifest(runtime, runtimeId, hostCwd)
-  const next = manifest.filter((m) => !(m.skillId === skillId && m.targetId === targetId))
+  const manifest = await readManifestData(runtime, runtimeId, hostCwd)
+  const next = manifest.skills.filter((m) => !(m.skillId === skillId && m.targetId === targetId))
   next.push(installed)
-  await writeManifest(runtime, runtimeId, hostCwd, next)
+  await writeManifest(runtime, runtimeId, hostCwd, { ...manifest, skills: next })
 
   return { installed, warnings }
 }
@@ -236,8 +260,11 @@ export async function uninstall(
   } catch (err) {
     log.warn('[skills] remove failed for %s: %O', target, err)
   }
-  const manifest = await readManifest(runtime, runtimeId, hostCwd)
-  await writeManifest(runtime, runtimeId, hostCwd, manifest.filter((m) => !(m.skillId === skillId && m.targetId === targetId)))
+  const manifest = await readManifestData(runtime, runtimeId, hostCwd)
+  await writeManifest(runtime, runtimeId, hostCwd, {
+    ...manifest,
+    skills: manifest.skills.filter((m) => !(m.skillId === skillId && m.targetId === targetId)),
+  })
 }
 
 export async function listInstalled(cwd: string): Promise<InstalledSkill[]> {

--- a/src/skills/main/targets.ts
+++ b/src/skills/main/targets.ts
@@ -30,6 +30,12 @@ export function skillsRootDir(targetId: SkillTargetId, runtimeId: string, hostCw
   return hostJoin(runtimeId, hostCwd, ...BASE_SEGMENTS[targetId])
 }
 
+/** The target's top-level tool dir under the workspace root (e.g. `.claude`,
+ *  `.codex`) — its presence is the signal that the agent is used there. */
+export function toolDirSegment(targetId: SkillTargetId): string {
+  return BASE_SEGMENTS[targetId][0]
+}
+
 export function targetInfo(targetId: SkillTargetId): SkillTargetInfo {
   return getSkillTarget(targetId)
 }


### PR DESCRIPTION
## cate CLI on by default

- `cliEnabled` now defaults to true. Existing installs keep whatever is already in their settings.json. The Settings toggle description spells out the trade-off (the token lands in the env of every process spawned in a terminal) so users can opt out.
- The `cate` binary stays on PATH even while the endpoint is disabled (`catePathEnv` no longer gated on `CATE_API`). Running it while off now prints how to enable the setting in Settings -> Terminal instead of "command not found", and the CLI's exit-3 message and help text were reworded to match.

## Per-workspace cate-cli skill seeding

- New `seedCateCliSkill` installs the bundled skill through the same path as the skills modal, so it is per-target, runtime-aware and tracked in `.cate/skills.json`. The global copy into `~/.claude/skills` at app start is gone.
- Targets: Cate's own agent always; Claude Code, Pi, OpenCode, Codex and Antigravity only when their tool dir already exists in the workspace, so repos don't grow dot-dirs for agents nobody uses.
- Seeds at most once per workspace/target via `seeded` markers in the manifest: user uninstalls stick and edited copies are never overwritten. Files come from the app bundle, so it works offline.
- Runs at workspace create, at folder attach, and on every runtime (re)connect. The last one is what makes remote workspaces seed like local ones, since their runtime connects after create/attach.
- New `cliSkillInstallEnabled` setting (default on) with a Settings -> Terminal toggle.

## Remote workspace parity

- `projectChatsStore` and `projectCateAgentStore` now persist through the runtime for remote roots, so Cate Agent chats and prefs survive a restart wherever the workspace lives. Corrupt remote files degrade to defaults instead of being quarantined over RPC.
- New `loginEnv`: the daemon captures the user's login-shell env at startup (`$SHELL -ilc env -0`) and merges it over `process.env`, so nvm/pyenv/~/.local/bin tools work on SSH and WSL hosts the same as locally. The local transport sets a marker to skip the capture since Electron already resolved it.
- SSH and WSL daemons now launch with the same `--exclude` and `--idle-suspend` config as the local one, and live changes to `fileExclusions` / `autoSuspendIdleTerminals` are forwarded to every connected runtime instead of only the local daemon.
- Runtime `file.writeFile` / `writeBinary` are now atomic (unique tmp + rename, preserves the target's mode, win32 rename retry), so a crash mid-write can't truncate a file on any host.
- Git ops on a host without git now fail with an actionable "install git" message (probe-confirmed) instead of a raw `spawn git ENOENT`.
- Terminal spawn and git-monitor drop their client-side path validation; the daemon's allowed-root check inside each op is the authoritative one. `validatePath`/`validateCwd` docs now state that client-side handles are pass-throughs.
- Remote-aware UI: "Reveal in Finder" is omitted for remote paths (file tree, explorer root, worktree cards, DocumentPanel error state); `cate-runtime://` locators are never sent to a search engine or rewritten by the browser panel; dropping a tree file into a terminal pastes the bare host path; source-control diffs re-encode paths through `formatLocator`; editor/document/palette titles use locator-aware basenames and a new `relativeDisplayPath` helper.

## Cross-window panel management

- Panels living in detached windows can now be closed from the workspace overview: new `CLOSE_WINDOW_PANEL` / `CLOSE_PANEL_IN_WINDOW` IPC routes the close to the owning window, which runs its own dirty/running confirm gates. Detached rows also get a context menu (Show in Window / Close) and keyboard activation.
- New "Move into New Window" on overview panel rows, backed by a location-agnostic `movePanelToNewWindow` that reuses the existing transfer snapshot path.
- Close Workspace, bulk workspace delete and Close All Panels now run behind the same aggregate dirty-editor / running-terminal confirms as single closes (`removeWorkspacesWithConfirm`, `closeAllPanelsWithConfirm`). The dock shell's close-tab flow moved into `closeDockWindowPanel` and gained the canvas confirm fan-out.
- The cross-window panel report now contains only placed panels (ghost records no longer surface as phantom rows) and stamps the derived row label, so titleless browser/editor panels read the same in every window.
- Rename fixes: committing a rename input unchanged no longer freezes a live auto-title via `titleUserOverridden` (dock tabs and overview rows). "Copy Working Directory" prefers the active terminal's cwd and is disabled when there is none.

## Tests

New coverage for the skill seeder, login env capture, atomic writes, missing-git guard, remote chat/pref stores, cross-window close, bulk confirm flows, move-to-new-window, rename seeding, placed-only panel reports, and dock window session restore.