### PR TITLE
Cate Agent: structured verifier verdicts with per-check results

### DIFF
--- a/src/agent/extensions/cate-agent-tools/index.ts
+++ b/src/agent/extensions/cate-agent-tools/index.ts
@@ -8,7 +8,7 @@
 //     loops by round until the goal is met. Never chooses coding agents and never edits
 //     files itself. Answers read-only tasks. Each iteration is checked automatically by
 //     an independent verifier driver (see runIterationCheck) — the orchestrator just
-//     reads the {met, reason} verdicts it's woken with.
+//     reads the {met, reason, checks, suggestion} verdicts it's woken with.
 //   - driver: ONE per iteration. Seeded with the iteration's overview + worktree cwd,
 //     it decides the 1-or-N agent decomposition, opens terminals, launches the CLIs,
 //     and submits the task — then is re-prompted as each terminal finishes.
@@ -54,8 +54,8 @@ const OBSERVER_PROMPT = [
 const ORCHESTRATOR_PROMPT = [
   "You are a chat agent for a coding workspace, read-only — no edit tools; all changes happen inside iterations. The user is talking to you in a persistent thread; keep it conversational.",
   "Questions, read-only tasks, and canvas/layout work (use `canvas`): just do the work and end your turn — your final message is shown to the user as your reply. No separate finish step.",
-  "Code changes: set_goal (goal + how to check it), then iterate one or more times to race attempts — each spawns a fresh worktree from an overview whose driver picks the agents. End your turn; each attempt is verified automatically and you're woken with its {met, reason}.",
-  "Once you've set a goal you're in the loop until it's met: select_winner among passers, iterate again folding in the failures, or fail with a reason. Here a bare turn-end does NOT finish the job — decide.",
+  "Code changes: set_goal (goal + how to check it), then iterate one or more times to race attempts — each spawns a fresh worktree from an overview whose driver picks the agents. End your turn; each attempt is verified automatically and you're woken with its verdict: {met, reason} plus per-check results ({check, met, observed, expected}) and the verifier's suggestion.",
+  "Once you've set a goal you're in the loop until it's met: select_winner among passers, iterate again folding the failures into the new overview (what each failed check observed vs expected, what past attempts already tried, the verifier's suggestion), or fail with a reason. Here a bare turn-end does NOT finish the job — decide.",
 ].join(" ")
 
 const DRIVER_PROMPT = [

--- a/src/renderer/cateAgent/cateAgentController.ts
+++ b/src/renderer/cateAgent/cateAgentController.ts
@@ -536,7 +536,13 @@ class CateAgentController implements CateAgentBridgeHost {
     if (r.runs.get(ctx.chatId)?.epoch !== ctx.epoch) return // superseded mid-check
     patchIteration(ctx.rootPath, ctx.chatId, iterationId, {
       status: verdict.met ? 'passed' : 'failed',
-      verify: { met: verdict.met, reason: verdict.reason, at: Date.now() },
+      verify: {
+        met: verdict.met,
+        reason: verdict.reason,
+        at: Date.now(),
+        ...(verdict.checks ? { checks: verdict.checks } : {}),
+        ...(verdict.suggestion ? { suggestion: verdict.suggestion } : {}),
+      },
     })
     void this.reconcile(ctx)
   }

--- a/src/renderer/cateAgent/cateAgentTools.ts
+++ b/src/renderer/cateAgent/cateAgentTools.ts
@@ -32,7 +32,7 @@ import { gitStatusStore } from '../stores/gitStatusStore'
 import { useCateAgentStore } from './cateAgentStore'
 import { generateId } from '../stores/canvas/helpers'
 import { newWorktreeId } from '../lib/worktreeSync'
-import type { Chat, ChatRun, WorktreeMeta, Iteration } from '../../shared/types'
+import type { Chat, ChatRun, WorktreeMeta, Iteration, VerdictCheck } from '../../shared/types'
 import type { CateAgentContext } from './cateAgentTypes'
 import {
   ptyFor,
@@ -315,7 +315,14 @@ export function buildRunContext(wsId: string, rootPath: string, chatId: string):
     agents: it.agents
       .filter((a) => a.kind !== 'verify')
       .map((a) => ({ agent: a.agent, scope: a.scope, terminalId: shortId(a.terminalId), busy: terminalBusy(wsId, a.terminalId) })),
-    verdict: it.verify ? { met: it.verify.met, reason: it.verify.reason } : null,
+    verdict: it.verify
+      ? {
+          met: it.verify.met,
+          reason: it.verify.reason,
+          ...(it.verify.checks ? { checks: it.verify.checks } : {}),
+          ...(it.verify.suggestion ? { suggestion: it.verify.suggestion } : {}),
+        }
+      : null,
   }))
   return json({
     goal: run.goal ?? null,
@@ -338,7 +345,7 @@ export async function runIterationCheck(
   rootPath: string,
   chatId: string,
   iteration: Iteration,
-): Promise<{ met: boolean; reason: string }> {
+): Promise<Verdict> {
   const run = runFor(rootPath, chatId)
   const meta = iteration.worktreeId ? worktreeMetaFor(wsId, iteration.worktreeId) : undefined
   const cwd = meta?.path ?? rootPath
@@ -348,7 +355,10 @@ export async function runIterationCheck(
   const prompt = [
     `Verify this goal in this worktree: "${goal}". How: ${check}.`,
     'Run the needed tests/build and inspect git diff. Be strict: if you cannot confirm it, it is NOT met.',
-    'Write the verdict to .cate/verdict.json as {"met": <true|false>, "reason": "<one sentence>"}, then stop. Change nothing else.',
+    'Write the verdict to .cate/verdict.json as {"met": <true|false>, "reason": "<1-2 sentence summary>",',
+    '"checks": [{"check": "<what you checked>", "met": <true|false>, "observed": "<verbatim outcome: pasted command output excerpt / exit code / what the diff shows — or unknown if you could not run it>", "expected": "<on failed checks: what a pass looks like>"}],',
+    '"suggestion": "<optional, only when not met: what the next attempt should do differently>"}.',
+    'met must be the conjunction of the checks. observed must be copied from output you actually produced — never invented. Then stop. Change nothing else.',
   ].join(' ')
 
   await runDriverToCompletion({
@@ -370,15 +380,61 @@ function chatTitleFor(rootPath: string, chatId: string): string {
   return getChat(rootPath, chatId)?.title ?? 'the task'
 }
 
+export interface Verdict {
+  met: boolean
+  reason: string
+  checks?: VerdictCheck[]
+  suggestion?: string
+}
+
+/** Caps applied when reading a verdict back — it's folded verbatim into the
+ *  orchestrator's wake context, so it's bounded at the source. */
+const VERDICT_STRING_MAX = 700
+const VERDICT_CHECKS_MAX = 20
+
+const verdictString = (raw: unknown): string | undefined => {
+  const s = typeof raw === 'string' ? raw.trim() : ''
+  return s ? s.slice(0, VERDICT_STRING_MAX) : undefined
+}
+
+/** Parse the verifier's `checks` into the flat {check, met, observed, expected?}
+ *  shape, capped in count and string length. Entries missing a check name or an
+ *  observed outcome drop; a malformed list just drops — it never fails a verdict. */
+export function parseVerdictChecks(raw: unknown): VerdictCheck[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: VerdictCheck[] = []
+  for (const entry of raw.slice(0, VERDICT_CHECKS_MAX)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const { check, met, observed, expected } = entry as Record<string, unknown>
+    const name = verdictString(check)
+    const seen = verdictString(observed)
+    if (!name || !seen) continue
+    const kept: VerdictCheck = { check: name, met: met === true, observed: seen }
+    const want = verdictString(expected)
+    if (want) kept.expected = want
+    out.push(kept)
+  }
+  return out.length ? out : undefined
+}
+
 /** Read + parse `.cate/verdict.json` from a worktree. Anything unreadable or
- *  malformed is a NOT-met verdict (the checker failed to commit to a clear pass). */
-async function readVerdict(cwd: string): Promise<{ met: boolean; reason: string }> {
+ *  malformed is a NOT-met verdict (the checker failed to commit to a clear pass).
+ *  A check reported failed forces met:false even if the top-level flag says true —
+ *  the conjunction is structural, not trusted. */
+async function readVerdict(cwd: string): Promise<Verdict> {
   try {
     const raw = await window.electronAPI.fsReadFile(`${cwd}/.cate/verdict.json`)
-    const parsed = JSON.parse(raw) as { met?: unknown; reason?: unknown }
-    const met = parsed.met === true
-    const reason = typeof parsed.reason === 'string' && parsed.reason.trim() ? parsed.reason.trim() : met ? 'met' : 'not met'
-    return { met, reason }
+    const parsed = JSON.parse(raw) as { met?: unknown; reason?: unknown; checks?: unknown; suggestion?: unknown }
+    const checks = parseVerdictChecks(parsed.checks)
+    const met = parsed.met === true && (checks ?? []).every((c) => c.met)
+    const reason = verdictString(parsed.reason) ?? (met ? 'met' : 'not met')
+    const suggestion = verdictString(parsed.suggestion)
+    return {
+      met,
+      reason,
+      ...(checks ? { checks } : {}),
+      ...(suggestion ? { suggestion } : {}),
+    }
   } catch {
     return { met: false, reason: 'the checker did not produce a clear verdict' }
   }
@@ -586,6 +642,15 @@ export async function runCateAgentTool(ctx: CateAgentContext, tool: string, para
       const run = runFor(rootPath, chatId)
       const winner = run?.iterations?.find((i) => i.id === iterationId)
       if (!run || !winner) return json({ ok: false, error: 'run or iteration not found' })
+      // Verdict-gated: only a verified passer can land. The wake prompt already says
+      // so; this makes it structural rather than advisory.
+      if (winner.status !== 'passed') {
+        const verdict = winner.verify ? `${winner.verify.met ? 'met' : 'not met'}: ${winner.verify.reason}` : 'no verdict yet'
+        return json({
+          ok: false,
+          error: `iteration ${shortId(winner.id)} has not passed verification (status: ${winner.status}, verdict ${verdict}) — select_winner only lands a passer. Iterate again or fail.`,
+        })
+      }
       if (!winner.worktreeId || !winner.branch) {
         return json({ ok: false, error: 'winning iteration has no worktree to land (non-git?) — use fail instead.' })
       }

--- a/src/renderer/cateAgent/cateAgentTools.verdict.test.ts
+++ b/src/renderer/cateAgent/cateAgentTools.verdict.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+//
+// The iterate/verify loop's verdict plumbing: parsing the verifier's per-check
+// results (junk-dropping + truncation), checks + suggestion travelling into the
+// orchestrator's wake context via buildRunContext, and the select_winner verdict
+// gate — only an iteration that passed verification can land.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Iteration } from '../../shared/types'
+
+const h = vi.hoisted(() => {
+  const iterations = [
+    {
+      id: 'it-passed-111',
+      todoId: 't1',
+      round: 1,
+      worktreeId: 'wt-pass',
+      branch: 'cate/pass',
+      agents: [],
+      status: 'passed',
+      verify: { met: true, reason: 'tests pass', at: 1 },
+      createdAt: 0,
+    },
+    {
+      id: 'it-failed-222',
+      todoId: 't1',
+      round: 1,
+      worktreeId: 'wt-fail',
+      branch: 'cate/fail',
+      agents: [],
+      status: 'failed',
+      verify: {
+        met: false,
+        reason: '2 tests fail',
+        at: 1,
+        checks: [{ check: 'vitest suite', met: false, observed: 'AssertionError: boom (store > undo)', expected: '0 failed' }],
+        suggestion: 'fix the undo stack ordering first',
+      },
+      createdAt: 0,
+    },
+    {
+      id: 'it-running-333',
+      todoId: 't1',
+      round: 1,
+      worktreeId: 'wt-run',
+      branch: 'cate/run',
+      agents: [],
+      status: 'running',
+      createdAt: 0,
+    },
+  ]
+  return {
+    run: { status: 'running', goal: 'the goal', check: 'run tests', round: 1, iterations },
+    patchRun: vi.fn(),
+    appendMessage: vi.fn(),
+    closeCanvasPanel: vi.fn(),
+    teardownWorktree: vi.fn(),
+    worktreeMetaFor: vi.fn((_wsId: string, id: string) => ({ path: `/worktrees/${id}`, color: 'rgb(0,0,0)' })),
+  }
+})
+
+vi.mock('../stores/appStore', () => ({
+  useAppStore: { getState: () => ({ workspaces: [{ id: 'ws1', panels: {} }] }) },
+  pickWorktreeColor: () => 'rgb(0,0,0)',
+}))
+vi.mock('../lib/workspace/canvasAccess', () => ({ getAgentCanvasStore: () => undefined }))
+vi.mock('./canvasAgentLauncher', () => ({ runCanvasAgentToCompletion: vi.fn() }))
+vi.mock('./cateAgentTerminals', () => ({
+  shortId: (id: string) => id.slice(0, 8),
+  closeCanvasPanel: h.closeCanvasPanel,
+  readTerminalState: vi.fn(),
+  ptyFor: () => undefined,
+  terminalBusy: () => false,
+}))
+vi.mock('../stores/settingsStore', () => ({ useSettingsStore: { getState: () => ({}) } }))
+vi.mock('../stores/chatsStore', () => ({
+  useChatsStore: {
+    getState: () => ({
+      getChats: () => [],
+      getChat: () => ({ id: 't1', title: 'x', messages: [], createdAt: 0, updatedAt: 0 }),
+      getRun: () => h.run,
+      patchRun: h.patchRun,
+      appendMessage: h.appendMessage,
+      patchMessage: vi.fn(),
+    }),
+  },
+}))
+vi.mock('../stores/gitStatusStore', () => ({ gitStatusStore: { refresh: vi.fn() } }))
+vi.mock('./cateAgentStore', () => ({ useCateAgentStore: { getState: () => ({ get: () => ({}), setUnseen: vi.fn(), appendFeed: vi.fn() }) } }))
+vi.mock('../stores/canvas/helpers', () => ({ generateId: () => 'id' }))
+vi.mock('./codingAgentLauncher', () => ({ runDriverToCompletion: vi.fn(), openDriverTerminal: vi.fn(), armBackgroundSend: vi.fn() }))
+vi.mock('./cateAgentWorktrees', () => ({ worktreeMetaFor: h.worktreeMetaFor, teardownWorktree: h.teardownWorktree }))
+vi.mock('../lib/logger', () => ({ default: { warn: vi.fn(), info: vi.fn() } }))
+
+import { runCateAgentTool, parseVerdictChecks, buildRunContext, runIterationCheck } from './cateAgentTools'
+import type { CateAgentContext } from './cateAgentTypes'
+
+const ctx: CateAgentContext = { panelId: 'cate-agent-orchestrator:t', workspaceId: 'ws1', rootPath: '/repo', role: 'orchestrator', chatId: 't1', canvasPanelId: 'canvas-1' }
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('parseVerdictChecks', () => {
+  it('keeps well-formed checks, trimming strings and defaulting met to false', () => {
+    const out = parseVerdictChecks([
+      { check: ' vitest suite ', met: true, observed: ' 214 passed ' },
+      { check: 'resize keeps aspect', met: 'yes', observed: 'ratio drifts', expected: 'ratio stable' },
+    ])
+    expect(out).toEqual([
+      { check: 'vitest suite', met: true, observed: '214 passed' },
+      { check: 'resize keeps aspect', met: false, observed: 'ratio drifts', expected: 'ratio stable' },
+    ])
+  })
+
+  it('drops entries missing a check name or observed outcome, and junk entries', () => {
+    const out = parseVerdictChecks([
+      { check: 'no observed', met: true },
+      { check: '  ', met: true, observed: 'blank name' },
+      'a string',
+      null,
+      ['nested'],
+      { check: 'kept', met: true, observed: 'ok', extra: 'ignored' },
+    ])
+    expect(out).toEqual([{ check: 'kept', met: true, observed: 'ok' }])
+  })
+
+  it('bounds size: check count and string lengths', () => {
+    const out = parseVerdictChecks(
+      Array.from({ length: 30 }, (_, i) => ({ check: `c${i}`, met: true, observed: 'o'.repeat(2000) })),
+    )!
+    expect(out).toHaveLength(20)
+    expect(out[0].observed).toHaveLength(700)
+  })
+
+  it('returns undefined when nothing survives', () => {
+    expect(parseVerdictChecks(undefined)).toBeUndefined()
+    expect(parseVerdictChecks(null)).toBeUndefined()
+    expect(parseVerdictChecks('not a list')).toBeUndefined()
+    expect(parseVerdictChecks([])).toBeUndefined()
+    expect(parseVerdictChecks([{ met: false }, null])).toBeUndefined()
+  })
+})
+
+describe('buildRunContext', () => {
+  it('folds each verdict, including its checks and suggestion, into the wake context', () => {
+    const out = JSON.parse(buildRunContext('ws1', '/repo', 't1'))
+    expect(out.goal).toBe('the goal')
+    const failed = out.iterations.find((i: { status: string }) => i.status === 'failed')
+    expect(failed.verdict).toEqual({
+      met: false,
+      reason: '2 tests fail',
+      checks: [{ check: 'vitest suite', met: false, observed: 'AssertionError: boom (store > undo)', expected: '0 failed' }],
+      suggestion: 'fix the undo stack ordering first',
+    })
+    const passed = out.iterations.find((i: { status: string }) => i.status === 'passed')
+    expect(passed.verdict).toEqual({ met: true, reason: 'tests pass' })
+  })
+})
+
+describe('runIterationCheck verdict read-back', () => {
+  const iteration = h.run.iterations[2] as Iteration // running, worktree wt-run
+
+  const stubVerdictFile = (content: string | Error): void => {
+    Object.assign(window, {
+      electronAPI: {
+        fsReadFile: vi.fn(() => (content instanceof Error ? Promise.reject(content) : Promise.resolve(content))),
+      },
+    })
+  }
+
+  it('forces met:false when any check failed, even if the top-level flag claims true', async () => {
+    stubVerdictFile(
+      JSON.stringify({
+        met: true,
+        reason: 'all good',
+        checks: [
+          { check: 'build', met: true, observed: 'exit 0' },
+          { check: 'tests', met: false, observed: '1 failed', expected: '0 failed' },
+        ],
+        suggestion: 'fix the failing test',
+      }),
+    )
+    const verdict = await runIterationCheck('ws1', '/repo', 't1', iteration)
+    expect(verdict.met).toBe(false)
+    expect(verdict.checks).toHaveLength(2)
+    expect(verdict.suggestion).toBe('fix the failing test')
+  })
+
+  it('treats a missing verdict file as not met', async () => {
+    stubVerdictFile(new Error('ENOENT'))
+    const verdict = await runIterationCheck('ws1', '/repo', 't1', iteration)
+    expect(verdict).toEqual({ met: false, reason: 'the checker did not produce a clear verdict' })
+  })
+})
+
+describe('select_winner verdict gate', () => {
+  it('rejects an iteration that failed verification, echoing its verdict', async () => {
+    const out = JSON.parse(await runCateAgentTool(ctx, 'select_winner', { iterationId: 'it-failed-222' }))
+    expect(out.ok).toBe(false)
+    expect(out.error).toContain('has not passed verification')
+    expect(out.error).toContain('not met: 2 tests fail')
+    expect(h.patchRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects an iteration with no verdict yet', async () => {
+    const out = JSON.parse(await runCateAgentTool(ctx, 'select_winner', { iterationId: 'it-running-333' }))
+    expect(out.ok).toBe(false)
+    expect(out.error).toContain('no verdict yet')
+    expect(h.patchRun).not.toHaveBeenCalled()
+  })
+
+  it('lands a passed iteration and discards the rest', async () => {
+    const out = JSON.parse(await runCateAgentTool(ctx, 'select_winner', { iterationId: 'it-passed-111', reason: 'clean diff' }))
+    expect(out).toEqual({ ok: true })
+    expect(h.patchRun).toHaveBeenCalledWith('/repo', 't1', expect.objectContaining({ status: 'review', worktreeId: 'wt-pass', branch: 'cate/pass' }))
+    const discarded = h.teardownWorktree.mock.calls.map((c) => c[2])
+    expect(discarded).toEqual(expect.arrayContaining(['wt-fail', 'wt-run']))
+    expect(discarded).not.toContain('wt-pass')
+  })
+})
+
+// Type-level guard: the fixtures above must stay valid Iterations.
+const _typecheck: Iteration[] = h.run.iterations as Iteration[]
+void _typecheck

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1014,13 +1014,32 @@ export interface ProjectSessionPanel {
 // This state lives on the chat's `run` (see ChatRun above).
 // -----------------------------------------------------------------------------
 
+/** One atomic check inside a verdict. `observed` is pasted from output the verifier
+ *  actually produced (test run, build, diff inspection) — or "unknown" when the check
+ *  could not be run — so a failed attempt's cause travels with its verdict as ground
+ *  truth, not judge prose. */
+export interface VerdictCheck {
+  /** What was checked, e.g. "vitest suite" or "shift-resize keeps aspect". */
+  check: string
+  met: boolean
+  /** Verbatim outcome (command output excerpt, exit code, what the diff shows). */
+  observed: string
+  /** What a pass would have looked like — set on failed checks. */
+  expected?: string
+}
+
 /** A single verification verdict for one iteration — produced by a checker coding
- *  agent that ran the check in the iteration's worktree and wrote {met, reason}. */
+ *  agent that ran the check in the iteration's worktree and wrote the verdict file.
+ *  `met` is the conjunction over `checks` when they're present. */
 export interface VerifyResult {
   met: boolean
   reason: string
   /** Unix ms when verification completed. */
   at: number
+  /** Per-check results backing the verdict, when the verifier provided them. */
+  checks?: VerdictCheck[]
+  /** The verifier's advisory next step for a failed attempt. */
+  suggestion?: string
 }
 
 export type IterationStatus =


### PR DESCRIPTION
The verifier used to attach free-form JSON evidence to its verdict, which needed a recursive bounding parser and gave the orchestrator an unpredictable blob. Research on evaluator-optimizer loops (Reflexion, Self-Refine, Anthropic's agent guidance) converges on a small fixed shape instead: binary verdict, per-check results grounded in real command output, and an advisory suggestion kept separate from the findings.

.cate/verdict.json is now {met, reason, checks, suggestion}:

- checks: flat [{check, met, observed, expected?}], observed pasted verbatim from output the verifier actually produced (or "unknown"), expected set on failures
- met is the conjunction of the checks, enforced on read: a failed check forces not-met even if the top-level flag claims true
- suggestion: what the next attempt should do differently, only when not met
- select_winner is verdict-gated: only an iteration that passed verification can land

Checks and suggestion travel into the orchestrator's wake context, and its prompt now tells it to fold observed vs expected plus the suggestion into the next iteration's overview. The recursive VerdictEvidence type and its parser are deleted; bounding is now just a count cap and string truncation. New tests cover the parser, the wake-context folding, the conjunction override, and the select_winner gate.