### PR TITLE
Harden workspace roots and input gestures for 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/main/workspaceManager.remoteRoots.test.ts
+++ b/src/main/workspaceManager.remoteRoots.test.ts
@@ -48,6 +48,7 @@ vi.mock('../skills/main/seedCateCliSkill', () => ({ seedCateCliSkill: vi.fn(asyn
 const { WORKSPACE_CREATE, WORKSPACE_UPDATE } = await import('../shared/ipc-channels')
 const { registerWorkspaceHandlers } = await import('./workspaceManager')
 const { seedCateCliSkill } = await import('../skills/main/seedCateCliSkill')
+const { resolveTrustedWorkspaceRoot } = await import('./workspaceRoots')
 
 describe('remote workspace root scopes', () => {
   it('registers roots by workspace id and replays them after connection and reconnect', async () => {
@@ -129,5 +130,36 @@ describe('remote workspace root scopes', () => {
     seed.mockClear()
     fireConnected('srv_other')
     expect(seed).not.toHaveBeenCalled()
+  })
+
+  it('rejects workspace creation when path aliases resolve to an open root', async () => {
+    registerWorkspaceHandlers()
+    const create = handlers.get(WORKSPACE_CREATE)!
+    const resolveRoot = vi.mocked(resolveTrustedWorkspaceRoot)
+    resolveRoot.mockResolvedValue('/canonical/project')
+
+    const first = await create({}, {
+      id: 'workspace-canonical-a',
+      name: 'A',
+      rootPath: '/alias/a',
+    }) as { ok: boolean }
+    const duplicate = await create({}, {
+      id: 'workspace-canonical-b',
+      name: 'B',
+      rootPath: '/alias/b',
+    }) as {
+      ok: boolean
+      error?: { code: string; conflictingWorkspaceId?: string }
+    }
+
+    expect(first.ok).toBe(true)
+    expect(duplicate).toEqual({
+      ok: false,
+      error: {
+        code: 'DUPLICATE_ROOT',
+        message: 'This folder is already open in another workspace: /canonical/project',
+        conflictingWorkspaceId: 'workspace-canonical-a',
+      },
+    })
   })
 })

--- a/src/main/workspaceManager.ts
+++ b/src/main/workspaceManager.ts
@@ -48,13 +48,17 @@ function generateId(): string {
 // it's opened here, so a second Cate (dev vs installed) won't autosave over us.
 // -----------------------------------------------------------------------------
 
-/** True if any workspace other than `exceptId` is rooted at `rootPath`. */
-function rootInUse(rootPath: string, exceptId?: string): boolean {
+/** Workspace other than `exceptId` rooted at `rootPath`, if one exists. */
+function workspaceUsingRoot(rootPath: string, exceptId?: string): WorkspaceInfo | undefined {
   for (const [id, w] of workspaces) {
     if (id === exceptId) continue
-    if (w.rootPath === rootPath) return true
+    if (w.rootPath === rootPath) return w
   }
-  return false
+  return undefined
+}
+
+function rootInUse(rootPath: string, exceptId?: string): boolean {
+  return workspaceUsingRoot(rootPath, exceptId) !== undefined
 }
 
 /** Claim the lock for a root; if a live instance already owns it, warn that
@@ -167,6 +171,18 @@ async function createWorkspace(
     }
   }
 
+  const duplicate = trustedRoot ? workspaceUsingRoot(trustedRoot, resolvedId) : undefined
+  if (duplicate) {
+    return {
+      ok: false,
+      error: {
+        code: 'DUPLICATE_ROOT',
+        message: `This folder is already open in another workspace: ${trustedRoot}`,
+        conflictingWorkspaceId: duplicate.id,
+      },
+    }
+  }
+
   const info: WorkspaceInfo = {
     id: resolvedId,
     name: name ?? 'Workspace',
@@ -237,12 +253,16 @@ async function updateWorkspace(id: string, changes: Partial<Omit<WorkspaceInfo, 
   // duplicate. The renderer redirects to the existing tab before reaching this,
   // but the resolved path is the authority — it catches symlink/trailing-slash
   // aliases the renderer's raw string compare misses.
-  if (nextRootPath && existing.rootPath !== nextRootPath && rootInUse(nextRootPath, id)) {
+  const duplicate = nextRootPath && existing.rootPath !== nextRootPath
+    ? workspaceUsingRoot(nextRootPath, id)
+    : undefined
+  if (duplicate) {
     return {
       ok: false,
       error: {
         code: 'DUPLICATE_ROOT',
         message: `This folder is already open in another workspace: ${nextRootPath}`,
+        conflictingWorkspaceId: duplicate.id,
       },
     }
   }

--- a/src/renderer/docking/DockResizeHandle.tsx
+++ b/src/renderer/docking/DockResizeHandle.tsx
@@ -26,7 +26,6 @@ export default function DockResizeHandle({ direction, onResize, onDoubleClick }:
       unpinCursorRef.current = null
       if (dragging.current) {
         dragging.current = false
-        document.body.classList.remove('canvas-interacting')
         document.body.style.cursor = ''
         document.body.style.userSelect = ''
       }

--- a/src/renderer/hooks/useNodeResize.ts
+++ b/src/renderer/hooks/useNodeResize.ts
@@ -15,7 +15,6 @@ import type { PanelType, Point, Size } from '../../shared/types'
 import { getCursorForEdge } from './resizeEdge'
 import type { ResizeEdge } from './resizeEdge'
 import { pinDocumentCursor } from '../lib/dom/pinDocumentCursor'
-import { acquireBodyClass, releaseBodyClass } from '../lib/dom/bodyClassRefcount'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
 
 // Re-exported so existing importers (CanvasNode, useNodeResizeCursor,
@@ -112,11 +111,6 @@ export function useNodeResize(
       const resizeCursor = getCursorForEdge(edge)
       document.body.style.cursor = resizeCursor
       const unpinCursor = pinDocumentCursor(resizeCursor)
-      // Take a refcount on the shared `canvas-interacting` class (pinDocumentCursor
-      // already added it). This keeps a concurrent wheel-pan's ~150ms quiet timer
-      // from stripping the class — and the pointer-events overrides it carries —
-      // out from under the live resize.
-      acquireBodyClass('canvas-interacting')
 
       // Detect shared borders for cardinal edges
       if (isCardinalEdge(edge)) {
@@ -416,7 +410,6 @@ export function useNodeResize(
         window.removeEventListener('blur', handleBlur)
         document.body.style.cursor = previousBodyCursor
         unpinCursor()
-        releaseBodyClass('canvas-interacting')
       }
 
       const handleMouseUp = (ev: MouseEvent) => {

--- a/src/renderer/lib/dom/bodyClassRefcount.test.ts
+++ b/src/renderer/lib/dom/bodyClassRefcount.test.ts
@@ -13,6 +13,7 @@ import {
   releaseBodyClass,
   bodyClassRefCount,
 } from './bodyClassRefcount'
+import { pinDocumentCursor } from './pinDocumentCursor'
 
 const CLS = 'canvas-interacting'
 
@@ -107,5 +108,18 @@ describe('bodyClassRefcount', () => {
     // The class must survive — the resize still depends on it for pointer-events.
     expect(document.body.classList.contains(CLS)).toBe(true)
     expect(bodyClassRefCount(CLS)).toBe(1)
+  })
+
+  it('cursor pinning releases only its own hold on the shared class', () => {
+    acquireBodyClass(CLS) // active canvas pan
+    const unpin = pinDocumentCursor('col-resize')
+    expect(bodyClassRefCount(CLS)).toBe(2)
+
+    unpin()
+    expect(bodyClassRefCount(CLS)).toBe(1)
+    expect(document.body.classList.contains(CLS)).toBe(true)
+
+    releaseBodyClass(CLS)
+    expect(document.body.classList.contains(CLS)).toBe(false)
   })
 })

--- a/src/renderer/lib/dom/pinDocumentCursor.ts
+++ b/src/renderer/lib/dom/pinDocumentCursor.ts
@@ -9,14 +9,19 @@
 // element; callers invoke it on mouseup (and on unmount if the gesture leaks).
 // =============================================================================
 
+import { acquireBodyClass, releaseBodyClass } from './bodyClassRefcount'
+
 export function pinDocumentCursor(cursor: string): () => void {
-  document.body.classList.add('canvas-interacting')
+  acquireBodyClass('canvas-interacting')
   const cursorStyleEl = document.createElement('style')
   cursorStyleEl.textContent = `*, *::before, *::after { cursor: ${cursor} !important; }`
   document.head.appendChild(cursorStyleEl)
+  let pinned = true
 
   return () => {
-    document.body.classList.remove('canvas-interacting')
+    if (!pinned) return
+    pinned = false
+    releaseBodyClass('canvas-interacting')
     cursorStyleEl.remove()
   }
 }

--- a/src/renderer/lib/terminal/terminalCoordAdjust.test.ts
+++ b/src/renderer/lib/terminal/terminalCoordAdjust.test.ts
@@ -5,6 +5,8 @@ import { shouldAdjustTerminalCoords } from './terminalCoordAdjust'
 const LEFT = 0
 const MIDDLE = 1
 const RIGHT = 2
+const LEFT_HELD = 1
+const MIDDLE_HELD = 4
 
 // A zoomed-in canvas: .xterm-screen carries a residual scale of 2, so xterm's
 // getBoundingClientRect()-based hit-testing is off by 2x and needs adjusting for
@@ -13,11 +15,11 @@ const ZOOMED = 2
 
 describe('shouldAdjustTerminalCoords', () => {
   it('adjusts a left-button press on a zoomed canvas (xterm selection needs it)', () => {
-    expect(shouldAdjustTerminalCoords('mousedown', LEFT, false, ZOOMED)).toBe(true)
+    expect(shouldAdjustTerminalCoords('mousedown', LEFT, false, ZOOMED, LEFT_HELD)).toBe(true)
   })
 
   it('adjusts left-button moves on a zoomed canvas (drag-select)', () => {
-    expect(shouldAdjustTerminalCoords('mousemove', LEFT, false, ZOOMED)).toBe(true)
+    expect(shouldAdjustTerminalCoords('mousemove', LEFT, false, ZOOMED, LEFT_HELD)).toBe(true)
   })
 
   // --- The middle-click-pan regression guard -------------------------------
@@ -28,23 +30,30 @@ describe('shouldAdjustTerminalCoords', () => {
   // guard that, when removed, reintroduces the "middle-click drag offsets the
   // pan at the beginning" bug.
   it('does NOT adjust a middle-button press on a zoomed canvas (pan start)', () => {
-    expect(shouldAdjustTerminalCoords('mousedown', MIDDLE, false, ZOOMED)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousedown', MIDDLE, false, ZOOMED, MIDDLE_HELD)).toBe(false)
   })
 
   it('does NOT adjust a right-button press on a zoomed canvas (pan start)', () => {
-    expect(shouldAdjustTerminalCoords('mousedown', RIGHT, false, ZOOMED)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousedown', RIGHT, false, ZOOMED, 2)).toBe(false)
+  })
+
+  it('does NOT adjust a move while the middle button is held, even if the body class is absent', () => {
+    // Mousemove.button is 0 in Chromium; MouseEvent.buttons is what identifies
+    // the still-held middle button. The body class is a second guard, not the
+    // only way to keep a canvas pan out of xterm's coordinate rewrite.
+    expect(shouldAdjustTerminalCoords('mousemove', LEFT, false, ZOOMED, MIDDLE_HELD)).toBe(false)
   })
 
   it('never adjusts while a canvas gesture owns the pointer (canvas-interacting)', () => {
     // Every event type stays raw once a pan/resize holds the body class.
-    expect(shouldAdjustTerminalCoords('mousedown', LEFT, true, ZOOMED)).toBe(false)
-    expect(shouldAdjustTerminalCoords('mousemove', LEFT, true, ZOOMED)).toBe(false)
-    expect(shouldAdjustTerminalCoords('mouseup', LEFT, true, ZOOMED)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousedown', LEFT, true, ZOOMED, LEFT_HELD)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousemove', LEFT, true, ZOOMED, LEFT_HELD)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mouseup', LEFT, true, ZOOMED, 0)).toBe(false)
   })
 
   it('does not adjust when the canvas is not zoomed (effective ~= 1)', () => {
-    expect(shouldAdjustTerminalCoords('mousedown', LEFT, false, 1)).toBe(false)
-    expect(shouldAdjustTerminalCoords('mousemove', LEFT, false, 1.0005)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousedown', LEFT, false, 1, LEFT_HELD)).toBe(false)
+    expect(shouldAdjustTerminalCoords('mousemove', LEFT, false, 1.0005, 0)).toBe(false)
   })
 })
 
@@ -61,8 +70,9 @@ function terminalRewrite(
   interacting: boolean,
   clientX: number,
   effective: number,
+  buttons: number,
 ): number {
-  if (!shouldAdjustTerminalCoords(type, button, interacting, effective)) return clientX
+  if (!shouldAdjustTerminalCoords(type, button, interacting, effective, buttons)) return clientX
   return clientX / effective // rect.left = 0
 }
 
@@ -73,12 +83,13 @@ describe('middle-click drag over a terminal does not offset the pan at the start
     // 1. Middle-button mousedown at raw client x = 400. canvas-interacting is
     //    NOT set yet (the canvas sets it in the bubble phase, after this capture
     //    handler). The pan records this as its origin (lastPanPos).
-    const panOrigin = terminalRewrite('mousedown', MIDDLE, false, 400, effective)
+    const panOrigin = terminalRewrite('mousedown', MIDDLE, false, 400, effective, MIDDLE_HELD)
     expect(panOrigin).toBe(400) // left RAW by the guard — not 200
 
-    // 2. Pan is now active -> canvas-interacting is held. The pointer moves to
-    //    raw client x = 410 (10px right). The move stays raw too.
-    const firstMove = terminalRewrite('mousemove', LEFT, true, 410, effective)
+    // 2. The pointer moves to raw client x = 410 (10px right). Even if the
+    //    shared body class is missing, buttons=4 identifies the middle drag and
+    //    keeps the move raw instead of feeding adjusted coordinates to canvas.
+    const firstMove = terminalRewrite('mousemove', LEFT, false, 410, effective, MIDDLE_HELD)
     expect(firstMove).toBe(410)
 
     // 3. The canvas pan applies (move - origin) straight to the viewport offset.

--- a/src/renderer/lib/terminal/terminalCoordAdjust.ts
+++ b/src/renderer/lib/terminal/terminalCoordAdjust.ts
@@ -12,12 +12,12 @@
 //  1. A canvas gesture (pan / edge-resize) already owns the pointer — the
 //     shared `canvas-interacting` body class is set. Rewriting here feeds the
 //     gesture a coordinate whose reference rect is itself moving.
-//  2. The OPENING press of a pan: a non-left mousedown. This capture handler
-//     runs before the canvas sets `canvas-interacting`, so case 1 can't catch
-//     it. If the mousedown were rewritten, the pan's start point would live in
-//     adjusted space while every follow-up move stays raw, so the first delta
-//     would be (raw - adjusted): a camera jump proportional to zoom. xterm only
-//     needs adjusted coords for left-button selection, which a pan isn't.
+//  2. A non-left press/release, or any move with a non-left button held. The
+//     opening press runs before the canvas sets `canvas-interacting`, and
+//     MouseEvent.button is normally 0 on follow-up moves even for a middle drag;
+//     MouseEvent.buttons carries the held-button state. Leaving the whole gesture
+//     raw prevents the pan origin and move coordinates from entering different
+//     spaces even if the shared body class is temporarily absent.
 //  3. The canvas isn't zoomed (effective ~= 1) — there is nothing to cancel.
 //
 // Keeping this decision as a pure function lets the middle-click-pan regression
@@ -37,18 +37,22 @@ export const ZOOM_ADJUST_EPSILON = 0.001
  * @param button      MouseEvent.button (0 = left, 1 = middle, 2 = right)
  * @param interacting Whether document.body carries the `canvas-interacting` class
  * @param effective   zoomLevel / renderScale — the residual scale on .xterm-screen
+ * @param buttons     MouseEvent.buttons bitmask (1 = left, 2 = right, 4 = middle)
  */
 export function shouldAdjustTerminalCoords(
   type: string,
   button: number,
   interacting: boolean,
   effective: number,
+  buttons: number,
 ): boolean {
   // (1) a pan/resize gesture owns the pointer — leave every event raw.
   if (interacting) return false
-  // (2) the opening press of a middle/right pan — leave it raw so lastPanPos is
-  //     recorded in the same space as the follow-up moves (no first-delta jump).
-  if (type === 'mousedown' && button !== 0) return false
+  // (2) xterm only needs adjusted coordinates for its own left-button gesture.
+  // Mousemove.button is normally 0 regardless of which button is held, so also
+  // inspect the buttons bitmask to keep middle/right pan moves raw.
+  if ((type === 'mousedown' || type === 'mouseup') && button !== 0) return false
+  if (type === 'mousemove' && (buttons & ~1) !== 0) return false
   // (3) not zoomed — nothing to cancel.
   if (Math.abs(effective - 1.0) < ZOOM_ADJUST_EPSILON) return false
   return true

--- a/src/renderer/lib/workspace/sessionLoad.ts
+++ b/src/renderer/lib/workspace/sessionLoad.ts
@@ -5,7 +5,7 @@
 
 import log from '../logger'
 import { isLocalLocator } from '../../../main/runtime/locator'
-import { applySidebarSession } from './sidebarSession'
+import { applySidebarSession, dedupeSnapshotsByRoot } from './sidebarSession'
 import { projectFilesToSnapshot } from './sessionSerialize'
 import type {
   SessionSnapshot,
@@ -85,7 +85,10 @@ async function loadFromProjectFiles(): Promise<MultiWorkspaceSession | null> {
   // the active workspace. Falls back to recentProjects order / index 0 when no
   // arrangement is stored yet (first run after upgrade).
   const sidebarSession = await window.electronAPI.sidebarSessionGet().catch(() => null)
-  const { workspaces, selectedWorkspaceIndex } = applySidebarSession(snapshots, sidebarSession)
+  const { workspaces, selectedWorkspaceIndex } = applySidebarSession(
+    dedupeSnapshotsByRoot(snapshots),
+    sidebarSession,
+  )
 
   return {
     version: 2,

--- a/src/renderer/lib/workspace/sessionSave.ts
+++ b/src/renderer/lib/workspace/sessionSave.ts
@@ -156,6 +156,17 @@ export async function saveSession(): Promise<void> {
     log.warn('[session] Dock window listing failed:', err)
   }
 
+  // One owner workspace per root. Legacy state may still contain duplicates;
+  // the selected workspace owns persistence, otherwise the first one does.
+  const workspacesByRoot = new Map<string, typeof persistableWorkspaces[number]>()
+  for (const w of persistableWorkspaces) {
+    if (!w.rootPath) continue
+    const existing = workspacesByRoot.get(w.rootPath)
+    if (!existing || w.id === updatedState.selectedWorkspaceId) {
+      workspacesByRoot.set(w.rootPath, w)
+    }
+  }
+
   // Remote (cate-runtime://) workspaces can't use the local .cate/ files —
   // their tree lives on a runtime. Collect their full snapshots + reconnect
   // info into the electron-store remoteProjects list so restart can rebuild and
@@ -165,6 +176,7 @@ export async function saveSession(): Promise<void> {
   for (const snapshot of snapshots) {
     if (!snapshot.rootPath || isLocalLocator(snapshot.rootPath)) continue
     if (!snapshot.connection || snapshot.connection.kind === 'local') continue
+    if (workspacesByRoot.get(snapshot.rootPath)?.id !== snapshot.workspaceId) continue
     remoteEntries.push({
       locator: snapshot.rootPath,
       connection: snapshot.connection,
@@ -184,17 +196,6 @@ export async function saveSession(): Promise<void> {
   // workspace. Local writes to local disk; remote routes through the runtime to
   // the remote repo's .cate/ (projectStateSave is locator-aware). This is what
   // lets a closed remote workspace restore on reopen, exactly like local.
-  // One owner workspace per root. When two share a root (a duplicated workspace),
-  // the SELECTED one owns the write so the live/active layout is what persists;
-  // otherwise the first in order owns it, deterministically.
-  const workspacesByRoot = new Map<string, typeof persistableWorkspaces[number]>()
-  for (const w of persistableWorkspaces) {
-    if (!w.rootPath) continue
-    const existing = workspacesByRoot.get(w.rootPath)
-    if (!existing || w.id === updatedState.selectedWorkspaceId) {
-      workspacesByRoot.set(w.rootPath, w)
-    }
-  }
   for (const snapshot of snapshots) {
     if (!snapshot.rootPath) continue
 

--- a/src/renderer/lib/workspace/sidebarSession.test.ts
+++ b/src/renderer/lib/workspace/sidebarSession.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { SessionSnapshot, SidebarSession } from '../../../shared/types'
-import { deriveSidebarSession, applySidebarSession } from './sidebarSession'
+import { deriveSidebarSession, applySidebarSession, dedupeSnapshotsByRoot } from './sidebarSession'
 
 // Minimal snapshot — only rootPath matters to the ordering logic.
 function snap(rootPath: string | null): SessionSnapshot {
@@ -26,6 +26,11 @@ describe('deriveSidebarSession', () => {
     expect(res.order).toEqual(['/p/a', '/p/c'])
   })
 
+  it('does not persist duplicate roots from legacy runtime state', () => {
+    const res = deriveSidebarSession([ws('a', '/p/a'), ws('dup', '/p/a'), ws('b', '/p/b')], 'a')
+    expect(res.order).toEqual(['/p/a', '/p/b'])
+  })
+
   it('sets selected to the root path of the selected workspace', () => {
     const res = deriveSidebarSession([ws('a', '/p/a'), ws('b', '/p/b')], 'b')
     expect(res.selected).toBe('/p/b')
@@ -39,6 +44,22 @@ describe('deriveSidebarSession', () => {
   it('selected is empty when the selected workspace has no rootPath', () => {
     const res = deriveSidebarSession([ws('a', '')], 'a')
     expect(res.selected).toBe('')
+  })
+})
+
+describe('dedupeSnapshotsByRoot', () => {
+  it('keeps the first snapshot for each root and preserves rootless snapshots', () => {
+    const first = snap('/p/a')
+    const duplicate = { ...snap('/p/a'), workspaceName: 'duplicate' }
+    const rootlessA = snap(null)
+    const rootlessB = snap(null)
+
+    expect(dedupeSnapshotsByRoot([first, rootlessA, duplicate, rootlessB, snap('/p/b')])).toEqual([
+      first,
+      rootlessA,
+      rootlessB,
+      snap('/p/b'),
+    ])
   })
 })
 

--- a/src/renderer/lib/workspace/sidebarSession.ts
+++ b/src/renderer/lib/workspace/sidebarSession.ts
@@ -6,12 +6,24 @@ import type { SessionSnapshot, SidebarSession } from '../../../shared/types'
 // loaded snapshots on restore. Both are pure so they can be unit-tested without
 // the store or IPC.
 
+/** Keep one restored workspace per persisted root. Rootless snapshots remain
+ * distinct; canonical path aliases are caught later by main's create guard. */
+export function dedupeSnapshotsByRoot(snapshots: SessionSnapshot[]): SessionSnapshot[] {
+  const seen = new Set<string>()
+  return snapshots.filter((snapshot) => {
+    if (!snapshot.rootPath) return true
+    if (seen.has(snapshot.rootPath)) return false
+    seen.add(snapshot.rootPath)
+    return true
+  })
+}
+
 /** Snapshot the current sidebar order + active workspace as root paths. */
 export function deriveSidebarSession(
   workspaces: ReadonlyArray<{ id: string; rootPath: string }>,
   selectedId: string,
 ): SidebarSession {
-  const order = workspaces.filter((w) => w.rootPath).map((w) => w.rootPath)
+  const order = [...new Set(workspaces.filter((w) => w.rootPath).map((w) => w.rootPath))]
   const selected = workspaces.find((w) => w.id === selectedId)?.rootPath ?? ''
   return { order, selected }
 }

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -584,10 +584,9 @@ export default function TerminalPanel({
     const adjustCoords = (e: MouseEvent) => {
       // Whether to rewrite this event's clientX/Y lives in a pure helper so the
       // middle-click-pan regression it prevents can be unit-tested. It skips the
-      // rewrite when a canvas gesture owns the pointer (canvas-interacting), when
-      // this is a pan's opening non-left mousedown (rewriting it would jump the
-      // camera on the first delta — see shouldAdjustTerminalCoords), and when the
-      // canvas isn't zoomed. See terminalCoordAdjust.ts for the full rationale.
+      // rewrite when a canvas gesture owns the pointer (canvas-interacting), for
+      // every event in a non-left-button gesture, and when the canvas isn't
+      // zoomed. See terminalCoordAdjust.ts for the full rationale.
       const effective = zoomLevel / renderScale
       if (
         !shouldAdjustTerminalCoords(
@@ -595,6 +594,7 @@ export default function TerminalPanel({
           e.button,
           document.body.classList.contains('canvas-interacting'),
           effective,
+          e.buttons,
         )
       )
         return

--- a/src/renderer/sidebar/WorkspaceTab.menu.test.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.menu.test.tsx
@@ -217,6 +217,15 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('workspace context menu', () => {
+  it('does not offer the removed duplicate-workspace action', async () => {
+    const ws = seed(makeWorkspace([panel('t1', 'terminal')]))
+    await renderTab(ws)
+
+    await rightClick(byText('Alpha'))
+
+    expect(lastMenuItems().some((item) => item.id === 'duplicate')).toBe(false)
+  })
+
   it("'select' calls selectWorkspace", async () => {
     const selectWorkspace = vi.fn()
     const ws = seed(makeWorkspace([panel('t1', 'terminal')]))

--- a/src/renderer/sidebar/WorkspaceTab.tsx
+++ b/src/renderer/sidebar/WorkspaceTab.tsx
@@ -368,7 +368,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
       { id: 'select-folder', label: 'Select Project Folder' },
       { id: 'copy-cwd', label: 'Copy Working Directory', enabled: hasCwd },
       { type: 'separator' },
-      { id: 'duplicate', label: 'Duplicate Workspace' },
       {
         id: 'close-panels',
         // Panels living in detached windows are NOT closed by this — say so.
@@ -410,7 +409,6 @@ export const WorkspaceTab: React.FC<WorkspaceTabProps> = ({
         if (dir) navigator.clipboard.writeText(dir)
         break
       }
-      case 'duplicate': app.duplicateWorkspace(workspace.id); break
       case 'close-panels': void closeAllPanelsWithConfirm(workspace.id); break
       case 'remove': void removeWorkspacesWithConfirm([workspace.id]); break
     }

--- a/src/renderer/stores/appStore/remoteSlice.ts
+++ b/src/renderer/stores/appStore/remoteSlice.ts
@@ -67,11 +67,21 @@ export function createRemoteSlice(set: AppSet, get: AppGet): RemoteSliceActions 
           const message = errorMessage(result?.error, 'Failed to update workspace root')
           set((state) => ({
             workspaces: state.workspaces.map((candidate) => (
-              candidate.id === wsId
-                ? { ...candidate, isRootPathPending: false, rootPathError: message }
+              candidate.id === wsId && candidate.rootPath === rootPath
+                ? {
+                    ...candidate,
+                    rootPath: ws.rootPath,
+                    name: ws.name,
+                    isRootPathPending: false,
+                    rootPathError: message,
+                  }
                 : candidate
             )),
           }))
+          const conflictingId = result?.error?.conflictingWorkspaceId
+          if (conflictingId && get().workspaces.some((candidate) => candidate.id === conflictingId)) {
+            void get().selectWorkspace(conflictingId)
+          }
           log.warn('[workspace-sync] Update rejected:', message)
           return false
         }
@@ -133,6 +143,17 @@ export function createRemoteSlice(set: AppSet, get: AppGet): RemoteSliceActions 
         connection: res.connection,
       })
       if (!result?.ok) {
+        set((state) => ({
+          workspaces: state.workspaces.map((candidate) => (
+            candidate.id === wsId && candidate.rootPath === res.rootPath
+              ? { ...candidate, rootPath: ws.rootPath, name: ws.name }
+              : candidate
+          )),
+        }))
+        const conflictingId = result?.error?.conflictingWorkspaceId
+        if (conflictingId && get().workspaces.some((candidate) => candidate.id === conflictingId)) {
+          void get().selectWorkspace(conflictingId)
+        }
         log.warn('[runtime] register failed:', result?.error?.message ?? 'unknown')
         return false
       }

--- a/src/renderer/stores/appStore/types.ts
+++ b/src/renderer/stores/appStore/types.ts
@@ -140,7 +140,6 @@ export interface AppStoreActions {
   setLocalRuntimePhase: (phase: RuntimePhase) => void
   setWorkspaceColor: (wsId: string, color: string) => void
   renameWorkspace: (wsId: string, name: string) => void
-  duplicateWorkspace: (wsId: string) => string
   closeAllPanels: (wsId: string) => void
   /** Increment a workspace's reload epoch so the main shell remounts and
    *  respawns its terminals after a from-disk layout rebuild. */

--- a/src/renderer/stores/appStore/workspaceSlice.ts
+++ b/src/renderer/stores/appStore/workspaceSlice.ts
@@ -3,9 +3,7 @@
 // =============================================================================
 
 import log from '../../lib/logger'
-import type { WorkspaceState } from '../../../shared/types'
 import { ALL_ZONES } from '../../../shared/types'
-import { generateId } from '../canvas/helpers'
 import type { AppSet, AppGet, AppStoreActions } from './types'
 import {
   createDefaultWorkspace,
@@ -36,7 +34,6 @@ type WorkspaceSliceActions = Pick<
   | 'ensureCenterCanvas'
   | 'setWorkspaceColor'
   | 'renameWorkspace'
-  | 'duplicateWorkspace'
   | 'reorderWorkspaces'
   | 'addAdditionalRoot'
   | 'removeAdditionalRoot'
@@ -91,8 +88,23 @@ export function createWorkspaceSlice(set: AppSet, get: AppGet): WorkspaceSliceAc
       }))
       // Sync to main process
       syncCreateToMain(ws).then((result) => {
-        if (!result?.ok) {
-          log.warn('[workspace-sync] Create rejected:', result?.error?.message)
+        if (!result) return
+        if (!result.ok) {
+          log.warn('[workspace-sync] Create rejected:', result.error.message)
+          const conflictingId = result.error.conflictingWorkspaceId
+          if (ws.rootPath) {
+            window.electronAPI.recentProjectsRemove(ws.rootPath).catch((err) =>
+              log.warn('[workspace] Failed to remove rejected project from recents:', err),
+            )
+          }
+          // Never leave an optimistic workspace that main refused to register:
+          // it has no allowed-root grant and cannot safely own panels or saves.
+          if (get().workspaces.some((candidate) => candidate.id === ws.id)) {
+            get().removeWorkspace(ws.id)
+          }
+          if (conflictingId && get().workspaces.some((candidate) => candidate.id === conflictingId)) {
+            void get().selectWorkspace(conflictingId)
+          }
           return
         }
         set((state) => ({
@@ -367,29 +379,6 @@ export function createWorkspaceSlice(set: AppSet, get: AppGet): WorkspaceSliceAc
         ),
       }))
       syncUpdateToMain(wsId, { name: trimmed })
-    },
-
-    duplicateWorkspace(wsId) {
-      const ws = get().workspaces.find((w) => w.id === wsId)
-      if (!ws) return wsId
-      // Carry the fields that make the workspace point at the same project: a
-      // remote workspace must stay reconnectable (connection), and the extra repos
-      // (additionalRoots) + managed worktrees must come along — otherwise a remote
-      // duplicate degrades to a broken non-reconnectable local one and a
-      // multi-root/worktree workspace loses everything but its primary root.
-      const copy: WorkspaceState = {
-        id: generateId(),
-        name: `${ws.name} Copy`,
-        color: ws.color,
-        rootPath: ws.rootPath,
-        connection: ws.connection,
-        additionalRoots: ws.additionalRoots ? [...ws.additionalRoots] : undefined,
-        worktrees: ws.worktrees ? ws.worktrees.map((wt) => ({ ...wt })) : undefined,
-        panels: {},
-      }
-      set((state) => ({ workspaces: [...state.workspaces, copy] }))
-      syncCreateToMain(copy)
-      return copy.id
     },
 
     reorderWorkspaces(fromIndex, toIndex) {

--- a/src/renderer/stores/duplicateWorkspaceRoot.test.ts
+++ b/src/renderer/stores/duplicateWorkspaceRoot.test.ts
@@ -19,78 +19,40 @@ vi.mock('../lib/terminal/terminalRegistry', () => ({
   },
 }))
 
+const workspaceUpdate = vi.fn()
+const workspaceCreate = vi.fn()
+const runtimeConnect = vi.fn()
+
 beforeEach(() => {
+  workspaceCreate.mockReset().mockImplementation(async (input: { id?: string; name?: string; rootPath?: string }) => ({
+    ok: true,
+    workspace: { id: input.id ?? 'gen', name: input.name ?? 'Workspace', color: '', rootPath: input.rootPath ?? '' },
+  }))
+  workspaceUpdate.mockReset().mockImplementation(async (id: string, changes: { rootPath?: string; name?: string }) => ({
+    ok: true,
+    workspace: { id, name: changes.name ?? 'Workspace', color: '', rootPath: changes.rootPath ?? '' },
+  }))
+  runtimeConnect.mockReset()
   const g = globalThis as unknown as { window?: { electronAPI?: unknown } }
   g.window = g.window ?? {}
   g.window.electronAPI = {
-    workspaceCreate: vi.fn(async (input: { id?: string; name?: string; rootPath?: string }) => ({
-      ok: true,
-      workspace: { id: input.id ?? 'gen', name: input.name ?? 'Workspace', color: '', rootPath: input.rootPath ?? '' },
-    })),
-    workspaceUpdate: vi.fn(async (id: string, changes: { rootPath?: string; name?: string }) => ({
-      ok: true,
-      workspace: { id, name: changes.name ?? 'Workspace', color: '', rootPath: changes.rootPath ?? '' },
-    })),
+    workspaceCreate,
+    workspaceUpdate,
     workspaceRemove: vi.fn(async () => ({ ok: true })),
     recentProjectsAdd: vi.fn(),
     recentProjectsRemove: vi.fn(async () => undefined),
+    runtimeConnect,
+    runtimeEnsure: vi.fn(async () => ({ ok: true })),
   }
 })
 
-import { useAppStore } from './appStore'
+import { awaitWorkspaceSync, useAppStore } from './appStore'
 
 function reset() {
   for (const w of [...useAppStore.getState().workspaces]) {
     useAppStore.getState().removeWorkspace(w.id)
   }
 }
-
-describe('duplicateWorkspace preserves project identity', () => {
-  beforeEach(reset)
-
-  it('keeps the connection so a remote duplicate stays reconnectable', () => {
-    const connection = {
-      kind: 'server' as const,
-      runtimeId: 'comp-1',
-      host: 'box',
-      user: 'me',
-      remotePath: '/srv/repo',
-    }
-    const a = useAppStore.getState().addWorkspace('Remote', 'cate-runtime://comp-1/srv/repo', 'ws-a', connection)
-
-    const dupId = useAppStore.getState().duplicateWorkspace(a)
-
-    const dup = useAppStore.getState().workspaces.find((w) => w.id === dupId)
-    expect(dup?.connection).toEqual(connection)
-    // Not degraded to a broken local workspace.
-    expect(dup?.connection?.kind).toBe('server')
-    expect(dup?.rootPath).toBe('cate-runtime://comp-1/srv/repo')
-  })
-
-  it('preserves additionalRoots and worktrees in the duplicate', () => {
-    const a = useAppStore.getState().addWorkspace('A', '/tmp/repo', 'ws-a')
-    useAppStore.getState().addAdditionalRoot(a, '/tmp/other-repo')
-    useAppStore.setState((s) => ({
-      workspaces: s.workspaces.map((w) =>
-        w.id === a
-          ? { ...w, worktrees: [{ id: 'wt-1', path: '/tmp/repo/.cate/worktrees/feat', color: '#abc', label: 'feat' }] }
-          : w,
-      ),
-    }))
-
-    const dupId = useAppStore.getState().duplicateWorkspace(a)
-    const dup = useAppStore.getState().workspaces.find((w) => w.id === dupId)
-
-    expect(dup?.additionalRoots).toEqual(['/tmp/other-repo'])
-    expect(dup?.worktrees).toEqual([
-      { id: 'wt-1', path: '/tmp/repo/.cate/worktrees/feat', color: '#abc', label: 'feat' },
-    ])
-    // Deep-copied, not aliased — mutating the original must not touch the copy.
-    const original = useAppStore.getState().workspaces.find((w) => w.id === a)
-    expect(dup?.additionalRoots).not.toBe(original?.additionalRoots)
-    expect(dup?.worktrees).not.toBe(original?.worktrees)
-  })
-})
 
 describe('same-instance duplicate-root guard', () => {
   beforeEach(reset)
@@ -137,5 +99,90 @@ describe('same-instance duplicate-root guard', () => {
     expect(window.electronAPI.workspaceUpdate).toHaveBeenCalled()
     const ids = useAppStore.getState().workspaces.map((w) => w.id).sort()
     expect(ids).toEqual([a, b].sort())
+  })
+
+  it('rolls back an optimistic local root when main rejects a canonical duplicate', async () => {
+    const a = useAppStore.getState().addWorkspace('A', '/tmp/dup', 'ws-a')
+    const c = useAppStore.getState().addWorkspace('C', '/tmp/other', 'ws-c')
+    await useAppStore.getState().selectWorkspace(c)
+    await awaitWorkspaceSync()
+    workspaceUpdate.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'DUPLICATE_ROOT',
+        message: 'already open',
+        conflictingWorkspaceId: a,
+      },
+    })
+
+    const ok = await useAppStore.getState().setWorkspaceRootPath(c, '/tmp/alias-of-dup')
+
+    expect(ok).toBe(false)
+    expect(useAppStore.getState().selectedWorkspaceId).toBe(a)
+    expect(useAppStore.getState().workspaces.find((w) => w.id === c)).toMatchObject({
+      name: 'C',
+      rootPath: '/tmp/other',
+      rootPathError: 'already open',
+      isRootPathPending: false,
+    })
+  })
+
+  it('rolls back an optimistic remote root when registration is rejected', async () => {
+    const connection = {
+      kind: 'server' as const,
+      runtimeId: 'runtime-a',
+      host: 'box',
+      user: 'me',
+      remotePath: '/repo',
+    }
+    const rootPath = 'cate-runtime://runtime-a/repo'
+    const a = useAppStore.getState().addWorkspace('Remote A', rootPath, 'ws-a', connection)
+    const c = useAppStore.getState().addWorkspace('C', '/tmp/other', 'ws-c')
+    await useAppStore.getState().selectWorkspace(c)
+    await awaitWorkspaceSync()
+    runtimeConnect.mockResolvedValueOnce({ ok: true, runtimeId: 'runtime-a', rootPath, connection })
+    workspaceUpdate.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'DUPLICATE_ROOT',
+        message: 'already open',
+        conflictingWorkspaceId: a,
+      },
+    })
+
+    const ok = await useAppStore.getState().connectRemoteWorkspace(c, {
+      kind: 'server',
+      host: 'box',
+      user: 'me',
+      remotePath: '/repo',
+    })
+
+    expect(ok).toBe(false)
+    expect(useAppStore.getState().selectedWorkspaceId).toBe(a)
+    expect(useAppStore.getState().workspaces.find((w) => w.id === c)).toMatchObject({
+      name: 'C',
+      rootPath: '/tmp/other',
+    })
+  })
+
+  it('removes an optimistic workspace when main rejects its canonical root', async () => {
+    const a = useAppStore.getState().addWorkspace('A', '/tmp/dup', 'ws-a')
+    await awaitWorkspaceSync()
+    workspaceCreate.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'DUPLICATE_ROOT',
+        message: 'already open',
+        conflictingWorkspaceId: a,
+      },
+    })
+
+    const rejected = useAppStore.getState().addWorkspace('Alias', '/tmp/alias-of-dup', 'ws-alias')
+    await awaitWorkspaceSync()
+
+    expect(rejected).toBe('ws-alias')
+    expect(useAppStore.getState().workspaces.map((w) => w.id)).toEqual([a])
+    expect(useAppStore.getState().selectedWorkspaceId).toBe(a)
+    expect(window.electronAPI.recentProjectsRemove).toHaveBeenCalledWith('/tmp/alias-of-dup')
   })
 })

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.5.0'
+export const RUNTIME_VERSION = '1.5.1'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -247,6 +247,8 @@ export interface RuntimeStatus {
 export interface WorkspaceMutationError {
   code: 'INVALID_ROOT_PATH' | 'INVALID_WORKSPACE_ID' | 'WORKSPACE_NOT_FOUND' | 'DUPLICATE_ROOT'
   message: string
+  /** Present for DUPLICATE_ROOT so the renderer can focus the existing workspace. */
+  conflictingWorkspaceId?: string
 }
 
 export type WorkspaceMutationResult =


### PR DESCRIPTION
## Summary

- remove the misleading **Duplicate Workspace** action and its store API
- enforce one canonical project root per workspace instance during both create and update
- roll back rejected optimistic local and remote workspace changes, then focus the existing workspace
- deduplicate legacy persisted workspace/sidebar/remote-project state while retaining per-root autosave ownership as defense in depth
- make document cursor pinning use the shared body-class refcount so overlapping gestures cannot clear each other's interaction state
- keep middle/right terminal mouse gestures in raw coordinate space across press, move, and release
- bump the Cate app and generated runtime version to **1.5.1**

## Why

Workspace folder selection had duplicate-root guards, but direct workspace creation bypassed them. The removed context-menu action deliberately created two live layouts backed by the same `.cate` persistence files, while canonical path aliases could also bypass renderer-side string checks.

Separately, cursor pinning directly added and removed the shared `canvas-interacting` class, which could clear another active gesture's hold. Terminal coordinate rewriting also relied too heavily on that class and did not inspect `MouseEvent.buttons`, allowing middle-button canvas pans over zoomed terminals to mix raw and adjusted coordinate spaces.

## Impact

Cate now maintains a clear one-workspace-per-canonical-root invariant, cleans up rejected optimistic state, and prevents legacy duplicate records from returning after restart. Canvas resize/pan interactions retain cursor ownership correctly, and non-left-button pans over terminals no longer jump at zoomed scales.

## Validation

- `npm run typecheck`
- `npm run build`
- focused Vitest suite covering workspace guards/persistence, context menu removal, cursor refcounting, terminal coordinate handling, and gesture cleanup: **77 tests passed**
- the broader suite was also attempted in the sandbox; unrelated socket/file-watcher integration tests remain unavailable there due to `EPERM` and watcher timeouts
