### PR TITLE
fix(macos): collapse the left sidebar's traffic-light inset in fullscreen

### DIFF
--- a/src/renderer/shells/MacWindowChrome.test.tsx
+++ b/src/renderer/shells/MacWindowChrome.test.tsx
@@ -3,8 +3,9 @@
 //
 // jsdom's navigator is not "Mac", so the real IS_MAC is false and the component
 // would render null. We mock the platform module to force the macOS path, then
-// verify the draggable lights strip renders (windowed and fullscreen) and that
-// the old sidebar toggle is gone (it now lives in the rail / MainWindowShell).
+// verify the draggable lights strip renders when windowed (and collapses away in
+// fullscreen) and that the old sidebar toggle is gone (it now lives in the rail
+// / MainWindowShell).
 // =============================================================================
 
 import React from 'react'
@@ -51,10 +52,11 @@ describe('MacWindowChrome', () => {
     expect(el.querySelector('button')).toBeNull()
   })
 
-  it('shrinks to a small pad in native fullscreen (lights gone)', () => {
+  // The lights are gone in fullscreen and a fullscreen window can't be dragged,
+  // so the island has nothing left to do — and the left rail's collapse toggle
+  // moves into this corner, which a leftover drag strip would sit on top of.
+  it('renders nothing in native fullscreen (lights gone)', () => {
     vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(true)
-    const el = render()
-    const island = el.querySelector<HTMLElement>('div')!
-    expect(island.style.width).toBe('8px')
+    expect(render().querySelector('div')).toBeNull()
   })
 })

--- a/src/renderer/shells/MacWindowChrome.tsx
+++ b/src/renderer/shells/MacWindowChrome.tsx
@@ -12,8 +12,10 @@
 // collapse toggle (inset below the lights), and a floating reopen toggle in
 // MainWindowShell handles the fully-hidden state — mirroring the right rail.
 //
-// In native fullscreen the OS hides the traffic lights, so the island shrinks
-// to a small left pad.
+// In native fullscreen the OS hides the traffic lights and the window can't be
+// dragged, so the island has nothing to reserve and nothing to drag: it renders
+// nothing, and the left rail reclaims the corner from y=0 (see Sidebar's
+// macChromeInset).
 //
 // Non-macOS keeps the frameless TitlebarStrip (menu bar + custom controls).
 // =============================================================================
@@ -25,21 +27,23 @@ import { useWindowFullscreen } from '../lib/useWindowFullscreen'
 // strip, so the traffic lights and dock tabs center on the same line and the
 // sidebar's content insets to exactly clear the chrome.
 export const MAC_CHROME_HEIGHT = 36
-// Horizontal space reserved for the native traffic lights. In fullscreen the
-// lights are gone, so the island shrinks to a small left pad.
+// Horizontal space reserved for the native traffic lights.
 export const TRAFFIC_LIGHTS_WIDTH = 78
-const FULLSCREEN_LEFT_PAD = 8
 // Width the dock tab bar reserves at the top-left (so its first tab clears the
 // island) when the left sidebar is fully hidden — lights + floating reopen
 // toggle in windowed mode, just the toggle in fullscreen.
 export const MAC_CHROME_WIDTH = 108
-export const MAC_CHROME_WIDTH_FS = 40
 
 export default function MacWindowChrome(): React.ReactElement | null {
   const isFullscreen = useWindowFullscreen()
 
   // Native chrome (menu bar + custom controls via TitlebarStrip) off macOS.
   if (!IS_MAC) return null
+
+  // No lights to clear and no window to drag in fullscreen — rendering the strip
+  // anyway would put a drag region over the left rail's collapse toggle, which
+  // sits in this corner once the inset collapses.
+  if (isFullscreen) return null
 
   // Empty draggable strip over the traffic-light area so the window can be moved
   // by dragging the top-left corner. The sidebar toggle now lives in the rail.
@@ -48,7 +52,7 @@ export default function MacWindowChrome(): React.ReactElement | null {
       className="absolute top-0 left-0 z-40 select-none"
       style={{
         height: MAC_CHROME_HEIGHT,
-        width: isFullscreen ? FULLSCREEN_LEFT_PAD : TRAFFIC_LIGHTS_WIDTH,
+        width: TRAFFIC_LIGHTS_WIDTH,
         WebkitAppRegion: 'drag',
       } as React.CSSProperties}
     />

--- a/src/renderer/sidebar/Sidebar.fullscreen.test.tsx
+++ b/src/renderer/sidebar/Sidebar.fullscreen.test.tsx
@@ -1,0 +1,50 @@
+// =============================================================================
+// Regression test for the macOS traffic-light inset on the left sidebar.
+//
+// The left sidebar reserves MAC_CHROME_HEIGHT at its top so its content clears
+// the native traffic lights. In native fullscreen macOS hides the lights, so
+// that reservation must collapse — otherwise the rail/content stay pushed down
+// by a 36px dead band with nothing in it.
+//
+// jsdom's navigator is not "Mac", so IS_MAC is mocked true to force the path.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+vi.mock('../lib/platform', () => ({ IS_MAC: true }))
+
+import { Sidebar } from './Sidebar'
+
+let host: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(false)
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+})
+
+function renderSidebar(): HTMLElement {
+  act(() => { root.render(<Sidebar />) })
+  return host.querySelector<HTMLElement>('[data-sidebar-scrollarea]')!
+}
+
+describe('Sidebar macOS chrome inset', () => {
+  it('reserves the traffic-light strip when windowed', () => {
+    expect(renderSidebar().style.paddingTop).toBe('36px')
+  })
+
+  it('collapses the reservation in native fullscreen (lights gone)', () => {
+    vi.mocked(window.electronAPI.isMainWindowFullscreen).mockReturnValue(true)
+    expect(renderSidebar().style.paddingTop).toBe('0px')
+  })
+})

