### PR TITLE
fix(browser): keep webview-backed tabs mounted so they don't reload on tab switch (#459)

### DIFF
--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -17,7 +17,7 @@ import { useDockTabActions, useAcceptsPanelType } from './useDockTabActions'
 import { setActivePanel } from '../lib/activePanel'
 import { Tooltip } from '../ui/Tooltip'
 import { useDockTabDrag } from './useDockTabDrag'
-import { PANEL_DEFINITIONS } from '../../shared/panels'
+import { PANEL_DEFINITIONS, keepsMountedWhenTabHidden } from '../../shared/panels'
 
 // Human-readable labels for each panel type, used in tooltips and the split menu.
 const PANEL_TYPE_LABELS: Record<PanelType, string> = Object.fromEntries(
@@ -345,15 +345,43 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         )}
       </div>
 
-      {/* Active panel content. Keyed by panel id: switching between two tabs of
-          the SAME component type (canvas↔canvas, terminal↔terminal) must
-          remount the content, not reuse the instance with a swapped panelId —
-          panels wire store subscriptions in mount-only effects, so a reused
-          instance keeps driving the previous panel's store (visible canvas
-          transformed by the hidden canvas's zoom/offset). */}
+      {/* Panel content. Each panel gets its OWN stable keyed slot (keyed by panel
+          id): switching between two tabs of the SAME component type
+          (canvas↔canvas, terminal↔terminal) must remount the content, not reuse
+          the instance with a swapped panelId — panels wire store subscriptions in
+          mount-only effects, so a reused instance keeps driving the previous
+          panel's store (visible canvas transformed by the hidden canvas's
+          zoom/offset).
+
+          Ordinary panels render only while active and unmount otherwise (freeing
+          xterm/WebGL, Monaco, etc.). Webview-backed panels
+          (keepsMountedWhenTabHidden: browser/extension) instead stay MOUNTED but
+          hidden when inactive, so their live `<webview>` guest process survives a
+          tab switch — unmounting and remounting would reload the page and lose all
+          in-page state (#459). Because each keep-alive panel keeps its stable
+          keyed slot, toggling active only flips visibility rather than
+          remounting. */}
       <div className="flex-1 min-h-0 overflow-hidden relative">
         {activePanelId ? (
-          <React.Fragment key={activePanelId}>{renderPanel(activePanelId)}</React.Fragment>
+          stack.panelIds.map((panelId) => {
+            const isActive = panelId === activePanelId
+            const keepAlive = keepsMountedWhenTabHidden(resolvePanel(panelId)?.type)
+            if (!isActive && !keepAlive) return null
+            return (
+              <div
+                key={panelId}
+                className="absolute inset-0"
+                // visibility:hidden (not display:none) keeps the hidden webview
+                // laid out at full size so it's ready the instant its tab is
+                // reselected; pointer-events:none stops the hidden layer from
+                // intercepting clicks meant for the active panel.
+                style={isActive ? undefined : { visibility: 'hidden', pointerEvents: 'none' }}
+                aria-hidden={isActive ? undefined : true}
+              >
+                {renderPanel(panelId)}
+              </div>
+            )
+          })
         ) : (
           <div className="flex items-center justify-center h-full text-muted text-sm">
             No panel

--- a/src/shared/panels.test.ts
+++ b/src/shared/panels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolvePanelSize } from './panels'
+import { resolvePanelSize, keepsMountedWhenTabHidden } from './panels'
 
 describe('resolvePanelSize', () => {
   it('returns the fixed per-type default', () => {
@@ -10,5 +10,24 @@ describe('resolvePanelSize', () => {
   it('ignores any leftover settings values', () => {
     expect(resolvePanelSize('terminal', { defaultPanelWidth: 999, defaultPanelHeight: 999 } as never))
       .toEqual({ width: 640, height: 400 })
+  })
+})
+
+describe('keepsMountedWhenTabHidden', () => {
+  it('is true for webview-backed panels whose live state cannot survive a remount (#459)', () => {
+    expect(keepsMountedWhenTabHidden('browser')).toBe(true)
+    expect(keepsMountedWhenTabHidden('extension')).toBe(true)
+  })
+
+  it('is false for panels whose state is cheap to rehydrate or lives in main', () => {
+    expect(keepsMountedWhenTabHidden('terminal')).toBe(false)
+    expect(keepsMountedWhenTabHidden('editor')).toBe(false)
+    expect(keepsMountedWhenTabHidden('agent')).toBe(false)
+    expect(keepsMountedWhenTabHidden('canvas')).toBe(false)
+  })
+
+  it('is false for an unknown/undefined type', () => {
+    expect(keepsMountedWhenTabHidden(undefined)).toBe(false)
+    expect(keepsMountedWhenTabHidden('nope')).toBe(false)
   })
 })

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -46,6 +46,14 @@ export interface SharedPanelDefinition {
    *  Terminals/editors leave this false: their backing state is in the main
    *  process (PTY) or trivially rehydrated (Monaco), so culling them is safe. */
   keepMountedOffscreen: boolean
+  /** When true, an inactive tab of this type stays mounted (hidden) in its dock
+   *  stack instead of being unmounted, so its live `<webview>` guest process
+   *  survives a tab switch. Without this, switching away from a browser/extension
+   *  tab and back reloads the page and loses all in-page state (#459).
+   *  Terminals/editors leave this false: unmounting an inactive terminal frees
+   *  its xterm/WebGL context (the PTY keeps running in main), which is the
+   *  cheaper trade-off. */
+  keepMountedWhenTabHidden: boolean
 }
 
 // -----------------------------------------------------------------------------
@@ -73,6 +81,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(77,217,100)', '<polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: false,
   },
   browser: {
     type: 'browser',
@@ -85,6 +94,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(74,158,255)', '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: true,
   },
   editor: {
     type: 'editor',
@@ -97,6 +107,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(255,159,10)', '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: false,
   },
   agent: {
     type: 'agent',
@@ -109,6 +120,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(74,158,255)', '<path d="M12 3l1.8 4.2L18 9l-4.2 1.8L12 15l-1.8-4.2L6 9l4.2-1.8L12 3z"/><path d="M19 14l.9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9L19 14z"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: false,
   },
   document: {
     type: 'document',
@@ -121,6 +133,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(175,82,222)', '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><circle cx="12" cy="15" r="3"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: false,
   },
   canvas: {
     type: 'canvas',
@@ -133,6 +146,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(191,90,242)', '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/>'),
     canLiveOnCanvas: false,
     keepMountedOffscreen: false,
+    keepMountedWhenTabHidden: false,
   },
   extension: {
     type: 'extension',
@@ -145,6 +159,7 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     ghostSvg: ghost('rgb(142,142,147)', '<path d="M16 4h2a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2 2 2 0 0 0 0 4 2 2 0 0 1 2 2v2a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2 2 2 0 0 0-4 0 2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2a2 2 0 0 1 2-2 2 2 0 0 0 0-4 2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2 2 2 0 0 0 4 0 2 2 0 0 1 2-2z"/>'),
     canLiveOnCanvas: true,
     keepMountedOffscreen: true,
+    keepMountedWhenTabHidden: true,
   },
 }
 
@@ -158,6 +173,13 @@ export function getSharedPanelDef(type: PanelType | string): SharedPanelDefiniti
  *  scrolled off-screen (its live `<webview>` state can't survive a remount). */
 export function keepsMountedOffscreen(type: PanelType | string | undefined): boolean {
   return !!type && getSharedPanelDef(type).keepMountedOffscreen
+}
+
+/** True when an inactive tab of this type must stay mounted (hidden) in its dock
+ *  stack rather than being unmounted — its live `<webview>` state can't survive a
+ *  remount, so unmounting on tab switch would reload the page (#459). */
+export function keepsMountedWhenTabHidden(type: PanelType | string | undefined): boolean {
+  return !!type && getSharedPanelDef(type).keepMountedWhenTabHidden
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #459.

## Problem

Switching from another tab in a dock stack (e.g. a terminal) back to a browser tab reloaded the browser page every time.

## Root cause

`DockTabStack` rendered **only the active tab's panel** and unmounted every inactive one. Terminals tolerate this because their state lives in the main-process PTY, but a browser (and extension) panel is backed by a live Electron `<webview>` DOM element. Unmounting it destroys the guest webContents, so switching away and back remounted a fresh `<webview>` that reloaded `webviewSrc` — losing scroll position, form input, and any in-page state.

## Fix

Introduce a `keepMountedWhenTabHidden` panel flag (true for `browser` and `extension` — the webview-backed types) that mirrors the existing `keepMountedOffscreen` pattern used for canvas viewport culling. `DockTabStack` now keeps those panels **mounted but hidden** (`visibility: hidden` + `pointer-events: none`) while their tab is inactive, each in a stable keyed slot so toggling active only flips visibility — no remount, so the `<webview>` guest process survives.

Ordinary panels (terminal / editor / agent / …) still unmount when inactive, so there's no added xterm/WebGL or Monaco cost.

## Notes / trade-offs

- Only webview-backed types stay resident; a browser tab now behaves like a real background browser tab (keeps running while hidden), which is the intended behavior here.
- `keepMountedOffscreen` (canvas culling) is intentionally left unchanged — this is scoped to the dock-tab switch reported in the issue.

## Testing

- Unit tests for the new `keepsMountedWhenTabHidden` helper (`src/shared/panels.test.ts`).
- `npx tsc --noEmit` clean on touched files; full docking + browser-panel suites pass.
- Manual check for a reviewer: put a browser tab and a terminal tab in the same dock stack, load a page / scroll / type into a form, switch to the terminal tab and back — the page should stay put with no reload.