### PR TITLE
Float the markdown toggle over the editor, keep the worktree chip off terminal search

### DIFF
--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -8,6 +8,7 @@ import { useDockStoreApi } from '../stores/DockStoreContext'
 import { registerDropZone, useDragStore } from '../drag'
 import type { DockTabStack as DockTabStackType, PanelState, PanelType } from '../../shared/types'
 import { useAppStore } from '../stores/appStore'
+import { PanelChromeProvider, type PanelChromeApi } from '../panels/panelChrome'
 import { Columns, Plus } from '@phosphor-icons/react'
 import { DockTabBar } from './DockTabBar'
 import { WorktreePill } from '../canvas/WorktreePill'
@@ -98,6 +99,11 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
   )
 
   const activePanel = activePanelId ? resolvePanel(activePanelId) : undefined
+
+  // Set while the visible panel's own UI covers its top-right corner (see the
+  // worktree chip below, which otherwise overlays exactly there).
+  const [cornerClaimed, setCornerClaimed] = useState(false)
+  const chromeApi = useMemo<PanelChromeApi>(() => ({ setCornerClaimed }), [])
 
   // Tab interaction actions (rename, click, context menus, add/split helpers).
   const actions = useDockTabActions({
@@ -389,7 +395,9 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
                 style={isActive ? undefined : { visibility: 'hidden', pointerEvents: 'none' }}
                 aria-hidden={isActive ? undefined : true}
               >
-                {renderPanel(panelId)}
+                <PanelChromeProvider api={chromeApi} enabled={isActive}>
+                  {renderPanel(panelId)}
+                </PanelChromeProvider>
               </div>
             )
           })
