### PR TITLE
feat(shortcuts): customizable next/previous workspace shortcuts

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -219,6 +219,9 @@ export function buildApplicationMenu(): void {
       submenu: [
         { ...actionMeta('focusNext'), label: 'Next Panel', click: dispatch('focusNext') },
         { ...actionMeta('focusPrevious'), label: 'Previous Panel', click: dispatch('focusPrevious') },
+        { type: 'separator' },
+        { ...actionMeta('previousWorkspace'), click: dispatch('previousWorkspace') },
+        { ...actionMeta('nextWorkspace'), click: dispatch('nextWorkspace') },
       ],
     },
     // Layouts menu — save / manage / load named canvas layouts. The list is

--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -170,6 +170,12 @@ export async function runAction(
     case 'commandPalette':
       useUIStore.getState().setShowCommandPalette(true)
       break
+    case 'nextWorkspace':
+      void appStore().switchWorkspaceByOffset(1)
+      break
+    case 'previousWorkspace':
+      void appStore().switchWorkspaceByOffset(-1)
+      break
     case 'zoomIn':
       { const canvas = canvasStore(); if (canvas) canvas.animateZoomTo(canvas.zoomLevel + 0.1) }
       break

--- a/src/renderer/stores/appStore/types.ts
+++ b/src/renderer/stores/appStore/types.ts
@@ -65,6 +65,10 @@ export interface AppStoreActions {
   // Workspace management
   addWorkspace: (name?: string, rootPath?: string, id?: string, connection?: RuntimeConnection) => string
   selectWorkspace: (id: string) => Promise<void>
+  /** Switch to the workspace `offset` steps away in list order, wrapping around
+   *  both ends. No-op with fewer than two workspaces. Backs the next/previous
+   *  workspace shortcuts. */
+  switchWorkspaceByOffset: (offset: number) => Promise<void>
   removeWorkspace: (id: string, forgetRecent?: boolean) => void
 
   // Panel creation — each adds a PanelState to the workspace AND places it

--- a/src/renderer/stores/appStore/workspaceSlice.ts
+++ b/src/renderer/stores/appStore/workspaceSlice.ts
@@ -31,6 +31,7 @@ type WorkspaceSliceActions = Pick<
   AppStoreActions,
   | 'addWorkspace'
   | 'selectWorkspace'
+  | 'switchWorkspaceByOffset'
   | 'removeWorkspace'
   | 'ensureCenterCanvas'
   | 'setWorkspaceColor'
@@ -42,6 +43,23 @@ type WorkspaceSliceActions = Pick<
   | 'getWorkspace'
   | 'selectedWorkspace'
 >
+
+/** Resolve the workspace `offset` steps away from `currentId` in list order,
+ *  wrapping around both ends. Returns null when switching is a no-op: fewer than
+ *  two workspaces, or `currentId` isn't in the list. Ordering follows the
+ *  `workspaces` array — the same order the sidebar renders. */
+export function workspaceIdAtOffset(
+  workspaces: readonly { id: string }[],
+  currentId: string,
+  offset: number,
+): string | null {
+  if (workspaces.length < 2) return null
+  const currentIndex = workspaces.findIndex((w) => w.id === currentId)
+  if (currentIndex === -1) return null
+  const len = workspaces.length
+  const nextIndex = (((currentIndex + offset) % len) + len) % len
+  return workspaces[nextIndex].id
+}
 
 export function createWorkspaceSlice(set: AppSet, get: AppGet): WorkspaceSliceActions {
   return {
@@ -315,6 +333,12 @@ export function createWorkspaceSlice(set: AppSet, get: AppGet): WorkspaceSliceAc
 
       // Sync to main process
       syncRemoveFromMain(id)
+    },
+
+    async switchWorkspaceByOffset(offset) {
+      const state = get()
+      const targetId = workspaceIdAtOffset(state.workspaces, state.selectedWorkspaceId, offset)
+      if (targetId) await get().selectWorkspace(targetId)
     },
 
     getWorkspace(id) {

--- a/src/renderer/stores/appStore/workspaceSwitch.test.ts
+++ b/src/renderer/stores/appStore/workspaceSwitch.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+// =============================================================================
+// Tests for workspaceIdAtOffset — the pure next/previous-workspace resolver
+// backing the customizable workspace-switch shortcut (issue #456). Ordering
+// follows the `workspaces` array (same order the sidebar renders), and stepping
+// wraps around both ends.
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { WorkspaceState } from '../../../shared/types'
+
+vi.mock('../../lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+vi.mock('../../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: {
+    setPendingRestore: vi.fn(),
+    dispose: vi.fn(),
+    disposeWorkspace: vi.fn(),
+    getEntry: vi.fn(),
+    has: vi.fn(() => false),
+  },
+}))
+
+import { workspaceIdAtOffset } from './workspaceSlice'
+import { useAppStore } from '../appStore'
+
+const ws = (id: string) => ({ id })
+
+/** A minimal already-activated local workspace: has a rootPath (so it isn't
+ *  swept as an uninitialized row) and a non-canvas panel (so selectWorkspace
+ *  skips the from-disk hydration path). */
+function localWorkspace(id: string): WorkspaceState {
+  return {
+    id,
+    name: id,
+    color: '',
+    rootPath: `/tmp/${id}`,
+    panels: { [`t-${id}`]: { id: `t-${id}`, type: 'terminal', title: 'Terminal', isDirty: false } },
+  } as WorkspaceState
+}
+
+describe('switchWorkspaceByOffset (store action)', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [localWorkspace('a'), localWorkspace('b'), localWorkspace('c')],
+      selectedWorkspaceId: 'a',
+    })
+  })
+
+  it('switches to the next workspace', async () => {
+    await useAppStore.getState().switchWorkspaceByOffset(1)
+    expect(useAppStore.getState().selectedWorkspaceId).toBe('b')
+  })
+
+  it('switches to the previous workspace, wrapping to the last', async () => {
+    await useAppStore.getState().switchWorkspaceByOffset(-1)
+    expect(useAppStore.getState().selectedWorkspaceId).toBe('c')
+  })
+
+  it('is a no-op with a single workspace', async () => {
+    useAppStore.setState({ workspaces: [localWorkspace('solo')], selectedWorkspaceId: 'solo' })
+    await useAppStore.getState().switchWorkspaceByOffset(1)
+    expect(useAppStore.getState().selectedWorkspaceId).toBe('solo')
+  })
+})
+
+describe('workspaceIdAtOffset', () => {
+  const three = [ws('a'), ws('b'), ws('c')]
+
+  it('steps forward to the next workspace', () => {
+    expect(workspaceIdAtOffset(three, 'a', 1)).toBe('b')
+    expect(workspaceIdAtOffset(three, 'b', 1)).toBe('c')
+  })
+
+  it('steps backward to the previous workspace', () => {
+    expect(workspaceIdAtOffset(three, 'c', -1)).toBe('b')
+    expect(workspaceIdAtOffset(three, 'b', -1)).toBe('a')
+  })
+
+  it('wraps forward from the last workspace to the first', () => {
+    expect(workspaceIdAtOffset(three, 'c', 1)).toBe('a')
+  })
+
+  it('wraps backward from the first workspace to the last', () => {
+    expect(workspaceIdAtOffset(three, 'a', -1)).toBe('c')
+  })
+
+  it('returns null when there are fewer than two workspaces', () => {
+    expect(workspaceIdAtOffset([ws('only')], 'only', 1)).toBeNull()
+    expect(workspaceIdAtOffset([], 'missing', 1)).toBeNull()
+  })
+
+  it('returns null when the current workspace is not in the list', () => {
+    expect(workspaceIdAtOffset(three, 'z', 1)).toBeNull()
+  })
+})

