### PR TITLE
feat(ui): restore header bar for detached windows on macOS

### DIFF
--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -209,6 +209,16 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
     return { draggedPanelId: dragSource.panelId, originalIndex: idx }
   }, [showTabPlaceholder, dragSource, stack.id, stack.panelIds])
 
+  // Center-zone tabs float over the panel body ONLY for a canvas, so the canvas
+  // grid shows through behind the chromeless header. For any other panel type a
+  // floating header would leave the panel's own content/toolbar (e.g. an editor's
+  // markdown Preview strip) sitting behind the tabs AND the window chrome
+  // (traffic-light island / sidebar toggles), which reads as a broken overlay. So
+  // non-canvas center stacks use a solid, in-flow strip that pushes content down —
+  // exactly like the docked side/bottom stacks.
+  const floatingCenterTabs =
+    !compact && zoneProp === 'center' && activePanel?.type === 'canvas'
+
   return (
     <div
       ref={stackRef}
@@ -233,22 +243,23 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
           content area below via a top accent border. */}
       <div
         className={`dock-tab-bar flex items-center overflow-hidden ${
-          // The main canvas header floats: it's positioned absolutely so the
-          // canvas content fills the full height BEHIND it, and its background +
-          // divider stay transparent until hovered (see .dock-tab-bar-floating in
+          // The canvas header floats: it's positioned absolutely so the canvas
+          // content fills the full height BEHIND it, and its background + divider
+          // stay transparent until hovered (see .dock-tab-bar-floating in
           // globals.css) — so at rest only the tabs and buttons read against the
           // canvas grid. Canvas-node mini-docks (compact) also go chromeless: no
           // solid band, no divider — the tabs float directly on the panel body so
-          // the active pill nests into the node's rounded corner. Only docked
-          // side/bottom stacks keep the solid, in-flow chrome + divider.
-          !compact && zoneProp === 'center'
+          // the active pill nests into the node's rounded corner. Docked side/bottom
+          // stacks AND non-canvas center stacks keep the solid, in-flow chrome +
+          // divider (so their panel content isn't occluded — see floatingCenterTabs).
+          floatingCenterTabs
             ? `dock-tab-bar-floating absolute top-0 left-0 right-0 z-20 ${showTabPlaceholder ? 'drop-active' : ''}`
             : compact
               ? ''
               : 'border-b border-subtle'
         } ${compact ? 'min-h-[26px] px-0.5' : 'min-h-[32px] px-1.5'}`}
         style={{
-          ...(!compact && zoneProp !== 'center'
+          ...(!compact && !floatingCenterTabs
             ? { backgroundColor: 'var(--node-chrome-bg, var(--surface-1))' }
             : null),
           ...(onTabBarMouseDown ? { cursor: 'grab' } : null),

--- a/src/renderer/shells/DockWindowShell.tsx
+++ b/src/renderer/shells/DockWindowShell.tsx
@@ -25,10 +25,10 @@ import { shouldCloseDockWindow } from './shouldCloseDockWindow'
 import WindowControls from './WindowControls'
 import { useWindowRuntime } from '../lib/hooks/useWindowRuntime'
 import WindowChrome from './WindowChrome'
+import DockWindowTitlebar from './DockWindowTitlebar'
 
 import { PanelHost } from '../panels/PanelHost'
 import { IS_MAC } from '../lib/platform'
-import { useWindowFullscreen } from '../lib/useWindowFullscreen'
 
 interface DockWindowShellProps {
   workspaceId?: string
@@ -49,9 +49,6 @@ const SYNC_INTERVAL_MS = 5000
 export default function DockWindowShell({ workspaceId: initialWorkspaceId }: DockWindowShellProps) {
   const [wsId, setWsId] = useState(initialWorkspaceId ?? '')
   const [ready, setReady] = useState(false)
-  // macOS: the tab bar reserves 78px for the native traffic lights — reclaimed
-  // in native fullscreen (this window's own), where the lights are hidden.
-  const isFullscreen = useWindowFullscreen()
   const dockStore = useMemo(() => createDockStore(), [])
   const syncTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const hadPanelsRef = useRef(false)
@@ -367,24 +364,30 @@ export default function DockWindowShell({ workspaceId: initialWorkspaceId }: Doc
   return (
     <DockStoreProvider store={dockStore}>
       <div className="dock-window-root relative h-screen w-screen flex flex-col bg-surface-4 overflow-hidden">
-        {/* Make the top tab bar the window drag region. On macOS reserve 78px on
-            the left for the traffic lights (reclaimed in native fullscreen where
-            they are hidden); on Windows/Linux reserve 132px on the right for our
-            custom WindowControls overlay (below). Override inside any canvas-node
-            ([data-node-id]) so nested mini-dock tab bars don't inherit the indent
-            or become drag handles. */}
+        {/* macOS: DockWindowTitlebar (below) is the header + drag region and owns
+            the traffic-light reservation, so the tab bar sits full-width beneath
+            it with no indent or drag behavior of its own. Windows/Linux keep the
+            tab bar AS the drag region and reserve 132px on the right for the
+            custom WindowControls overlay. Override inside any canvas-node
+            ([data-node-id]) so nested mini-dock tab bars don't inherit either. */}
         <style>{`
+          ${IS_MAC ? '' : `
           .dock-window-root .dock-tab-bar {
-            ${IS_MAC ? `padding-left: ${isFullscreen ? 0 : 78}px;` : 'padding-right: 132px;'}
+            padding-right: 132px;
             -webkit-app-region: drag;
           }
           .dock-window-root .dock-tab-bar > * { -webkit-app-region: no-drag; }
+          `}
           .dock-window-root [data-node-id] .dock-tab-bar {
             padding-left: 0;
             padding-right: 0;
             -webkit-app-region: no-drag;
           }
         `}</style>
+        {/* macOS: conventional header/title bar (unlike the main window's floating
+            island) — traffic-light reservation + drag region + active panel title.
+            Collapses in native fullscreen. */}
+        <DockWindowTitlebar workspaceId={wsId} />
         {/* Frameless Windows/Linux: custom window controls pinned to the top-right,
             over the tab bar's reserved right padding. */}
         {!IS_MAC && (

--- a/src/renderer/shells/DockWindowTitlebar.test.tsx
+++ b/src/renderer/shells/DockWindowTitlebar.test.tsx
@@ -1,0 +1,78 @@
+// =============================================================================
+// Tests for DockWindowTitlebar — the macOS header bar for detached dock windows.
+//
+// jsdom's navigator is not "Mac", so the real IS_MAC is false and the component
+// would render null. We mock the platform module to force the macOS path, then
+// verify: it shows the active panel's title when windowed, falls back sensibly,
+// and collapses (renders nothing) in native fullscreen.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+vi.mock('../lib/platform', () => ({ IS_MAC: true }))
+
+import DockWindowTitlebar from './DockWindowTitlebar'
+import { useAppStore } from '../stores/appStore'
+import { useActivePanelStore } from '../lib/activePanel'
+import type { PanelState } from '../../shared/types'
+
+const WS = 'ws-test'
+
+let host: HTMLDivElement
+let root: Root
+
+function panel(id: string, title: string): PanelState {
+  return { id, type: 'terminal', title } as PanelState
+}
+
+function seedWorkspace(panels: Record<string, PanelState>) {
+  act(() => {
+    useAppStore.setState({
+      workspaces: [{ id: WS, name: 'Test', rootPath: '/tmp', panels } as never],
+    })
+  })
+}
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(false)
+  act(() => { useActivePanelStore.setState({ activePanelId: null }) })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  vi.restoreAllMocks()
+})
+
+function render() {
+  act(() => { root.render(<DockWindowTitlebar workspaceId={WS} />) })
+  return host
+}
+
+describe('DockWindowTitlebar', () => {
+  it('shows the active panel title when windowed', () => {
+    seedWorkspace({ a: panel('a', 'Terminal — cate'), b: panel('b', 'Editor') })
+    act(() => { useActivePanelStore.setState({ activePanelId: 'b' }) })
+    const el = render()
+    expect(el.textContent).toContain('Editor')
+  })
+
+  it('falls back to the first panel title when nothing is active', () => {
+    seedWorkspace({ a: panel('a', 'Terminal — cate') })
+    const el = render()
+    expect(el.textContent).toContain('Terminal — cate')
+  })
+
+  it('renders nothing in native fullscreen', () => {
+    seedWorkspace({ a: panel('a', 'Terminal — cate') })
+    vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(true)
+    const el = render()
+    expect(el.querySelector('.dock-window-titlebar')).toBeNull()
+  })
+})

--- a/src/renderer/shells/DockWindowTitlebar.tsx
+++ b/src/renderer/shells/DockWindowTitlebar.tsx
@@ -1,0 +1,67 @@
+// =============================================================================
+// DockWindowTitlebar — macOS-only header bar for detached dock windows.
+//
+// Detached windows keep a conventional title bar (unlike the main window, which
+// uses the floating MacWindowChrome island). This is a full-width themed strip
+// pinned to the top: it (a) reserves horizontal space for the native traffic
+// lights, (b) provides the window drag region, and (c) shows the active panel's
+// title centered in the remaining space. The dock tab bar sits full-width just
+// below it (DockWindowShell drops the tab bar's traffic-light indent on macOS).
+//
+// In native fullscreen the OS hides the traffic lights and there is no window to
+// drag, so — like the old TitlebarStrip — this collapses to nothing and the tab
+// bar fills from y=0.
+//
+// Non-macOS detached windows keep their frameless custom WindowControls overlay
+// (DockWindowShell), so this renders nothing there.
+// =============================================================================
+
+import { IS_MAC } from '../lib/platform'
+import { useWindowFullscreen } from '../lib/useWindowFullscreen'
+import { useActivePanelStore } from '../lib/activePanel'
+import { useAppStore } from '../stores/appStore'
+
+// Matches the dock tab bar's min-height so the header + tabs read as one stack,
+// and centers the native traffic lights (dock lights sit at y≈11, see
+// windowFactory trafficLightPosition) on this row.
+export const DOCK_TITLEBAR_HEIGHT = 36
+// Horizontal space reserved on the left for the native traffic lights; the title
+// centers in the space to their right.
+const TRAFFIC_LIGHTS_WIDTH = 78
+
+interface DockWindowTitlebarProps {
+  workspaceId: string
+}
+
+export default function DockWindowTitlebar({
+  workspaceId,
+}: DockWindowTitlebarProps): React.ReactElement | null {
+  const isFullscreen = useWindowFullscreen()
+  const activePanelId = useActivePanelStore((s) => s.activePanelId)
+  const panels = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId)?.panels)
+
+  // Non-macOS keeps the frameless WindowControls overlay; native fullscreen hides
+  // the lights and the window can't be dragged, so collapse (tabs fill from y=0).
+  if (!IS_MAC) return null
+  if (isFullscreen) return null
+
+  // Prefer the active panel's title; fall back to the first panel, then a
+  // neutral app name so the bar is never blank.
+  const title =
+    (activePanelId ? panels?.[activePanelId]?.title : undefined) ??
+    (panels ? Object.values(panels)[0]?.title : undefined) ??
+    'Cate'
+
+  return (
+    <div
+      className="dock-window-titlebar shrink-0 bg-titlebar-bg select-none flex items-center justify-center"
+      style={{
+        height: DOCK_TITLEBAR_HEIGHT,
+        paddingLeft: TRAFFIC_LIGHTS_WIDTH,
+        WebkitAppRegion: 'drag',
+      } as React.CSSProperties}
+    >
+      <span className="px-3 text-xs text-secondary truncate">{title}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

The window-chrome rework (#453) replaced the macOS main-window title strip with the floating `MacWindowChrome` island, giving every window a headerbarless look. Detached (dock) windows lost their header too — the dock tab bar became the drag region, indented past the traffic lights.

This restores a conventional title bar for **detached windows on macOS**, while the **main window keeps the new island / headerbarless look**.

## Changes

- **New `DockWindowTitlebar`** — a macOS-only 36px themed strip (`bg-titlebar-bg`) that reserves the traffic-light space, acts as the window drag region, and shows the **active panel's title** (via the per-window `useActivePanelStore`, falling back to the first panel, then `"Cate"`). Collapses to nothing in native fullscreen, like the old `TitlebarStrip`.
- **`DockWindowShell`** renders it above the tab bar and drops the tab bar's macOS traffic-light indent + drag region (the header owns dragging now). Windows/Linux (custom `WindowControls` + 132px reserve) and nested canvas-node tab bars are unchanged.
- **Main process untouched** — dock traffic lights already sit at `{x:12, y:11}`, which centers on the new 36px header.

## Layout

```
┌──────────────────────────────────┐
│ ● ● ●        Terminal — cate      │  ← header (drag + traffic lights + title)
├──────────────────────────────────┤
│ [ Tab 1 ] [ Tab 2 ] [ + ]        │  ← tab bar, full width
├──────────────────────────────────┤
│           panel content          │
└──────────────────────────────────┘
```

## Tests

- `DockWindowTitlebar.test.tsx`: active title on mac, first-panel fallback, fullscreen-collapse.
- Full `shells` + `docking` suites pass (38 tests).