--- a/src/renderer/sidebar/Sidebar.tsx
+++ b/src/renderer/sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import pkg from '../../../package.json'
 import { Tooltip } from '../ui/Tooltip'
 import { CateLogo } from '../ui/CateLogo'
 import { IS_MAC } from '../lib/platform'
+import { useWindowFullscreen } from '../lib/useWindowFullscreen'
 import { MAC_CHROME_HEIGHT } from '../shells/MacWindowChrome'
 
 // ---------------------------------------------------------------------------
@@ -144,10 +145,13 @@ const ActivityBarSidebar: React.FC<ActivityBarSidebarProps> = ({ side, defaultWi
 
   // macOS: the traffic-light island (MacWindowChrome) floats over the top-left,
   // so the left sidebar insets its content below it while its surface fills to
-  // y=0 (seamless behind the lights). The toggle lives in this strip in both
-  // windowed and fullscreen (only the lights disappear in fullscreen), so the
-  // inset is unconditional on the left. Only the left side sits under it.
-  const macChromeInset = side === 'left' && IS_MAC ? MAC_CHROME_HEIGHT : 0
+  // y=0 (seamless behind the lights). Only the left side sits under it. Nothing
+  // of ours lives in that strip any more (the rail carries its own toggle in its
+  // own 36px header), so it exists purely to clear the lights — in native
+  // fullscreen the OS hides them and the inset must collapse, or the rail and
+  // content stay pushed down by an empty band.
+  const isFullscreen = useWindowFullscreen()
+  const macChromeInset = side === 'left' && IS_MAC && !isFullscreen ? MAC_CHROME_HEIGHT : 0
 
   const [width, setWidth] = useState(defaultWidth)
   const [isResizing, setIsResizing] = useState(false)


### PR DESCRIPTION
## Problem

macOS only. In native fullscreen the left sidebar's rail and file tree sat pushed down by an empty 36px band, while the canvas tab bar beside them correctly started at `y=0`.

## Root cause

The left sidebar reserves `MAC_CHROME_HEIGHT` (36px) at its top so its content clears the native traffic lights (`macChromeInset`, `Sidebar.tsx`). Every other consumer of that reservation already collapses it in native fullscreen — the floating island, the dock tab bar's left indent, and the detached-window titlebar all gate on `useWindowFullscreen()`. The sidebar's inset was the only one that didn't; it was hardcoded to "always on macOS".

The comment above it justified this with *"the toggle lives in this strip in both windowed and fullscreen"* — but that stopped being true in 4cff3c6, when the left rail gained its own 36px header for the collapse toggle. Once the toggle moved out, the strip existed purely to clear the lights, which macOS hides in fullscreen.

## Changes

- **`Sidebar.tsx`** — gate `macChromeInset` on `!isFullscreen`, matching the `IS_MAC && !isFullscreen` idiom already used in `MainWindowShell`.
- **`MacWindowChrome.tsx`** — render nothing in fullscreen instead of shrinking to an 8px pad. Not cosmetic: the island is an `absolute top-0 left-0 z-40` **drag region**, so once the inset collapses and the rail's collapse toggle moves into that corner (x 4–36, y 0–36), the leftover strip would overlap its left 4px and make that sliver unclickable. In fullscreen it has no lights to reserve and no window to drag. Drops the now-unused `FULLSCREEN_LEFT_PAD` and `MAC_CHROME_WIDTH_FS`.

## Testing

- New `Sidebar.fullscreen.test.tsx` covers both states. Written first and confirmed failing against the bug (`expected '36px' to be '0px'`) before the fix landed.
- Updated the one existing `MacWindowChrome` test that asserted the old 8px-pad behaviour.
- Full suite green (2527 passed), typecheck clean.
- Verified visually in fullscreen on macOS.