@@ -401,8 +409,10 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
         {/* Worktree chip — overlaid on the panel's top-right rather than crammed
             into the tab strip (where it starved the title). Collapsed to its icon
             until hovered so it covers almost no content (#370). Self-hides for
-            non-terminal/agent panels and single-worktree workspaces. */}
-        {activePanel && effectiveWorkspaceId && (
+            non-terminal/agent panels and single-worktree workspaces, and stands
+            down while the panel claims the corner for its own UI (see
+            panelChrome) rather than sitting on top of it. */}
+        {activePanel && effectiveWorkspaceId && !cornerClaimed && (
           // right-3 (12px), not right-1.5: terminal/agent panels are xterm-backed
           // and always reserve a 6px scrollbar lane (overflow-y: scroll). Offset
           // past it so the chip clears the scrollbar and leaves a 6px gap that

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -744,26 +744,6 @@ export default function EditorPanel({
 
   return (
     <div className="w-full h-full flex flex-col">
-      {/* Markdown header strip — the Source/Preview toggle lives in its own
-          row instead of floating over the first line of content (#370). */}
-      {isMarkdown && !diffMode && (
-        <div
-          className="flex items-center justify-end shrink-0 px-1.5 py-1 border-b border-subtle"
-          style={{ backgroundColor: 'var(--node-chrome-bg, var(--surface-1))' }}
-        >
-          <button
-            onClick={() => setMarkdownPreview(!markdownPreview)}
-            className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
-              markdownPreview
-                ? 'bg-agent/15 text-agent hover:bg-agent/25'
-                : 'bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary'
-            }`}
-            title={markdownPreview ? 'Show source' : 'Preview markdown'}
-          >
-            {markdownPreview ? 'Source' : 'Preview'}
-          </button>
-        </div>
-      )}
       {conflict && !diffMode && (
         <EditorConflictBanner
           kind={conflict.kind}
@@ -793,6 +773,23 @@ export default function EditorPanel({
           </div>
         )}
         <div ref={containerRef} className={`w-full h-full ${(markdownPreview && isMarkdown) || loadError ? 'hidden' : ''}`} />
+        {/* Source/Preview toggle — floats over the content's top-right instead
+            of taking a header row. right-3 (12px) clears Monaco's 8px vertical
+            scrollbar lane; z-40 keeps it above the diff (z-30) and load-error
+            (z-20) overlays, matching the reach it had as a header. */}
+        {isMarkdown && !diffMode && (
+          <button
+            onClick={() => setMarkdownPreview(!markdownPreview)}
+            className={`absolute top-1.5 right-3 z-40 px-2 py-0.5 rounded text-[11px] font-medium shadow-sm transition-colors ${
+              markdownPreview
+                ? 'bg-agent/15 text-agent hover:bg-agent/25'
+                : 'bg-surface-3 text-secondary hover:bg-surface-4 hover:text-primary'
+            }`}
+            title={markdownPreview ? 'Show source' : 'Preview markdown'}
+          >
+            {markdownPreview ? 'Source' : 'Preview'}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -19,6 +19,7 @@ import { terminalRegistry } from '../lib/terminal/terminalRegistry'
 import { formatTerminalPaste, type DroppedRef } from './terminalDrop'
 import { useAppStore } from '../stores/appStore'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useClaimPanelCorner } from './panelChrome'
 import { useOptionalCanvasStoreApi, useOptionalCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { focusedNodeId } from '../stores/canvas/selectionModel'
 import { resolveTerminalFontSize } from '../lib/terminal/terminalSettings'
@@ -170,6 +171,10 @@ export default function TerminalPanel({
     setSearchQuery('')
     terminalRegistry.clearSearch(panelId)
   }, [panelId])
+
+  // The search row sits in the panel's top-right, where the host overlays the
+  // worktree chip — claim the corner so the chip stands down while it's up.
+  useClaimPanelCorner(showSearch)
 
   // -------------------------------------------------------------------------
   // Keyboard shortcut: Cmd+F / Ctrl+F opens search; Escape closes it

--- a/src/renderer/panels/panelChrome.tsx
+++ b/src/renderer/panels/panelChrome.tsx
@@ -1,0 +1,46 @@
+// =============================================================================
+// Panel chrome — the contract between a panel and whatever host renders chrome
+// on top of it.
+//
+// The host (DockTabStack) overlays the worktree chip on the panel's top-right.
+// A panel that puts its own UI in that corner — the terminal's search row, say —
+// reports the clash by claiming the corner, and the host's chrome stands down
+// for as long as the claim is held.
+//
+// Panels report; the host decides. That keeps the host from having to know what
+// any given panel keeps in its corner, and keeps panel-local widget state out of
+// the global stores.
+// =============================================================================
+
+import React, { createContext, useContext, useEffect } from 'react'
+
+export interface PanelChromeApi {
+  /** Report whether the panel's own UI currently occupies its top-right corner. */
+  setCornerClaimed: (claimed: boolean) => void
+}
+
+/** Panels rendered without a chrome host (detached dock windows, tests) claim
+ *  into the void rather than needing to know whether a host is there. */
+const NOOP: PanelChromeApi = { setCornerClaimed: () => {} }
+
+export const PanelChromeContext = createContext<PanelChromeApi>(NOOP)
+
+export const PanelChromeProvider: React.FC<{
+  api: PanelChromeApi
+  /** Only the visible panel can clash with the host's chrome; hidden keep-alive
+   *  slots are wired to the no-op so they can't hold a claim off-screen. */
+  enabled: boolean
+  children: React.ReactNode
+}> = ({ api, enabled, children }) => (
+  <PanelChromeContext.Provider value={enabled ? api : NOOP}>{children}</PanelChromeContext.Provider>
+)
+
+/** Claim the panel's top-right corner while `claimed` is true. Released on
+ *  unmount, so every path that hides the claiming UI is covered. */
+export function useClaimPanelCorner(claimed: boolean): void {
+  const { setCornerClaimed } = useContext(PanelChromeContext)
+  useEffect(() => {
+    setCornerClaimed(claimed)
+    return () => setCornerClaimed(false)
+  }, [claimed, setCornerClaimed])
+}


### PR DESCRIPTION
Two panel chrome fixes.

**Editor.** The markdown Source/Preview toggle had a whole header row to itself. Removed the row, the button now floats where it used to sit. Markdown panels get the vertical space back.

This reverses the EditorPanel half of #370, so the old gripe is back: in source mode the button covers the end of line 1. Easy to make it fade until hover like the code block copy button if it bugs anyone.

**Terminal.** The worktree chip overlays the panel's top-right, which is where the search row's close button lives, so they sat on top of each other:

Fix is a small panel/host contract in `panelChrome.tsx`. A panel claims its top-right while its own UI covers it, the host chrome stands down until the claim drops. Terminal claims while search is open.

Went with context instead of a store since it is between a panel and the host drawing over it. Nothing global, no panel-id bookkeeping, claim releases on unmount. Hidden keep-alive slots get a no-op api so a background browser panel cannot suppress the visible tab's chip.

Typecheck clean, renderer suite green (1407 tests). `local-daemon-tarball` fails on main too, unrelated.