### PR TITLE
fix(focus): keep keyboard focus with panels and dialogs

### DIFF
--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -156,6 +156,9 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   const nodeRef = useRef<HTMLDivElement>(null)
   const [isHovered, setIsHovered] = useState(false)
   const [isAnimatingLayout, setIsAnimatingLayout] = useState(false)
+  // True while a file/panel drag is hovering an unfocused node, so the dim
+  // overlay lets the drop fall through to the panel content that owns it.
+  const [fileDragOver, setFileDragOver] = useState(false)
   const animationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const node = useCanvasStoreContext(
@@ -650,15 +653,11 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
       <div
         data-panel-content
         onDragLeave={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-            const overlay = e.currentTarget.querySelector<HTMLElement>('[data-unfocused-overlay]')
-            if (overlay && !isFocused) overlay.style.pointerEvents = 'auto'
-          }
+          // Left the panel entirely (not just moving between children): the
+          // overlay goes back to blocking so an unfocused node stays click-to-focus.
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) setFileDragOver(false)
         }}
-        onDrop={() => {
-          const el = nodeRef.current?.querySelector<HTMLElement>('[data-unfocused-overlay]')
-          if (el && !isFocused) el.style.pointerEvents = 'auto'
-        }}
+        onDrop={() => setFileDragOver(false)}
         style={{
           position: 'relative',
           height: rootIsTabs ? '100%' : `calc(100% - ${GRAB_STRIP_HEIGHT}px)`,
@@ -690,11 +689,13 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
             focusThisNode()
           }}
           onDragEnter={(e) => {
+            // Let a file/panel drag fall through to the panel content (which owns
+            // the drop) instead of landing on this blocking overlay.
             if (
               e.dataTransfer.types.includes('Files') ||
               e.dataTransfer.types.includes('application/cate-file')
             ) {
-              ;(e.currentTarget as HTMLElement).style.pointerEvents = 'none'
+              setFileDragOver(true)
             }
           }}
           style={{
@@ -704,7 +705,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
             right: 0,
             bottom: 0,
             backgroundColor: 'var(--node-dim-overlay)',
-            pointerEvents: isFocused || isDockDragging ? 'none' : 'auto',
+            pointerEvents: isFocused || isDockDragging || fileDragOver ? 'none' : 'auto',
             cursor: isFocused ? undefined : 'default',
             zIndex: 1,
             opacity: isFocused || isDockDragging ? 0 : 1,

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -14,6 +14,8 @@ import remarkGfm from 'remark-gfm'
 import type { EditorPanelProps } from './types'
 import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useOptionalCanvasStoreContext } from '../stores/CanvasStoreContext'
+import { focusedNodeId } from '../stores/canvas/selectionModel'
 import {
   registerEditorSave,
   unregisterEditorSave,
@@ -288,6 +290,7 @@ export default function EditorPanel({
   panelId,
   workspaceId,
   filePath,
+  nodeId,
 }: EditorPanelProps) {
   useRenderCount('EditorPanel')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -312,6 +315,26 @@ export default function EditorPanel({
       useAppStore.getState().setPanelMarkdownPreview(workspaceId, panelId, next),
     [workspaceId, panelId],
   )
+
+  // When this panel becomes the focused canvas node, move keyboard focus into
+  // the editor so typing works without a second click — matching TerminalPanel
+  // and BrowserPanel. (A panel with no CanvasStoreProvider — e.g. docked in a
+  // detached window — reads as not-focused.) Retries across a few frames because
+  // the Monaco instance is created asynchronously and may not exist yet when
+  // focus first lands. Skipped in markdown-preview mode (no text surface).
+  const isFocused = useOptionalCanvasStoreContext((s) => focusedNodeId(s) === nodeId, false)
+  useEffect(() => {
+    if (!isFocused || markdownPreview) return
+    let raf = 0
+    let tries = 0
+    const tryFocus = (): void => {
+      const editor = editorRef.current ?? diffEditorRef.current
+      if (editor) { editor.focus(); return }
+      if (tries++ < 10) raf = requestAnimationFrame(tryFocus)
+    }
+    raf = requestAnimationFrame(tryFocus)
+    return () => cancelAnimationFrame(raf)
+  }, [isFocused, markdownPreview])
   const rootPath = ws?.rootPath
   const isMarkdown = !!filePath && /\.mdx?$/i.test(filePath)
 

--- a/src/renderer/ui/Modal.tsx
+++ b/src/renderer/ui/Modal.tsx
@@ -17,7 +17,7 @@
 // exported so even hand-rolled overlays match without a component per element.
 // =============================================================================
 
-import { useEffect, type CSSProperties, type HTMLAttributes, type ReactNode } from 'react'
+import { useEffect, useState, type CSSProperties, type HTMLAttributes, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from '@phosphor-icons/react'
 import { Tooltip } from './Tooltip'
@@ -59,6 +59,30 @@ export const SEGMENT = {
     }`,
 }
 
+/** Return keyboard focus to wherever it was before this dialog opened. The
+ *  active element is captured on the first render — before the dialog's own
+ *  autoFocus moves focus — and restored on unmount, but only when focus fell
+ *  back to <body> (i.e. the dialog closed without the user deliberately focusing
+ *  something else). Without this, closing a dialog/palette leaves focus on
+ *  <body> and keyboard shortcuts stop reaching the panel until the user clicks. */
+function useRestoreFocusOnUnmount(): void {
+  const [previous] = useState<Element | null>(() =>
+    typeof document === 'undefined' ? null : document.activeElement,
+  )
+  useEffect(() => {
+    return () => {
+      const active = document.activeElement
+      if (
+        previous instanceof HTMLElement &&
+        previous.isConnected &&
+        (active === null || active === document.body)
+      ) {
+        previous.focus({ preventScroll: true })
+      }
+    }
+  }, [previous])
+}
+
 interface PaletteDialogShellProps {
   /** Dismiss when the backdrop (outside the card) is clicked. */
   onClose: () => void
@@ -87,6 +111,7 @@ export function PaletteDialogShell({
   aside,
   asideClassName,
 }: PaletteDialogShellProps) {
+  useRestoreFocusOnUnmount()
   return (
     <div className={`fixed inset-0 flex flex-row items-start justify-center gap-2 z-50 ${BACKDROP}`} onClick={onClose}>
       <div
@@ -192,6 +217,7 @@ export function Modal({
   bodyClassName,
   ...card
 }: ModalProps) {
+  useRestoreFocusOnUnmount()
   const escapeCloses = closeOnEscape ?? dismissable
   useEffect(() => {
     if (!escapeCloses) return


### PR DESCRIPTION
fix(canvas): keep keyboard focus with panels and dialogs

Three focus fixes in the canvas interaction subsystem:

- Restore focus to the previously-focused element when a Modal or
  PaletteDialogShell closes, so shortcuts keep working after the command
  palette / a dialog is dismissed instead of dying on <body>.
- Focus the editor when its canvas node becomes focused, matching
  TerminalPanel and BrowserPanel — keyboard nav now lands the caret in
  Monaco without a second click.
- Replace the unfocused-overlay's imperative pointerEvents mutation with
  a declarative state flag so a cancelled file-drag can no longer leave a
  panel in the wrong interaction state.

The two-click focus model for unfocused panels is intentionally kept.

Closes #448 

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
