### PR TITLE
feat(sidebar): restore left rail with 3 states + rail-to-rail view DnD

### DIFF
--- a/src/renderer/shells/MacWindowChrome.test.tsx
+++ b/src/renderer/shells/MacWindowChrome.test.tsx
@@ -3,8 +3,8 @@
 //
 // jsdom's navigator is not "Mac", so the real IS_MAC is false and the component
 // would render null. We mock the platform module to force the macOS path, then
-// verify: the sidebar toggle renders and calls uiStore.toggleSidebar, and it
-// stays rendered in native fullscreen (only the traffic lights disappear).
+// verify the draggable lights strip renders (windowed and fullscreen) and that
+// the old sidebar toggle is gone (it now lives in the rail / MainWindowShell).
 // =============================================================================
 
 import React from 'react'
@@ -14,8 +14,7 @@ import { act } from 'react'
 
 vi.mock('../lib/platform', () => ({ IS_MAC: true }))
 
-import MacWindowChrome from './MacWindowChrome'
-import { useUIStore } from '../stores/uiStore'
+import MacWindowChrome, { TRAFFIC_LIGHTS_WIDTH } from './MacWindowChrome'
 
 let host: HTMLDivElement
 let root: Root
@@ -39,23 +38,23 @@ function render() {
 }
 
 describe('MacWindowChrome', () => {
-  it('renders the sidebar toggle when windowed', () => {
+  it('renders a draggable lights strip when windowed', () => {
     const el = render()
-    expect(el.querySelector('button[aria-label="Toggle sidebar"]')).not.toBeNull()
+    const island = el.querySelector<HTMLElement>('div')
+    expect(island).not.toBeNull()
+    expect(island!.style.width).toBe(`${TRAFFIC_LIGHTS_WIDTH}px`)
   })
 
-  it('toggle button calls uiStore.toggleSidebar', () => {
-    const spy = vi.fn()
-    act(() => { useUIStore.setState({ toggleSidebar: spy }) })
+  it('no longer renders a sidebar toggle button (moved to the rail)', () => {
     const el = render()
-    const btn = el.querySelector<HTMLButtonElement>('button[aria-label="Toggle sidebar"]')!
-    act(() => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
-    expect(spy).toHaveBeenCalledTimes(1)
+    expect(el.querySelector('button[aria-label="Toggle sidebar"]')).toBeNull()
+    expect(el.querySelector('button')).toBeNull()
   })
 
-  it('still renders the toggle in native fullscreen (lights gone, toggle stays)', () => {
+  it('shrinks to a small pad in native fullscreen (lights gone)', () => {
     vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(true)
     const el = render()
-    expect(el.querySelector('button[aria-label="Toggle sidebar"]')).not.toBeNull()
+    const island = el.querySelector<HTMLElement>('div')!
+    expect(island.style.width).toBe('8px')
   })
 })

--- a/src/renderer/shells/MacWindowChrome.tsx
+++ b/src/renderer/shells/MacWindowChrome.tsx
@@ -4,66 +4,53 @@
 // Replaces the old full-width TitlebarStrip on macOS. Instead of a distinct
 // header bar above the app, this is a small transparent island pinned to the
 // top-left corner that (a) reserves horizontal space for the native traffic
-// lights, (b) provides the window drag region, and (c) hosts the left-sidebar
-// toggle right of the lights. All other UI — sidebar, dock tabs, canvas — fills
-// the window from y=0, so there is no dead header above the canvas.
+// lights and (b) provides the window drag region over that strip. All other
+// UI — sidebar, dock tabs, canvas — fills the window from y=0, so there is no
+// dead header above the canvas.
 //
-// In native fullscreen the OS hides the traffic lights, so the dots reservation
-// collapses and the toggle slides to the left edge — but the island (and the
-// sidebar toggle) stays, so the sidebar can still be opened/closed there.
+// The left-sidebar toggle no longer lives here: the left rail carries its own
+// collapse toggle (inset below the lights), and a floating reopen toggle in
+// MainWindowShell handles the fully-hidden state — mirroring the right rail.
+//
+// In native fullscreen the OS hides the traffic lights, so the island shrinks
+// to a small left pad.
 //
 // Non-macOS keeps the frameless TitlebarStrip (menu bar + custom controls).
 // =============================================================================
 
-import { SidebarSimple } from '@phosphor-icons/react'
 import { IS_MAC } from '../lib/platform'
 import { useWindowFullscreen } from '../lib/useWindowFullscreen'
-import { useUIStore } from '../stores/uiStore'
-import { Tooltip } from '../ui/Tooltip'
 
 // Matches the dock tab bar's min-height (36px) and the sidebar's opaque top
-// strip, so the toggle, traffic lights, and dock tabs all center on the same
-// line and the sidebar's content insets to exactly clear the chrome.
+// strip, so the traffic lights and dock tabs center on the same line and the
+// sidebar's content insets to exactly clear the chrome.
 export const MAC_CHROME_HEIGHT = 36
-// Horizontal space reserved for the native traffic lights; the toggle sits to
-// their right. In fullscreen the lights are gone, so the toggle hugs the edge.
-const TRAFFIC_LIGHTS_WIDTH = 78
+// Horizontal space reserved for the native traffic lights. In fullscreen the
+// lights are gone, so the island shrinks to a small left pad.
+export const TRAFFIC_LIGHTS_WIDTH = 78
 const FULLSCREEN_LEFT_PAD = 8
 // Width the dock tab bar reserves at the top-left (so its first tab clears the
-// island) when the left sidebar is collapsed — full island (lights + toggle) in
-// windowed mode, just the toggle in fullscreen.
+// island) when the left sidebar is fully hidden — lights + floating reopen
+// toggle in windowed mode, just the toggle in fullscreen.
 export const MAC_CHROME_WIDTH = 108
 export const MAC_CHROME_WIDTH_FS = 40
 
-const NO_DRAG = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
-
 export default function MacWindowChrome(): React.ReactElement | null {
   const isFullscreen = useWindowFullscreen()
-  const toggleSidebar = useUIStore((s) => s.toggleSidebar)
 
   // Native chrome (menu bar + custom controls via TitlebarStrip) off macOS.
   if (!IS_MAC) return null
 
+  // Empty draggable strip over the traffic-light area so the window can be moved
+  // by dragging the top-left corner. The sidebar toggle now lives in the rail.
   return (
     <div
-      className="absolute top-0 left-0 z-40 flex items-center select-none"
+      className="absolute top-0 left-0 z-40 select-none"
       style={{
         height: MAC_CHROME_HEIGHT,
-        paddingLeft: isFullscreen ? FULLSCREEN_LEFT_PAD : TRAFFIC_LIGHTS_WIDTH,
+        width: isFullscreen ? FULLSCREEN_LEFT_PAD : TRAFFIC_LIGHTS_WIDTH,
         WebkitAppRegion: 'drag',
       } as React.CSSProperties}
-    >
-      <Tooltip label="Toggle Sidebar">
-        <button
-          type="button"
-          aria-label="Toggle sidebar"
-          onClick={() => toggleSidebar()}
-          style={NO_DRAG}
-          className="flex items-center justify-center w-[22px] h-[22px] rounded text-secondary hover:text-primary hover:bg-hover transition-colors"
-        >
-          <SidebarSimple size={16} />
-        </button>
-      </Tooltip>
-    </div>
+    />
   )
 }

--- a/src/renderer/shells/MainWindowShell.tsx
+++ b/src/renderer/shells/MainWindowShell.tsx
@@ -19,7 +19,8 @@ import {
 import { useUIStore } from '../stores/uiStore'
 import { IS_MAC } from '../lib/platform'
 import { useWindowFullscreen } from '../lib/useWindowFullscreen'
-import { MAC_CHROME_WIDTH, MAC_CHROME_WIDTH_FS } from './MacWindowChrome'
+import { MAC_CHROME_WIDTH, MAC_CHROME_WIDTH_FS, TRAFFIC_LIGHTS_WIDTH } from './MacWindowChrome'
+import { BAR_WIDTH } from '../sidebar/Sidebar'
 import { SidebarSimple } from '@phosphor-icons/react'
 import { Tooltip } from '../ui/Tooltip'
 
@@ -36,20 +37,32 @@ const EDGE_ZONE_SIZE = 60
  *  reopen toggle shown when the right sidebar is fully hidden. */
 const RIGHT_CHROME_WIDTH = 40
 
+/** Left inset for the floating left-reopen toggle when not clearing the macOS
+ *  lights (fullscreen / non-macOS) — a small edge hug. */
+const LEFT_TOGGLE_EDGE_PAD = 8
+
 export default function MainWindowShell({
   renderPanel,
   getPanelTitle,
   onClosePanel,
 }: MainWindowShellProps) {
-  // macOS: when the left sidebar is collapsed, the dock tab bar sits at the
-  // window's top-left under the traffic-light island, so reserve room for it on
-  // the top-level tab bar (not nested canvas-node bars). Cleared when the
-  // sidebar is open (it holds the space instead). In fullscreen the lights are
-  // gone, so only the toggle needs clearing.
+  // macOS: reserve room at the top-left so the leftmost dock tab bar clears the
+  // traffic-light island. How much depends on the left sidebar's state:
+  //   • fully hidden → clear the lights + the floating reopen toggle,
+  //   • rail-only    → the 40px rail already covers the left of the lights, so
+  //                    only the remainder needs clearing,
+  //   • opened       → the sidebar holds the space; no reserve.
+  // In fullscreen the lights are gone, so only the hidden state (with its
+  // floating toggle) needs a small reserve. Nested canvas-node bars are exempt.
+  const leftSidebarHidden = useUIStore((s) => s.leftSidebarHidden)
   const leftSidebarOpen = useUIStore((s) => s.activeLeftSidebarView !== null)
+  const setLeftSidebarHidden = useUIStore((s) => s.setLeftSidebarHidden)
   const isFullscreen = useWindowFullscreen()
-  const reserveTrafficLights = IS_MAC && !leftSidebarOpen
-  const chromeReserve = isFullscreen ? MAC_CHROME_WIDTH_FS : MAC_CHROME_WIDTH
+  let leftReserve = 0
+  if (IS_MAC) {
+    if (leftSidebarHidden) leftReserve = isFullscreen ? MAC_CHROME_WIDTH_FS : MAC_CHROME_WIDTH
+    else if (!leftSidebarOpen && !isFullscreen) leftReserve = Math.max(0, TRAFFIC_LIGHTS_WIDTH - BAR_WIDTH)
+  }
 
   // Right sidebar fully hidden → float a reopen toggle at the top-right, next to
   // the center tab bar's split button (mirrors the top-left sidebar toggle).
@@ -148,11 +161,11 @@ export default function MainWindowShell({
       style={workspaceAccent ? ({ ['--workspace-accent' as string]: workspaceAccent } as React.CSSProperties) : undefined}
     >
       {/* macOS: indent the top-level dock tab bar so its first tab clears the
-          traffic-light island when the left sidebar is collapsed. Nested
-          canvas-node tab bars ([data-node-id]) are exempt. */}
-      {reserveTrafficLights && (
+          traffic-light island (amount scales with the left sidebar state).
+          Nested canvas-node tab bars ([data-node-id]) are exempt. */}
+      {leftReserve > 0 && (
         <style>{`
-          .main-window-shell-root .dock-tab-bar { padding-left: ${chromeReserve}px; }
+          .main-window-shell-root .dock-tab-bar { padding-left: ${leftReserve}px; }
           .main-window-shell-root [data-node-id] .dock-tab-bar { padding-left: 0; }
         `}</style>
       )}
@@ -180,6 +193,30 @@ export default function MainWindowShell({
               className="flex items-center justify-center w-7 h-7 rounded-[10px] text-muted hover:text-primary hover:bg-hover transition-colors"
             >
               <SidebarSimple size={16} style={{ transform: 'scaleX(-1)' }} />
+            </button>
+          </Tooltip>
+        </div>
+      )}
+      {/* Left sidebar fully hidden → float a reopen toggle at the top-left, past
+          the macOS traffic lights (mirrors the right reopen toggle). Marked
+          no-drag so it stays clickable over the window drag island. */}
+      {leftSidebarHidden && (
+        <div
+          className="absolute top-0 left-0 z-40 flex items-center select-none"
+          style={{
+            height: 36,
+            paddingLeft: IS_MAC && !isFullscreen ? TRAFFIC_LIGHTS_WIDTH : LEFT_TOGGLE_EDGE_PAD,
+            WebkitAppRegion: 'no-drag',
+          } as React.CSSProperties}
+        >
+          <Tooltip label="Show sidebar" placement="bottom">
+            <button
+              type="button"
+              aria-label="Show sidebar"
+              onClick={() => setLeftSidebarHidden(false)}
+              className="flex items-center justify-center w-7 h-7 rounded-[10px] text-muted hover:text-primary hover:bg-hover transition-colors"
+            >
+              <SidebarSimple size={16} />
             </button>
           </Tooltip>
         </div>

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -91,7 +91,14 @@ const SidebarViewContent: React.FC<{ view: SidebarView; rootPath: string }> = ({
 // Shared activity bar sidebar — parameterized by side
 // ---------------------------------------------------------------------------
 
-const BAR_WIDTH = 40
+/** Width of an activity-bar rail (icon strip). Shared with MainWindowShell so
+ *  it can reserve the right amount of top-left space past the macOS lights. */
+export const BAR_WIDTH = 40
+
+// dataTransfer MIME for rail-to-rail view drags. Native HTML5 DnD is used here
+// (same-window, lightweight) — deliberately separate from the panel useDragStore
+// system, which handles cross-window panel drags.
+const DRAG_MIME = 'application/x-cate-sidebar-view'
 
 interface ActivityBarSidebarProps {
   side: SidebarSide
@@ -108,10 +115,22 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
   const setActiveView = useUIStore((s) =>
     side === 'left' ? s.setActiveLeftSidebarView : s.setActiveRightSidebarView,
   )
-  // Right sidebar can be fully hidden (rail + content, width 0) via its top
-  // toggle; reopened from the floating top-right toggle in MainWindowShell.
+  // Either sidebar can be fully hidden (rail + content, width 0) via its top
+  // toggle; reopened from the floating edge toggle in MainWindowShell. Selected
+  // by side so the shared rail's toggle drives the correct one.
+  const leftSidebarHidden = useUIStore((s) => s.leftSidebarHidden)
   const rightSidebarHidden = useUIStore((s) => s.rightSidebarHidden)
+  const setLeftSidebarHidden = useUIStore((s) => s.setLeftSidebarHidden)
   const setRightSidebarHidden = useUIStore((s) => s.setRightSidebarHidden)
+  const sidebarHidden = side === 'left' ? leftSidebarHidden : rightSidebarHidden
+  const setSidebarHidden = side === 'left' ? setLeftSidebarHidden : setRightSidebarHidden
+
+  // Rail-to-rail view drag (native HTML5 DnD). draggingView is shared across
+  // both rails so each can act as a drop target for the other.
+  const moveSidebarView = useUIStore((s) => s.moveSidebarView)
+  const draggingView = useUIStore((s) => s.draggingView)
+  const setDraggingView = useUIStore((s) => s.setDraggingView)
+  const isDragActive = draggingView !== null
 
   // Guard: if activeView is not present on this side (e.g. layout changed), clear it
   useEffect(() => {
@@ -134,6 +153,35 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
   const [isResizing, setIsResizing] = useState(false)
   const startXRef = useRef(0)
   const startWidthRef = useRef(0)
+
+  // When a rail is empty it collapses to 0. During a view drag, reveal it as a
+  // drop target when the cursor enters this side's half of the window, so a user
+  // can move every view off a rail and still drop back onto it.
+  const [dragRevealed, setDragRevealed] = useState(false)
+  useEffect(() => {
+    if (!isDragActive || !isEmpty) {
+      setDragRevealed(false)
+      return
+    }
+    const onDragOver = (e: DragEvent) => {
+      const half = window.innerWidth / 2
+      setDragRevealed(side === 'left' ? e.clientX < half : e.clientX >= half)
+    }
+    window.addEventListener('dragover', onDragOver)
+    return () => window.removeEventListener('dragover', onDragOver)
+  }, [isDragActive, isEmpty, side])
+
+  // Drop indicator: the index where a drop would land among this rail's icons.
+  // Mirrored in a ref because the drop handler needs the freshest value (dragOver
+  // state updates may not have flushed, and dragLeave can clear it just before
+  // drop fires).
+  const [dropIndicator, setDropIndicatorState] = useState<number | null>(null)
+  const dropIndicatorRef = useRef<number | null>(null)
+  const setDropIndicator = useCallback((value: number | null) => {
+    dropIndicatorRef.current = value
+    setDropIndicatorState(value)
+  }, [])
+  const iconsContainerRef = useRef<HTMLDivElement | null>(null)
 
   const selectedWorkspace = useAppStore((s) => {
     const id = s.selectedWorkspaceId
@@ -178,7 +226,67 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
     else setActiveView(view)
   }, [activeView, setActiveView])
 
+  // --- Drag handlers (rail-to-rail view DnD) ---
+
+  const handleIconDragStart = (e: React.DragEvent, view: SidebarView) => {
+    e.dataTransfer.setData(DRAG_MIME, view)
+    e.dataTransfer.setData('text/plain', view)
+    e.dataTransfer.effectAllowed = 'move'
+    setDraggingView(view)
+  }
+
+  const handleIconDragEnd = () => {
+    setDraggingView(null)
+    setDropIndicator(null)
+  }
+
+  // Index (0..views.length) where a drop at clientY would insert, from each
+  // icon's mid-height.
+  const computeDropIndex = (clientY: number): number => {
+    const container = iconsContainerRef.current
+    if (!container) return views.length
+    const buttons = Array.from(container.querySelectorAll<HTMLElement>('[data-sidebar-icon]'))
+    for (let i = 0; i < buttons.length; i++) {
+      const rect = buttons[i].getBoundingClientRect()
+      if (clientY < rect.top + rect.height / 2) return i
+    }
+    return buttons.length
+  }
+
+  const handleBarDragOver = (e: React.DragEvent) => {
+    if (!isDragActive) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
+    setDropIndicator(computeDropIndex(e.clientY))
+  }
+
+  const handleBarDragLeave = (e: React.DragEvent) => {
+    // Only clear when the cursor leaves the bar entirely (not on inner moves).
+    const related = e.relatedTarget as Node | null
+    if (!related || !(e.currentTarget as HTMLElement).contains(related)) {
+      setDropIndicator(null)
+    }
+  }
+
+  const handleBarDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const view = ((e.dataTransfer.getData(DRAG_MIME) || e.dataTransfer.getData('text/plain')) as SidebarView) || draggingView
+    // Recompute from the cursor — the indicator ref can be cleared by a stray
+    // dragLeave immediately before drop fires.
+    const targetIndex = computeDropIndex(e.clientY)
+    setDropIndicator(null)
+    setDraggingView(null)
+    if (view) moveSidebarView(view, side, targetIndex)
+  }
+
   // --- Render ---
+
+  // Drop-indicator line shown between icons during a view drag.
+  const dropLine = (
+    <div className="w-6 h-[2px] my-0.5 bg-blue-400 rounded-full pointer-events-none" />
+  )
 
   const bar = (
     <div
@@ -189,44 +297,64 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
           ? 'color-mix(in srgb, var(--surface-0) 60%, transparent)'
           : undefined,
       }}
+      onDragOver={handleBarDragOver}
+      onDragLeave={handleBarDragLeave}
+      onDrop={handleBarDrop}
     >
       {/* Collapse toggle — its own 36px header so it centers on the same line
-          as the canvas tab bar's +/split buttons (and the left-side toggle),
-          then fully hides the right sidebar. Reopened from the floating
-          top-right toggle. */}
+          as the canvas tab bar's +/split buttons, then fully hides this
+          sidebar. Reopened from the floating edge toggle in MainWindowShell.
+          The icon points toward the window edge it collapses to. */}
       <div className="flex items-center justify-center w-full flex-shrink-0" style={{ height: 36 }}>
-        <Tooltip label="Hide sidebar" placement="left">
+        <Tooltip label="Hide sidebar" placement={side === 'left' ? 'right' : 'left'}>
           <button
             type="button"
             className="flex items-center justify-center w-8 h-8 rounded-lg text-muted hover:text-secondary hover:bg-hover transition-colors"
-            onClick={() => setRightSidebarHidden(true)}
+            onClick={() => setSidebarHidden(true)}
             aria-label="Hide sidebar"
           >
-            <SidebarSimple size={16} className="pointer-events-none" style={{ transform: 'scaleX(-1)' }} />
+            <SidebarSimple
+              size={16}
+              className="pointer-events-none"
+              style={side === 'right' ? { transform: 'scaleX(-1)' } : undefined}
+            />
           </button>
         </Tooltip>
       </div>
-      <div className="flex flex-col items-center w-full relative">
-        {views.map((view) => {
+      <div ref={iconsContainerRef} className="flex flex-col items-center w-full relative">
+        {views.map((view, index) => {
           const meta = VIEW_META[view]
           const Icon = meta.icon
           const isActive = activeView === view
+          const showBefore = isDragActive && dropIndicator === index
+          const showAfter =
+            isDragActive && index === views.length - 1 && dropIndicator === views.length
           return (
-            <div key={view} className="relative w-full flex items-center justify-center">
-              <div
-                role="button"
-                tabIndex={0}
-                className={`relative flex items-center justify-center w-8 h-8 my-1 rounded-lg transition-colors cursor-pointer ${
-                  isActive ? 'text-primary' : 'text-muted hover:text-secondary'
-                }`}
-                onClick={() => handleIconClick(view)}
-                title={isActive ? `${meta.title}. Click to collapse.` : meta.title}
-              >
-                <Icon size={16} className="pointer-events-none" />
+            <React.Fragment key={view}>
+              {showBefore && dropLine}
+              <div className="relative w-full flex items-center justify-center">
+                <div
+                  role="button"
+                  tabIndex={0}
+                  data-sidebar-icon=""
+                  draggable
+                  onDragStart={(e) => handleIconDragStart(e, view)}
+                  onDragEnd={handleIconDragEnd}
+                  className={`relative flex items-center justify-center w-8 h-8 my-1 rounded-lg transition-colors cursor-pointer ${
+                    isActive ? 'text-primary' : 'text-muted hover:text-secondary'
+                  }`}
+                  onClick={() => handleIconClick(view)}
+                  title={isActive ? `${meta.title}. Click to collapse.` : meta.title}
+                >
+                  <Icon size={16} className="pointer-events-none" />
+                </div>
               </div>
-            </div>
+              {showAfter && dropLine}
+            </React.Fragment>
           )
         })}
+        {/* Empty-rail drop target (revealed during a drag). */}
+        {isDragActive && views.length === 0 && dropIndicator !== null && dropLine}
       </div>
       {side === 'right' && (
         <div className="mt-auto flex flex-col items-center pb-1 w-full">
@@ -301,19 +429,16 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
     </div>
   )
 
-  // Left has no activity-bar rail — just the content, opened/closed by the
-  // MacWindowChrome sidebar toggle (collapses fully to 0). Right keeps its 40px
-  // rail (it hosts the extra views + skills/layouts/settings actions).
+  // Both rails share the three-state model: fully hidden (0), rail-only
+  // (BAR_WIDTH), or opened (BAR_WIDTH + content width). An empty rail collapses
+  // to 0 unless a drag revealed it as a drop target. The right rail also hosts
+  // the skills/layouts/settings actions; the left does not.
   const sidebarWidth =
-    side === 'left'
-      ? isExpanded
-        ? width
-        : 0
-      : rightSidebarHidden || isEmpty
-        ? 0
-        : isExpanded
-          ? BAR_WIDTH + width
-          : BAR_WIDTH
+    sidebarHidden || (isEmpty && !dragRevealed)
+      ? 0
+      : isExpanded
+        ? BAR_WIDTH + width
+        : BAR_WIDTH
 
   return (
     <div
@@ -321,9 +446,14 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
       className={`flex-shrink-0 relative flex flex-row h-full select-none overflow-hidden ${
         isResizing ? '' : 'transition-[width] duration-200 ease-in-out'
       } ${
-        // Right sidebar only: hairline seam on its canvas-facing (left) edge.
-        // Omitted when collapsed to 0 width so no stray 1px line shows.
-        side === 'right' && sidebarWidth !== 0 ? 'border-l border-subtle' : ''
+        // Hairline seam on each rail's canvas-facing edge (right rail's left
+        // edge, left rail's right edge). Omitted at 0 width so no stray 1px
+        // line shows when collapsed.
+        sidebarWidth === 0
+          ? ''
+          : side === 'right'
+            ? 'border-l border-subtle'
+            : 'border-r border-subtle'
       }`}
       style={{
         width: sidebarWidth,
@@ -348,8 +478,13 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
         className="pointer-events-none absolute top-0 left-0 right-0 h-9"
         style={{ backgroundColor: side === 'right' ? 'var(--canvas-bg)' : 'var(--surface-1)' }}
       />
+      {/* Rail hugs the window edge (left rail on the left, right rail on the
+          right); content sits on the canvas-facing side of each. */}
       {side === 'left' ? (
-        content
+        <>
+          {bar}
+          {content}
+        </>
       ) : (
         <>
           {content}

--- a/src/renderer/stores/uiStore.test.tsx
+++ b/src/renderer/stores/uiStore.test.tsx
@@ -10,11 +10,11 @@
 // =============================================================================
 
 import React from 'react'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 
-import { useSidebarLayout, normalizeSidebarLayout } from './uiStore'
+import { useSidebarLayout, normalizeSidebarLayout, useUIStore } from './uiStore'
 import { useSettingsStore } from './settingsStore'
 import type { SidebarLayout } from '../../shared/types'
 
@@ -63,6 +63,79 @@ describe('useSidebarLayout', () => {
     })
     expect(lastLayout).toBe(firstRef)
     expect(renderCount).toBe(mountRenders)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// moveSidebarView + left-sidebar state (drag-and-drop between rails)
+// ---------------------------------------------------------------------------
+
+describe('moveSidebarView', () => {
+  // A full layout covering all five views, so normalizeSidebarLayout appends
+  // nothing and the move math is exact.
+  function seedLayout(layout: SidebarLayout) {
+    // Stub setSetting so it writes state without the (unmocked) settingsSet IPC.
+    const setSetting = vi.fn((key: string, value: unknown) =>
+      useSettingsStore.setState({ [key]: value } as never),
+    )
+    useSettingsStore.setState({ sidebarLayout: layout, setSetting } as never)
+    return setSetting
+  }
+
+  afterEach(() => {
+    useUIStore.setState({ activeLeftSidebarView: 'workspaces', activeRightSidebarView: null })
+  })
+
+  it('moves a view across rails, persists the layout, and focuses it on the target side', () => {
+    const setSetting = seedLayout({ left: ['workspaces', 'explorer', 'search'], right: ['git', 'cateAgent'] })
+    useUIStore.setState({ activeLeftSidebarView: 'explorer', activeRightSidebarView: null })
+
+    useUIStore.getState().moveSidebarView('explorer', 'right', 0)
+
+    expect(setSetting).toHaveBeenCalledTimes(1)
+    const [key, value] = setSetting.mock.calls[0]
+    expect(key).toBe('sidebarLayout')
+    expect((value as SidebarLayout).left).toEqual(['workspaces', 'search'])
+    expect((value as SidebarLayout).right).toEqual(['explorer', 'git', 'cateAgent'])
+    // Was active on the source (left) → cleared there, focused on the target.
+    expect(useUIStore.getState().activeLeftSidebarView).toBeNull()
+    expect(useUIStore.getState().activeRightSidebarView).toBe('explorer')
+  })
+
+  it('reorders within a rail, adjusting the index for the removed source', () => {
+    seedLayout({ left: ['workspaces', 'explorer', 'search'], right: ['git', 'cateAgent'] })
+
+    // Move the first icon to the end: source 0 < target 3 → insertAt 2.
+    useUIStore.getState().moveSidebarView('workspaces', 'left', 3)
+
+    expect(useSettingsStore.getState().sidebarLayout.left).toEqual(['explorer', 'search', 'workspaces'])
+  })
+})
+
+describe('left sidebar visibility', () => {
+  it('setLeftSidebarHidden and toggleLeftSidebar flip the hidden flag', () => {
+    useUIStore.getState().setLeftSidebarHidden(true)
+    expect(useUIStore.getState().leftSidebarHidden).toBe(true)
+    useUIStore.getState().toggleLeftSidebar()
+    expect(useUIStore.getState().leftSidebarHidden).toBe(false)
+  })
+
+  it('toggleSidebar cycles hidden → open → rail-only → open', () => {
+    useSettingsStore.setState({ sidebarLayout: { left: ['workspaces', 'explorer'], right: ['git'] } } as never)
+
+    // Hidden → reveal and open the first left view.
+    useUIStore.setState({ leftSidebarHidden: true, activeLeftSidebarView: null })
+    useUIStore.getState().toggleSidebar()
+    expect(useUIStore.getState().leftSidebarHidden).toBe(false)
+    expect(useUIStore.getState().activeLeftSidebarView).toBe('workspaces')
+
+    // Open → collapse to rail-only.
+    useUIStore.getState().toggleSidebar()
+    expect(useUIStore.getState().activeLeftSidebarView).toBeNull()
+
+    // Rail-only → open the first left view again.
+    useUIStore.getState().toggleSidebar()
+    expect(useUIStore.getState().activeLeftSidebarView).toBe('workspaces')
   })
 })
 

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -60,11 +60,19 @@ interface UIStoreState {
   activeLeftSidebarView: SidebarView | null
   /** Active view on the right sidebar, null = collapsed */
   activeRightSidebarView: SidebarView | null
+  /** When true the left sidebar (activity rail + content) is fully hidden
+   *  (width 0), reopened via the floating top-left toggle. Mirror of
+   *  rightSidebarHidden; distinct from activeLeftSidebarView === null, which
+   *  only collapses the content and keeps the rail visible. */
+  leftSidebarHidden: boolean
   /** When true the right sidebar (activity rail + content) is fully hidden
    *  (width 0), reopened via the floating top-right toggle. Distinct from
    *  activeRightSidebarView === null, which only collapses the content and
    *  keeps the rail visible. */
   rightSidebarHidden: boolean
+  /** View icon currently being dragged between rails, or null when idle.
+   *  Transient (not persisted); the layout itself lives in settingsStore. */
+  draggingView: SidebarView | null
   /** Worktree being hovered (chip or sidebar row) — transiently highlights all
    *  its member nodes + sludge. Null when nothing is hovered. */
   hoveredWorktreeId: string | null
@@ -87,10 +95,19 @@ interface UIStoreActions {
   setActiveTool: (tool: CanvasTool) => void
   setActiveLeftSidebarView: (view: SidebarView | null) => void
   setActiveRightSidebarView: (view: SidebarView | null) => void
+  /** Show/hide the entire left sidebar (rail + content). */
+  setLeftSidebarHidden: (hidden: boolean) => void
+  /** Flip the left sidebar between fully hidden and shown. */
+  toggleLeftSidebar: () => void
   /** Show/hide the entire right sidebar (rail + content). */
   setRightSidebarHidden: (hidden: boolean) => void
   /** Flip the right sidebar between fully hidden and shown. */
   toggleRightSidebar: () => void
+  /** Mark a view icon as being dragged (rail-to-rail DnD); null to clear. */
+  setDraggingView: (view: SidebarView | null) => void
+  /** Move a sidebar view to targetSide at targetIndex, persisting the new
+   *  layout to settings and focusing the moved view on its new side. */
+  moveSidebarView: (view: SidebarView, targetSide: SidebarSide, targetIndex: number) => void
   /** Highlight (hover) a worktree's member nodes; pass null to clear. */
   setHoveredWorktree: (id: string | null) => void
   /** Lock the focus lens onto a worktree (caller frames the camera separately). */
@@ -118,7 +135,9 @@ export const useUIStore = create<UIStore>((set, get) => ({
   activeTool: 'select',
   activeLeftSidebarView: 'workspaces',
   activeRightSidebarView: null,
+  leftSidebarHidden: false,
   rightSidebarHidden: false,
+  draggingView: null,
   hoveredWorktreeId: null,
   focusedWorktreeId: null,
 
@@ -157,9 +176,15 @@ export const useUIStore = create<UIStore>((set, get) => ({
   },
 
   toggleSidebar() {
-    // Toggles the left sidebar between collapsed (null) and the first view on the left.
-    const { activeLeftSidebarView } = get()
-    if (activeLeftSidebarView !== null) {
+    // Cmd+B / menu / command-palette action. Across the three-state left rail:
+    //   • fully hidden → reveal and open the first left view,
+    //   • opened       → collapse to rail-only (content hidden, rail kept),
+    //   • rail-only     → open the first left view.
+    const { leftSidebarHidden, activeLeftSidebarView } = get()
+    if (leftSidebarHidden) {
+      const first = getSidebarLayout().left[0] ?? null
+      set({ leftSidebarHidden: false, activeLeftSidebarView: first })
+    } else if (activeLeftSidebarView !== null) {
       set({ activeLeftSidebarView: null })
     } else {
       const first = getSidebarLayout().left[0] ?? null
@@ -183,12 +208,59 @@ export const useUIStore = create<UIStore>((set, get) => ({
     set({ activeRightSidebarView: view })
   },
 
+  setLeftSidebarHidden(hidden) {
+    set({ leftSidebarHidden: hidden })
+  },
+
+  toggleLeftSidebar() {
+    set((s) => ({ leftSidebarHidden: !s.leftSidebarHidden }))
+  },
+
   setRightSidebarHidden(hidden) {
     set({ rightSidebarHidden: hidden })
   },
 
   toggleRightSidebar() {
     set((s) => ({ rightSidebarHidden: !s.rightSidebarHidden }))
+  },
+
+  setDraggingView(view) {
+    set({ draggingView: view })
+  },
+
+  moveSidebarView(view, targetSide, targetIndex) {
+    // Layout's single home is settingsStore; work on a copy, then persist.
+    const current = getSidebarLayout()
+    const layout: SidebarLayout = { left: current.left.slice(), right: current.right.slice() }
+
+    // Find the view's source side + index.
+    let sourceSide: SidebarSide | null = null
+    let sourceIndex = layout.left.indexOf(view)
+    if (sourceIndex >= 0) sourceSide = 'left'
+    else if ((sourceIndex = layout.right.indexOf(view)) >= 0) sourceSide = 'right'
+    if (sourceSide === null) return
+
+    // Remove from source, then compensate the target index for the removal when
+    // moving within the same rail and the source sat before the drop point.
+    layout[sourceSide].splice(sourceIndex, 1)
+    let insertAt = targetIndex
+    if (sourceSide === targetSide && sourceIndex < targetIndex) insertAt -= 1
+    insertAt = Math.max(0, Math.min(insertAt, layout[targetSide].length))
+    layout[targetSide].splice(insertAt, 0, view)
+
+    // Persist (settingsStore is the source of truth; components read via
+    // useSidebarLayout, so this drives the re-render).
+    useSettingsStore.getState().setSetting('sidebarLayout', layout)
+
+    // Keep active views coherent: if the moved view was active on its source
+    // side, clear it there; focus it on the target side so its landing shows.
+    const state = get()
+    const patch: Partial<UIStoreState> = {}
+    if (sourceSide === 'left' && state.activeLeftSidebarView === view) patch.activeLeftSidebarView = null
+    if (sourceSide === 'right' && state.activeRightSidebarView === view) patch.activeRightSidebarView = null
+    if (targetSide === 'left') patch.activeLeftSidebarView = view
+    else patch.activeRightSidebarView = view
+    set(patch)
   },
 
 


### PR DESCRIPTION
## Summary

The recent UI rework left the **left sidebar** content-only — it could only be open or collapsed to 0. This PR gives it the same full model the right sidebar already has: **fully hidden → rail-only → opened**, driven by a new `leftSidebarHidden` flag mirroring `rightSidebarHidden`.

## What changed

- **Three-state left rail** — new `leftSidebarHidden` UI state and toggles in `uiStore`, mirroring the right sidebar.
- **Rail-to-rail view drag-and-drop** — restored the native HTML5 DnD (draggable icons, drop-indicator line, empty-rail drag-reveal) so views move and reorder between the left and right rails, persisted to settings via `moveSidebarView`.
- **macOS chrome** — the left rail carries its own collapse toggle (inset below the traffic lights); `MacWindowChrome` drops its toggle and becomes a drag strip; a floating reopen toggle in `MainWindowShell` handles the hidden state, offset past the lights. The center tab-bar reserve now scales with the left rail's width.

## Testing

- `uiStore` and `MacWindowChrome` unit tests updated/extended.
- Ran the app via `npm run dev` (with runtime tarball) and exercised the left rail's hidden/rail/open states and cross-rail view drag.
