### PR TITLE
chore(release): bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.6",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.4.0-beta.6",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.4.0-beta.6",
+  "version": "1.5.0",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.4.0-beta.6'
+export const RUNTIME_VERSION = '1.5.0'


### PR DESCRIPTION
## What changed

- Bump the Cate application version from `1.4.0-beta.6` to stable `1.5.0`.
- Keep the package lockfile and bundled runtime version aligned.

## Why

Prepare the stable `v1.5.0` build and release. After this PR merges, tagging the merge commit as `v1.5.0` triggers the existing release workflow.

## Impact

Release artifacts and runtime tarballs will be built and published under version `1.5.0`.

## Validation

- Parsed package metadata and confirmed all release-version fields equal `1.5.0`.
- Confirmed `src/runtime/version.ts` equals `1.5.0`.
- Ran `git diff --check`.
