### PR TITLE
chore(release): bump version to 1.4.0-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.4.0-beta.3",
+      "version": "1.4.0-beta.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0-beta.4",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.4.0-beta.3'
+export const RUNTIME_VERSION = '1.4.0-beta.4'


### PR DESCRIPTION
Bumps the app version to **1.4.0-beta.4** to cut a new beta release including the UI rework (#453).

- `package.json` / `package-lock.json` → 1.4.0-beta.4
- `src/runtime/version.ts` `RUNTIME_VERSION` → 1.4.0-beta.4

Once merged, pushing the `v1.4.0-beta.4` tag triggers the Release workflow (GitHub pre-release + per-OS builds).