### PR TITLE
chore(release): bump version to 1.4.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.5",
+  "version": "1.4.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.4.0-beta.5",
+      "version": "1.4.0-beta.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.5",
+  "version": "1.4.0-beta.6",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.4.0-beta.5'
+export const RUNTIME_VERSION = '1.4.0-beta.6'


### PR DESCRIPTION
Beta build for testing before the 1.5.0 bump.

Bumps `package.json` → `1.4.0-beta.6`, with `package-lock.json` and the generated `src/runtime/version.ts` following (regenerated via `npm run build:runtime`, not hand-edited). Same three-file shape as #463.

`RUNTIME_VERSION` is kept equal to the app version so the release tag `v1.4.0-beta.6` hosts the matching runtime tarballs.

## What's in this beta since 1.4.0-beta.5
- #466 — `CATE_FAKE_PLATFORM` dev preview + pi `KnownProvider` drift tolerance
- #467 — canvas split render, lone-tab drop preview, sidebar chrome (macOS window-drag + the Windows/Linux toggle/tab overlap), and the window-close quit gates (Cancel now actually cancels; the session flush no longer silently skips on that path)
- #468 — floating markdown toggle, worktree chip off terminal search
- #464 — keyboard focus retained across panels and dialogs

## Note: pi packages are unpinned
`package.json` carries `^0.80.6`, and CI deletes the lockfile before installing, so this build will resolve pi to **0.80.7** (locally `bun i` already does). That is intentional for now — the pin lived in the closed 1.5.0 release PR. Worth restoring on the 1.5.0 bump if you want release builds reproducible.