### PR TITLE
fix: canvas split render, tab drop preview, sidebar chrome, and window-close quit gates

### DIFF
--- a/src/main/lifecycle/quitConfirm.test.ts
+++ b/src/main/lifecycle/quitConfirm.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// quitConfirm pulls in electron + the settings/shell siblings at module load.
+// Stub them so the module evaluates in a plain node test env, and keep the
+// stubs mutable so each case can pick the running-terminal / setting state.
+const state = vi.hoisted(() => ({
+  warnBeforeQuit: false,
+  running: [] as Array<{ processName: string | null }>,
+  // Queued dialog answers, consumed in order: 0 = Quit, 1 = Cancel.
+  responses: [] as number[],
+  shown: [] as Array<{ parented: boolean; options: Record<string, unknown> }>,
+}))
+
+vi.mock('electron', () => {
+  const dialog = {
+    showMessageBox: (a: unknown, b?: unknown) => {
+      const parented = b !== undefined
+      state.shown.push({
+        parented,
+        options: (parented ? b : a) as Record<string, unknown>,
+      })
+      return Promise.resolve({ response: state.responses.shift() ?? 1 })
+    },
+  }
+  const e = { dialog }
+  return { ...e, default: e }
+})
+vi.mock('../settingsFile', () => ({ getSetting: () => state.warnBeforeQuit }))
+vi.mock('../ipc/shell', () => ({ getRunningTerminals: () => state.running }))
+
+const { decideQuitPrompt, guardQuit, isQuitCommitted, markQuitCommitted, resetQuitAttempt } =
+  await import('./quitConfirm')
+
+/** A stand-in for the live BrowserWindow the dialog would sheet onto. */
+const fakeWin = { isDestroyed: () => false } as unknown as Electron.BrowserWindow
+
+/** Let the dialog's promise chain settle (showMessageBox resolves immediately). */
+const settle = () => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  resetQuitAttempt()
+  state.warnBeforeQuit = false
+  state.running = []
+  state.responses = []
+  state.shown = []
+})
+
+describe('decideQuitPrompt', () => {
+  it('does not prompt when nothing is running and warn-before-quit is off', () => {
+    expect(decideQuitPrompt({ warnBeforeQuit: false, running: [] })).toBeNull()
+  })
+
+  it('prompts a plain quit confirmation when warn-before-quit is on', () => {
+    const prompt = decideQuitPrompt({ warnBeforeQuit: true, running: [] })
+    expect(prompt).not.toBeNull()
+    expect(prompt!.message).toBe('Quit Cate?')
+    expect(prompt!.detail).toBeUndefined()
+  })
+
+  it('warns about a single running terminal, naming the process', () => {
+    const prompt = decideQuitPrompt({
+      warnBeforeQuit: false,
+      running: [{ processName: 'npm run dev' }],
+    })
+    expect(prompt!.message).toBe('“npm run dev” is still running. Quit anyway?')
+    expect(prompt!.detail).toContain('process running in this terminal')
+  })
+
+  it('falls back to a generic message when the single process name is unknown', () => {
+    const prompt = decideQuitPrompt({ warnBeforeQuit: false, running: [{ processName: null }] })
+    expect(prompt!.message).toBe('A terminal is still running. Quit anyway?')
+  })
+
+  it('counts multiple running terminals', () => {
+    const prompt = decideQuitPrompt({
+      warnBeforeQuit: false,
+      running: [{ processName: 'vim' }, { processName: 'top' }],
+    })
+    expect(prompt!.message).toBe('2 terminals are still running. Quit anyway?')
+    expect(prompt!.detail).toContain('these terminals')
+  })
+
+  it('lets a running-terminal warning take precedence over the plain quit prompt', () => {
+    const prompt = decideQuitPrompt({
+      warnBeforeQuit: true,
+      running: [{ processName: 'vim' }],
+    })
+    expect(prompt!.message).toContain('still running')
+  })
+})
+
+describe('guardQuit', () => {
+  it('proceeds without a dialog when there is nothing to confirm', () => {
+    const event = { preventDefault: vi.fn() }
+    const onConfirm = vi.fn()
+
+    expect(guardQuit(event, fakeWin, onConfirm)).toBe('proceed')
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(state.shown).toHaveLength(0)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('defers and prevents the action while a terminal is running', () => {
+    state.running = [{ processName: 'claude' }]
+    const event = { preventDefault: vi.fn() }
+
+    expect(guardQuit(event, fakeWin, vi.fn())).toBe('deferred')
+    // Prevented synchronously — the caller must not tear anything down.
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(state.shown).toHaveLength(1)
+    expect(state.shown[0].options.buttons).toEqual(['Quit', 'Cancel'])
+    expect(state.shown[0].options.cancelId).toBe(1)
+  })
+
+  // The regression this whole module exists for.
+  it('Cancel does not run the action and does not latch — a later quit re-prompts', async () => {
+    state.running = [{ processName: 'claude' }]
+    state.responses = [1] // Cancel
+    const onConfirm = vi.fn()
+
+    guardQuit({ preventDefault: vi.fn() }, fakeWin, onConfirm)
+    await settle()
+
+    expect(onConfirm).not.toHaveBeenCalled()
+
+    // A second quit attempt must ask again rather than sail through.
+    state.responses = [1]
+    expect(guardQuit({ preventDefault: vi.fn() }, fakeWin, onConfirm)).toBe('deferred')
+    expect(state.shown).toHaveLength(2)
+  })
+
+  it('Quit runs the action and latches so later gates pass without re-prompting', async () => {
+    state.running = [{ processName: 'claude' }]
+    state.responses = [0] // Quit
+    const onConfirm = vi.fn()
+
+    guardQuit({ preventDefault: vi.fn() }, fakeWin, onConfirm)
+    await settle()
+
+    expect(onConfirm).toHaveBeenCalledOnce()
+
+    // The replayed action re-enters the gate, and the app-level before-quit gate
+    // follows it — neither may show a second dialog.
+    const event = { preventDefault: vi.fn() }
+    expect(guardQuit(event, fakeWin, vi.fn())).toBe('proceed')
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(state.shown).toHaveLength(1)
+  })
+
+  it('does not latch when there was nothing to confirm', () => {
+    // A quit with no terminals must not disarm the prompt for the rest of the
+    // session — the app can outlive a quit attempt (Cancel at another gate).
+    expect(guardQuit({ preventDefault: vi.fn() }, fakeWin, vi.fn())).toBe('proceed')
+
+    state.running = [{ processName: 'claude' }]
+    expect(guardQuit({ preventDefault: vi.fn() }, fakeWin, vi.fn())).toBe('deferred')
+  })
+
+  it('falls back to an app-modal dialog when there is no live parent window', () => {
+    state.running = [{ processName: 'claude' }]
+
+    guardQuit({ preventDefault: vi.fn() }, null, vi.fn())
+    expect(state.shown[0].parented).toBe(false)
+
+    resetQuitAttempt()
+    const dead = { isDestroyed: () => true } as unknown as Electron.BrowserWindow
+    guardQuit({ preventDefault: vi.fn() }, dead, vi.fn())
+    expect(state.shown[1].parented).toBe(false)
+  })
+})
+
+describe('quit-attempt state', () => {
+  it('starts uncommitted and commits only when told', () => {
+    expect(isQuitCommitted()).toBe(false)
+    markQuitCommitted()
+    expect(isQuitCommitted()).toBe(true)
+  })
+
+  // The never-reset-latch fix: a committed flag surviving an abandoned attempt
+  // would make the NEXT quit skip both the confirmation and the session flush.
+  it('resetQuitAttempt clears the commit so a later quit re-runs every gate', () => {
+    markQuitCommitted()
+    resetQuitAttempt()
+    expect(isQuitCommitted()).toBe(false)
+
+    // ...and the confirmation is armed again rather than sailing through.
+    state.running = [{ processName: 'claude' }]
+    expect(guardQuit({ preventDefault: vi.fn() }, fakeWin, vi.fn())).toBe('deferred')
+  })
+
+  it('Cancel resets the attempt, so a stale commit cannot leak into the next quit', async () => {
+    // Contrived but load-bearing: whatever a previous attempt left behind, a
+    // cancelled attempt must hand the next one a clean slate.
+    markQuitCommitted()
+    resetQuitAttempt()
+
+    state.running = [{ processName: 'claude' }]
+    state.responses = [1] // Cancel
+    guardQuit({ preventDefault: vi.fn() }, fakeWin, vi.fn())
+    await settle()
+
+    expect(isQuitCommitted()).toBe(false)
+  })
+})

--- a/src/main/lifecycle/quitConfirm.ts
+++ b/src/main/lifecycle/quitConfirm.ts
@@ -1,0 +1,133 @@
+import { dialog, type BrowserWindow } from 'electron'
+import { getSetting } from '../settingsFile'
+import { getRunningTerminals } from '../ipc/shell'
+
+// ---------------------------------------------------------------------------
+// Quit-attempt state, shared by the two places a quit is gated:
+//   • app 'before-quit'            — confirms with the user, then flushes the
+//                                    session (shutdown.ts)
+//   • the last main window 'close' — routes into the quit sequence rather than
+//                                    tearing itself down (windowFactory.ts)
+//
+// It lives in its own module because shutdown.ts already imports windowFactory
+// (for the `activate` re-open), so windowFactory can't import shutdown back.
+//
+// A quit attempt is NOT a one-way door: the user can cancel the confirmation and
+// keep working. So every flag here is scoped to the attempt and cleared by
+// resetQuitAttempt() the moment one is abandoned — never a permanent latch.
+// (Permanent latches were a live hazard: a stale `true` makes a LATER quit skip
+// the confirmation and the session flush entirely.)
+// ---------------------------------------------------------------------------
+
+/** The user has confirmed THIS attempt. Keeps the prompt to a single appearance
+ *  as the quit crosses its gates. Deliberately NOT set when there was simply
+ *  nothing to confirm — that isn't a decision to remember. */
+let quitConfirmed = false
+
+/** This attempt has cleared every gate: the session is saved and the app is on
+ *  its way out. Windows may now be torn down for real. */
+let quitCommitted = false
+
+export function isQuitCommitted(): boolean {
+  return quitCommitted
+}
+
+/** The quit has passed its gates — teardown may proceed. */
+export function markQuitCommitted(): void {
+  quitCommitted = true
+}
+
+/** A quit attempt ended with the app still running, so forget it: the next
+ *  attempt must confirm and flush from scratch. */
+export function resetQuitAttempt(): void {
+  quitConfirmed = false
+  quitCommitted = false
+}
+
+/** A confirmation dialog to show before quitting, or null to quit immediately.
+ *  Two independent reasons gate quit: terminals still running a foreground
+ *  process (data-loss warning, takes precedence so its specific message wins),
+ *  and the user's "Warn before quit" preference (a plain confirmation). */
+export function decideQuitPrompt(opts: {
+  warnBeforeQuit: boolean
+  running: Array<{ processName: string | null }>
+}): { message: string; detail?: string } | null {
+  const count = opts.running.length
+  if (count > 0) {
+    const name = count === 1 ? opts.running[0].processName?.trim() : undefined
+    return {
+      message:
+        count > 1
+          ? `${count} terminals are still running. Quit anyway?`
+          : name
+            ? `“${name}” is still running. Quit anyway?`
+            : 'A terminal is still running. Quit anyway?',
+      detail:
+        count > 1
+          ? 'The processes running in these terminals will be terminated.'
+          : 'The process running in this terminal will be terminated.',
+    }
+  }
+  if (opts.warnBeforeQuit) {
+    return { message: 'Quit Cate?' }
+  }
+  return null
+}
+
+export type QuitGuardResult = 'proceed' | 'deferred'
+
+/**
+ * Gate a quit-causing action behind the running-terminal / "warn before quit"
+ * confirmation.
+ *
+ * Returns 'proceed' when the caller may tear down right away — nothing to
+ * confirm, or the user already confirmed this quit at an earlier gate.
+ *
+ * Returns 'deferred' when a dialog is now up. The caller MUST return without
+ * touching any window: the quit has been prevented, `onConfirm` re-runs the
+ * action if the user picks Quit, and Cancel simply leaves everything as it was.
+ */
+export function guardQuit(
+  event: { preventDefault: () => void },
+  parent: BrowserWindow | null | undefined,
+  onConfirm: () => void,
+): QuitGuardResult {
+  if (quitConfirmed) return 'proceed'
+
+  const prompt = decideQuitPrompt({
+    warnBeforeQuit: getSetting('warnBeforeQuit'),
+    running: getRunningTerminals(),
+  })
+  if (!prompt) return 'proceed'
+
+  // Prevent FIRST — the dialog is async, so the action must be stopped now and
+  // replayed from onConfirm rather than resumed.
+  event.preventDefault()
+
+  const options: Electron.MessageBoxOptions = {
+    type: 'warning',
+    message: prompt.message,
+    detail: prompt.detail,
+    buttons: ['Quit', 'Cancel'],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  }
+
+  // Sheet it onto the window that triggered the quit when there is one; fall
+  // back to an app-modal dialog rather than passing a dead/absent parent.
+  void (parent && !parent.isDestroyed()
+    ? dialog.showMessageBox(parent, options)
+    : dialog.showMessageBox(options)
+  ).then((result) => {
+    if (result.response !== 0) {
+      // Cancel — the app lives on, so this attempt must leave nothing behind.
+      resetQuitAttempt()
+      return
+    }
+    quitConfirmed = true
+    onConfirm()
+  })
+
+  return 'deferred'
+}

--- a/src/main/lifecycle/shutdown.test.ts
+++ b/src/main/lifecycle/shutdown.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 
-// decideQuitPrompt is a pure function, but shutdown.ts imports the whole main
-// process graph (electron + native-backed siblings) at module load. Stub every
-// top-level import so the module evaluates in a plain node test env; none of
-// these are exercised by the function under test.
+// runHardExit takes its collaborators as arguments, but shutdown.ts imports the
+// whole main process graph (electron + native-backed siblings) at module load.
+// Stub every top-level import so the module evaluates in a plain node test env;
+// none of these are exercised by the function under test.
+//
+// The quit confirmation itself lives in ./quitConfirm — see quitConfirm.test.ts
+// for decideQuitPrompt and the guard's Cancel/Quit behavior.
 vi.mock('electron', () => {
   const e = { app: {}, BrowserWindow: {}, ipcMain: {}, dialog: {} }
   return { ...e, default: e }
@@ -33,51 +36,7 @@ vi.mock('../extensions/ExtensionServerManager', () => ({
 vi.mock('../extensions/storage', () => ({ flushAllPendingWritesSync: () => {} }))
 vi.mock('../auto-updater', () => ({ isUpdatePendingInstall: () => false }))
 
-const { decideQuitPrompt, runHardExit } = await import('./shutdown')
-
-describe('decideQuitPrompt', () => {
-  it('does not prompt when nothing is running and warn-before-quit is off', () => {
-    expect(decideQuitPrompt({ warnBeforeQuit: false, running: [] })).toBeNull()
-  })
-
-  it('prompts a plain quit confirmation when warn-before-quit is on', () => {
-    const prompt = decideQuitPrompt({ warnBeforeQuit: true, running: [] })
-    expect(prompt).not.toBeNull()
-    expect(prompt!.message).toBe('Quit Cate?')
-    expect(prompt!.detail).toBeUndefined()
-  })
-
-  it('warns about a single running terminal, naming the process', () => {
-    const prompt = decideQuitPrompt({
-      warnBeforeQuit: false,
-      running: [{ processName: 'npm run dev' }],
-    })
-    expect(prompt!.message).toBe('“npm run dev” is still running. Quit anyway?')
-    expect(prompt!.detail).toContain('process running in this terminal')
-  })
-
-  it('falls back to a generic message when the single process name is unknown', () => {
-    const prompt = decideQuitPrompt({ warnBeforeQuit: false, running: [{ processName: null }] })
-    expect(prompt!.message).toBe('A terminal is still running. Quit anyway?')
-  })
-
-  it('counts multiple running terminals', () => {
-    const prompt = decideQuitPrompt({
-      warnBeforeQuit: false,
-      running: [{ processName: 'vim' }, { processName: 'top' }],
-    })
-    expect(prompt!.message).toBe('2 terminals are still running. Quit anyway?')
-    expect(prompt!.detail).toContain('these terminals')
-  })
-
-  it('lets a running-terminal warning take precedence over the plain quit prompt', () => {
-    const prompt = decideQuitPrompt({
-      warnBeforeQuit: true,
-      running: [{ processName: 'vim' }],
-    })
-    expect(prompt!.message).toContain('still running')
-  })
-})
+const { runHardExit } = await import('./shutdown')
 
 describe('runHardExit', () => {
   it('prevents natural teardown, awaits dispose, then exits — in that order', async () => {

--- a/src/main/lifecycle/shutdown.ts
+++ b/src/main/lifecycle/shutdown.ts
@@ -1,12 +1,11 @@
-import { app, ipcMain, dialog } from 'electron'
+import { app, ipcMain } from 'electron'
 import log from '../logger'
 import { createWindow } from '../windows/windowFactory'
 import { setMainWindowReady, flushPendingOpenPaths } from './openPath'
 import { getActiveMainWindow, sendToWindow, listDockWindowIds, listWindows, windowFromEvent } from '../windowRegistry'
 import { flushDockWindowsBeforeQuit } from '../dockWindowFlush'
 import { flushAllLoggers, killAllTerminals } from '../ipc/terminal'
-import { getRunningTerminals } from '../ipc/shell'
-import { getSetting } from '../settingsFile'
+import { guardQuit, isQuitCommitted, markQuitCommitted } from './quitConfirm'
 import { saveProjectStateSync } from '../projectWorkspaceStore'
 import { flushPendingWritesSync as flushSettingsPendingWritesSync } from '../settingsFile'
 import { flushWorkspaceStateSync } from '../workspaceStateStore'
@@ -29,19 +28,21 @@ import {
 // Quit coordination — the renderer needs live PTYs to capture terminal CWD
 // and scrollback, so we defer PTY teardown until the renderer confirms the
 // session save is complete. Flow:
-//   1. before-quit: flush loggers, send SESSION_FLUSH_SAVE to renderer, defer quit
+//   1. before-quit: confirm with the user (quitConfirm), flush loggers, send
+//      SESSION_FLUSH_SAVE to the renderer, defer quit
 //   2. renderer saves session (async — needs live PTYs for CWD/scrollback)
 //   3. renderer sends SESSION_FLUSH_SAVE_DONE
-//   4. main process re-triggers app.quit()
-//   5. before-quit fires again (sessionFlushed = true, falls through)
+//   4. main process marks the quit committed and re-triggers app.quit()
+//   5. before-quit fires again (isQuitCommitted() — falls through)
 //   6. will-quit: sync fallback save, kill PTYs, _exit(0)
+//
+// EVERY quit route lands here with its windows still alive: Cmd+Q and menu-Quit
+// arrive directly, and closing the last main window is turned into an app.quit()
+// by windowFactory's 'close' gate rather than destroying itself first. That
+// ordering is what gives step 1 a window to attach the prompt to and step 2 a
+// live renderer to save from.
 // ---------------------------------------------------------------------------
 
-let sessionFlushed = false
-// Set once the user has confirmed (or there was nothing to confirm) that it's OK
-// to quit while terminals are still running a foreground process. Gates the
-// flush/quit sequence below so the confirmation only runs on the first pass.
-let quitConfirmed = false
 const FLUSH_TIMEOUT_MS = 1500
 // Bound the pre-quit dock-window sync so an unresponsive detached window can't
 // stall quit. Kept short relative to FLUSH_TIMEOUT_MS — it runs BEFORE the main
@@ -93,36 +94,6 @@ export async function runHardExit(
   deps.exit(0)
 }
 
-/** A confirmation dialog to show before quitting, or null to quit immediately.
- *  Two independent reasons gate quit: terminals still running a foreground
- *  process (data-loss warning, takes precedence so its specific message wins),
- *  and the user's "Warn before quit" preference (a plain confirmation). */
-export function decideQuitPrompt(opts: {
-  warnBeforeQuit: boolean
-  running: Array<{ processName: string | null }>
-}): { message: string; detail?: string } | null {
-  const count = opts.running.length
-  if (count > 0) {
-    const name = count === 1 ? opts.running[0].processName?.trim() : undefined
-    return {
-      message:
-        count > 1
-          ? `${count} terminals are still running. Quit anyway?`
-          : name
-            ? `“${name}” is still running. Quit anyway?`
-            : 'A terminal is still running. Quit anyway?',
-      detail:
-        count > 1
-          ? 'The processes running in these terminals will be terminated.'
-          : 'The process running in this terminal will be terminated.',
-    }
-  }
-  if (opts.warnBeforeQuit) {
-    return { message: 'Quit Cate?' }
-  }
-  return null
-}
-
 /**
  * Wire the app-lifecycle event handlers: window-all-closed, activate, and the
  * before-quit / will-quit / quit teardown sequence. Called once from the index
@@ -152,7 +123,7 @@ export function registerLifecycleHandlers(): void {
   })
 
   app.on('before-quit', (event) => {
-    if (sessionFlushed) {
+    if (isQuitCommitted()) {
       // Second pass — renderer already saved, let quit proceed to will-quit
       log.info('before-quit: session already flushed, proceeding')
       return
@@ -161,43 +132,20 @@ export function registerLifecycleHandlers(): void {
     // First gate: warn before tearing down terminals that are still running a
     // foreground process (dev server, editor, agent, …) — and, when the user has
     // enabled "Warn before quit", confirm a plain quit too. Mirrors the
-    // per-terminal close confirmation. Deferred async, so we prevent the quit and
-    // re-trigger it once the user confirms.
+    // per-terminal close confirmation. Deferred async, so the quit is prevented
+    // and re-triggered once the user confirms.
+    //
+    // Every quit route reaches this gate with its windows alive (see the flow
+    // note at the top), so the prompt always has a window to sheet onto and a
+    // Cancel always leaves a fully intact app.
     //
     // Note: updates install on a NORMAL quit (electron-updater autoInstallOnAppQuit),
     // so there's no special update case here — the user is quitting deliberately and
     // the normal terminal-confirmation applies. will-quit handles the install hook.
-    if (!quitConfirmed) {
-      const prompt = decideQuitPrompt({
-        warnBeforeQuit: getSetting('warnBeforeQuit'),
-        running: getRunningTerminals(),
-      })
-      if (prompt) {
-        event.preventDefault()
-        const focusWin =
-          getActiveMainWindow() ?? listWindows()[0]
-        void dialog
-          .showMessageBox(focusWin!, {
-            type: 'warning',
-            message: prompt.message,
-            detail: prompt.detail,
-            buttons: ['Quit', 'Cancel'],
-            defaultId: 1,
-            cancelId: 1,
-            noLink: true,
-          })
-          .then((result) => {
-            if (result.response === 0) {
-              quitConfirmed = true
-              app.quit() // re-trigger quit; this gate now passes
-            }
-            // Cancel: leave the app running.
-          })
-        return
-      }
-      // Nothing to confirm — skip the confirmation on the re-triggered pass too.
-      quitConfirmed = true
-    }
+    const gate = guardQuit(event, getActiveMainWindow() ?? listWindows()[0], () => {
+      app.quit() // re-trigger quit; the guard now passes
+    })
+    if (gate === 'deferred') return
 
     log.info('Before quit, flushing loggers and requesting session save')
     flushAllLoggers()
@@ -205,7 +153,7 @@ export function registerLifecycleHandlers(): void {
 
     if (!mainWin) {
       // No renderer to save — proceed immediately
-      sessionFlushed = true
+      markQuitCommitted()
       return
     }
 
@@ -213,7 +161,7 @@ export function registerLifecycleHandlers(): void {
     event.preventDefault()
 
     const proceed = () => {
-      sessionFlushed = true
+      markQuitCommitted()
       app.quit()
     }
 
@@ -247,7 +195,7 @@ export function registerLifecycleHandlers(): void {
     })
       .catch(() => {})
       .finally(() => {
-        if (sessionFlushed) return
+        if (isQuitCommitted()) return
         if (mainWin.isDestroyed()) {
           // Renderer gone mid-flush — nothing to save from, let quit proceed.
           proceed()
@@ -256,7 +204,7 @@ export function registerLifecycleHandlers(): void {
         sendToWindow(mainWin.id, SESSION_FLUSH_SAVE)
         // Safety timeout — don't hang forever if the renderer is unresponsive
         setTimeout(() => {
-          if (!sessionFlushed) {
+          if (!isQuitCommitted()) {
             log.warn('Session flush timed out after %dms, proceeding with quit', FLUSH_TIMEOUT_MS)
             proceed()
           }

--- a/src/main/windows/windowFactory.flushOnClose.test.ts
+++ b/src/main/windows/windowFactory.flushOnClose.test.ts
@@ -8,7 +8,13 @@
 // windowFactory.reveal.test.ts.
 //
 // The fake BrowserWindow mirrors Electron's documented lifecycle: close() emits
-// 'close' then 'closed'; destroy() skips 'close' but still emits 'closed'.
+// 'close' (with a preventable event) then 'closed'; destroy() skips 'close' but
+// still emits 'closed'.
+//
+// Note on the main window: its 'close' gate routes the last main window into the
+// quit sequence (app.quit()) instead of closing, so the teardown these tests
+// exercise only happens once the quit is committed — see
+// windowFactory.quitGuard.test.ts. Cases below commit it explicitly.
 // =============================================================================
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
@@ -21,24 +27,24 @@ const hooks = vi.hoisted(() => {
     id: number
     destroyed: boolean
     sent: Array<{ channel: string; args: unknown[] }>
-    emit(ev: string): void
+    emit(ev: string, e?: unknown): void
     close(): void
     destroy(): void
-    webContents: { emit(ev: string): void; send(channel: string, ...args: unknown[]): void }
+    webContents: { emit(ev: string, e?: unknown): void; send(channel: string, ...args: unknown[]): void }
     [key: string]: unknown
   }
 
   function makeEmitter() {
-    const once: Record<string, Array<() => void>> = {}
-    const on: Record<string, Array<() => void>> = {}
+    const once: Record<string, Array<(e: unknown) => void>> = {}
+    const on: Record<string, Array<(e: unknown) => void>> = {}
     return {
-      once(ev: string, cb: () => void) { (once[ev] ??= []).push(cb) },
-      on(ev: string, cb: () => void) { (on[ev] ??= []).push(cb) },
-      emit(ev: string) {
+      once(ev: string, cb: (e: unknown) => void) { (once[ev] ??= []).push(cb) },
+      on(ev: string, cb: (e: unknown) => void) { (on[ev] ??= []).push(cb) },
+      emit(ev: string, e?: unknown) {
         const fired = once[ev] ?? []
         once[ev] = []
-        fired.forEach((f) => f())
-        ;(on[ev] ?? []).forEach((f) => f())
+        fired.forEach((f) => f(e))
+        ;(on[ev] ?? []).forEach((f) => f(e))
       },
     }
   }
@@ -64,9 +70,12 @@ const hooks = vi.hoisted(() => {
       isMinimized() { return false },
       isFullScreen() { return false },
       isMaximized() { return false },
-      // Electron: close() runs the 'close' gate, then tears down and emits 'closed'.
+      // Electron: close() runs the 'close' gate with a preventable event, then
+      // (if no listener prevented it) tears down and emits 'closed'.
       close() {
-        win.emit('close')
+        let prevented = false
+        win.emit('close', { preventDefault: () => { prevented = true } })
+        if (prevented) return
         win.destroyed = true
         win.emit('closed')
       },
@@ -87,6 +96,7 @@ vi.mock('electron', () => {
   const BrowserWindow = function () { return hooks.makeWin() }
   const electron = {
     BrowserWindow,
+    app: { quit: () => {} },
     nativeImage: { createFromPath: () => ({}) },
     nativeTheme: { themeSource: 'system' },
   }
@@ -117,8 +127,11 @@ vi.mock('../runtime/runtimeManager', () => ({
 vi.mock('../grantedPathStore', () => ({ listPersistentGrants: () => Promise.resolve([]) }))
 vi.mock('../menu', () => ({ rebuildApplicationMenu: () => {} }))
 vi.mock('../featureFlags', () => ({ disableRendererSandbox: () => false }))
+vi.mock('../settingsFile', () => ({ getSetting: () => false }))
+vi.mock('../ipc/shell', () => ({ getRunningTerminals: () => [] }))
 
 const { createWindow } = await import('./windowFactory')
+const { markQuitCommitted, resetQuitAttempt } = await import('../lifecycle/quitConfirm')
 const { closeWindowsForWorkspace } = await import('../windowRegistry')
 const { SESSION_FLUSH_SAVE } = await import('../../shared/ipc-channels')
 
@@ -129,9 +142,11 @@ const flushesTo = (win: FakeWin): number =>
 
 describe('createWindow close -> session flush wiring', () => {
   beforeEach(() => {
-    // Close any window a previous test left registered so the shared registry
-    // (active-main tracking, workspace maps) starts clean.
-    for (const w of [...hooks.created]) { if (!w.destroyed) w.close() }
+    resetQuitAttempt()
+    // Drop any window a previous test left registered so the shared registry
+    // (active-main tracking, workspace maps) starts clean. destroy() rather than
+    // close() — close() on a lone main window now defers to the quit sequence.
+    for (const w of [...hooks.created]) { if (!w.destroyed) w.destroy() }
     hooks.created.length = 0
   })
 
@@ -148,7 +163,9 @@ describe('createWindow close -> session flush wiring', () => {
 
   it('closing the main window itself does not take the flush path', () => {
     const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    markQuitCommitted() // as before-quit does, once it has confirmed + flushed
     main.close()
+    expect(main.destroyed).toBe(true)
     expect(flushesTo(main)).toBe(0)
   })
 
@@ -175,10 +192,12 @@ describe('createWindow close -> session flush wiring', () => {
     const main = createWindow({ type: 'main' }) as unknown as FakeWin
     const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
 
-    // Real quit order: main's 'close' handler close()s the docks while main is
-    // still registered, so each dock flush targets the dying-but-live main.
-    // Pinned here: main.close() cascades into dock.close(), whose 'closed'
-    // flush is sent to main BEFORE main's own 'closed' unregisters it.
+    // Real quit order: once the quit is committed, main's 'close' handler
+    // close()s the docks while main is still registered, so each dock flush
+    // targets the dying-but-live main. Pinned here: main.close() cascades into
+    // dock.close(), whose 'closed' flush is sent to main BEFORE main's own
+    // 'closed' unregisters it.
+    markQuitCommitted()
     main.close()
     expect(dock.destroyed).toBe(true)
     expect(flushesTo(main)).toBe(1)

--- a/src/main/windows/windowFactory.quitGuard.test.ts
+++ b/src/main/windows/windowFactory.quitGuard.test.ts
@@ -1,0 +1,225 @@
+// =============================================================================
+// createWindow close gate — closing the LAST main window IS quitting the app, so
+// it must route into the quit sequence (app.quit()) instead of tearing itself
+// down, and it must do so while the window is still alive.
+//
+// The bugs this pins: the old path destroyed the main window (reaping every
+// detached dock window with it) and only then hit window-all-closed →
+// app.quit() → 'before-quit'. By then the confirmation had no window to attach
+// to — cancelling left a running app with zero windows, which looks exactly like
+// a quit, and the next 'activate' built a fresh window, which looks like a
+// restart — and the session flush found no renderer, silently skipping the
+// terminal CWD/scrollback save.
+//
+// Driven through the REAL createWindow + REAL windowRegistry with only the
+// Electron shell and window-scoped collaborators faked — same harness shape as
+// windowFactory.flushOnClose.test.ts, plus a 'close' event object carrying
+// preventDefault (Electron passes one; that file's fake didn't need it).
+// =============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const hooks = vi.hoisted(() => {
+  let nextId = 1
+  const created: FakeWin[] = []
+
+  interface FakeWin {
+    id: number
+    destroyed: boolean
+    emit(ev: string, e?: unknown): void
+    close(): void
+    destroy(): void
+    webContents: { emit(ev: string, e?: unknown): void; send(channel: string, ...args: unknown[]): void }
+    [key: string]: unknown
+  }
+
+  function makeEmitter() {
+    const once: Record<string, Array<(e: unknown) => void>> = {}
+    const on: Record<string, Array<(e: unknown) => void>> = {}
+    return {
+      once(ev: string, cb: (e: unknown) => void) { (once[ev] ??= []).push(cb) },
+      on(ev: string, cb: (e: unknown) => void) { (on[ev] ??= []).push(cb) },
+      emit(ev: string, e?: unknown) {
+        const fired = once[ev] ?? []
+        once[ev] = []
+        fired.forEach((f) => f(e))
+        ;(on[ev] ?? []).forEach((f) => f(e))
+      },
+    }
+  }
+
+  function makeWin(): FakeWin {
+    const win: FakeWin = {
+      ...makeEmitter(),
+      id: nextId++,
+      destroyed: false,
+      webContents: { ...makeEmitter(), send() {} },
+      loadURL() {},
+      loadFile() {},
+      show() {},
+      focus() {},
+      isDestroyed() { return win.destroyed },
+      getPosition() { return [0, 0] },
+      getSize() { return [800, 600] },
+      isMinimized() { return false },
+      isFullScreen() { return false },
+      isMaximized() { return false },
+      // Electron: close() runs the 'close' gate with a preventable event; a
+      // listener calling preventDefault() keeps the window alive.
+      close() {
+        let prevented = false
+        win.emit('close', { preventDefault: () => { prevented = true } })
+        if (prevented) return
+        win.destroyed = true
+        win.emit('closed')
+      },
+      destroy() {
+        win.destroyed = true
+        win.emit('closed')
+      },
+    }
+    created.push(win)
+    return win
+  }
+
+  return { created, makeWin }
+})
+
+const appState = vi.hoisted(() => ({ quitCalls: 0 }))
+
+vi.mock('electron', () => {
+  const BrowserWindow = function () { return hooks.makeWin() }
+  const electron = {
+    BrowserWindow,
+    app: { quit: () => { appState.quitCalls++ } },
+    nativeImage: { createFromPath: () => ({}) },
+    nativeTheme: { themeSource: 'system' },
+  }
+  return { ...electron, default: electron }
+})
+
+vi.mock('../logger', () => ({ default: { info() {}, warn() {}, debug() {}, error() {} } }))
+vi.mock('./reveal', () => ({ revealWindow: () => {}, IS_E2E: false }))
+vi.mock('./crashRecovery', () => ({ installRendererCrashRecovery: () => {} }))
+vi.mock('./fullscreen', () => ({ anyWindowFullscreen: () => false }))
+vi.mock('../store', () => ({ readBootSnapshot: () => null, writeBootSnapshot: () => {} }))
+vi.mock('../perf/perfMonitor', () => ({ PERF_ENABLED: false, countIpc: () => {} }))
+vi.mock('../ipc/filesystem', () => ({ stopWatchersForWindow: () => {} }))
+vi.mock('../ipc/git-monitor', () => ({ stopMonitorsForWindow: () => {} }))
+vi.mock('../ipc/search', () => ({ stopSearchesForWindow: () => {} }))
+vi.mock('../ipc/pathValidation', () => ({
+  clearFileGrantsForWindow: () => {},
+  clearScopedWriteAllowancesForWindow: () => {},
+  grantFileAccess: () => Promise.resolve(),
+}))
+vi.mock('../runtime/runtimeManager', () => ({
+  forwardFileGrant: () => {},
+  forwardClearFileGrantsForWindow: () => {},
+  forwardClearScopedWriteAllowancesForWindow: () => {},
+}))
+vi.mock('../grantedPathStore', () => ({ listPersistentGrants: () => Promise.resolve([]) }))
+vi.mock('../menu', () => ({ rebuildApplicationMenu: () => {} }))
+vi.mock('../featureFlags', () => ({ disableRendererSandbox: () => false }))
+// Real quitConfirm state — only its data sources are faked.
+vi.mock('../settingsFile', () => ({ getSetting: () => false }))
+vi.mock('../ipc/shell', () => ({ getRunningTerminals: () => [] }))
+
+const { createWindow } = await import('./windowFactory')
+const { markQuitCommitted, resetQuitAttempt } = await import('../lifecycle/quitConfirm')
+
+type FakeWin = ReturnType<typeof hooks.makeWin>
+
+describe('createWindow main-window close → quit sequence routing', () => {
+  beforeEach(() => {
+    appState.quitCalls = 0
+    resetQuitAttempt()
+    // Drop any window a previous test left registered so the shared registry
+    // (active-main tracking) starts clean. destroy() skips the 'close' gate.
+    for (const w of [...hooks.created]) { if (!w.destroyed) w.destroy() }
+    hooks.created.length = 0
+  })
+
+  // The core of both fixes: the window must still be alive when the quit
+  // sequence runs, so 'before-quit' has something to prompt on and a live
+  // renderer to flush the session from.
+  it('closing the last main window defers to app.quit() and keeps the window alive', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+
+    main.close()
+
+    expect(appState.quitCalls).toBe(1)
+    expect(main.destroyed).toBe(false)
+  })
+
+  it('keeps detached dock windows alive too while the quit sequence runs', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+
+    main.close()
+
+    // The reap loop lives past the gate's early return — nothing is torn down
+    // until the quit actually commits (so a Cancel leaves the docks standing).
+    expect(main.destroyed).toBe(false)
+    expect(dock.destroyed).toBe(false)
+  })
+
+  it('once the quit is committed, the close goes through and reaps dock windows', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+
+    // What before-quit does after confirming + flushing the session.
+    markQuitCommitted()
+    main.close()
+
+    expect(main.destroyed).toBe(true)
+    expect(dock.destroyed).toBe(true)
+    // No re-entrant app.quit() — Electron is already tearing down.
+    expect(appState.quitCalls).toBe(0)
+  })
+
+  it('does not re-enter app.quit() when the committed close cascades', () => {
+    const main = createWindow({ type: 'main' }) as unknown as FakeWin
+    main.close()
+    expect(appState.quitCalls).toBe(1)
+
+    // The quit sequence commits and Electron closes the window for real.
+    markQuitCommitted()
+    main.close()
+
+    expect(main.destroyed).toBe(true)
+    expect(appState.quitCalls).toBe(1) // still 1 — no loop
+  })
+
+  it('closing a non-last main window closes normally without quitting the app', () => {
+    const first = createWindow({ type: 'main' }) as unknown as FakeWin
+    createWindow({ type: 'main' })
+
+    first.close()
+
+    expect(first.destroyed).toBe(true)
+    expect(appState.quitCalls).toBe(0)
+  })
+
+  it('routes only once the last main window of several is closed', () => {
+    const first = createWindow({ type: 'main' }) as unknown as FakeWin
+    const second = createWindow({ type: 'main' }) as unknown as FakeWin
+
+    first.close() // not last — closes silently
+    expect(appState.quitCalls).toBe(0)
+    expect(first.destroyed).toBe(true)
+
+    second.close() // now the last one — routes into the quit sequence
+    expect(appState.quitCalls).toBe(1)
+    expect(second.destroyed).toBe(false)
+  })
+
+  it('closing a dock window never routes into the quit sequence', () => {
+    createWindow({ type: 'main' })
+    const dock = createWindow({ type: 'dock', workspaceId: 'ws-A' }) as unknown as FakeWin
+
+    dock.close()
+
+    expect(appState.quitCalls).toBe(0)
+    expect(dock.destroyed).toBe(true)
+  })
+})

--- a/src/main/windows/windowFactory.ts
+++ b/src/main/windows/windowFactory.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, nativeImage, nativeTheme } from 'electron'
+import { app, BrowserWindow, nativeImage, nativeTheme } from 'electron'
 import path from 'path'
 import log from '../logger'
 import { installRendererCrashRecovery } from './crashRecovery'
@@ -21,6 +21,7 @@ import {
   forwardClearScopedWriteAllowancesForWindow,
 } from '../runtime/runtimeManager'
 import { listPersistentGrants } from '../grantedPathStore'
+import { isQuitCommitted } from '../lifecycle/quitConfirm'
 import { rebuildApplicationMenu } from '../menu'
 import { disableRendererSandbox } from '../featureFlags'
 import { WINDOW_FULLSCREEN_STATE, WINDOW_MAXIMIZE_STATE, SESSION_FLUSH_SAVE } from '../../shared/ipc-channels'
@@ -178,11 +179,35 @@ export function createWindow(params?: CateWindowParams): BrowserWindow {
     }
   })()
 
-  // When the main window is closed, also close any detached dock windows so
-  // the app actually quits (otherwise they keep the process alive and
-  // `window-all-closed` never fires).
   if (windowType === 'main') {
-    win.on('close', () => {
+    win.on('close', (event) => {
+      // Closing the LAST main window IS quitting the app (`window-all-closed` →
+      // app.quit()), so route it through the real quit sequence FIRST — while
+      // this window and its renderer are still alive. app.quit() runs
+      // 'before-quit', which both confirms with the user and flushes the session
+      // (the renderer needs live PTYs to read terminal CWD/scrollback).
+      //
+      // Letting the window die first broke both of those: the confirmation had
+      // no window left to attach to, so Cancel left a running app with zero
+      // windows (indistinguishable from a quit) and the next 'activate' built a
+      // fresh window (which read as a restart) — and the session flush found no
+      // renderer and silently skipped, losing terminal CWD/scrollback.
+      //
+      // Once the attempt has cleared its gates, Electron closes the windows for
+      // real and this gate stands aside. "New Window" allows several main
+      // windows; closing a non-last one quits nothing, so it isn't gated.
+      const isLastMainWindow = !listWindows().some(
+        (other) =>
+          other.id !== windowId && !other.isDestroyed() && getWindowType(other.id) === 'main',
+      )
+      if (isLastMainWindow && !isQuitCommitted()) {
+        event.preventDefault()
+        app.quit()
+        return
+      }
+
+      // Close any detached dock windows so the app actually quits (otherwise
+      // they keep the process alive and `window-all-closed` never fires).
       for (const other of listWindows()) {
         if (other.id === windowId) continue
         const t = getWindowType(other.id)

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -322,7 +322,15 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
       const dRight = rect.right - prevRect.right
       prevRect = rect
       prevWindowWidth = window.innerWidth
-      if (!windowResized && Math.abs(dLeft) < 0.5 && Math.abs(dRight) > 0.5) {
+      // The sidebar push (animated) and divider drags this compensation is for
+      // nudge the edge incrementally — a small delta per callback. Creating or
+      // removing a split instead jumps this pane by a large chunk in a single
+      // callback; that's not an external push to chase, and chasing it yanks the
+      // content sideways (the intermittent glitch seen on split). Skip such
+      // structural jumps: only compensate when the right edge moved by less than
+      // a quarter of the pane width.
+      const structuralJump = Math.abs(dRight) > rect.width * 0.25
+      if (!windowResized && !structuralJump && Math.abs(dLeft) < 0.5 && Math.abs(dRight) > 0.5) {
         const { viewportOffset } = canvasApi.getState()
         canvasApi.setState({ viewportOffset: { x: viewportOffset.x + dRight, y: viewportOffset.y } })
       }

--- a/src/renderer/drag/__tests__/scenarios.test.tsx
+++ b/src/renderer/drag/__tests__/scenarios.test.tsx
@@ -424,11 +424,12 @@ describe('drag integration — dock-drop scenarios', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // 6. Single-tab self-drop guard — dragging the only tab of a stack back onto
-  //    that same stack's center is a trivial no-op: resolveDrop returns null
-  //    (the self-stack guard in resolve.ts:158-168), so commit never runs and
-  //    the panel stays put. The drop zone sits alone (no canvas under it) so a
-  //    null dock target resolves to a null overall target.
+  // 6. Single-tab self-drop — dragging the only tab of a stack back onto that
+  //    same stack's center resolves to a dock-tab target (so the "+ new tab"
+  //    drop preview renders during the drag), but the commit treats it as a
+  //    no-op: the lone panel is already the stack's sole occupant, so undock +
+  //    redock would prune the stack out from under itself. Net effect — the
+  //    panel stays put.
   // ---------------------------------------------------------------------------
   it('6: single-tab self-drop on its own stack is a no-op', () => {
     dockScene = renderDockScene({
@@ -447,11 +448,12 @@ describe('drag integration — dock-drop scenarios', () => {
     dockScene.mouse.dragBy({ x: 20, y: 10 })
     dockScene.mouse.moveTo({ x: 120, y: 20 })
     const target = dockScene.drag().target
-    // The self-stack single-tab guard makes the resolved target null.
-    expect(target).toBeNull()
+    // The lone tab resolves to a dock-tab target so the "+ new tab" preview
+    // shows during the drag; the commit (below) treats it as a no-op.
+    expect(target).toMatchObject({ kind: 'dock-tab', stackId: 's1' })
     dockScene.mouse.up()
 
-    // Panel untouched — still the sole tab of its stack.
+    // Panel untouched — still the sole tab of its stack (commit no-op).
     expect(dockScene.stackPanelIds('s1')).toEqual(['p1'])
   })
 

--- a/src/renderer/drag/commit.ts
+++ b/src/renderer/drag/commit.ts
@@ -9,7 +9,7 @@ import type { PanelTransferSnapshot, PanelType, DockDropTarget, Point, Size } fr
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from '../stores/canvasStore'
 import type { DragSource, DropTarget } from './types'
-import { findZoneForStack } from '../stores/dockTreeUtils'
+import { findZoneForStack, findTabStackAcrossZones } from '../stores/dockTreeUtils'
 import { getDefaultSession } from './session'
 
 export interface CommitContext {
@@ -90,6 +90,19 @@ export async function commitDrop(
       // Stack vanished between resolve and commit — abort without touching the
       // source.
       if (!zone) return
+      // Lone tab dropped back onto its own stack (center): it's already the sole
+      // occupant, so undock+redock would prune the stack out from under the
+      // redock. Leave the layout untouched — a visual no-op. (resolve.ts still
+      // returns this target so the "+ new tab" preview shows during the drag.)
+      if (
+        target.kind === 'dock-tab' &&
+        source.origin.kind === 'dock-tab' &&
+        source.origin.dockStoreApi === target.dockStoreApi &&
+        source.origin.stackId === target.stackId
+      ) {
+        const stack = findTabStackAcrossZones(targetState.zones, target.stackId)
+        if (!stack || stack.panelIds.length <= 1) return
+      }
       const dockTarget: DockDropTarget =
         target.kind === 'dock-tab'
           ? { type: 'tab', stackId: target.stackId }

--- a/src/renderer/drag/resolve.test.ts
+++ b/src/renderer/drag/resolve.test.ts
@@ -237,7 +237,7 @@ describe('resolveDrop — dock zones', () => {
     expect((t as { stackId?: string })?.stackId).toBe('small-stack')
   })
 
-  it('self-drop guard: single-tab dock-tab (center) on its own stack returns null', () => {
+  it('self-drop: single-tab dock-tab (center) on its own stack → dock-tab target (preview shows; commit no-ops)', () => {
     const dock = makeDockStoreWithStack('stack-1', ['only'])
     const ownStack: DropZoneEntry = {
       id: 'own',
@@ -252,6 +252,33 @@ describe('resolveDrop — dock zones', () => {
     }
     const t = resolveDropT(
       { client: { x: 250, y: 10 }, screen: { x: 250, y: 10 }, insideWindow: true },
+      src,
+      grab,
+      ghostSize,
+      'editor',
+      env({ zones: [ownStack] }),
+    )
+    expect((t as { kind?: string })?.kind).toBe('dock-tab')
+    expect((t as { stackId?: string })?.stackId).toBe('stack-1')
+  })
+
+  it('self-drop guard: single-tab at an EDGE of its own stack returns null (no self-split of a lone panel)', () => {
+    const dock = makeDockStoreWithStack('stack-1', ['only'])
+    const ownStack: DropZoneEntry = {
+      id: 'own',
+      zone: 'left',
+      stackId: 'stack-1',
+      dockStoreApi: dock,
+      getRect: () => rect(0, 0, 500, 400),
+    }
+    const src: DragSource = {
+      panelId: 'panel-T',
+      origin: { kind: 'dock-tab', dockStoreApi: dock, zone: 'left', stackId: 'stack-1' },
+    }
+    const t = resolveDropT(
+      // Far right of the stack → 'right' edge (a split), which is suppressed for
+      // a lone panel dropping on its own stack.
+      { client: { x: 490, y: 200 }, screen: { x: 490, y: 200 }, insideWindow: true },
       src,
       grab,
       ghostSize,

--- a/src/renderer/drag/resolve.ts
+++ b/src/renderer/drag/resolve.ts
@@ -177,11 +177,16 @@ function resolveDockHit(
       source.origin.dockStoreApi === targetStore &&
       best.entry.stackId === source.origin.stackId
     if (isSelfStack) {
-      // Single-panel self-drops are trivial no-ops; multi-panel self-drops
-      // (center re-dock or edge split) produce real layout changes.
+      // A lone panel can't meaningfully split against its own stack (the other
+      // half would be empty), so suppress lone-panel self-splits. But dragging
+      // that lone tab back onto its own tab strip (center) is a valid no-op that
+      // should still preview as "+ new tab" — so let center fall through to the
+      // dock-tab target below. The commit treats it as a no-op (see commit.ts).
+      // Multi-panel self-drops (center re-dock or edge split) are real changes.
       const zones = (targetStore.getState() as { zones?: WindowDockState }).zones
       const stack = zones ? findTabStackAcrossZones(zones, best.entry.stackId) : null
-      if (!stack || stack.panelIds.length <= 1) return null
+      const lonePanel = !stack || stack.panelIds.length <= 1
+      if (lonePanel && edge !== 'center') return null
     }
     if (edge === 'center') {
       return { kind: 'dock-tab', dockStoreApi: targetStore, stackId: best.entry.stackId }

--- a/src/renderer/shells/MainWindowShell.tsx
+++ b/src/renderer/shells/MainWindowShell.tsx
@@ -19,7 +19,7 @@ import {
 import { useUIStore } from '../stores/uiStore'
 import { IS_MAC } from '../lib/platform'
 import { useWindowFullscreen } from '../lib/useWindowFullscreen'
-import { MAC_CHROME_WIDTH, MAC_CHROME_WIDTH_FS, TRAFFIC_LIGHTS_WIDTH } from './MacWindowChrome'
+import { MAC_CHROME_WIDTH, TRAFFIC_LIGHTS_WIDTH } from './MacWindowChrome'
 import { BAR_WIDTH } from '../sidebar/Sidebar'
 import { SidebarSimple } from '@phosphor-icons/react'
 import { Tooltip } from '../ui/Tooltip'
@@ -41,28 +41,37 @@ const RIGHT_CHROME_WIDTH = 40
  *  lights (fullscreen / non-macOS) — a small edge hug. */
 const LEFT_TOGGLE_EDGE_PAD = 8
 
+/** Horizontal space reserved at the tab bar's left end for the floating reopen
+ *  toggle shown when the left sidebar is fully hidden — the mirror of
+ *  RIGHT_CHROME_WIDTH, and enough for the toggle's edge pad + its 28px button.
+ *  Needed on every platform; non-fullscreen macOS reserves MAC_CHROME_WIDTH
+ *  instead, which clears the traffic lights AND the toggle. */
+const LEFT_CHROME_WIDTH = 40
+
 export default function MainWindowShell({
   renderPanel,
   getPanelTitle,
   onClosePanel,
 }: MainWindowShellProps) {
-  // macOS: reserve room at the top-left so the leftmost dock tab bar clears the
-  // traffic-light island. How much depends on the left sidebar's state:
-  //   • fully hidden → clear the lights + the floating reopen toggle,
-  //   • rail-only    → the 40px rail already covers the left of the lights, so
-  //                    only the remainder needs clearing,
+  // Reserve room at the top-left so the leftmost dock tab bar's first tab clears
+  // whatever floats over that corner. Two independent things can sit there:
+  //   • the floating reopen toggle — rendered on EVERY platform, but only while
+  //     the left sidebar is fully hidden,
+  //   • the macOS traffic-light island — only on macOS, and not in fullscreen.
+  // So by left sidebar state:
+  //   • fully hidden → clear the toggle, and the lights too where they exist,
+  //   • rail-only    → no toggle; the 40px rail already covers the left of the
+  //                    lights, so only the remainder needs clearing (mac only),
   //   • opened       → the sidebar holds the space; no reserve.
-  // In fullscreen the lights are gone, so only the hidden state (with its
-  // floating toggle) needs a small reserve. Nested canvas-node bars are exempt.
+  // Nested canvas-node bars are exempt.
   const leftSidebarHidden = useUIStore((s) => s.leftSidebarHidden)
   const leftSidebarOpen = useUIStore((s) => s.activeLeftSidebarView !== null)
   const setLeftSidebarHidden = useUIStore((s) => s.setLeftSidebarHidden)
   const isFullscreen = useWindowFullscreen()
+  const macLights = IS_MAC && !isFullscreen
   let leftReserve = 0
-  if (IS_MAC) {
-    if (leftSidebarHidden) leftReserve = isFullscreen ? MAC_CHROME_WIDTH_FS : MAC_CHROME_WIDTH
-    else if (!leftSidebarOpen && !isFullscreen) leftReserve = Math.max(0, TRAFFIC_LIGHTS_WIDTH - BAR_WIDTH)
-  }
+  if (leftSidebarHidden) leftReserve = macLights ? MAC_CHROME_WIDTH : LEFT_CHROME_WIDTH
+  else if (macLights && !leftSidebarOpen) leftReserve = Math.max(0, TRAFFIC_LIGHTS_WIDTH - BAR_WIDTH)
 
   // Right sidebar fully hidden → float a reopen toggle at the top-right, next to
   // the center tab bar's split button (mirrors the top-left sidebar toggle).
@@ -160,8 +169,9 @@ export default function MainWindowShell({
       className="main-window-shell-root flex flex-col h-full w-full min-h-0 min-w-0 relative"
       style={workspaceAccent ? ({ ['--workspace-accent' as string]: workspaceAccent } as React.CSSProperties) : undefined}
     >
-      {/* macOS: indent the top-level dock tab bar so its first tab clears the
-          traffic-light island (amount scales with the left sidebar state).
+      {/* Indent the top-level dock tab bar so its first tab clears the floating
+          reopen toggle (all platforms) and the macOS traffic-light island
+          (amount scales with the left sidebar state — see leftReserve above).
           Nested canvas-node tab bars ([data-node-id]) are exempt. */}
       {leftReserve > 0 && (
         <style>{`
@@ -205,7 +215,7 @@ export default function MainWindowShell({
           className="absolute top-0 left-0 z-40 flex items-center select-none"
           style={{
             height: 36,
-            paddingLeft: IS_MAC && !isFullscreen ? TRAFFIC_LIGHTS_WIDTH : LEFT_TOGGLE_EDGE_PAD,
+            paddingLeft: macLights ? TRAFFIC_LIGHTS_WIDTH : LEFT_TOGGLE_EDGE_PAD,
             WebkitAppRegion: 'no-drag',
           } as React.CSSProperties}
         >

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -473,10 +473,18 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
       }}
     >
       {/* Opaque top strip — matches the dock tab bar height (36px) so the
-          sidebar chrome lines up with the canvas tab bar. */}
+          sidebar chrome lines up with the canvas tab bar. On the macOS left
+          sidebar this band is the traffic-light inset (macChromeInset): nothing
+          interactive sits under it (the rail/content start below the inset), so
+          make it a window-drag region — otherwise the strip beside the traffic
+          lights is a dead zone you can't drag the window by. Elsewhere it stays
+          inert (pointer-events-none). */}
       <div
-        className="pointer-events-none absolute top-0 left-0 right-0 h-9"
-        style={{ backgroundColor: side === 'right' ? 'var(--canvas-bg)' : 'var(--surface-1)' }}
+        className={`absolute top-0 left-0 right-0 h-9 ${macChromeInset > 0 ? '' : 'pointer-events-none'}`}
+        style={{
+          backgroundColor: side === 'right' ? 'var(--canvas-bg)' : 'var(--surface-1)',
+          ...(macChromeInset > 0 ? { WebkitAppRegion: 'drag' } : {}),
+        } as React.CSSProperties}
       />
       {/* Rail hugs the window edge (left rail on the left, right rail on the
           right); content sits on the canvas-facing side of each. */}


### PR DESCRIPTION
Seven bugs, fixed with surgical changes. Branched off `main` so it can merge cleanly.

## 1. Intermittent render glitch when splitting a pane
`Canvas.tsx` — The ResizeObserver "anchor-compensation" (added in #295 to keep content anchored when the sidebar *pushes* the dock) also fired on a split's discrete resize. Splitting halves a pane in one jump against a stale `prevRect`, yanking `viewportOffset.x` sideways — but only on the re-split path that doesn't remount, hence intermittent.
**Fix:** only compensate incremental edge moves (`< 25%` of pane width per callback); skip structural jumps like split create/remove. The animated sidebar push and divider drags are unaffected.

## 2. No "+ new tab" preview when dragging the lone tab back onto its stack
`resolve.ts` + `commit.ts` — `resolveDrop` returned `null` for any single-panel self-stack drop, which suppressed the drop preview entirely (the preview is gated on a non-null `dock-tab` target).
**Fix:** the lone-tab **center** self-drop now resolves to a `dock-tab` target so the "+ new tab" preview renders, and the no-op is enforced at commit time (a lone tab re-docking into its own stack would otherwise undock → prune the stack → redock into a dead id). Lone-panel *edge* self-splits stay suppressed.

## 3. Can't drag the window from the left sidebar's top strip (macOS)
`Sidebar.tsx` — On macOS the left sidebar insets its content 36px below the traffic-light island, and that band was filled only by a `pointer-events-none` strip with no `-webkit-app-region` — a dead zone while every other part of the top strip is draggable.
**Fix:** give that strip `-webkit-app-region: drag` on the macOS left sidebar (scoped to the existing `macChromeInset > 0` condition). Nothing interactive sits under it — the rail/content start below y=36.

---

## 4-6. Closing the window bypassed both quit gates (one root cause)

Three separate symptoms, one ordering mistake. The quit gates live on app `'before-quit'`, but closing a window never went through them: the red X / titlebar button / Cmd+Shift+W destroyed the main window (reaping every detached dock window with it), and only then did `window-all-closed` → `app.quit()` → `'before-quit'` fire. By then it was too late for either gate:

- **4. Cancel on the quit prompt still "closed" the app — and "restarted" it.** The confirmation had no window left to attach to, so it opened parentless. Cancel *did* abort the quit, but the windows were already gone, so the app sat alive with **zero windows** — indistinguishable from having quit. The next dock-icon click then hit `app.on('activate')`, which built a fresh window: the "restart". Cmd+Q was unaffected, since `'before-quit'` fires there while the windows still live.
- **5. The renderer session flush was silently skipped on this path.** `getActiveMainWindow()` returned `undefined`, so `before-quit` took its `if (!mainWin) return` branch and never asked the renderer to save. The renderer needs *live PTYs* to capture terminal CWD/scrollback, so that state was lost; only `will-quit`'s sync fallback ran, persisting stale cached data.
- **6. The quit latches were permanent.** A stale `true` would make a *later* quit skip both the confirmation and the flush.

**Fix — correct the ordering rather than duplicate the gates.** Closing the last main window *is* quitting, so windowFactory's `'close'` gate now `preventDefault()`s and calls `app.quit()`, letting the one quit sequence own the confirmation *and* the flush while the window and its renderer are still alive. Once the attempt commits, Electron closes the windows for real and the gate stands aside. Only the **last** main window is gated — "New Window" allows several, and closing a non-last one quits nothing. Cancel now leaves everything standing, **detached windows included** (the gate returns early, before the dock-reaping loop — `preventDefault()` stops the close, not the other listeners).

The attempt state moves to `quitConfirm.ts` (its own module — `shutdown.ts` already imports `windowFactory`, so `windowFactory` can't import `shutdown` back) and is no longer a set of permanent latches: a quit attempt isn't a one-way door, so Cancel clears it via `resetQuitAttempt()`. That was previously unreachable by luck; it's now load-bearing, since the close gate reads that state to avoid re-entering `app.quit()`.

## 7. Sidebar reopen toggle overlapped the first dock tab on Windows/Linux
`MainWindowShell.tsx` — the tab bar's left reserve sat entirely inside `if (IS_MAC)`, but the floating toggle it has to clear renders on **every** platform. Off macOS the toggle (x 8..36, z-40) sat directly on top of the first tab (x≈6, z-20). The right-hand mirror already reserves its 40px unconditionally; the left path had conflated "clear the toggle" (all platforms) with "clear the traffic lights" (macOS only) and gated both.
**Fix:** reserve for the toggle everywhere; the lights only add more on non-fullscreen macOS. Mac fullscreen already reserved exactly the toggle's 40px footprint, so it folds into the same constant with no macOS change.

## Verification
- `npm run typecheck` ✓, full `vitest` suite ✓ (2525 passed), `eslint` ✓ (0 errors).
- Bugs 4-6 are covered by new unit + integration tests (`quitConfirm.test.ts`, `windowFactory.quitGuard.test.ts`); the close-gate and guard tests were confirmed to **fail against the old code** and pass against the new, so they pin real behavior rather than just passing.
- Bug 4 was also reproduced and re-checked live: pre-fix, clicking the X destroyed the window, logged `All windows closed, quitting`, showed a parentless dialog, and Cancel left a windowless app that `activate` then "restarted". Post-fix the dialog sheets onto the still-live window and Cancel leaves it intact.
- Bug 7 checked live on both platforms via `CATE_FAKE_PLATFORM=linux` (#466) and real macOS chrome.
- Bug 5's fix is covered by tests (the close now routes through `app.quit()` with the renderer alive) but was **not** observed end-to-end — worth a manual sanity check that terminal CWD/scrollback survives a red-X quit.
- Bugs 1 & 3 are inherently interactive/native (intermittent RO-timing glitch; native macOS `app-region` window-drag) — please sanity-check manually on macOS.

### Note on the test harness
`windowFactory.flushOnClose.test.ts`'s fake emitted `'close'` with no event object; real Electron always passes one, so the fake now does too. Its main-window cases commit the quit first, since a lone main window's close now defers to the quit sequence — that's the deliberate behavior change above, so those assertions were updated rather than preserved.