### PR TITLE
chore(release): bump version to 1.4.0-beta.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.4",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.4.0-beta.4",
+      "version": "1.4.0-beta.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.4",
+  "version": "1.4.0-beta.5",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.4.0-beta.4'
+export const RUNTIME_VERSION = '1.4.0-beta.5'


### PR DESCRIPTION
Bumps version to `1.4.0-beta.5` (package.json, package-lock.json, src/runtime/version.ts).

Includes since beta.4:
- #461 fix(browser): keep webview-backed tabs mounted so they don't reload on tab switch (#459)
- #462 feat(shortcuts): customizable next/previous workspace shortcuts

CI is intentionally skipped on this bump commit (`[skip ci]`). The `v1.4.0-beta.5` release build runs from the tag after merge.