### PR TITLE
Make Cate CLI and extension automation non-disruptive

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -61,8 +61,9 @@ This is the **complete** surface today. It is intentionally small; new methods a
 cate.version()                                 // API version (int), for feature detection
 cate.panel.id                                  // this panel instance's id
 cate.panel.setTitle(title)
-cate.panel.list() => [{ panelId, type, title, focused, filePath?, url? }]  // this window's panels (`panel` scope)
+cate.panel.list() => [{ panelId, type, title, focused, filePath?, url? }]  // workspace panels across windows (`panel` scope)
 cate.panel.focus(panelId)                      // reveal/focus a panel (`panel` scope)
+cate.panel.close(panelId)                      // close without revealing first (`panel` scope)
 cate.workspace.get()                           // { rootPath, branch, worktree }  (branch/worktree null for now)
 cate.theme.get()                               // { id, type, app, terminal } theme tokens
 cate.editor.openFile(path, { line?, column? }) // path is confined to the workspace root
@@ -88,13 +89,22 @@ cate.browser.wait({ panelId?, timeoutMs? }) => { url, title, loading: false }  /
 cate.browser.press({ key, ref?, panelId? }) => { ok: true }     // TRUSTED key input (Enter submits forms)
 ```
 
-`panel.setTitle` (self-identity) needs no scope; `panel.list` and `panel.focus`
+`panel.setTitle` (self-identity) needs no scope; `panel.list`, `panel.focus`, and `panel.close`
 read/steer other panels and require the `panel` scope. `panel.list` is the
 single enumeration surface — browser panels carry their `url` there, editors
 their `filePath`, and the `focused` entry answers "what is the user looking
 at" (there is no `browser.list` or `editor.active`). `press` accepts Enter,
 Tab, Escape, Backspace, Delete, Space, the arrows, PageUp/PageDown, Home, End;
 with `ref` the element is focused first.
+
+Panel creation through this API is deliberately non-disruptive for both
+extensions and `CATE_API` callers: `editor.openFile`, `canvas.createPanel`, and
+the create branch of `browser.open` use automatic background placement. They do
+not open the placement picker, switch tabs, change canvas selection/focus, or
+move the camera. `panel.focus` is the explicit opt-in operation for changing the
+user's view. A newly created browser stays mounted off-screen, and `browser.open`
+does not resolve until its webview is registered, so an automation loop can
+immediately continue with `wait` and `snapshot`.
 
 `cateApi` scopes in the manifest declare which namespaces an extension uses; the host enforces them (default-deny) and Cate surfaces them as the extension's permissions in Settings → Extensions.
 

--- a/skills/cate-cli/SKILL.md
+++ b/skills/cate-cli/SKILL.md
@@ -98,8 +98,10 @@ cate editor open src/app.ts       # open a file; prints the new panel's short id
 cate editor open src/app.ts:42    # ...and jump to line 42 (or :42:7 for a column)
 cate panel list                   # ALL panels: id, type, path/url/title; * = focused
 cate panel focus 1a2b3c4d         # reveal/focus a panel (short ids from `list` ok)
-cate canvas create terminal       # open a new empty panel of the given type
-cate panel set-title My Panel     # rename the calling panel
+cate panel close 1a2b3c4d         # close a panel without revealing it first
+cate canvas create terminal       # auto-place a new panel in the background
+cate panel set-title My Panel     # rename this Cate terminal panel
+cate panel set-title My Panel --panel 1a2b3c4d  # agent shells target explicitly
 cate version                      # host API version (for feature detection)
 ```
 
@@ -109,6 +111,13 @@ the focused panel marked `*`. Its short ids feed `panel focus` and `--panel`.
 So "what is the user looking at?" is the `*` row, and there is no separate
 browser or editor list. To open a file (any type — a PDF becomes a document
 panel), use `cate editor open`; `canvas create` is for empty panels.
