### PR TITLE
feat(dev): preview Windows/Linux chrome from a Mac

### DIFF
--- a/src/agent/main/authManager.ts
+++ b/src/agent/main/authManager.ts
@@ -16,7 +16,6 @@
 
 import { shell, type WebContents } from 'electron'
 import type {
-  KnownProvider,
   OAuthCredentials,
   OAuthLoginCallbacks,
 } from '@earendil-works/pi-ai'
@@ -38,6 +37,21 @@ import type {
   ProviderVerification,
 } from '../../shared/types'
 import { AUTH_OAUTH_EVENT } from '../../shared/ipc-channels'
+
+// Only the fields listAvailableModels reads off a builtin model row.
+type BuiltinModelRow = {
+  provider: string
+  id: string
+  name?: string
+  contextWindow?: number
+  reasoning?: boolean
+}
+// getBuiltinModels is a generic keyed on pi's KnownProvider union. That union
+// can drift ahead of the generated model catalog (0.80.7 added providers with
+// no catalog entry), which makes the generic reject a plain KnownProvider arg.
+// The impl just indexes a static map and returns [] for unknown ids, so call it
+// through a widened, catalog-independent signature.
+const listBuiltinModels = getBuiltinModels as unknown as (provider: string) => BuiltinModelRow[]
 
 // ---------------------------------------------------------------------------
 // On-disk auth.json shape (mirrors pi's AuthStorageData)
@@ -204,8 +218,11 @@ export class AuthManager {
     for (const providerId of connected) {
       if (providerId === 'custom-openai') continue
       // getBuiltinModels indexes a static catalog and returns [] for unknown
-      // ids, so the cast is safe even for providers pi doesn't recognise.
-      for (const m of getBuiltinModels(providerId as KnownProvider)) {
+      // ids, so calling it with any provider string is safe. pi's KnownProvider
+      // union can drift ahead of that catalog (0.80.7 widened the union past the
+      // generated model keys), so call through a widened, catalog-independent
+      // signature instead of the exported generic.
+      for (const m of listBuiltinModels(providerId)) {
         const key = `${m.provider}:${m.id}`
         if (seen.has(key)) continue
         seen.add(key)

--- a/src/main/windows/windowFactory.ts
+++ b/src/main/windows/windowFactory.ts
@@ -32,6 +32,13 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
   const windowType = params?.type ?? 'main'
   const isDock = windowType === 'dock'
 
+  // Dev preview override: CATE_FAKE_PLATFORM=win32|linux|darwin lets you see the
+  // other platforms' window chrome from a Mac. It drives the native frame/traffic
+  // lights below and is forwarded to the renderer (?platform=) so IS_MAC matches.
+  const fakePlatform = process.env.CATE_FAKE_PLATFORM
+  const effectivePlatform = fakePlatform || process.platform
+  const isMacChrome = effectivePlatform === 'darwin'
+
   // Boot snapshot — used only for the main window. Lets us restore the user's
   // last window bounds + theme-matched background color synchronously, so the
   // first frame matches the final UI and there's no white flash.
@@ -67,11 +74,11 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
     // Windows/Linux: go fully frameless and draw our own window controls in the
     // renderer (WindowControls), so the chrome matches the theme. `titleBarStyle`
     // is irrelevant once `frame:false`.
-    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+    titleBarStyle: isMacChrome ? 'hiddenInset' : 'default',
     // Center the traffic lights on the 36px chrome line shared by the dock tab
     // bar, the MacWindowChrome toggle, and the sidebar's top strip (y≈11 for a
     // 36px row). Dock and main windows use the same line so they read alike.
-    trafficLightPosition: process.platform !== 'darwin'
+    trafficLightPosition: !isMacChrome
       ? undefined
       : isDock
         ? { x: 12, y: 11 }
@@ -80,7 +87,7 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
           : undefined,
     // macOS main windows keep a (hidden-inset) native frame; dock windows — and
     // every window on Windows/Linux — are frameless.
-    frame: process.platform === 'darwin' ? !isDock : false,
+    frame: isMacChrome ? !isDock : false,
     backgroundColor: bgColor,
     icon: nativeImage.createFromPath(iconPath),
     webPreferences: {
@@ -258,6 +265,9 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
   // to match the window backdrop on the first frame (main window only).
   if (windowType === 'main') queryParts.push(`bg=${encodeURIComponent(bgColor)}`)
   if (params?.workspaceId) queryParts.push(`workspaceId=${encodeURIComponent(params.workspaceId)}`)
+  // Forward the dev platform override so the renderer's IS_MAC matches the
+  // native chrome chosen above.
+  if (fakePlatform) queryParts.push(`platform=${encodeURIComponent(effectivePlatform)}`)
   const query = queryParts.length > 0 ? `?${queryParts.join('&')}` : ''
 
   // Defer loadURL until persisted grants are applied. Without this, the

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -1,4 +1,18 @@
 // Single source of the renderer's macOS check. Main-process code should use
 // `process.platform === 'darwin'` instead — this relies on the renderer's
 // navigator and isn't available there.
-export const IS_MAC = navigator.userAgent.includes('Mac')
+//
+// Dev preview override: when the main process is launched with
+// `CATE_FAKE_PLATFORM=win32|linux|darwin`, it forwards the value as a
+// `?platform=` query param on the renderer URL. That lets you preview the
+// Windows/Linux chrome (custom TitlebarStrip + WindowControls) from a Mac
+// without a VM. Falls back to the real navigator when unset.
+function resolveIsMac(): boolean {
+  try {
+    const fake = new URLSearchParams(location.search).get('platform')
+    if (fake) return fake === 'darwin'
+  } catch { /* no location (tests) — fall through */ }
+  return navigator.userAgent.includes('Mac')
+}
+
+export const IS_MAC = resolveIsMac()

--- a/src/renderer/lib/terminal/terminalInput.ts
+++ b/src/renderer/lib/terminal/terminalInput.ts
@@ -8,9 +8,11 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { resolveTerminalKeySequence } from './terminalKeymap'
 import { openTerminalUrl } from './terminalUrlOpen'
 import { resolveTerminalLinkTarget } from './terminalLinks'
+import { IS_MAC } from '../platform'
 
-const isMacPlatform =
-  typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform || navigator.userAgent)
+// Route through the shared IS_MAC so the CATE_FAKE_PLATFORM dev override also
+// flips terminal keymap/paste-chord behavior, keeping one platform source.
+const isMacPlatform = IS_MAC
 
 /**
  * True for the Windows/Linux paste chord (Ctrl+V or Ctrl+Shift+V). xterm.js has


### PR DESCRIPTION
The Mac-vs-other UI difference is all gated by `IS_MAC` in the renderer plus the native frame options in `windowFactory`. This adds `CATE_FAKE_PLATFORM` so you can preview the Windows/Linux chrome from a Mac without a VM.

```bash
CATE_FAKE_PLATFORM=win32 npm run dev
CATE_FAKE_PLATFORM=linux npm run dev
```

- `windowFactory` uses the override for `frame` / `titleBarStyle` / traffic lights, and forwards it to the renderer as `?platform=`.
- `platform.ts` `IS_MAC` reads that param, falling back to the real navigator when unset.
- Terminal keymap now routes through the same `IS_MAC` so paste-chord behavior flips too.

No behavior change when the env var is unset. Dock/detached windows inherit it via the same query param.