--- a/src/renderer/stores/shortcutStore.test.ts
+++ b/src/renderer/stores/shortcutStore.test.ts
@@ -29,6 +29,14 @@ describe('shortcutStore', () => {
     expect(matchShortcutEvent(keyEvent(' ', { ctrl: true }))).toBe('toggleTool')
   })
 
+  it('nextWorkspace / previousWorkspace default to Cmd+Option+Arrow (#456)', async () => {
+    const { matchShortcutEvent } = await loadStores()
+    expect(matchShortcutEvent(keyEvent('ArrowRight', { meta: true, alt: true }))).toBe('nextWorkspace')
+    expect(matchShortcutEvent(keyEvent('ArrowLeft', { meta: true, alt: true }))).toBe('previousWorkspace')
+    // Plain Cmd+Arrow stays panel navigation, not workspace switching.
+    expect(matchShortcutEvent(keyEvent('ArrowRight', { meta: true }))).not.toBe('nextWorkspace')
+  })
+
   it('clearShortcut disables a binding so it never matches (#372)', async () => {
     const { clearShortcut, getResolvedShortcuts, matchShortcutEvent } = await loadStores()
     clearShortcut('toggleTool')

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -30,6 +30,8 @@ import {
   ArrowUUpRight,
   ChatCircle,
   Eye,
+  CaretLeft,
+  CaretRight,
 } from '@phosphor-icons/react'
 import { browserPanelUrl, SHORTCUT_DISPLAY_NAMES, type PanelType, type MenuActionId, type ShortcutAction } from '../../shared/types'
 import { PaletteDialogShell } from './Modal'
@@ -81,6 +83,8 @@ const ObserveIcon = () => <Eye size={ICON_SIZE} />
 const CloseIcon = () => <X size={ICON_SIZE} />
 const UndoIcon = () => <ArrowUUpLeft size={ICON_SIZE} />
 const RedoIcon = () => <ArrowUUpRight size={ICON_SIZE} />
+const PreviousWorkspaceIcon = () => <CaretLeft size={ICON_SIZE} />
+const NextWorkspaceIcon = () => <CaretRight size={ICON_SIZE} />
 
 // -----------------------------------------------------------------------------
 // Result types
@@ -209,6 +213,8 @@ export const CommandPalette: React.FC = () => {
           try { window.electronAPI?.trackFeatureUsed?.('onboarding_replayed') } catch { /* noop */ }
         },
       },
+      { id: 'previousWorkspace', title: shortcutTitle('previousWorkspace'), icon: <PreviousWorkspaceIcon />, action: run('previousWorkspace') },
+      { id: 'nextWorkspace', title: shortcutTitle('nextWorkspace'), icon: <NextWorkspaceIcon />, action: run('nextWorkspace') },
       { id: 'reloadWorkspace', title: 'Reload Workspace from Disk', icon: <ReloadIcon />, action: run('reloadWorkspace') },
       // Remote-only: delete the daemon from the host. Main re-probes to the
       // 'missing' phase; the canvas lock then offers "Install Runtime" for a

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -595,6 +595,8 @@ export const SHORTCUT_DEFINITIONS = {
   toggleSearch: { label: 'Toggle Search', shortcut: storedShortcut('f', { command: true, shift: true }) },
   toggleMinimap: { label: 'Toggle Minimap', shortcut: storedShortcut('m', { command: true, shift: true }) },
   commandPalette: { label: 'Command Palette', shortcut: storedShortcut('k', { command: true }) },
+  nextWorkspace: { label: 'Next Workspace', shortcut: storedShortcut('→', { command: true, option: true }) },
+  previousWorkspace: { label: 'Previous Workspace', shortcut: storedShortcut('←', { command: true, option: true }) },
   zoomIn: { label: 'Zoom In', shortcut: storedShortcut('=', { command: true }) },
   zoomOut: { label: 'Zoom Out', shortcut: storedShortcut('-', { command: true }) },
   zoomReset: { label: 'Reset Zoom', shortcut: storedShortcut('0', { command: true }) },


### PR DESCRIPTION
Closes #456.

Adds two new bindable keyboard actions to switch between workspaces:

- **Next Workspace** — default **⌘⌥→**
- **Previous Workspace** — default **⌘⌥←**

They cycle through the workspaces in sidebar order and **wrap around** at both ends. Both are fully customizable (rebind, or disable) in **Settings → Shortcuts**, since the shortcut UI is data-driven from `SHORTCUT_DEFINITIONS` — the "customizable" part of the request comes for free.

### Why ⌘⌥→ / ⌘⌥←
The shortcut matcher lowercases `event.key`, so a `Cmd+Shift+]` press arrives as `}` and can never match a stored `]` (the catalog only ever pairs Shift with letters for this reason). Arrows normalise cleanly, `Cmd+Option` is unused elsewhere in the catalog, and ←/→ is the clearest prev/next mnemonic. Like tab-switching, the actions fire regardless of what's focused (they aren't subject to the arrow-key canvas-nav focus guards).

### Implementation
- The switch logic lives in the store as a pure, unit-tested helper `workspaceIdAtOffset(workspaces, currentId, offset)` + a thin `switchWorkspaceByOffset` action (mirrors `reorderWorkspaces`), so it isn't buried in the key handler.
- `runAction`, the **⌘K command palette**, and the **Go menu** all wire up the two actions for discoverability.

### Tests
- `workspaceSwitch.test.ts` — helper wrap/no-op edge cases + the store action changing the active workspace end-to-end.
- `shortcutStore.test.ts` — the new defaults resolve/match and don't collide with plain ⌘-arrow panel navigation.
- Full suite: 2498 passing, 0 failing; `tsc --noEmit` and `eslint` clean.

_Note: verified via the unit/integration suite and typecheck; not yet driven manually in a packaged build._