+
+Panel/file/browser creation is deliberately non-disruptive: it uses automatic
+background placement and does not open the placement picker, change focus or
+selection, switch tabs, or move the canvas camera. `panel focus` is the explicit
+opt-in command for changing the user's view. A new browser is kept mounted even
+off-screen, and `browser open` waits for its webview before returning, so the
+next `wait`/`snapshot` is safe to run immediately.
 
 Each group maps to a host scope that a Cate terminal is granted. Two host scopes
 are **not** available from a terminal: `agent` (a terminal must not drive the
@@ -126,7 +135,7 @@ verbs above are the complete surface.
 - `--max <n>` — `snapshot` only: max ref lines to print (default 150; 0 = all).
 - `--timeout <ms>` — request timeout (default 30000).
 - `-h`, `--help` — usage.
-- `--version` — the CLI's own version.
+- `--version` — the CLI's own version (prints `cate cli <version>`).
 
 ## Output and exit codes
 

--- a/src/cli/cate.test.ts
+++ b/src/cli/cate.test.ts
@@ -286,7 +286,7 @@ describe('run — exit codes', () => {
     const fetchMock = vi.fn()
     const deps = makeDeps({ fetch: fetchMock as unknown as typeof fetch })
     expect(await run(['--version'], deps)).toBe(0)
-    expect(deps.out).toEqual([CLI_VERSION])
+    expect(deps.out).toEqual([`cate cli ${CLI_VERSION}`])
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -573,5 +573,69 @@ describe('--max validation', () => {
     const deps = makeDeps()
     expect(await run(['browser', 'snapshot', '--max', 'lots'], deps)).toBe(2)
     expect(deps.err.join('\n')).toMatch(/invalid --max/)
+  })
+})
+
+describe('strict command contracts', () => {
+  it('rejects unexpected positional arguments instead of silently ignoring them', () => {
+    expect(() => buildRequest(['panel', 'list', 'extra'], noFlags)).toThrow(/unexpected argument/)
+    expect(() => buildRequest(['browser', 'open', 'https://x', 'extra'], noFlags)).toThrow(/unexpected argument/)
+    expect(() => buildRequest(['browser', 'press', '@e1', 'Enter', 'extra'], noFlags)).toThrow(/unexpected argument/)
+  })
+
+  it('rejects command-specific flags on unrelated commands', () => {
+    expect(() => buildRequest(['version'], { ...noFlags, max: '1' })).toThrow(/--max is only valid/)
+    expect(() => buildRequest(['editor', 'open', 'x.ts'], { ...noFlags, panel: 'p1' })).toThrow(/--panel is not valid/)
+  })
+
+  it('maps panel close and resolves its short id', () => {
+    expect(buildRequest(['panel', 'close', 'abcd1234'], noFlags)).toEqual({
+      method: 'cate.panel.close',
+      args: { panelId: 'abcd1234' },
+      resolvePanel: 'panel',
+    })
+  })
+
+  it('resolves --panel for set-title against all panel types', () => {
+    expect(buildRequest(['panel', 'set-title', 'Renamed'], { ...noFlags, panel: 'abcd1234' })).toEqual({
+      method: 'cate.panel.setTitle',
+      args: { title: 'Renamed', panelId: 'abcd1234' },
+      resolvePanel: 'panel',
+    })
+  })
+})
+
+describe('terminal panel identity', () => {
+  it('uses CATE_PANEL_ID for an unaddressed set-title', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ result: null }))
+    const deps = makeDeps({
+      fetch: fetchMock as unknown as typeof fetch,
+      env: { CATE_API: 'http://127.0.0.1:1', CATE_TOKEN: 't', CATE_PANEL_ID: 'full-panel-id' },
+    })
+    expect(await run(['panel', 'set-title', 'My', 'Terminal'], deps)).toBe(0)
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
+    expect(body).toEqual({ method: 'cate.panel.setTitle', args: { title: 'My Terminal', panelId: 'full-panel-id' } })
+    expect(deps.out).toEqual(['ok'])
+  })
+
+  it('requires --panel when the shell has no panel identity', async () => {
+    const fetchMock = vi.fn()
+    const deps = makeDeps({ fetch: fetchMock as unknown as typeof fetch })
+    expect(await run(['panel', 'set-title', 'x'], deps)).toBe(2)
+    expect(deps.err.join('\n')).toMatch(/requires --panel/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('human-facing output and help', () => {
+  it('formats ui.notify as ok', () => {
+    expect(formatHuman('cate.ui.notify', { ok: true })).toBe('ok')
+  })
+
+  it('shows group-specific help', async () => {
+    const deps = makeDeps()
+    expect(await run(['browser', '--help'], deps)).toBe(0)
+    expect(deps.out.join('\n')).toMatch(/^Usage: cate browser/)
+    expect(deps.out.join('\n')).not.toContain('Groups:')
   })
 })

--- a/src/cli/cate.ts
+++ b/src/cli/cate.ts
@@ -30,7 +30,7 @@ import { parseArgs } from 'node:util'
 
 /** Version of the CLI tool itself (printed by --version). The API's own version
  *  is reachable via `cate version`. */
-export const CLI_VERSION = '2'
+export const CLI_VERSION = '3'
 
 /** Default request timeout (ms) when --timeout is not given. */
 export const DEFAULT_TIMEOUT_MS = 30_000
@@ -98,6 +98,19 @@ function needPositiveInt(value: string, name: string): number {
   return n
 }
 
+/** Enforce exact positional arity for fixed-shape verbs. Variadic verbs
+ * (notify, type, set-title) validate their own minimum and deliberately skip
+ * this helper. */
+function exact(args: string[], count: number): string[] {
+  if (args.length > count) throw new UsageError(`unexpected argument: ${args[count]}`)
+  return args
+}
+
+function noArgs(args: string[]): Record<string, never> {
+  exact(args, 0)
+  return {}
+}
+
 /** Split a `path[:line[:col]]` target into openFile args. Only a TRAILING
  *  `:<digits>` (or `:<digits>:<digits>`) counts as a position, so Windows drive
  *  prefixes and stray colons inside names stay part of the path. */
@@ -113,13 +126,13 @@ export const GROUPS: Record<string, Group> = {
   browser: {
     // No `list` — `cate panel list` is the single enumeration surface (browser
     // panels carry their url there).
-    open: (a) => ({ method: 'cate.browser.open', args: { url: need(a[0], 'url') } }),
+    open: (a) => ({ method: 'cate.browser.open', args: { url: need(exact(a, 1)[0], 'url') } }),
     // No `current`/`back`/`forward` — `wait` answers "where am I / is it
     // settled" (it returns instantly when idle), and agents navigate by URL.
-    reload: () => ({ method: 'cate.browser.reload', args: {} }),
-    screenshot: () => ({ method: 'cate.browser.screenshot', args: {} }),
-    snapshot: () => ({ method: 'cate.browser.snapshot', args: {} }),
-    click: (a) => ({ method: 'cate.browser.click', args: { ref: need(a[0], 'ref') } }),
+    reload: (a) => ({ method: 'cate.browser.reload', args: noArgs(a) }),
+    screenshot: (a) => ({ method: 'cate.browser.screenshot', args: noArgs(a) }),
+    snapshot: (a) => ({ method: 'cate.browser.snapshot', args: noArgs(a) }),
+    click: (a) => ({ method: 'cate.browser.click', args: { ref: need(exact(a, 1)[0], 'ref') } }),
     type: (a) => ({
       method: 'cate.browser.type',
       // Join the remaining positionals so multi-word text needs no quoting.
@@ -127,12 +140,12 @@ export const GROUPS: Record<string, Group> = {
     }),
     wait: (a) => ({
       method: 'cate.browser.wait',
-      args: a[0] !== undefined ? { timeoutMs: needPositiveInt(a[0], 'ms') } : {},
+      args: exact(a, 1)[0] !== undefined ? { timeoutMs: needPositiveInt(a[0], 'ms') } : {},
     }),
     // `press <key>` sends to whatever the guest has focused; `press <ref> <key>`
     // focuses the element first.
     press: (a) =>
-      a.length >= 2
+      exact(a, 2).length >= 2
         ? { method: 'cate.browser.press', args: { ref: a[0], key: need(a[1], 'key') } }
         : { method: 'cate.browser.press', args: { key: need(a[0], 'key') } },
   },
@@ -146,19 +159,27 @@ export const GROUPS: Record<string, Group> = {
   editor: {
     // openFileAsPanel routes by file type (a PDF opens a document panel), so
     // this one verb covers every file-backed panel — no `canvas create --file`.
-    open: (a) => ({ method: 'cate.editor.openFile', args: parseFileTarget(need(a[0], 'path')) }),
+    open: (a) => ({ method: 'cate.editor.openFile', args: parseFileTarget(need(exact(a, 1)[0], 'path')) }),
   },
   canvas: {
-    create: (a) => ({ method: 'cate.canvas.createPanel', args: { type: need(a[0], 'type') } }),
+    create: (a) => ({ method: 'cate.canvas.createPanel', args: { type: need(exact(a, 1)[0], 'type') } }),
   },
   panel: {
-    list: () => ({ method: 'cate.panel.list', args: {} }),
+    list: (a) => ({ method: 'cate.panel.list', args: noArgs(a) }),
     focus: (a) => ({
       method: 'cate.panel.focus',
-      args: { panelId: need(a[0], 'panelId') },
+      args: { panelId: need(exact(a, 1)[0], 'panelId') },
       resolvePanel: 'panel',
     }),
-    'set-title': (a) => ({ method: 'cate.panel.setTitle', args: { title: needRest(a, 'title') } }),
+    close: (a) => ({
+      method: 'cate.panel.close',
+      args: { panelId: need(exact(a, 1)[0], 'panelId') },
+      resolvePanel: 'panel',
+    }),
+    'set-title': (a) => ({
+      method: 'cate.panel.setTitle',
+      args: { title: needRest(a, 'title') },
+    }),
   },
   // NOTE: no `agent` or `storage` group. Those scopes are never granted to the
   // first-party terminal endpoint this CLI talks to (see workspaceCateApi
@@ -227,12 +248,19 @@ export function buildRequest(positionals: string[], flags: Flags): Request {
     req = builder(positionals.slice(2), flags)
   }
 
-  // --panel addresses a specific target panel (args.panelId). Explicit args win.
-  // Every browser verb targets a panel, so a --panel short prefix on one is
-  // resolved against the browser entries of `panel list`.
-  if (flags.panel !== undefined && req.args.panelId === undefined) {
+  const panelFlagAllowed = req.method.startsWith('cate.browser.') || req.method === 'cate.panel.setTitle'
+  if (flags.panel !== undefined && !panelFlagAllowed) {
+    throw new UsageError(`--panel is not valid for ${positionals.slice(0, 2).join(' ')}`)
+  }
+  if (flags.max !== undefined && req.method !== 'cate.browser.snapshot') {
+    throw new UsageError('--max is only valid for browser snapshot')
+  }
+
+  // --panel addresses a specific target panel (args.panelId). Browser targets
+  // resolve only against browser rows; set-title accepts every panel type.
+  if (flags.panel !== undefined) {
     req.args.panelId = flags.panel
-    if (req.method.startsWith('cate.browser.')) req.resolvePanel = 'browser'
+    req.resolvePanel = req.method.startsWith('cate.browser.') ? 'browser' : 'panel'
   }
   return req
 }
@@ -438,6 +466,11 @@ export function formatHuman(method: string, value: unknown, opts?: { max?: numbe
     case 'cate.browser.press':
       // These resolve to { ok: true } — nothing to print.
       return 'ok'
+    case 'cate.ui.notify':
+    case 'cate.panel.focus':
+    case 'cate.panel.setTitle':
+    case 'cate.panel.close':
+      return 'ok'
     case 'cate.panel.list':
       return formatPanelList(value)
     case 'cate.editor.openFile':
@@ -469,7 +502,7 @@ Groups:
   ui         notify <message...>
   editor     open <path[:line[:col]]>
   canvas     create <type>
-  panel      list | focus <id> | set-title <title...>
+  panel      list | focus <id> | close <id> | set-title <title...>
 
 \`panel list\` enumerates every panel (editors with file paths, browsers with
 urls); its short ids feed \`panel focus\` and \`--panel\`.
@@ -480,10 +513,29 @@ Flags:
   --max <n>        snapshot: max ref lines to print (default ${SNAPSHOT_MAX_DEFAULT}; 0 = all)
   --timeout <ms>   request timeout (default ${DEFAULT_TIMEOUT_MS})
   -h, --help       show this help
-  --version        print the CLI version
+  --version        print the CLI version (distinct from host API version)
 
 Requires CATE_API and CATE_TOKEN in the environment. Cate injects them into new
 terminals while "Command-line control (cate CLI)" is enabled (Settings → Terminal).`
+
+const GROUP_USAGE: Record<string, string> = {
+  browser: `Usage: cate browser open <url> | wait [ms] | reload | screenshot | snapshot\n` +
+    `       cate browser click <ref> | type <ref> <text...> | press [ref] <key>`,
+  ui: 'Usage: cate ui notify <message...>',
+  editor: 'Usage: cate editor open <path[:line[:col]]>',
+  canvas: 'Usage: cate canvas create <type>',
+  panel: 'Usage: cate panel list | focus <id> | close <id> | set-title <title...>',
+}
+
+function helpFor(positionals: string[]): string {
+  return GROUP_USAGE[positionals[0]] ?? USAGE
+}
+
+function writeUsageError(deps: RunDeps, message: string): number {
+  deps.stderr(`cate: ${message}`)
+  deps.stderr("Try 'cate --help' for usage.")
+  return 2
+}
 
 export interface RunDeps {
   fetch: typeof fetch
@@ -498,18 +550,16 @@ export async function run(argv: string[], deps: RunDeps): Promise<number> {
   try {
     parsed = parseCli(argv)
   } catch (err) {
-    deps.stderr(`cate: ${err instanceof Error ? err.message : String(err)}`)
-    deps.stderr(USAGE)
-    return 2
+    return writeUsageError(deps, err instanceof Error ? err.message : String(err))
   }
 
   // Explicit --version / --help win even with no positional command.
   if (parsed.flags.version) {
-    deps.stdout(CLI_VERSION)
+    deps.stdout(`cate cli ${CLI_VERSION}`)
     return 0
   }
   if (parsed.flags.help) {
-    deps.stdout(USAGE)
+    deps.stdout(helpFor(parsed.positionals))
     return 0
   }
   if (parsed.positionals.length === 0) {
@@ -521,21 +571,25 @@ export async function run(argv: string[], deps: RunDeps): Promise<number> {
   try {
     req = buildRequest(parsed.positionals, parsed.flags)
   } catch (err) {
-    deps.stderr(`cate: ${err instanceof Error ? err.message : String(err)}`)
-    deps.stderr(USAGE)
-    return 2
+    return writeUsageError(deps, err instanceof Error ? err.message : String(err))
   }
 
   const timeout = parsed.flags.timeout ? Number(parsed.flags.timeout) : DEFAULT_TIMEOUT_MS
-  if (!Number.isFinite(timeout) || timeout <= 0) {
-    deps.stderr(`cate: invalid --timeout: ${parsed.flags.timeout}`)
-    return 2
+  if (!Number.isInteger(timeout) || timeout <= 0) {
+    return writeUsageError(deps, `invalid --timeout: ${parsed.flags.timeout}`)
   }
 
   const max = parsed.flags.max !== undefined ? Number(parsed.flags.max) : undefined
   if (max !== undefined && (!Number.isInteger(max) || max < 0)) {
-    deps.stderr(`cate: invalid --max: ${parsed.flags.max}`)
-    return 2
+    return writeUsageError(deps, `invalid --max: ${parsed.flags.max}`)
+  }
+
+  // A terminal knows its own panel id; an autonomous agent shell may not. The
+  // latter can still retitle explicitly with --panel <id> from `panel list`.
+  if (req.method === 'cate.panel.setTitle' && req.args.panelId === undefined) {
+    const panelId = deps.env.CATE_PANEL_ID
+    if (!panelId) return writeUsageError(deps, 'panel set-title requires --panel outside a Cate terminal panel')
+    req.args.panelId = panelId
   }
 
   const sendDeps: SendDeps = { fetch: deps.fetch, env: deps.env, timeout }

--- a/src/main/extensions/browserControl.integration.test.ts
+++ b/src/main/extensions/browserControl.integration.test.ts
@@ -47,16 +47,20 @@ vi.mock('electron', () => ({
 }))
 
 // --- window registry + panel union: the FAKE windows the forward targets. --------
-const { activeWindow, windowsById, windowPanelList } = vi.hoisted(() => ({
+const { activeWindow, windowsById, windowPanelList, upsertWindowPanel } = vi.hoisted(() => ({
   activeWindow: { value: undefined as unknown },
   windowsById: new Map<number, unknown>(),
   windowPanelList: { value: [] as Array<{ panelId: string; type: string; ownerWindowId: number }> },
+  upsertWindowPanel: vi.fn(),
 }))
 vi.mock('../windowRegistry', () => ({
   getActiveMainWindow: () => activeWindow.value,
   getWindow: (id: number) => windowsById.get(id),
 }))
-vi.mock('../windowPanels', () => ({ getWindowPanels: () => windowPanelList.value }))
+vi.mock('../windowPanels', () => ({
+  getWindowPanels: () => windowPanelList.value,
+  upsertWindowPanel,
+}))
 
 // --- remaining leaf boundaries cateApiHandlers imports (mirror its own test). -----
 vi.mock('./ExtensionManager', () => ({
@@ -121,7 +125,7 @@ interface CapturedForward {
 // CATE_HOST_FORWARD, it captures the payload and (unless told to stay silent)
 // drives the reply back through the SAME channel the real forwardToOwner listens
 // on — ipcMain.on(CATE_HOST_FORWARD_REPLY) — making the round-trip real.
-function makeWindow(opts: { replyResult?: unknown; reply?: boolean } = {}) {
+function makeWindow(opts: { id?: number; replyResult?: unknown; reply?: boolean } = {}) {
   const forwards: CapturedForward[] = []
   const send = vi.fn((channel: string, payload: CapturedForward) => {
     if (channel !== CATE_HOST_FORWARD) return
@@ -134,7 +138,7 @@ function makeWindow(opts: { replyResult?: unknown; reply?: boolean } = {}) {
       }
     })
   })
-  return { win: { isDestroyed: () => false, webContents: { send } }, send, forwards }
+  return { win: { id: opts.id ?? 1, isDestroyed: () => false, webContents: { send } }, send, forwards }
 }
 
 interface HttpReply { status: number; body: unknown }
@@ -203,9 +207,32 @@ beforeEach(() => {
   activeWindow.value = undefined
   windowsById.clear()
   windowPanelList.value = []
+  upsertWindowPanel.mockClear()
 })
 
 describe('browser-control integration — HTTP → real dispatch → forward → renderer reply', () => {
+  it('records a newly opened browser immediately so its returned id is routable', async () => {
+    const owner = makeWindow({ id: 77, replyResult: { panelId: 'new-browser', url: 'https://x.test' } })
+    activeWindow.value = owner.win
+
+    const { runtime, output } = makeRuntime()
+    const endpoint = firstPartySession(runtime, ['browser'])
+    const res = await request(endpoint, output, {
+      json: { method: 'cate.browser.open', args: { url: 'https://x.test' } },
+    })
+
+    expect(res.body).toEqual({ result: { panelId: 'new-browser', url: 'https://x.test' } })
+    expect(upsertWindowPanel).toHaveBeenCalledWith(77, {
+      panelId: 'new-browser',
+      type: 'browser',
+      title: 'https://x.test',
+      workspaceId: WS,
+      url: 'https://x.test',
+      focused: false,
+    })
+    endpoint.dispose()
+  })
+
   it('happy path: cate.browser.open reaches the owner renderer and the reply flows back as HTTP 200', async () => {
     // A browser panel 'b1' owned by the same fake window that is active.
     const owner = makeWindow({ replyResult: { ok: true, navigated: 'https://x.test' } })

--- a/src/main/extensions/cateApiHandlers.test.ts
+++ b/src/main/extensions/cateApiHandlers.test.ts
@@ -61,16 +61,31 @@ vi.mock('./ExtensionManager', () => ({
 // importing cateApiHandlers doesn't drag in the proxy/server/IPC machinery.
 vi.mock('./proxyServer', () => ({ getProxyUrlFor: vi.fn() }))
 vi.mock('./ExtensionServerManager', () => ({ extensionServerManager: {} }))
-const { activeWindow, windowsById, windowPanelList } = vi.hoisted(() => ({
+const { activeWindow, windowsById, windowPanelList, revealWindowPanel, upsertWindowPanel } = vi.hoisted(() => ({
   activeWindow: { value: undefined as unknown },
   windowsById: new Map<number, unknown>(),
-  windowPanelList: { value: [] as Array<{ panelId: string; type: string; ownerWindowId: number }> },
+  windowPanelList: { value: [] as Array<{
+    panelId: string
+    type: string
+    title?: string
+    workspaceId?: string
+    ownerWindowId: number
+    filePath?: string
+    url?: string
+    focused?: boolean
+  }> },
+  revealWindowPanel: vi.fn(() => true),
+  upsertWindowPanel: vi.fn(),
 }))
 vi.mock('../windowRegistry', () => ({
   getActiveMainWindow: () => activeWindow.value,
   getWindow: (id: number) => windowsById.get(id),
 }))
-vi.mock('../windowPanels', () => ({ getWindowPanels: () => windowPanelList.value }))
+vi.mock('../windowPanels', () => ({
+  getWindowPanels: () => windowPanelList.value,
+  revealWindowPanel,
+  upsertWindowPanel,
+}))
 vi.mock('../runtime/locator', () => ({
   LOCAL_RUNTIME_ID: 'local',
   parseLocator: (raw: string) => ({ runtimeId: 'local', path: raw }),
@@ -122,6 +137,9 @@ beforeEach(() => {
   activeWindow.value = undefined
   windowsById.clear()
   windowPanelList.value = []
+  revealWindowPanel.mockClear()
+  revealWindowPanel.mockReturnValue(true)
+  upsertWindowPanel.mockClear()
   kv.clear()
   panelKv.clear()
   showOsNotification.mockClear()
@@ -188,16 +206,50 @@ describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
     ['cate.panel.setTitle', { title: 'Renamed' }],
     ['cate.panel.list', {}],
     ['cate.panel.focus', { panelId: 'p1' }],
+    ['cate.panel.close', { panelId: 'p1' }],
   ])('forwards %s to the owning renderer', async (method, args) => {
     const forward = vi.fn(async () => ({ panelId: 'new' }))
     const res = await dispatchCateInvoke(scope(forward), method, args)
     expect(forward).toHaveBeenCalledTimes(1)
-    expect(forward).toHaveBeenCalledWith(expect.objectContaining({ method, args, extensionId: EXT, workspaceId: WS, panelId: PANEL }))
+    expect(forward).toHaveBeenCalledWith(expect.objectContaining({
+      method,
+      args: expect.objectContaining(args),
+      extensionId: EXT,
+      workspaceId: WS,
+      panelId: PANEL,
+    }))
     expect(res).toEqual({ panelId: 'new' })
   })
 
   it('rejects unknown methods as unsupported', async () => {
     expect(await dispatchCateInvoke(scope(), 'cate.bogus.method', undefined)).toEqual({ error: 'unsupported', method: 'cate.bogus.method' })
+  })
+
+  it('panel.list merges immediate local rows with detached-window rows', async () => {
+    windowPanelList.value = [{
+      panelId: 'detached-browser',
+      type: 'browser',
+      title: 'Docs',
+      workspaceId: WS,
+      ownerWindowId: 2,
+      url: 'https://docs.example/',
+      focused: true,
+    }]
+    const forward = vi.fn(async () => [
+      { panelId: 'local-editor', type: 'editor', title: 'a.ts', focused: false, filePath: '/ws/root/a.ts' },
+    ])
+
+    expect(await dispatchCateInvoke(scope(forward), 'cate.panel.list', {})).toEqual([
+      { panelId: 'local-editor', type: 'editor', title: 'a.ts', focused: false, filePath: '/ws/root/a.ts' },
+      { panelId: 'detached-browser', type: 'browser', title: 'Docs', focused: true, url: 'https://docs.example/' },
+    ])
+  })
+
+  it('panel.focus routes a detached panel through the cross-window revealer', async () => {
+    windowPanelList.value = [{ panelId: 'detached', type: 'editor', workspaceId: WS, ownerWindowId: 2 }]
+
+    expect(await dispatchCateInvoke(scope(), 'cate.panel.focus', { panelId: 'detached' })).toEqual({ ok: true })
+    expect(revealWindowPanel).toHaveBeenCalledWith('detached')
   })
 
   it('denies methods whose scope the manifest does not declare', async () => {
@@ -412,9 +464,10 @@ describe('dispatchCateInvoke — cate.browser.* namespace', () => {
     expect(requiredScopeFor('cate.browser.press')).toBe('browser')
   })
 
-  it('panel.list/focus need the `panel` scope; panel self-identity stays scope-free', () => {
+  it('panel.list/focus/close need the `panel` scope; panel self-identity stays scope-free', () => {
     expect(requiredScopeFor('cate.panel.list')).toBe('panel')
     expect(requiredScopeFor('cate.panel.focus')).toBe('panel')
+    expect(requiredScopeFor('cate.panel.close')).toBe('panel')
     expect(requiredScopeFor('cate.panel.setTitle')).toBeNull()
   })
 

--- a/src/main/extensions/cateApiHandlers.ts
+++ b/src/main/extensions/cateApiHandlers.ts
@@ -56,7 +56,7 @@ import { agentManager } from '../../agent/main/agentManager'
 import { getExtensionStorage } from './storage'
 import { getWorkspaceInfo } from '../workspaceManager'
 import { getActiveMainWindow, getWindow } from '../windowRegistry'
-import { getWindowPanels } from '../windowPanels'
+import { getWindowPanels, revealWindowPanel, upsertWindowPanel } from '../windowPanels'
 import { parseLocator, LOCAL_RUNTIME_ID } from '../runtime/locator'
 import { getAllSettings, getSetting } from '../settingsFile'
 import { resolveActiveTheme } from '../themeBootCache'
@@ -189,17 +189,17 @@ export function forwardToActiveWindow(payload: InvokePayload): Promise<InvokeRes
  */
 function resolveBrowserTargetWindow(
   panelId: string | undefined,
-): { wc: WebContents } | { error: string } {
+): { wc: WebContents; ownerWindowId: number } | { error: string } {
   if (panelId) {
     const info = getWindowPanels().find((p) => p.panelId === panelId)
     if (!info || info.type !== 'browser') return { error: 'no-such-browser' }
     const win = getWindow(info.ownerWindowId)
     if (!win || win.isDestroyed()) return { error: 'no-host-window' }
-    return { wc: win.webContents }
+    return { wc: win.webContents, ownerWindowId: info.ownerWindowId }
   }
   const win = getActiveMainWindow()
   if (!win || win.isDestroyed()) return { error: 'no-host-window' }
-  return { wc: win.webContents }
+  return { wc: win.webContents, ownerWindowId: win.id }
 }
 
 // ---------------------------------------------------------------------------
@@ -209,9 +209,6 @@ function resolveBrowserTargetWindow(
 const FORWARDED_METHODS = new Set([
   'editor.openFile',
   'canvas.createPanel',
-  'panel.setTitle',
-  'panel.list',
-  'panel.focus',
 ])
 
 function unsupported(method: string): InvokeResult {
@@ -243,6 +240,7 @@ export function requiredScopeFor(method: string): string | null | undefined {
     // panels — they need an explicit `panel` grant.
     case 'cate.panel.list':
     case 'cate.panel.focus':
+    case 'cate.panel.close':
       return 'panel'
     default:
       // A panel controlling its own identity (id / title / badge) needs no scope.
@@ -403,6 +401,14 @@ export async function dispatchCateInvoke(
   if (required !== null && !scopeGranted(declared, required)) {
     return { error: 'scope-denied', method }
   }
+  // panel.setTitle is scope-free only for a panel changing its own identity.
+  // Addressing another panel (the CLI's --panel form) requires the panel scope.
+  if (method === 'cate.panel.setTitle') {
+    const target = (args as { panelId?: unknown } | null)?.panelId
+    if (typeof target === 'string' && target !== panelId && !scopeGranted(declared, 'panel')) {
+      return { error: 'scope-denied', method }
+    }
+  }
 
   // Storage (handled in main, backed by storage.ts). Routed by prefix — mirrors
   // requiredScopeFor's storage.* branch — so dispatchStorage's switch is the sole
@@ -423,7 +429,21 @@ export async function dispatchCateInvoke(
     if (scope.caller !== 'first-party' && !(await ensureConsent(extensionId, 'browser'))) {
       return { error: 'consent-denied', method }
     }
-    return forwardToOwner(target.wc, { extensionId, workspaceId, panelId: panelId ?? '', method, args })
+    const result = await forwardToOwner(target.wc, { extensionId, workspaceId, panelId: panelId ?? '', method, args })
+    if (method === 'cate.browser.open' && !a.panelId && result && typeof result === 'object') {
+      const opened = result as { panelId?: unknown; url?: unknown }
+      if (typeof opened.panelId === 'string') {
+        upsertWindowPanel(target.ownerWindowId, {
+          panelId: opened.panelId,
+          type: 'browser',
+          title: typeof opened.url === 'string' ? opened.url : 'Browser',
+          workspaceId,
+          url: typeof opened.url === 'string' ? opened.url : '',
+          focused: false,
+        })
+      }
+    }
+    return result
   }
 
   switch (method) {
@@ -456,6 +476,62 @@ export async function dispatchCateInvoke(
       }
       log.info('[extensions] %s notify (%s): %s', extensionId, a.level ?? 'info', message)
       return { ok: true }
+    }
+
+    case 'cate.panel.list': {
+      // Read the active renderer synchronously so a just-created panel is
+      // visible before the 200ms cross-window discovery report lands, then add
+      // panels owned by detached/other windows from main's authoritative union.
+      const local = await scope.forward({ extensionId, workspaceId, panelId: panelId ?? '', method, args })
+      if (!Array.isArray(local)) return local
+      const rows = [...local] as Array<Record<string, unknown>>
+      const seen = new Set(rows.map((row) => row.panelId).filter((id): id is string => typeof id === 'string'))
+      for (const panel of getWindowPanels()) {
+        if (panel.workspaceId !== workspaceId || seen.has(panel.panelId)) continue
+        rows.push({
+          panelId: panel.panelId,
+          type: panel.type,
+          title: panel.title,
+          focused: panel.focused === true,
+          ...(panel.filePath ? { filePath: panel.filePath } : {}),
+          ...(panel.type === 'browser' ? { url: panel.url ?? '' } : {}),
+        })
+        seen.add(panel.panelId)
+      }
+      return rows
+    }
+
+    case 'cate.panel.focus': {
+      const a = (args ?? {}) as { panelId?: unknown }
+      const targetPanelId = typeof a.panelId === 'string' ? a.panelId : ''
+      if (!targetPanelId) return { error: 'bad-args', method }
+      const owner = getWindowPanels().find((p) => p.panelId === targetPanelId && p.workspaceId === workspaceId)
+      if (owner) {
+        return revealWindowPanel(targetPanelId) ? { ok: true } : { error: 'panel-not-revealable', method }
+      }
+      // Fresh local panels can beat the debounced cross-window report.
+      return scope.forward({ extensionId, workspaceId, panelId: panelId ?? '', method, args })
+    }
+
+    case 'cate.panel.setTitle':
+    case 'cate.panel.close': {
+      const a = (args ?? {}) as { panelId?: unknown }
+      const targetPanelId = typeof a.panelId === 'string' && a.panelId ? a.panelId : panelId ?? ''
+      if (!targetPanelId) return { error: 'bad-args', method }
+      const routedArgs = { ...((args ?? {}) as Record<string, unknown>), panelId: targetPanelId }
+      const owner = getWindowPanels().find((p) => p.panelId === targetPanelId && p.workspaceId === workspaceId)
+      const win = owner ? getWindow(owner.ownerWindowId) : undefined
+      if (win && !win.isDestroyed()) {
+        return forwardToOwner(win.webContents, {
+          extensionId,
+          workspaceId,
+          panelId: panelId ?? '',
+          method,
+          args: routedArgs,
+        })
+      }
+      // Same fresh-panel race as list/focus: try the active workspace renderer.
+      return scope.forward({ extensionId, workspaceId, panelId: panelId ?? '', method, args: routedArgs })
     }
 
     // --- Agent: drive a pi session through the bundled pi --------------------

--- a/src/main/extensions/frontendkitPanel.test.tsx
+++ b/src/main/extensions/frontendkitPanel.test.tsx
@@ -29,7 +29,7 @@ type Mock = ReturnType<typeof makeBridge>
 function makeBridge() {
   return {
     version: vi.fn(async () => 1),
-    panel: { id: 'main', setTitle: vi.fn(async (_title: string) => {}) },
+    panel: { id: 'main', setTitle: vi.fn(async (_title: string) => {}), list: vi.fn(), focus: vi.fn(), close: vi.fn() },
     workspace: { get: vi.fn(async () => ({ rootPath: '/ws/root', branch: null, worktree: null })) },
     theme: {
       get: vi.fn(async () => ({

--- a/src/main/extensions/kitchensinkPanel.test.tsx
+++ b/src/main/extensions/kitchensinkPanel.test.tsx
@@ -59,7 +59,7 @@ class FakeWebSocket {
 function makeBridge() {
   return {
     version: vi.fn(async () => 1),
-    panel: { id: 'main', setTitle: vi.fn(async (_title: string) => {}) },
+    panel: { id: 'main', setTitle: vi.fn(async (_title: string) => {}), list: vi.fn(), focus: vi.fn(), close: vi.fn() },
     workspace: { get: vi.fn(async () => ({ rootPath: '/ws/root', branch: null, worktree: null })) },
     theme: {
       get: vi.fn(async () => ({

--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -457,7 +457,7 @@ describe('CATE_API env injection into spawned terminals', () => {
   // Spawn through the real TERMINAL_CREATE handler and return the env object
   // that spawnTerminal passed down to runtime.process.create (the PTY env).
   async function spawnAndGetEnv(
-    options: { cols: number; rows: number; cwd?: string; shell?: string; workspaceId?: string },
+    options: { cols: number; rows: number; cwd?: string; shell?: string; workspaceId?: string; panelId?: string },
   ): Promise<Record<string, string> | undefined> {
     diag.ptyCreate.mockResolvedValue({ id: 'pty-env', pid: 123, shell: '/bin/zsh' })
     const mod = await import('./terminal')
@@ -474,6 +474,18 @@ describe('CATE_API env injection into spawned terminals', () => {
 
     expect(cateApi.ensureEndpoint).toHaveBeenCalledWith('ws-1')
     expect(env).toEqual({ CATE_API: 'http://127.0.0.1:9876', CATE_TOKEN: 'tok-abc' })
+  })
+
+  it('injects CATE_PANEL_ID when the PTY belongs to a Cate terminal panel', async () => {
+    cateApi.ensureEndpoint.mockResolvedValue({ port: 9876, token: 'tok-abc' })
+
+    const env = await spawnAndGetEnv({ cols: 80, rows: 24, workspaceId: 'ws-1', panelId: 'panel-123' })
+
+    expect(env).toEqual({
+      CATE_API: 'http://127.0.0.1:9876',
+      CATE_TOKEN: 'tok-abc',
+      CATE_PANEL_ID: 'panel-123',
+    })
   })
 
   it('injects nothing (fail closed) when there is no workspaceId — ensureEndpoint is never consulted', async () => {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -226,7 +226,7 @@ function cleanupTerminal(id: string): void {
 }
 
 async function spawnTerminal(
-  options: { cols: number; rows: number; cwd?: string; shell?: string; workspaceId?: string },
+  options: { cols: number; rows: number; cwd?: string; shell?: string; workspaceId?: string; panelId?: string },
   ownerWindowId: number,
 ): Promise<string> {
   const { runtimeId, path: cwdPath } = parseLocator(options.cwd ?? '')
@@ -246,7 +246,11 @@ async function spawnTerminal(
   if (options.workspaceId) {
     const endpoint = await workspaceCateApi.ensureEndpoint(options.workspaceId)
     if (endpoint) {
-      cateApiEnv = { CATE_API: `http://127.0.0.1:${endpoint.port}`, CATE_TOKEN: endpoint.token }
+      cateApiEnv = {
+        CATE_API: `http://127.0.0.1:${endpoint.port}`,
+        CATE_TOKEN: endpoint.token,
+        ...(options.panelId ? { CATE_PANEL_ID: options.panelId } : {}),
+      }
     }
   }
 

--- a/src/main/windowPanels.test.ts
+++ b/src/main/windowPanels.test.ts
@@ -21,6 +21,7 @@ import {
 } from './windowRegistry'
 import {
   setWindowPanels,
+  upsertWindowPanel,
   getWindowPanels,
   revealWindowPanel,
   closeWindowPanel,
@@ -131,6 +132,50 @@ describe('cross-window panel discovery (main)', () => {
     expect(byId.leaf2.parentCanvasId).toBe('cv')
     expect(byId.cv.parentCanvasId).toBeUndefined()
     expect(byId.top.parentCanvasId).toBeUndefined()
+  })
+
+  it('passes through list metadata used by the cross-window Cate API', () => {
+    open(142, 'dock', 'ws-A')
+    setWindowPanels(142, [
+      {
+        panelId: 'browser-docs',
+        type: 'browser',
+        title: 'Docs',
+        workspaceId: 'ws-A',
+        url: 'https://docs.example/',
+        focused: true,
+      },
+      {
+        panelId: 'editor-file',
+        type: 'editor',
+        title: 'a.ts',
+        workspaceId: 'ws-A',
+        filePath: '/workspace/a.ts',
+        focused: false,
+      },
+    ])
+
+    const byId = Object.fromEntries(getWindowPanels().map((p) => [p.panelId, p]))
+    expect(byId['browser-docs']).toMatchObject({ url: 'https://docs.example/', focused: true })
+    expect(byId['editor-file']).toMatchObject({ filePath: '/workspace/a.ts', focused: false })
+  })
+
+  it('makes one provisional panel routable until the next full renderer report', () => {
+    open(143, 'main', 'ws-A')
+    setWindowPanels(143, [report('existing', 'terminal', 'Terminal')])
+
+    upsertWindowPanel(143, {
+      panelId: 'fresh-browser',
+      type: 'browser',
+      title: 'https://example.com',
+      workspaceId: 'ws-A',
+      url: 'https://example.com',
+      focused: false,
+    })
+    expect(getWindowPanels().map((panel) => panel.panelId)).toEqual(['existing', 'fresh-browser'])
+
+    setWindowPanels(143, [report('existing', 'terminal', 'Terminal')])
+    expect(getWindowPanels().map((panel) => panel.panelId)).toEqual(['existing'])
   })
 
   it('passes through the panel worktreeId so the overview can tint detached rows', () => {

--- a/src/main/windowPanels.ts
+++ b/src/main/windowPanels.ts
@@ -38,6 +38,9 @@ export function setWindowPanels(windowId: number, report: WindowPanelReport[]): 
       type: p.type,
       title: p.title || p.type,
       workspaceId: p.workspaceId,
+      filePath: p.filePath,
+      url: p.url,
+      focused: p.focused,
       ownerWindowId: windowId,
       ownerWindowType,
       parentCanvasId: p.parentCanvasId,
@@ -47,6 +50,37 @@ export function setWindowPanels(windowId: number, report: WindowPanelReport[]): 
       hasPorts: p.hasPorts,
     })),
   )
+  broadcastWindowPanels()
+}
+
+/** Add or refresh one panel immediately, before the owning renderer's normal
+ * debounced full report arrives. Used for API-created browsers so the returned
+ * panel id can be routed by an immediate follow-up command. The next full
+ * report remains authoritative and replaces this provisional row. */
+export function upsertWindowPanel(windowId: number, panel: WindowPanelReport): void {
+  const ownerWindowType = getWindowType(windowId)
+  if (!ownerWindowType) return
+  const panels = windowPanels.get(windowId) ?? []
+  const next = {
+    panelId: panel.panelId,
+    type: panel.type,
+    title: panel.title || panel.type,
+    workspaceId: panel.workspaceId,
+    filePath: panel.filePath,
+    url: panel.url,
+    focused: panel.focused,
+    ownerWindowId: windowId,
+    ownerWindowType,
+    parentCanvasId: panel.parentCanvasId,
+    worktreeId: panel.worktreeId,
+    agentState: panel.agentState,
+    agentName: panel.agentName,
+    hasPorts: panel.hasPorts,
+  }
+  const index = panels.findIndex((candidate) => candidate.panelId === panel.panelId)
+  windowPanels.set(windowId, index < 0
+    ? [...panels, next]
+    : panels.map((candidate, candidateIndex) => candidateIndex === index ? next : candidate))
   broadcastWindowPanels()
 }
 
@@ -76,7 +110,7 @@ let lastWindowPanelSignature = ''
 export function broadcastWindowPanels(): void {
   const panels = getWindowPanels()
   const signature = panels
-    .map((p) => `${p.ownerWindowId}:${p.panelId}:${p.type}:${p.title}:${p.workspaceId}:${p.parentCanvasId ?? ''}:${p.worktreeId ?? ''}:${p.agentState ?? ''}:${p.agentName ?? ''}:${p.hasPorts ? 1 : 0}`)
+    .map((p) => `${p.ownerWindowId}:${p.panelId}:${p.type}:${p.title}:${p.workspaceId}:${p.filePath ?? ''}:${p.url ?? ''}:${p.focused ? 1 : 0}:${p.parentCanvasId ?? ''}:${p.worktreeId ?? ''}:${p.agentState ?? ''}:${p.agentName ?? ''}:${p.hasPorts ? 1 : 0}`)
     .sort()
     .join('|')
   if (signature === lastWindowPanelSignature) return

--- a/src/preload/cateHost.ts
+++ b/src/preload/cateHost.ts
@@ -50,6 +50,7 @@ const api: CateHost = {
     setTitle: (title: string) => invoke('cate.panel.setTitle', { title }).then(() => undefined),
     list: () => invoke('cate.panel.list') as Promise<CatePanelInfo[]>,
     focus: (targetPanelId: string) => invoke('cate.panel.focus', { panelId: targetPanelId }),
+    close: (targetPanelId: string) => invoke('cate.panel.close', { panelId: targetPanelId }),
   },
 
   workspace: {

--- a/src/renderer/hooks/useCateHostActionResponder.test.tsx
+++ b/src/renderer/hooks/useCateHostActionResponder.test.tsx
@@ -26,18 +26,20 @@ const REMOTE_ROOT_LOCATOR = `cate-runtime://srv_a1${REMOTE_ROOT_BARE}`
 
 const h = vi.hoisted(() => ({
   openFileAsPanel: vi.fn(() => 'new-editor-id'),
-  revealPanel: vi.fn(async () => {}),
+  revealPanel: vi.fn(async () => true),
+  closePanelWithConfirm: vi.fn(async () => true),
   createExtensionPanel: vi.fn(() => 'new-ext-id'),
   updatePanelTitle: vi.fn(),
   editorCreate: vi.fn(() => 'reg-editor-id'),
-  placementForActivePanel: vi.fn(),
+  placementForBackgroundPanel: vi.fn(),
   setPendingReveal: vi.fn(),
   activePanelId: null as string | null,
 }))
 
 vi.mock('../lib/fs/fileRouting', () => ({ openFileAsPanel: h.openFileAsPanel }))
 vi.mock('../lib/workspace/panelReveal', () => ({ revealPanel: h.revealPanel }))
-vi.mock('../lib/workspace/canvasAccess', () => ({ placementForActivePanel: h.placementForActivePanel }))
+vi.mock('../lib/workspace/canvasAccess', () => ({ placementForBackgroundPanel: h.placementForBackgroundPanel }))
+vi.mock('../lib/closePanelWithConfirm', () => ({ closePanelWithConfirm: h.closePanelWithConfirm }))
 vi.mock('../lib/editor/editorReveal', () => ({ setPendingReveal: h.setPendingReveal }))
 vi.mock('../lib/activePanel', () => ({ getActivePanelId: () => h.activePanelId }))
 vi.mock('../lib/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
@@ -123,14 +125,11 @@ async function fire(method: string, args: unknown, extra?: Partial<{ panelId: st
   })
 }
 
-// The placement a keybind (Cmd+T / Cmd+N) would compute for the active panel.
-// A distinctive non-center value proves the responder reuses placementForActivePanel
-// rather than the old hardcoded center dock.
-const ACTIVE_PLACEMENT = { target: 'dock', zone: 'left', stackId: 'stack-9' }
+const BACKGROUND_PLACEMENT = { target: 'canvas', canvasPanelId: 'canvas-1', focus: false }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  h.placementForActivePanel.mockReturnValue(ACTIVE_PLACEMENT)
+  h.placementForBackgroundPanel.mockReturnValue(BACKGROUND_PLACEMENT)
   h.activePanelId = null
   actionCb = null
   replies.length = 0
@@ -151,14 +150,12 @@ describe('useCateHostActionResponder', () => {
     expect(actionCb).toBeTypeOf('function')
   })
 
-  it('opens a file with the keybind placement (active panel), not a hardcoded dock', async () => {
+  it('opens a file with background placement and does not reveal/focus it', async () => {
     await fire('cate.editor.openFile', { path: 'package.json' })
 
-    // Relative path resolved against the workspace root, and placed exactly where
-    // a Cmd+N would put it (placementForActivePanel), not always center-dock.
-    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/package.json`, undefined, ACTIVE_PLACEMENT)
-    expect(h.placementForActivePanel).toHaveBeenCalled()
-    expect(h.revealPanel).toHaveBeenCalledWith(WS, 'new-editor-id')
+    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/package.json`, undefined, BACKGROUND_PLACEMENT)
+    expect(h.placementForBackgroundPanel).toHaveBeenCalled()
+    expect(h.revealPanel).not.toHaveBeenCalled()
     expect(replies).toContainEqual({ requestId: 'req-cate.editor.openFile', ok: true, result: { panelId: 'new-editor-id' } })
   })
 
@@ -172,13 +169,10 @@ describe('useCateHostActionResponder', () => {
     expect(h.setPendingReveal).not.toHaveBeenCalled()
   })
 
-  it('falls back to the default (undefined) placement when no panel is active', async () => {
-    // placementForActivePanel returns undefined → the create call gets the
-    // workspace's default (primary-canvas) placement, same as a keybind with
-    // nothing focused.
-    h.placementForActivePanel.mockReturnValue(undefined)
+  it('uses unpinned background canvas placement when no canvas is active', async () => {
+    h.placementForBackgroundPanel.mockReturnValue({ target: 'canvas', focus: false })
     await fire('cate.editor.openFile', { path: 'package.json' })
-    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/package.json`, undefined, undefined)
+    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/package.json`, undefined, { target: 'canvas', focus: false })
   })
 
   it('rejects an absolute openFile path that escapes the workspace root', async () => {
@@ -195,7 +189,7 @@ describe('useCateHostActionResponder', () => {
 
   it('allows an absolute openFile path that is inside the workspace root', async () => {
     await fire('cate.editor.openFile', { path: `${ROOT}/src/app.ts` })
-    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/src/app.ts`, undefined, ACTIVE_PLACEMENT)
+    expect(h.openFileAsPanel).toHaveBeenCalledWith(WS, `${ROOT}/src/app.ts`, undefined, BACKGROUND_PLACEMENT)
   })
 
   it('accepts an absolute path inside a REMOTE workspace (locator rootPath) and re-attaches the scheme', async () => {
@@ -209,7 +203,7 @@ describe('useCateHostActionResponder', () => {
       REMOTE_WS,
       `${REMOTE_ROOT_LOCATOR}/src/app.ts`,
       undefined,
-      ACTIVE_PLACEMENT,
+      BACKGROUND_PLACEMENT,
     )
     expect(replies).toContainEqual({ requestId: 'req-cate.editor.openFile', ok: true, result: { panelId: 'new-editor-id' } })
   })
@@ -223,16 +217,17 @@ describe('useCateHostActionResponder', () => {
   it('creates an extension panel via canvas.createPanel(extension)', async () => {
     await fire('cate.canvas.createPanel', { type: 'extension', extensionPanelId: 'main' })
 
-    expect(h.createExtensionPanel).toHaveBeenCalledWith(WS, 'cate.kitchensink', 'main', undefined, ACTIVE_PLACEMENT)
-    expect(h.revealPanel).toHaveBeenCalledWith(WS, 'new-ext-id')
+    expect(h.createExtensionPanel).toHaveBeenCalledWith(WS, 'cate.kitchensink', 'main', undefined, BACKGROUND_PLACEMENT)
+    expect(h.revealPanel).not.toHaveBeenCalled()
     expect(replies).toContainEqual({ requestId: 'req-cate.canvas.createPanel', ok: true, result: { panelId: 'new-ext-id' } })
   })
 
   it('honors an explicit { position } by placing on the canvas at that point', async () => {
     await fire('cate.canvas.createPanel', { type: 'extension', extensionPanelId: 'main', position: { x: 120, y: 80 } })
-    expect(h.createExtensionPanel).toHaveBeenCalledWith(WS, 'cate.kitchensink', 'main', undefined, { target: 'canvas', position: { x: 120, y: 80 } })
-    // An explicit position overrides the keybind placement entirely.
-    expect(h.placementForActivePanel).not.toHaveBeenCalled()
+    expect(h.createExtensionPanel).toHaveBeenCalledWith(WS, 'cate.kitchensink', 'main', undefined, {
+      ...BACKGROUND_PLACEMENT,
+      position: { x: 120, y: 80 },
+    })
   })
 
   it('rejects a createPanel(extension) with no extensionPanelId', async () => {
@@ -244,7 +239,7 @@ describe('useCateHostActionResponder', () => {
   it('resolves a relative filePath when createPanel spawns a non-extension type', async () => {
     await fire('cate.canvas.createPanel', { type: 'editor', filePath: 'src/index.ts' })
     expect(h.editorCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceId: WS, placement: ACTIVE_PLACEMENT, filePath: `${ROOT}/src/index.ts` }),
+      expect.objectContaining({ workspaceId: WS, placement: BACKGROUND_PLACEMENT, filePath: `${ROOT}/src/index.ts` }),
     )
   })
 
@@ -296,6 +291,19 @@ describe('useCateHostActionResponder', () => {
 
     await fire('cate.panel.focus', { panelId: 'detached-panel' })
     expect(replies).toContainEqual({ requestId: 'req-cate.panel.focus', ok: false, error: 'panel-not-in-window' })
+  })
+
+  it('panel.focus reports failure when the panel record cannot be revealed', async () => {
+    h.revealPanel.mockResolvedValueOnce(false)
+    await fire('cate.panel.focus', { panelId: 'ed-1' })
+    expect(replies).toContainEqual({ requestId: 'req-cate.panel.focus', ok: false, error: 'panel-not-revealable' })
+  })
+
+  it('panel.close closes through the confirmation path without revealing it', async () => {
+    await fire('cate.panel.close', { panelId: 'ed-1' })
+    expect(h.closePanelWithConfirm).toHaveBeenCalledWith(WS, 'ed-1')
+    expect(h.revealPanel).not.toHaveBeenCalled()
+    expect(replies).toContainEqual({ requestId: 'req-cate.panel.close', ok: true })
   })
 
 })

--- a/src/renderer/hooks/useCateHostActionResponder.ts
+++ b/src/renderer/hooks/useCateHostActionResponder.ts
@@ -18,26 +18,25 @@ import { getActivePanelId } from '../lib/activePanel'
 import { PANEL_REGISTRY } from '../panels/registry'
 import { openFileAsPanel } from '../lib/fs/fileRouting'
 import { revealPanel } from '../lib/workspace/panelReveal'
-import { placementForActivePanel } from '../lib/workspace/canvasAccess'
+import { placementForBackgroundPanel } from '../lib/workspace/canvasAccess'
 import { setPendingReveal } from '../lib/editor/editorReveal'
+import { closePanelWithConfirm } from '../lib/closePanelWithConfirm'
 import { toAbsolutePath, pathKey } from '../../shared/pathUtils'
 import { parseLocator, formatLocator } from '../../main/runtime/locator'
 import { handleBrowserMethod } from '../lib/browser/browserDriver'
 import { browserPanelUrl, isStartPageUrl, type PanelType, type Point } from '../../shared/types'
 import type { PanelPlacement } from '../stores/appStore'
 
-// Reverse-API panel creation reuses the SAME placement the keyboard shortcuts
-// use (Cmd+T / Cmd+N): tab into the active dock stack, pin to the active canvas,
-// or fall back to the workspace's default (primary canvas) placement — honoring
-// the user's placement-picker setting just like a keybind. An explicit
-// { position } from the extension overrides that and lands the panel on the
-// canvas at that exact point.
-function placementFromArgs(args: Record<string, unknown>): PanelPlacement | undefined {
+// Host-API panel creation (CLI + extensions) is always non-interactive: callers
+// may add panels but must not open the placement picker, switch tabs, change
+// selection/focus, or move the user's camera. An explicit { position } still
+// chooses the canvas point while preserving those background semantics.
+function placementFromArgs(workspaceId: string, args: Record<string, unknown>): PanelPlacement | undefined {
   const p = args.position
   if (p && typeof p === 'object' && typeof (p as Point).x === 'number' && typeof (p as Point).y === 'number') {
-    return { target: 'canvas', position: p as Point }
+    return { ...placementForBackgroundPanel(workspaceId), position: p as Point }
   }
-  return placementForActivePanel()
+  return placementForBackgroundPanel(workspaceId)
 }
 
 interface HostActionPayload {
@@ -134,10 +133,7 @@ export function useCateHostActionResponder(): void {
             // escapes it (absolute or traversal).
             const resolved = resolveWorkspacePath(workspaceId, filePath)
             if (!resolved) return reply(false, { error: 'path outside workspace' })
-            // Reuse the keybind placement (active dock stack / active canvas /
-            // default) so an extension-opened file lands exactly where a
-            // Cmd+N-opened one would, not always pinned to the center dock.
-            const newPanelId = openFileAsPanel(workspaceId, resolved, undefined, placementForActivePanel())
+            const newPanelId = openFileAsPanel(workspaceId, resolved, undefined, placementForBackgroundPanel(workspaceId))
             if (!newPanelId) return reply(false, { error: 'open failed' })
             // Honor an optional { line } (and column) by stashing a one-shot
             // editor reveal — the SAME path search results and terminal file
@@ -147,15 +143,13 @@ export function useCateHostActionResponder(): void {
               const column = typeof args.column === 'number' ? args.column : undefined
               setPendingReveal(newPanelId, { line, ...(column !== undefined ? { column } : {}) })
             }
-            // Reveal/focus so the editor is brought to front.
-            void revealPanel(workspaceId, newPanelId).catch(() => { /* best effort */ })
             return reply(true, { result: { panelId: newPanelId } })
           }
 
           case 'cate.canvas.createPanel': {
             const type = typeof args.type === 'string' ? (args.type as PanelType) : undefined
             if (!type || !PANEL_REGISTRY[type]) return reply(false, { error: 'unknown panel type' })
-            const placement = placementFromArgs(args)
+            const placement = placementFromArgs(workspaceId, args)
             let newPanelId: string | null
             if (type === 'extension') {
               const extId = typeof args.extensionId === 'string' ? args.extensionId : payload.extensionId
@@ -177,7 +171,6 @@ export function useCateHostActionResponder(): void {
               })
             }
             if (!newPanelId) return reply(false, { error: 'panel creation failed' })
-            void revealPanel(workspaceId, newPanelId).catch(() => { /* best effort */ })
             return reply(true, { result: { panelId: newPanelId } })
           }
 
@@ -209,8 +202,20 @@ export function useCateHostActionResponder(): void {
               .getState()
               .workspaces.find((w) => w.id === workspaceId)?.panels?.[targetPanelId]
             if (!panel) return reply(false, { error: 'panel-not-in-window' })
-            await revealPanel(workspaceId, targetPanelId)
+            const revealed = await revealPanel(workspaceId, targetPanelId)
+            if (!revealed) return reply(false, { error: 'panel-not-revealable' })
             return reply(true)
+          }
+
+          case 'cate.panel.close': {
+            const targetPanelId = typeof args.panelId === 'string' ? args.panelId : payload.panelId
+            if (!targetPanelId) return reply(false, { error: 'panelId required' })
+            const panel = useAppStore
+              .getState()
+              .workspaces.find((w) => w.id === workspaceId)?.panels?.[targetPanelId]
+            if (!panel) return reply(false, { error: 'panel-not-in-window' })
+            const closed = await closePanelWithConfirm(workspaceId, targetPanelId)
+            return closed ? reply(true) : reply(false, { error: 'close-cancelled' })
           }
 
           case 'cate.panel.setTitle': {

--- a/src/renderer/lib/browser/browserDriver.test.ts
+++ b/src/renderer/lib/browser/browserDriver.test.ts
@@ -55,6 +55,11 @@ vi.mock('../activePanel', () => ({
   getActivePanelId: () => h.activePanelId,
 }))
 
+const BACKGROUND_PLACEMENT = { target: 'canvas', canvasPanelId: 'canvas-1', focus: false }
+vi.mock('../workspace/canvasAccess', () => ({
+  placementForBackgroundPanel: () => BACKGROUND_PLACEMENT,
+}))
+
 vi.mock('../portalRegistry', () => ({
   portalRegistry: {
     get: (panelId: string) => h.webviews.get(panelId) ?? null,
@@ -143,8 +148,11 @@ describe('target resolution', () => {
 describe('open', () => {
   it('creates a browser panel when the workspace has none', async () => {
     h.workspaces[0].panels = { term: { id: 'term', type: 'terminal', title: 'Term' } }
+    const webview = makeWebview()
+    setTimeout(() => h.webviews.set('created-browser-id', webview), 10)
     const out = await handleBrowserMethod(WS, M('open'), { url: 'https://new/' })
-    expect(h.createBrowser).toHaveBeenCalledWith(WS, 'https://new/')
+    expect(h.createBrowser).toHaveBeenCalledWith(WS, 'https://new/', undefined, BACKGROUND_PLACEMENT)
+    expect(webview.loadURL).toHaveBeenCalledWith('https://new/')
     expect(out).toEqual({ ok: true, result: { panelId: 'created-browser-id', url: 'https://new/' } })
   })
 
@@ -157,9 +165,12 @@ describe('open', () => {
     expect(out).toEqual({ ok: true, result: { panelId: 'b1', url: 'https://go/' } })
   })
 
-  it('updates the active tab when the webview is not attached yet (succeeds)', async () => {
+  it('waits for an unattached webview before reporting success', async () => {
+    const webview = makeWebview()
+    setTimeout(() => h.webviews.set('b1', webview), 10)
     const out = await handleBrowserMethod(WS, M('open'), { url: 'https://later/' })
     expect(h.updateBrowserActiveTabUrl).toHaveBeenCalledWith(WS, 'b1', 'https://later/')
+    expect(webview.loadURL).toHaveBeenCalledWith('https://later/')
     expect(out).toEqual({ ok: true, result: { panelId: 'b1', url: 'https://later/' } })
   })
 
@@ -177,13 +188,15 @@ describe('open', () => {
     const loaded = await handleBrowserMethod(WS, M('open'), { url: 'https://go/' })
     expect(loaded).toEqual({ ok: true, result: { panelId: 'b1', url: 'https://go/' } })
 
-    // Branch 2: existing browser panel whose webview is not attached yet.
+    // Branch 2: existing browser panel whose webview attaches on the next render.
     h.webviews = new Map()
+    setTimeout(() => h.webviews.set('b1', makeWebview()), 10)
     const pending = await handleBrowserMethod(WS, M('open'), { url: 'https://later/' })
     expect(pending).toEqual({ ok: true, result: { panelId: 'b1', url: 'https://later/' } })
 
     // Branch 3: no browser panel — the driver creates one.
     h.workspaces[0].panels = { term: { id: 'term', type: 'terminal', title: 'Term' } }
+    setTimeout(() => h.webviews.set('created-browser-id', makeWebview()), 10)
     const created = await handleBrowserMethod(WS, M('open'), { url: 'https://new/' })
     expect(created).toEqual({ ok: true, result: { panelId: 'created-browser-id', url: 'https://new/' } })
   })

--- a/src/renderer/lib/browser/browserDriver.ts
+++ b/src/renderer/lib/browser/browserDriver.ts
@@ -23,6 +23,7 @@
 import { useAppStore } from '../../stores/appStore'
 import { getActivePanelId } from '../activePanel'
 import { portalRegistry, type PortalWebview } from '../portalRegistry'
+import { placementForBackgroundPanel } from '../workspace/canvasAccess'
 
 export type BrowserOutcome = { ok: true; result?: unknown } | { ok: false; error: string }
 
@@ -66,6 +67,19 @@ function getWebview(panelId: string): { webview: PortalWebview } | { error: stri
   const webview = portalRegistry.get(panelId)
   if (!webview) return { error: 'webview-not-ready' }
   return { webview }
+}
+
+/** A background-created browser mounts on the next React commit. Wait for its
+ * portal registration before reporting `open` success so an autonomous caller
+ * can immediately follow with `wait`/`snapshot` instead of racing the render. */
+async function waitForWebview(panelId: string, timeoutMs = 3_000): Promise<PortalWebview | null> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const webview = portalRegistry.get(panelId)
+    if (webview) return webview
+    if (Date.now() >= deadline) return null
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
 }
 
 // --- Injected DOM scripts ----------------------------------------------------
@@ -208,24 +222,28 @@ export async function handleBrowserMethod(
     const url = typeof args.url === 'string' ? args.url : undefined
     if (!url) return { ok: false, error: 'url-required' }
     const target = resolveTargetPanelId(workspaceId, args)
+    let panelId: string
     if ('error' in target) {
       if (target.error === 'no-browser') {
-        const panelId = useAppStore.getState().createBrowser(workspaceId, url)
-        return { ok: true, result: { panelId, url } }
+        panelId = useAppStore.getState().createBrowser(
+          workspaceId,
+          url,
+          undefined,
+          placementForBackgroundPanel(workspaceId),
+        )
+      } else {
+        return { ok: false, error: target.error }
       }
-      return { ok: false, error: target.error }
+    } else {
+      panelId = target.panelId
     }
-    const webview = portalRegistry.get(target.panelId)
-    // Mirror terminalUrlOpen: if the webview isn't attached yet, still update the
-    // stored URL so the panel navigates there on mount — a real success.
-    if (!webview) {
-      useAppStore.getState().updateBrowserActiveTabUrl(workspaceId, target.panelId, url)
-      return { ok: true, result: { panelId: target.panelId, url } }
-    }
+
+    useAppStore.getState().updateBrowserActiveTabUrl(workspaceId, panelId, url)
+    const webview = portalRegistry.get(panelId) ?? (await waitForWebview(panelId))
+    if (!webview) return { ok: false, error: 'webview-not-ready' }
     try {
       webview.loadURL(url)
-      useAppStore.getState().updateBrowserActiveTabUrl(workspaceId, target.panelId, url)
-      return { ok: true, result: { panelId: target.panelId, url } }
+      return { ok: true, result: { panelId, url } }
     } catch {
       return { ok: false, error: 'webview-not-ready' }
     }

--- a/src/renderer/lib/canvas/canvasBridge.test.ts
+++ b/src/renderer/lib/canvas/canvasBridge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { createCanvasStore } from '../../stores/canvasStore'
+import { createCanvasOps } from './canvasBridge'
+
+describe('createCanvasOps background placement', () => {
+  it('adds a node without changing selection, focus epoch, or camera', () => {
+    const store = createCanvasStore()
+    store.getState().addNode('selected-panel', 'editor', { x: 10, y: 20 })
+    store.setState({ viewportOffset: { x: 123, y: 456 }, zoomLevel: 0.75, focusEpoch: 9 })
+    const before = store.getState()
+
+    createCanvasOps(store).addNodeAndFocus('background-browser', 'browser', undefined, undefined, false)
+
+    const after = store.getState()
+    expect(after.nodeForPanel('background-browser')).toBeTruthy()
+    expect(after.selection).toEqual(before.selection)
+    expect(after.selectionActive).toBe(before.selectionActive)
+    expect(after.focusEpoch).toBe(before.focusEpoch)
+    expect(after.viewportOffset).toEqual(before.viewportOffset)
+    expect(after.zoomLevel).toBe(before.zoomLevel)
+  })
+})

--- a/src/renderer/lib/canvas/canvasBridge.ts
+++ b/src/renderer/lib/canvas/canvasBridge.ts
@@ -46,8 +46,18 @@ export function createCanvasOps(storeApi: StoreApi<CanvasStore>): CanvasOperatio
     storeApi,
 
     addNodeAndFocus(panelId: string, panelType: PanelType, position?: Point, size?: Size, focus = true) {
+      // addNode selects the new node as part of its interactive-create contract.
+      // Background API creates must preserve the user's canvas selection too,
+      // not merely skip focusAndCenter (which only preserves the camera).
+      const previousSelection = focus
+        ? null
+        : {
+            selection: storeApi.getState().selection,
+            selectionActive: storeApi.getState().selectionActive,
+          }
       const nodeId = storeApi.getState().addNode(panelId, panelType, position, size)
       if (focus) storeApi.getState().focusAndCenter(nodeId)
+      else if (previousSelection) storeApi.setState(previousSelection)
     },
 
     beginPlacement(

--- a/src/renderer/lib/terminal/terminalLifecycle.test.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.test.ts
@@ -229,7 +229,7 @@ describe('spawn → wire → dispose happy path', () => {
     // One PTY spawn, standard 80x24 defaults (real fit happens on attach).
     expect(terminalCreate).toHaveBeenCalledTimes(1)
     expect(terminalCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ cols: 80, rows: 24, workspaceId: 'ws-1' }),
+      expect.objectContaining({ cols: 80, rows: 24, workspaceId: 'ws-1', panelId: 'panel-happy' }),
     )
 
     // Registry + identity bimap populated, entry alive.

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -346,6 +346,7 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
       cwd: resolvedCwd,
       shell: (shell as string) || undefined,
       workspaceId: opts.workspaceId,
+      panelId,
     })
 
     // If the entry was disposed while we were waiting, dispose() couldn't kill

--- a/src/renderer/lib/workspace/canvasAccess.placement.test.tsx
+++ b/src/renderer/lib/workspace/canvasAccess.placement.test.tsx
@@ -12,10 +12,12 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import {
   placementForActivePanel,
+  placementForBackgroundPanel,
   getActiveCanvasPanelId,
 } from './canvasAccess'
 import { setActivePanel } from '../activePanel'
 import { getOrCreateCanvasStoreForPanel, releaseCanvasStoreForPanel } from '../../stores/canvasStore'
+import { useAppStore } from '../../stores/appStore'
 
 const PRIMARY = 'canvas-primary'
 const SECONDARY = 'canvas-secondary'
@@ -24,6 +26,7 @@ afterEach(() => {
   releaseCanvasStoreForPanel(PRIMARY)
   releaseCanvasStoreForPanel(SECONDARY)
   setActivePanel(null)
+  useAppStore.setState({ selectedWorkspaceId: '' })
 })
 
 describe('placementForActivePanel with multiple canvases', () => {
@@ -59,5 +62,29 @@ describe('placementForActivePanel with multiple canvases', () => {
     setActivePanel(SECONDARY)
 
     expect(getActiveCanvasPanelId()).toBe(SECONDARY)
+  })
+
+  it('background placement pins the active canvas without requesting focus', () => {
+    getOrCreateCanvasStoreForPanel(PRIMARY)
+    getOrCreateCanvasStoreForPanel(SECONDARY)
+    setActivePanel(SECONDARY)
+    useAppStore.setState({ selectedWorkspaceId: 'ws-active' })
+
+    expect(placementForBackgroundPanel('ws-active')).toEqual({
+      target: 'canvas',
+      canvasPanelId: SECONDARY,
+      focus: false,
+    })
+  })
+
+  it('does not pin a visible canvas that belongs to another workspace', () => {
+    getOrCreateCanvasStoreForPanel(SECONDARY)
+    setActivePanel(SECONDARY)
+    useAppStore.setState({ selectedWorkspaceId: 'ws-visible' })
+
+    expect(placementForBackgroundPanel('ws-background')).toEqual({
+      target: 'canvas',
+      focus: false,
+    })
   })
 })

--- a/src/renderer/lib/workspace/canvasAccess.ts
+++ b/src/renderer/lib/workspace/canvasAccess.ts
@@ -89,6 +89,21 @@ export function placementForActivePanel(): PanelPlacement | undefined {
   return undefined
 }
 
+/** Placement for host-API creates (CLI + extensions). API callers may add
+ * panels to the canvas, but must not steal the user's focus/selection or move
+ * the camera. Pin to the canvas currently on screen when possible; otherwise
+ * the normal placement fallback resolves the workspace's primary canvas. */
+export function placementForBackgroundPanel(workspaceId: string): Extract<PanelPlacement, { target: 'canvas' }> {
+  const canvasPanelId = useAppStore.getState().selectedWorkspaceId === workspaceId
+    ? getActiveCanvasPanelId()
+    : null
+  return {
+    target: 'canvas',
+    focus: false,
+    ...(canvasPanelId ? { canvasPanelId } : {}),
+  }
+}
+
 function computeWorkspaceCanvasPanelId(workspaceId: string): string | null {
   const state = useAppStore.getState()
   const ws = state.workspaces.find((candidate) => candidate.id === workspaceId)

--- a/src/renderer/lib/workspace/windowPanelSync.test.tsx
+++ b/src/renderer/lib/workspace/windowPanelSync.test.tsx
@@ -34,6 +34,7 @@ import { createDockStore } from '../../stores/dockStore'
 import { registerWorkspaceDockStore, releaseWorkspaceDockStore } from './dockRegistry'
 import { registerNodeDockStore, unregisterNodeDockStore } from '../../panels/nodeDockRegistry'
 import { setupWindowPanelSync } from './windowPanelSync'
+import { setActivePanel } from '../activePanel'
 import type { WindowPanelReport, PanelState } from '../../../shared/types'
 
 function panel(id: string, type: PanelState['type'], worktreeId?: string): PanelState {
@@ -232,7 +233,7 @@ describe('windowPanelSync — placed-only report + derived titles', () => {
     releaseWorkspaceDockStore(ws)
   })
 
-  it('stamps the derived label: a titleless browser reports its URL, a titleless editor its basename', async () => {
+  it('reports derived labels, routing metadata, and focus changes', async () => {
     const reports: WindowPanelReport[][] = []
     ;(window as any).electronAPI = {
       reportWindowPanels: vi.fn(async (r: WindowPanelReport[]) => { reports.push(r) }),
@@ -254,14 +255,27 @@ describe('windowPanelSync — placed-only report + derived titles', () => {
       } as any],
       selectedWorkspaceId: ws,
     } as any)
+    setActivePanel('b1')
 
     const stop = setupWindowPanelSync()
     await tick()
 
-    const byId = Object.fromEntries(reports[reports.length - 1].filter((r) => r.workspaceId === ws).map((r) => [r.panelId, r]))
+    let byId = Object.fromEntries(reports[reports.length - 1].filter((r) => r.workspaceId === ws).map((r) => [r.panelId, r]))
     expect(byId.b1?.title).toBe('https://example.com/docs')
+    expect(byId.b1?.url).toBe('https://example.com/docs')
+    expect(byId.b1?.focused).toBe(true)
     expect(byId.e1?.title).toBe('main.ts')
+    expect(byId.e1?.filePath).toBe('/x/src/main.ts')
+    expect(byId.e1?.focused).toBe(false)
+
+    reports.length = 0
+    setActivePanel('e1')
+    await new Promise((r) => setTimeout(r, 300))
+    byId = Object.fromEntries(reports[reports.length - 1].filter((r) => r.workspaceId === ws).map((r) => [r.panelId, r]))
+    expect(byId.b1?.focused).toBe(false)
+    expect(byId.e1?.focused).toBe(true)
 
     stop()
+    setActivePanel(null)
   })
 })

--- a/src/renderer/lib/workspace/windowPanelSync.ts
+++ b/src/renderer/lib/workspace/windowPanelSync.ts
@@ -21,7 +21,9 @@ import { buildColdStartCanvasChildOwners, partitionWorkspacePanels } from '../..
 import { getWorkspaceDockSnapshot } from './canvasAccess'
 import { collectPanelIds } from '../../../shared/collectPanelIds'
 import { panelRowLabel } from '../panelTitle'
-import type { WindowPanelReport } from '../../../shared/types'
+import { useActivePanelStore } from '../activePanel'
+import { parseLocator } from '../../../main/runtime/locator'
+import { browserPanelUrl, isStartPageUrl, type WindowPanelReport } from '../../../shared/types'
 
 let cleanup: (() => void) | null = null
 
@@ -100,6 +102,7 @@ export function setupWindowPanelSync(): () => void {
       // rows.
       const agentInfo = selectAgentInfoByPanel(status, ws.id)
       const withPorts = panelsWithPorts(ws.id)
+      const activePanelId = useActivePanelStore.getState().activePanelId
       // Report only PLACED panels, using the same partition rules as the local
       // tree (ghost records — in ws.panels but referenced by no canvas or dock —
       // would otherwise surface in other windows as phantom rows). Placement
@@ -124,6 +127,11 @@ export function setupWindowPanelSync(): () => void {
           // title), so a panel reads the same in other windows as it does here.
           title: panelRowLabel(p),
           workspaceId: ws.id,
+          ...(p.filePath ? { filePath: parseLocator(p.filePath).path } : {}),
+          ...(p.type === 'browser'
+            ? { url: isStartPageUrl(browserPanelUrl(p)) ? '' : (browserPanelUrl(p) ?? '') }
+            : {}),
+          focused: p.id === activePanelId,
           parentCanvasId: childToCanvas.get(p.id),
           worktreeId: p.worktreeId,
           agentState: agentInfo[p.id]?.state,
@@ -166,6 +174,7 @@ export function setupWindowPanelSync(): () => void {
     syncCanvasSubscriptions()
     schedule()
   })
+  const unsubscribeActivePanel = useActivePanelStore.subscribe(schedule)
   syncCanvasSubscriptions()
 
   // Re-report when agent state / ports change so detached rows track the owner's
@@ -182,6 +191,7 @@ export function setupWindowPanelSync(): () => void {
 
   cleanup = () => {
     unsubscribeApp()
+    unsubscribeActivePanel()
     unsubscribeStatus()
     for (const unsub of canvasSubs.values()) unsub()
     canvasSubs.clear()

--- a/src/renderer/stores/appStore/helpers.ts
+++ b/src/renderer/stores/appStore/helpers.ts
@@ -254,7 +254,8 @@ function placePanel(
   const dockStore = getOrCreateWorkspaceDockStore(workspaceId)
   // Canvas panels go to the center dock zone, not onto a canvas as a node
   if (panelType === 'canvas') {
-    dockStore.getState().dockPanel(panelId, 'center')
+    const activate = placement?.target !== 'canvas' || placement.focus !== false
+    dockStore.getState().dockPanel(panelId, 'center', undefined, activate)
     return
   }
   if (placement?.target === 'dock') {

--- a/src/renderer/stores/dockStore.test.ts
+++ b/src/renderer/stores/dockStore.test.ts
@@ -108,6 +108,21 @@ describe('createDefaultDockState', () => {
   })
 })
 
+describe('background docking', () => {
+  it('appends without activating the new tab or opening a hidden zone', () => {
+    const store = createDockStore()
+    store.getState().dockPanel('visible', 'bottom')
+    // Hide the populated zone, then add through the background API path.
+    store.getState().toggleZone('bottom')
+    store.getState().dockPanel('background', 'bottom', undefined, false)
+
+    const stack = rootStack(store, 'bottom')
+    expect(stack.panelIds).toEqual(['visible', 'background'])
+    expect(stack.activeIndex).toBe(0)
+    expect(store.getState().zones.bottom.visible).toBe(false)
+  })
+})
+
 describe('zone visibility and sizing', () => {
   it('toggleZone flips visibility', () => {
     const store = createDockStore()

--- a/src/renderer/stores/dockStore.ts
+++ b/src/renderer/stores/dockStore.ts
@@ -176,7 +176,9 @@ interface DockStoreActions {
   setZoneSize: (position: DockZonePosition, size: number) => void
 
   // Panel placement
-  dockPanel: (panelId: string, zone: DockZonePosition, target?: DockDropTarget) => void
+  /** `activate: false` appends in the background without selecting the new tab
+   * or opening a hidden zone (used by host-API creates). */
+  dockPanel: (panelId: string, zone: DockZonePosition, target?: DockDropTarget, activate?: boolean) => void
   undockPanel: (panelId: string) => void
 
   // Tab management within a stack
@@ -235,7 +237,7 @@ export function createDockStore(initialState?: DockStateSnapshot) {
 
   // --- Panel placement ---
 
-  dockPanel(panelId, zone, target) {
+  dockPanel(panelId, zone, target, activate = true) {
     set((state) => {
       const zoneState = state.zones[zone]
       let newLayout = zoneState.layout
@@ -258,7 +260,7 @@ export function createDockStore(initialState?: DockStateSnapshot) {
           const updatedStack: DockTabStack = {
             ...stack,
             panelIds: newPanelIds,
-            activeIndex: insertIndex,
+            activeIndex: activate ? insertIndex : stack.activeIndex,
           }
           newLayout = newLayout
             ? replaceInTree(newLayout, stack.id, updatedStack)
@@ -313,7 +315,7 @@ export function createDockStore(initialState?: DockStateSnapshot) {
           newLayout = {
             ...newLayout,
             panelIds: [...newLayout.panelIds, panelId],
-            activeIndex: newLayout.panelIds.length,
+            activeIndex: activate ? newLayout.panelIds.length : newLayout.activeIndex,
           }
         } else {
           // Root is a split — find the first tab stack and append there
@@ -322,7 +324,7 @@ export function createDockStore(initialState?: DockStateSnapshot) {
             const updatedStack: DockTabStack = {
               ...firstStack,
               panelIds: [...firstStack.panelIds, panelId],
-              activeIndex: firstStack.panelIds.length,
+              activeIndex: activate ? firstStack.panelIds.length : firstStack.activeIndex,
             }
             newLayout = replaceInTree(newLayout, firstStack.id, updatedStack)
           }
@@ -334,7 +336,7 @@ export function createDockStore(initialState?: DockStateSnapshot) {
           ...state.zones,
           [zone]: {
             ...zoneState,
-            visible: true, // auto-show zone when docking
+            visible: activate ? true : zoneState.visible,
             layout: newLayout,
           },
         },

--- a/src/shared/cate-host-api.d.ts
+++ b/src/shared/cate-host-api.d.ts
@@ -49,13 +49,16 @@ export interface CatePanel {
   /** This panel instance's id. */
   readonly id: string
   setTitle(title: string): Promise<void>
-  /** List this window's panels (requires the `panel` scope). Panels detached
-   *  into other windows are not included. THE single enumeration surface: the
+  /** List panels across this workspace's windows (requires the `panel` scope).
+   *  THE single enumeration surface: the
    *  focused entry answers "what is the user looking at", and browser panels
    *  carry their `url` (there is no separate browser list). */
   list(): Promise<CatePanelInfo[]>
   /** Reveal/focus a panel by id (requires the `panel` scope). */
   focus(panelId: string): Promise<unknown>
+  /** Close a panel through its normal dirty/running confirmation path. Does not
+   *  reveal or focus the panel first (requires the `panel` scope). */
+  close(panelId: string): Promise<unknown>
 }
 
 /** One open panel, as reported by `cate.panel.list()`. `filePath` is the bare
@@ -116,12 +119,14 @@ export interface CateHost {
     get(): Promise<CateHostTheme>
   }
   editor: {
+    /** Opens in the background: no focus, selection, tab, or camera change. */
     openFile(path: string, opts?: { line?: number; column?: number }): Promise<unknown>
   }
   canvas: {
-    /** Open a new panel. Only the fields declared here are honored by the host;
-     *  `position` pins the panel to that canvas point (otherwise it follows the
-     *  user's Cmd+T/Cmd+N placement setting). `filePath` is confined to the
+    /** Open a new panel in the background without changing focus/selection,
+     *  switching tabs, or moving the camera. Only the fields declared here are
+     *  honored by the host; `position` pins the panel to that canvas point.
+     *  `filePath` is confined to the
      *  workspace root. For `type: 'extension'`, `extensionPanelId` is required and
      *  `extensionId` defaults to the calling extension. */
     createPanel(
@@ -172,7 +177,8 @@ export interface CateHost {
    *  filesystem `path` (see the note in docs/extensions.md — a webview guest can't
    *  read it directly; a server-backed extension can). */
   browser: {
-    /** Point a panel at `url` (or open a new one); returns the target panel + url.
+    /** Point a panel at `url` (or auto-place a new background panel); resolves
+     *  after the webview is mounted and returns the target panel + url.
      *  To enumerate open browser panels, use `cate.panel.list()`. */
     open(opts: { url: string; panelId?: string }): Promise<{ panelId: string; url: string }>
     /** Reload a panel. */

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -56,6 +56,8 @@ export interface ElectronAPI {
     cwd?: string
     shell?: string
     workspaceId?: string
+    /** Owning Cate panel, exposed to the spawned shell as CATE_PANEL_ID. */
+    panelId?: string
   }): Promise<string>
 
   /** Write data (keystrokes) to a terminal. */

--- a/src/shared/panels.test.ts
+++ b/src/shared/panels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolvePanelSize, keepsMountedWhenTabHidden } from './panels'
+import { resolvePanelSize, keepsMountedOffscreen, keepsMountedWhenTabHidden } from './panels'
 
 describe('resolvePanelSize', () => {
   it('returns the fixed per-type default', () => {
@@ -29,5 +29,13 @@ describe('keepsMountedWhenTabHidden', () => {
   it('is false for an unknown/undefined type', () => {
     expect(keepsMountedWhenTabHidden(undefined)).toBe(false)
     expect(keepsMountedWhenTabHidden('nope')).toBe(false)
+  })
+})
+
+describe('keepsMountedOffscreen', () => {
+  it('keeps browsers mounted so background API automation remains reachable', () => {
+    expect(keepsMountedOffscreen('browser')).toBe(true)
+    expect(keepsMountedOffscreen('extension')).toBe(true)
+    expect(keepsMountedOffscreen('editor')).toBe(false)
   })
 })

--- a/src/shared/panels.ts
+++ b/src/shared/panels.ts
@@ -93,7 +93,9 @@ export const PANEL_DEFINITIONS: Record<PanelType, SharedPanelDefinition> = {
     minimumSize: { width: 400, height: 300 },
     ghostSvg: ghost('rgb(74,158,255)', '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>'),
     canLiveOnCanvas: true,
-    keepMountedOffscreen: false,
+    // Browser automation must remain usable when an API caller creates the
+    // panel in the background without moving the user's camera.
+    keepMountedOffscreen: true,
     keepMountedWhenTabHidden: true,
   },
   editor: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -280,6 +280,11 @@ export interface WindowPanelReport {
   type: PanelType
   title: string
   workspaceId: string
+  /** File/browser identity used by the cross-window cate.panel.list surface. */
+  filePath?: string
+  url?: string
+  /** Canonical active-panel marker from the owning window. */
+  focused?: boolean
   /** Set when this panel lives inside a canvas panel in its window. */
   parentCanvasId?: string
   /** The panel's worktree tag (if any), so the overview can tint a detached


### PR DESCRIPTION
## Summary

- make all shared Cate host API panel creation non-interactive for both the CLI and extensions
- auto-place new browser/editor/canvas panels without changing the user's focus, selection, active tab, or canvas camera
- wait for background browser webviews to mount and register ownership immediately so autonomous follow-up commands are reliable
- make panel listing and control consistent across windows, add `panel close`, and inject `CATE_PANEL_ID` for terminal self-targeting
- harden CLI argument/flag validation, help, version output, short-id resolution, and human-readable results
- document the shared background-placement contract and add regression coverage

## Root cause

The CLI and extensions share the same host API, but API-created panels reused interactive user placement and reveal paths. That could open the placement picker, select/focus the new panel, activate a dock tab, or center the camera. Browser creation also returned before the webview and cross-window ownership report were ready, so an autonomous agent could not reliably follow `browser open` with `wait` or `snapshot`.

## Impact

Autonomous agents and extensions can now create and operate browser panels in the background without taking over the user's view. Explicit `panel focus` remains the only panel command that intentionally changes the user's view.

## Validation

- `npm test`: 2,600 passed, 5 skipped
- `npm run typecheck`
- `npm run lint`: zero errors (existing hook warnings remain)
- `npm run build`
- real bundled CLI/socket and browser-control integration tests
