### PR TITLE
feat(ui): responsive canvas toolbar that collapses to a corner button

### DIFF
--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -3,7 +3,7 @@
 // Ported from CanvasToolbar.swift.
 // =============================================================================
 
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Terminal,
@@ -20,7 +20,7 @@ import {
 import Minimap from './Minimap'
 import WorktreeToolbarMenu from './WorktreeToolbarMenu'
 import ExtensionToolbarMenu from './ExtensionToolbarMenu'
-import { useCanvasStoreApi } from '../stores/CanvasStoreContext'
+import { useCanvasStoreApi, useCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { useUIStore } from '../stores/uiStore'
 import { useUIStateStore } from '../stores/uiStateStore'
 import { cornerFromPoint } from '../lib/canvasCorners'
@@ -34,13 +34,10 @@ interface CanvasToolbarProps {
   canvasPanelId: string
   workspaceId: string
   rootPath: string
-  zoom: number
   onNewTerminal: () => void
   onNewBrowser: () => void
   onNewEditor: () => void
   onNewAgent: () => void
-  onZoomIn: () => void
-  onZoomOut: () => void
 }
 
 const ToolbarButton: React.FC<{
@@ -49,12 +46,13 @@ const ToolbarButton: React.FC<{
   size?: 'panel' | 'zoom'
   active?: boolean
   onMouseDown?: (e: React.MouseEvent) => void
+  placement?: 'top' | 'right'
   children: React.ReactNode
-}> = ({ onClick, title, size = 'panel', active = false, onMouseDown, children }) => {
+}> = ({ onClick, title, size = 'panel', active = false, onMouseDown, placement = 'top', children }) => {
   const sizeClass = size === 'panel' ? 'w-9 h-9' : 'w-8 h-8'
   const activeClass = active ? 'bg-hover-strong' : 'bg-transparent'
   return (
-    <Tooltip label={title} placement="top">
+    <Tooltip label={title} placement={placement}>
       <button
         type="button"
         onClick={onClick}
@@ -73,7 +71,7 @@ const ToolbarButton: React.FC<{
 // picker (onClick), while dragging onto the canvas spawns a ghost that follows
 // the cursor and drops a terminal at that exact spot (explicit position →
 // bypasses the picker). The cursor is treated as the new terminal's centre.
-const TerminalSpawnButton: React.FC<{ onClick: () => void; canvasPanelId: string }> = ({ onClick, canvasPanelId }) => {
+const TerminalSpawnButton: React.FC<{ onClick: () => void; canvasPanelId: string; placement?: 'top' | 'right' }> = ({ onClick, canvasPanelId, placement = 'top' }) => {
   const canvasApi = useCanvasStoreApi()
   const [ghost, setGhost] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
   const justDragged = useRef(false)
@@ -133,6 +131,7 @@ const TerminalSpawnButton: React.FC<{ onClick: () => void; canvasPanelId: string
         onMouseDown={handleMouseDown}
         title="Terminal. Click for recommendations, or drag onto the canvas."
         size="panel"
+        placement={placement}
       >
         <Terminal size={18} />
       </ToolbarButton>
@@ -171,11 +170,12 @@ const ModeButton: React.FC<{
   onClick: () => void
   title: string
   active: boolean
+  placement?: 'top' | 'right'
   children: React.ReactNode
-}> = ({ onClick, title, active, children }) => {
+}> = ({ onClick, title, active, placement = 'top', children }) => {
   const activeClass = active ? 'bg-hover-strong' : 'bg-transparent'
   return (
-    <Tooltip label={title} placement="top">
+    <Tooltip label={title} placement={placement}>
       <button
         type="button"
         onClick={onClick}
@@ -193,15 +193,13 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   canvasPanelId,
   workspaceId,
   rootPath,
-  zoom,
   onNewTerminal,
   onNewBrowser,
   onNewEditor,
   onNewAgent,
-  onZoomIn,
-  onZoomOut,
 }) => {
   const canvasApi = useCanvasStoreApi()
+  const zoom = useCanvasStoreContext((s) => s.zoomLevel)
   const minimapOpen = useUIStore((s) => s.minimapOpen)
   const toggleMinimapOpen = useUIStore((s) => s.toggleMinimapOpen)
   const activeTool = useUIStore((s) => s.activeTool)
@@ -214,6 +212,93 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   const zoomOutKey = displayString(shortcuts.zoomOut)
   const zoomResetKey = displayString(shortcuts.zoomReset)
   const zoomText = `${Math.round(zoom * 100)}%`
+
+  // Responsive layout keyed on canvas width. When there's room we show the
+  // original horizontal bar centered along the bottom; when the canvas gets too
+  // narrow (split view, small window) — where a centered bar would crowd the
+  // corner minimap — we collapse to a single bottom-left button that reveals a
+  // vertical version on hover.
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [areaWidth, setAreaWidth] = useState(0)
+
+  useEffect(() => {
+    const area = wrapperRef.current?.closest('[data-canvas-area]') as HTMLElement | null
+    if (!area) return
+    const measure = () => setAreaWidth(area.clientWidth)
+    const ro = new ResizeObserver(measure)
+    ro.observe(area)
+    measure()
+    return () => ro.disconnect()
+  }, [])
+
+  // Below this canvas width the centered bar would crowd the corner minimap.
+  // Default to horizontal until measured so we don't flash the button on load.
+  const HORIZONTAL_MIN_WIDTH = 640
+  const mode: 'horizontal' | 'compact' =
+    areaWidth > 0 && areaWidth < HORIZONTAL_MIN_WIDTH ? 'compact' : 'horizontal'
+  const isHorizontal = mode === 'horizontal'
+
+  // In 'compact' mode: hovering reveals the vertical bar, clicking the resting
+  // button pins it open, and an open worktree/extension fly-out keeps it open so
+  // the pointer can travel to the portaled popover without collapsing the card.
+  const [hovered, setHovered] = useState(false)
+  const [pinned, setPinned] = useState(false)
+  const [openMenu, setOpenMenu] = useState<'worktree' | 'extension' | null>(null)
+  const expanded = hovered || pinned || openMenu !== null
+  const ToolIcon = activeTool === 'hand' ? Hand : Cursor
+
+  // The buttons are identical between layouts — only the tooltip side, fly-out
+  // direction, and divider orientation change. Shared so the two layouts can't
+  // drift apart.
+  const place: 'top' | 'right' = isHorizontal ? 'top' : 'right'
+  const menuSide: 'up' | 'right' = isHorizontal ? 'up' : 'right'
+  const divider = <div className={isHorizontal ? 'w-px h-5 bg-surface-5 mx-1' : 'h-px w-6 bg-surface-5 my-1'} />
+  const items = (
+    <>
+      <ModeButton
+        onClick={() => setActiveTool('select')}
+        title={`Select tool (Space, or ${toggleToolKey} inside a panel)`}
+        active={activeTool === 'select'}
+        placement={place}
+      >
+        <Cursor size={18} />
+      </ModeButton>
+      <ModeButton
+        onClick={() => setActiveTool('hand')}
+        title={`Hand tool for panning (Space, or ${toggleToolKey} inside a panel)`}
+        active={activeTool === 'hand'}
+        placement={place}
+      >
+        <Hand size={18} />
+      </ModeButton>
+      <WorktreeToolbarMenu
+        canvasPanelId={canvasPanelId}
+        workspaceId={workspaceId}
+        rootPath={rootPath}
+        tooltipPlacement={place}
+        menuSide={menuSide}
+        onOpenChange={(o) => setOpenMenu(o ? 'worktree' : null)}
+      />
+      {divider}
+      <TerminalSpawnButton onClick={onNewTerminal} canvasPanelId={canvasPanelId} placement={place} />
+      <ToolbarButton onClick={onNewBrowser} title={`Browser (${newBrowserKey})`} size="panel" placement={place}>
+        <Globe size={18} />
+      </ToolbarButton>
+      <ToolbarButton onClick={onNewEditor} title={`Editor (${newEditorKey})`} size="panel" placement={place}>
+        <FileText size={18} />
+      </ToolbarButton>
+      <ToolbarButton onClick={onNewAgent} title="Agent" size="panel" placement={place}>
+        <ChatCircle size={18} />
+      </ToolbarButton>
+      <ExtensionToolbarMenu
+        canvasPanelId={canvasPanelId}
+        workspaceId={workspaceId}
+        tooltipPlacement={place}
+        menuSide={menuSide}
+        onOpenChange={(o) => setOpenMenu(o ? 'extension' : null)}
+      />
+    </>
+  )
 
   // Minimap pill docking corner + drag-to-dock handling. The corner is driven
   // straight from the UI-state store so an external shove (the Cate Agent landing on
@@ -267,58 +352,23 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
 
   return (
     <>
-    <div className="absolute inset-x-0 bottom-4 z-50 flex justify-center pointer-events-none">
-      <div data-onboarding="toolbar" className="relative pointer-events-auto">
-        <div className="rounded-full border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]">
+    {isHorizontal ? (
+      /* Wide canvas — the original horizontal bar, centered along the bottom. */
+      <div ref={wrapperRef} className="absolute inset-x-0 bottom-4 z-50 flex justify-center pointer-events-none">
+        <div
+          data-onboarding="toolbar"
+          data-toolbar-card
+          className="relative pointer-events-auto rounded-full border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)]"
+        >
           <div className="flex items-center gap-0.5 px-1 py-1">
-            {/* Interaction tools (Select / Hand) */}
-            <ModeButton
-              onClick={() => setActiveTool('select')}
-              title={`Select tool (Space, or ${toggleToolKey} inside a panel)`}
-              active={activeTool === 'select'}
-            >
-              <Cursor size={18} />
-            </ModeButton>
-            <ModeButton
-              onClick={() => setActiveTool('hand')}
-              title={`Hand tool for panning (Space, or ${toggleToolKey} inside a panel)`}
-              active={activeTool === 'hand'}
-            >
-              <Hand size={18} />
-            </ModeButton>
-
-            {/* Parallel worktrees — drop-up: focus a worktree's spatial lens,
-                open a terminal in one, or start a new parallel branch. */}
-            <WorktreeToolbarMenu
-              canvasPanelId={canvasPanelId}
-              workspaceId={workspaceId}
-              rootPath={rootPath}
-            />
-
-            {/* Divider */}
+            {items}
+            {/* Zoom controls — only in the horizontal bar, where there's room. */}
             <div className="w-px h-5 bg-surface-5 mx-1" />
-
-            {/* Basic panel buttons */}
-            <TerminalSpawnButton onClick={onNewTerminal} canvasPanelId={canvasPanelId} />
-            <ToolbarButton onClick={onNewBrowser} title={`Browser (${newBrowserKey})`} size="panel">
-              <Globe size={18} />
-            </ToolbarButton>
-            <ToolbarButton onClick={onNewEditor} title={`Editor (${newEditorKey})`} size="panel">
-              <FileText size={18} />
-            </ToolbarButton>
-            <ToolbarButton onClick={onNewAgent} title="Agent" size="panel">
-              <ChatCircle size={18} />
-            </ToolbarButton>
-
-            {/* Extensions — only shown when an enabled extension exposes a panel.
-                One panel opens directly; several open a drop-up picker. */}
-            <ExtensionToolbarMenu canvasPanelId={canvasPanelId} workspaceId={workspaceId} />
-
-            {/* Divider */}
-            <div className="w-px h-5 bg-surface-5 mx-1" />
-
-            {/* Zoom controls */}
-            <ToolbarButton onClick={onZoomOut} title={`Zoom Out (${zoomOutKey})`} size="zoom">
+            <ToolbarButton
+              onClick={() => canvasApi.getState().animateZoomTo(zoom - 0.1)}
+              title={`Zoom Out (${zoomOutKey})`}
+              size="zoom"
+            >
               <Minus size={16} />
             </ToolbarButton>
             <Tooltip label={`Reset zoom to 100% (${zoomResetKey})`} placement="top">
@@ -332,14 +382,66 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
                 {zoomText}
               </button>
             </Tooltip>
-            <ToolbarButton onClick={onZoomIn} title={`Zoom In (${zoomInKey})`} size="zoom">
+            <ToolbarButton
+              onClick={() => canvasApi.getState().animateZoomTo(zoom + 0.1)}
+              title={`Zoom In (${zoomInKey})`}
+              size="zoom"
+            >
               <Plus size={16} />
             </ToolbarButton>
           </div>
         </div>
       </div>
+    ) : (
+      /* Narrow canvas — a single bottom-left button that reveals a vertical bar
+         on hover. It floats directly above the resting button; the transparent
+         paddingBottom keeps the hover region continuous so the pointer can travel
+         up without it collapsing. */
+      <div ref={wrapperRef} className="absolute bottom-4 left-4 z-50 pointer-events-none">
+        <div
+          data-onboarding="toolbar"
+          className="relative pointer-events-auto"
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          <div
+            aria-hidden={!expanded}
+            style={{
+              position: 'absolute',
+              bottom: '100%',
+              left: 0,
+              paddingBottom: 10,
+              opacity: expanded ? 1 : 0,
+              transform: expanded ? 'translateY(0)' : 'translateY(6px)',
+              pointerEvents: expanded ? 'auto' : 'none',
+              transition: 'opacity 160ms ease, transform 160ms cubic-bezier(0.16,1,0.3,1)',
+            }}
+          >
+            <div
+              data-toolbar-card
+              className="rounded-2xl border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)] flex flex-col-reverse items-center gap-0.5 p-1"
+            >
+              {items}
+            </div>
+          </div>
 
-    </div>
+          {/* Resting button — shows the active tool; click pins the bar open,
+              hovering it (or the bar above) reveals. */}
+          <Tooltip label={pinned ? 'Collapse toolbar' : 'Tools — hover to expand, click to keep open'} placement="right">
+            <button
+              type="button"
+              onClick={() => setPinned((p) => !p)}
+              aria-label="Toolbar"
+              aria-expanded={expanded}
+              style={{ WebkitTapHighlightColor: 'transparent' }}
+              className={`w-11 h-11 flex items-center justify-center rounded-full border border-subtle bg-surface-0 shadow-[0_8px_24px_-6px_var(--shadow-node)] ${expanded ? 'text-primary' : 'text-secondary'} hover:text-primary active:scale-[0.92] focus:outline-none focus-visible:outline-none transition-all duration-100`}
+            >
+              <ToolIcon size={18} />
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+    )}
 
     {/* Minimap — pill button docked to any corner. The pill grows toward the
         canvas centre to reveal the map, while the toggle button stays pinned to

--- a/src/renderer/canvas/ExtensionToolbarMenu.tsx
+++ b/src/renderer/canvas/ExtensionToolbarMenu.tsx
@@ -24,9 +24,18 @@ import {
 interface ExtensionToolbarMenuProps {
   canvasPanelId: string
   workspaceId: string
+  tooltipPlacement?: 'top' | 'right'
+  menuSide?: 'up' | 'right'
+  onOpenChange?: (open: boolean) => void
 }
 
-const ExtensionToolbarMenu: React.FC<ExtensionToolbarMenuProps> = ({ canvasPanelId, workspaceId }) => {
+const ExtensionToolbarMenu: React.FC<ExtensionToolbarMenuProps> = ({
+  canvasPanelId,
+  workspaceId,
+  tooltipPlacement = 'top',
+  menuSide = 'up',
+  onOpenChange,
+}) => {
   const entries = useExtensionsStore((s) => s.entries)
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<{ left: number; bottom: number } | null>(null)
@@ -35,6 +44,13 @@ const ExtensionToolbarMenu: React.FC<ExtensionToolbarMenuProps> = ({ canvasPanel
   useEffect(() => {
     ensureExtensionsStarted()
   }, [])
+
+  // Keep the parent card expanded while the picker is open (real transitions only).
+  const onOpenChangeRef = useRef(onOpenChange)
+  onOpenChangeRef.current = onOpenChange
+  useEffect(() => {
+    onOpenChangeRef.current?.(open)
+  }, [open])
 
   const targets = enabledPanelTargets(entries)
 
@@ -64,15 +80,22 @@ const ExtensionToolbarMenu: React.FC<ExtensionToolbarMenuProps> = ({ canvasPanel
       setOpen(false)
       return
     }
-    const r = btnRef.current?.getBoundingClientRect()
-    if (r) {
-      // Center the popover over the button, clamped to the viewport.
-      const width = 240
-      const left = Math.max(8, Math.min(r.left + r.width / 2 - width / 2, window.innerWidth - width - 8))
-      setPos({ left, bottom: window.innerHeight - r.top + 10 })
+    if (menuSide === 'right') {
+      // Fly out to the right of the compact vertical bar, growing upward.
+      const cardEl = btnRef.current?.closest('[data-toolbar-card]') as HTMLElement | null
+      const r = (cardEl ?? btnRef.current)?.getBoundingClientRect()
+      if (r) setPos({ left: r.right + 8, bottom: window.innerHeight - r.bottom })
+    } else {
+      // Drop up from the horizontal bar, centered over the button.
+      const r = btnRef.current?.getBoundingClientRect()
+      if (r) {
+        const width = 240
+        const left = Math.max(8, Math.min(r.left + r.width / 2 - width / 2, window.innerWidth - width - 8))
+        setPos({ left, bottom: window.innerHeight - r.top + 10 })
+      }
     }
     setOpen(true)
-  }, [targets, open, openTarget])
+  }, [targets, open, openTarget, menuSide])
 
   // Nothing enabled exposes a panel — no button.
   if (targets.length === 0) return null
@@ -82,7 +105,7 @@ const ExtensionToolbarMenu: React.FC<ExtensionToolbarMenuProps> = ({ canvasPanel
 
   return (
     <>
-      <Tooltip label={title} placement="top">
+      <Tooltip label={title} placement={tooltipPlacement}>
         <button
           ref={btnRef}
           type="button"

--- a/src/renderer/canvas/WorktreeToolbarMenu.tsx
+++ b/src/renderer/canvas/WorktreeToolbarMenu.tsx
@@ -41,6 +41,9 @@ interface WorktreeToolbarMenuProps {
   canvasPanelId: string
   workspaceId: string
   rootPath: string
+  tooltipPlacement?: 'top' | 'right'
+  menuSide?: 'up' | 'right'
+  onOpenChange?: (open: boolean) => void
 }
 
 interface PopoverPos {
@@ -52,12 +55,23 @@ const WorktreeToolbarMenu: React.FC<WorktreeToolbarMenuProps> = ({
   canvasPanelId,
   workspaceId,
   rootPath,
+  tooltipPlacement = 'top',
+  menuSide = 'up',
+  onOpenChange,
 }) => {
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<PopoverPos | null>(null)
   const btnRef = useRef<HTMLButtonElement>(null)
   const focusedWorktreeId = useUIStore((s) => s.focusedWorktreeId)
   const active = open || !!focusedWorktreeId
+
+  // Notify the parent card on real open/close transitions only (not on every
+  // render), so an open fly-out keeps the collapsing toolbar expanded.
+  const onOpenChangeRef = useRef(onOpenChange)
+  onOpenChangeRef.current = onOpenChange
+  useEffect(() => {
+    onOpenChangeRef.current?.(open)
+  }, [open])
 
   const close = useCallback(() => setOpen(false), [])
 
@@ -66,17 +80,23 @@ const WorktreeToolbarMenu: React.FC<WorktreeToolbarMenuProps> = ({
       setOpen(false)
       return
     }
-    const toolbarEl = btnRef.current?.closest('[data-onboarding="toolbar"]') as HTMLElement | null
-    const r = (toolbarEl ?? btnRef.current)?.getBoundingClientRect()
+    // Anchor to the toolbar card: drop up from it in the horizontal bar, or fly
+    // out to its right in the compact vertical bar (growing upward either way).
+    const cardEl = btnRef.current?.closest('[data-toolbar-card]') as HTMLElement | null
+    const r = (cardEl ?? btnRef.current)?.getBoundingClientRect()
     if (r) {
-      setPos({ left: r.left, bottom: window.innerHeight - r.top + 10 })
+      setPos(
+        menuSide === 'right'
+          ? { left: r.right + 8, bottom: window.innerHeight - r.bottom }
+          : { left: r.left, bottom: window.innerHeight - r.top + 10 },
+      )
     }
     setOpen(true)
-  }, [open])
+  }, [open, menuSide])
 
   return (
     <>
-      <Tooltip label="Parallel worktrees" placement="top">
+      <Tooltip label="Parallel worktrees" placement={tooltipPlacement}>
         <button
           ref={btnRef}
           type="button"

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -18,7 +18,6 @@ import { EmptyCanvasOverlay } from './EmptyCanvasOverlay'
 import type { PanelType, Point, DockLayoutNode, WindowDockState } from '../../shared/types'
 import { useAppStore, useSelectedWorkspace, type PanelPlacement } from '../stores/appStore'
 import { useCateAgentStore } from '../cateAgent/cateAgentStore'
-import { useStore } from 'zustand'
 import { useStoreWithEqualityFn } from 'zustand/traditional'
 import type { StoreApi } from 'zustand'
 import { keepsMountedOffscreen } from '../../shared/panels'
@@ -234,7 +233,6 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
     setActivePanel(panelId)
   }, [panelId])
 
-  const zoomLevel = useStore(store, (s) => s.zoomLevel)
   // `nodeIds` is the full ordered list (used where we need to know about every
   // node regardless of visibility — e.g. the "canvas empty" welcome page).
   // `visibleNodeIds` is viewport-culled: we only mount CanvasNodeWrapper for
@@ -311,14 +309,6 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
     if (newId && wt.worktreeId) app.setPanelWorktreeId(wsId, newId, wt.worktreeId)
   }, [workspaceId, here, store])
 
-  const onZoomIn = useCallback(() => {
-    store.getState().animateZoomTo(zoomLevel + 0.1)
-  }, [zoomLevel, store])
-
-  const onZoomOut = useCallback(() => {
-    store.getState().animateZoomTo(zoomLevel - 0.1)
-  }, [zoomLevel, store])
-
   return (
     <CanvasStoreProvider store={store}>
       {/* `isolate` keeps the toolbar/minimap's z-50 contained within this panel
@@ -357,13 +347,10 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
             canvasPanelId={panelId}
             workspaceId={workspaceId}
             rootPath={workspaceRootPath}
-            zoom={zoomLevel}
             onNewTerminal={onNewTerminal}
             onNewBrowser={onNewBrowser}
             onNewEditor={onNewEditor}
             onNewAgent={onNewAgent}
-            onZoomIn={onZoomIn}
-            onZoomOut={onZoomOut}
           />
         )}
       </div>


### PR DESCRIPTION
## What

Reworks the floating canvas toolbar so it no longer overlaps the minimap on narrow / split-view canvases.

- **Width breakpoint (640px canvas width)** auto-switches between two layouts:
  - **Wide →** the original horizontal bottom-center bar (with zoom controls).
  - **Narrow →** a single bottom-left button showing the active tool that reveals a compact vertical bar on hover; click pins it open.
- Measured via `ResizeObserver` on the canvas area, so split views decide independently and re-evaluate live on resize. Defaults to horizontal until measured (no load flash).
- Both layouts render from **one shared button list**, so they can't drift apart — only tooltip side, divider orientation, and menu fly-out direction differ.
- Worktree / extension menus **drop up** from the horizontal bar and **fly out to the right** of the compact vertical bar.
- **Zoom controls only in the horizontal bar** to keep the compact one slim; the toolbar reads zoom straight from the canvas store instead of via props (removed the now-dead zoom prop plumbing in `CanvasPanel`).

## Why

On narrow/split-view canvases the centered toolbar's edge reached the corner-docked minimap, and an open minimap grew inward over it. Collapsing to the opposite corner when space is tight removes the collision while keeping the full bar when there's room.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] `CanvasToolbar.test.ts` passes
- [x] Ran in dev: verified horizontal ↔ compact switch on resize, hover-expand + pin, worktree/extension fly-outs in both modes, live zoom %.