### PR TITLE
Add regression coverage for core systems

### DIFF
--- a/src/agent/extensions/cate-agent-tools/index.test.ts
+++ b/src/agent/extensions/cate-agent-tools/index.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import registerCateAgentTools from "./index"
+
+interface RegisteredTool {
+  name: string
+  execute: (...args: any[]) => Promise<any>
+}
+
+function makeApi(allTools = ["read", "write", "edit", "bash"]) {
+  const tools: RegisteredTool[] = []
+  const handlers = new Map<string, (event: any) => Promise<any>>()
+  const setActiveTools = vi.fn()
+  const pi = {
+    registerTool: (tool: RegisteredTool) => tools.push(tool),
+    on: (event: string, handler: (value: any) => Promise<any>) => handlers.set(event, handler),
+    getAllTools: () => allTools.map((name) => ({ name })),
+    setActiveTools,
+  }
+  return { pi, tools, handlers, setActiveTools }
+}
+
+afterEach(() => {
+  delete process.env.CATE_AGENT_ROLE
+})
+
+describe("cate-agent-tools", () => {
+  it("is inert for ordinary agent sessions", () => {
+    const api = makeApi()
+
+    registerCateAgentTools(api.pi as any)
+
+    expect(api.tools).toEqual([])
+    expect(api.handlers.size).toBe(0)
+  })
+
+  it("keeps the orchestrator read-only and appends its role prompt", async () => {
+    process.env.CATE_AGENT_ROLE = "orchestrator"
+    const api = makeApi(["read", "write", "edit", "bash", "iterate", "canvas"])
+    registerCateAgentTools(api.pi as any)
+
+    const result = await api.handlers.get("before_agent_start")!({ systemPrompt: "base prompt" })
+
+    expect(api.setActiveTools).toHaveBeenCalledWith(["read", "bash", "iterate", "canvas"])
+    expect(result.systemPrompt).toContain("base prompt")
+    expect(result.systemPrompt).toContain("read-only")
+    expect(api.tools.map((tool) => tool.name)).toEqual([
+      "read_terminal",
+      "set_goal",
+      "iterate",
+      "select_winner",
+      "canvas",
+      "fail",
+    ])
+  })
+
+  it("narrows the driver to terminal controls and preserves the bridge envelope", async () => {
+    process.env.CATE_AGENT_ROLE = "driver"
+    const api = makeApi(["read", "create_terminal", "read_terminal", "send_keys", "write"])
+    registerCateAgentTools(api.pi as any)
+
+    await api.handlers.get("before_agent_start")!({ systemPrompt: "base" })
+    expect(api.setActiveTools).toHaveBeenCalledWith(["create_terminal", "read_terminal", "send_keys"])
+
+    const input = vi.fn(async () => undefined)
+    const sendKeys = api.tools.find((tool) => tool.name === "send_keys")!
+    const result = await sendKeys.execute(
+      "call-1",
+      { terminalId: "term-1", keys: "npm test", enter: false, background: true },
+      undefined,
+      undefined,
+      { ui: { input } },
+    )
+
+    expect(input).toHaveBeenCalledWith(
+      'cate-agent-tools:{"tool":"send_keys","params":{"terminalId":"term-1","keys":"npm test","enter":false,"background":true}}',
+      "",
+    )
+    expect(result).toEqual({
+      content: [{ type: "text", text: "(send_keys: no response from Cate)" }],
+      details: { tool: "send_keys", raw: null },
+    })
+  })
+})

--- a/src/agent/extensions/cate-ask-user/index.test.ts
+++ b/src/agent/extensions/cate-ask-user/index.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest"
+import registerAskUser from "./index"
+
+function registeredTool() {
+  let tool: any
+  registerAskUser({ registerTool: (value: any) => { tool = value } } as any)
+  return tool
+}
+
+describe("cate-ask-user", () => {
+  it("rejects calls containing no non-blank question without opening UI", async () => {
+    const input = vi.fn()
+    const result = await registeredTool().execute(
+      "call-1",
+      { questions: [{ question: "   " }] },
+      undefined,
+      undefined,
+      { ui: { input } },
+    )
+
+    expect(input).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      content: [{ type: "text", text: "No question was provided." }],
+      details: { questions: [], answers: [] },
+    })
+  })
+
+  it("round-trips one structured envelope and sanitizes answer values", async () => {
+    const questions = [
+      { question: "Which target?", options: [{ label: "Desktop" }], allowOther: true },
+      { question: "Any constraints?" },
+    ]
+    const input = vi.fn(async (_title: string, _defaultValue: string) =>
+      JSON.stringify({ answers: [["Desktop", 42], []] }),
+    )
+    const result = await registeredTool().execute(
+      "call-1",
+      { questions },
+      undefined,
+      undefined,
+      { ui: { input } },
+    )
+
+    expect(input).toHaveBeenCalledTimes(1)
+    const [title, defaultValue] = input.mock.calls[0]
+    expect(defaultValue).toBe("")
+    expect(title.startsWith("cate-ask-user:")).toBe(true)
+    expect(JSON.parse(title.slice("cate-ask-user:".length))).toEqual({ questions })
+    expect(result.content[0].text).toBe(
+      "The user answered:\n- Which target?\n  Desktop\n- Any constraints?\n  (no answer)",
+    )
+    expect(result.details.answers).toEqual([["Desktop"], []])
+  })
+
+  it.each([undefined, "not json", JSON.stringify({ answers: [[], []] })])(
+    "treats a dismissed or unusable response as unanswered",
+    async (raw) => {
+      const result = await registeredTool().execute(
+        "call-1",
+        { questions: [{ question: "Continue?" }] },
+        undefined,
+        undefined,
+        { ui: { input: vi.fn(async () => raw) } },
+      )
+
+      expect(result.content[0].text).toBe("The user dismissed the question(s) without answering.")
+      expect(result.details.answers).toEqual([])
+    },
+  )
+})

--- a/src/agent/extensions/cate-plan-mode/index.test.ts
+++ b/src/agent/extensions/cate-plan-mode/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest"
+import registerPlanMode from "./index"
+
+function makeApi() {
+  const commands = new Map<string, any>()
+  const handlers = new Map<string, (event: any) => Promise<any>>()
+  let tool: any
+  const sendMessage = vi.fn()
+  const pi = {
+    registerCommand: (name: string, command: any) => commands.set(name, command),
+    on: (event: string, handler: (value: any) => Promise<any>) => handlers.set(event, handler),
+    registerTool: (value: any) => { tool = value },
+    sendMessage,
+  }
+  registerPlanMode(pi as any)
+  return { commands, handlers, get tool() { return tool }, sendMessage }
+}
+
+describe("cate-plan-mode", () => {
+  it("only augments prompts and blocks mutations while enabled", async () => {
+    const api = makeApi()
+    const setStatus = vi.fn()
+    const ctx = { ui: { setStatus } }
+
+    expect(await api.handlers.get("before_agent_start")!({ systemPrompt: "base" })).toBeUndefined()
+    expect(await api.handlers.get("tool_call")!({ toolName: "write", input: {} })).toBeUndefined()
+
+    await api.commands.get("plan").handler("", ctx)
+
+    expect(setStatus).toHaveBeenCalledWith("plan-mode", "Plan mode")
+    const prompt = await api.handlers.get("before_agent_start")!({ systemPrompt: "base" })
+    expect(prompt.systemPrompt).toContain("Plan mode is ACTIVE")
+    await expect(api.handlers.get("tool_call")!({ toolName: "Write", input: {} })).resolves.toMatchObject({
+      block: true,
+      reason: expect.stringContaining("'Write' modifies the workspace"),
+    })
+    await expect(
+      api.handlers.get("tool_call")!({ toolName: "bash", input: { command: "git status && npm run test" } }),
+    ).resolves.toMatchObject({ block: true, reason: expect.stringContaining("'npm write'") })
+    await expect(
+      api.handlers.get("tool_call")!({ toolName: "bash", input: { command: "rg -n todo src" } }),
+    ).resolves.toBeUndefined()
+
+    await api.commands.get("plan").handler("", ctx)
+    expect(setStatus).toHaveBeenLastCalledWith("plan-mode", undefined)
+    expect(await api.handlers.get("tool_call")!({ toolName: "write", input: {} })).toBeUndefined()
+  })
+
+  it("records a plan, aborts the planning turn, and restates it after compaction", async () => {
+    const api = makeApi()
+    const abort = vi.fn()
+    const plan = {
+      summary: "Protect the workflow with regression tests.",
+      steps: [
+        { title: "Add tests", detail: "Exercise the extension callbacks." },
+        { title: "Verify" },
+      ],
+    }
+
+    const result = await api.tool.execute("call-1", plan, undefined, undefined, { abort })
+    expect(abort).toHaveBeenCalledOnce()
+    expect(result.details).toEqual(plan)
+
+    const setStatus = vi.fn()
+    await api.commands.get("apply-plan").handler(" fresh ", { ui: { setStatus } })
+
+    expect(setStatus).toHaveBeenCalledWith("plan-mode", undefined)
+    expect(api.sendMessage).toHaveBeenCalledWith(
+      {
+        customType: "cate-plan-execute",
+        content: expect.stringContaining(
+          "1. Add tests — Exercise the extension callbacks.\n2. Verify",
+        ),
+        display: false,
+      },
+      { triggerTurn: true },
+    )
+  })
+})

--- a/src/agent/extensions/subagent/index.test.ts
+++ b/src/agent/extensions/subagent/index.test.ts
@@ -8,6 +8,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./agents.ts", () => ({ discoverAgents: mocks.discoverAgents }))
 vi.mock("node:child_process", () => ({ spawn: mocks.spawn }))
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  getMarkdownTheme: vi.fn(() => ({})),
+  withFileMutationQueue: async (_filePath: string, mutate: () => Promise<unknown>) => mutate(),
+}))
 
 import registerSubagent from "./index"
 

--- a/src/agent/extensions/subagent/index.test.ts
+++ b/src/agent/extensions/subagent/index.test.ts
@@ -1,0 +1,127 @@
+import { EventEmitter } from "node:events"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  discoverAgents: vi.fn(),
+  spawn: vi.fn(),
+}))
+
+vi.mock("./agents.ts", () => ({ discoverAgents: mocks.discoverAgents }))
+vi.mock("node:child_process", () => ({ spawn: mocks.spawn }))
+
+import registerSubagent from "./index"
+
+function registeredTool() {
+  let tool: any
+  registerSubagent({ registerTool: (value: any) => { tool = value } } as any)
+  return tool
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: "/workspace",
+    hasUI: false,
+    ui: { confirm: vi.fn() },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mocks.discoverAgents.mockReturnValue({
+    agents: [{
+      name: "worker",
+      description: "Works",
+      source: "user",
+      filePath: "/agents/worker.md",
+      systemPrompt: "",
+    }],
+    projectAgentsDir: null,
+  })
+})
+
+describe("subagent orchestration", () => {
+  it("requires exactly one execution mode and caps parallel fan-out", async () => {
+    const tool = registeredTool()
+    const mixed = await tool.execute(
+      "call-1",
+      { agent: "worker", task: "single", tasks: [{ agent: "worker", task: "parallel" }] },
+      undefined,
+      undefined,
+      context(),
+    )
+    expect(mixed.content[0].text).toContain("Provide exactly one mode")
+
+    const tasks = Array.from({ length: 9 }, (_, i) => ({ agent: "worker", task: `task-${i}` }))
+    const oversized = await tool.execute("call-2", { tasks }, undefined, undefined, context())
+    expect(oversized.content[0].text).toBe("Too many parallel tasks (9). Max is 8.")
+    expect(oversized.details).toMatchObject({ mode: "parallel", results: [] })
+    expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+
+  it("requires confirmation before running a project-controlled agent", async () => {
+    mocks.discoverAgents.mockReturnValue({
+      agents: [{
+        name: "local-worker",
+        description: "Works",
+        source: "project",
+        filePath: "/workspace/.pi/agents/local-worker.md",
+        systemPrompt: "",
+      }],
+      projectAgentsDir: "/workspace/.pi/agents",
+    })
+    const confirm = vi.fn(async () => false)
+
+    const result = await registeredTool().execute(
+      "call-1",
+      { agent: "local-worker", task: "inspect", agentScope: "project" },
+      undefined,
+      undefined,
+      context({ hasUI: true, ui: { confirm } }),
+    )
+
+    expect(confirm).toHaveBeenCalledWith(
+      "Run project-local agents?",
+      expect.stringContaining("Agents: local-worker\nSource: /workspace/.pi/agents"),
+    )
+    expect(result.content[0].text).toBe("Canceled: project-local agents not approved.")
+    expect(mocks.spawn).not.toHaveBeenCalled()
+  })
+
+  it("runs at most four parallel processes and truncates only display output", async () => {
+    let active = 0
+    let peak = 0
+    const fullOutput = "x".repeat(52 * 1024)
+    mocks.spawn.mockImplementation(() => {
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter
+        stderr: EventEmitter
+        killed: boolean
+        kill: ReturnType<typeof vi.fn>
+      }
+      proc.stdout = new EventEmitter()
+      proc.stderr = new EventEmitter()
+      proc.killed = false
+      proc.kill = vi.fn()
+      active++
+      peak = Math.max(peak, active)
+      setTimeout(() => {
+        proc.stdout.emit("data", `${JSON.stringify({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: fullOutput }] },
+        })}\n`)
+        active--
+        proc.emit("close", 0)
+      }, 0)
+      return proc
+    })
+    const tasks = Array.from({ length: 8 }, (_, i) => ({ agent: "worker", task: `task-${i}` }))
+
+    const result = await registeredTool().execute("call-1", { tasks }, undefined, undefined, context())
+
+    expect(peak).toBe(4)
+    expect(mocks.spawn).toHaveBeenCalledTimes(8)
+    expect(result.content[0].text).toContain("Parallel: 8/8 succeeded")
+    expect(result.content[0].text).toContain("[Output truncated:")
+    expect(result.details.results[0].messages[0].content[0].text).toHaveLength(fullOutput.length)
+  })
+})

--- a/src/agent/main/ipcAgent.test.ts
+++ b/src/agent/main/ipcAgent.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Handler = (event: { sender: FakeSender }, ...args: unknown[]) => unknown
+
+interface FakeSender {
+  id: number
+  once: ReturnType<typeof vi.fn>
+}
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  listeners: new Map<string, Handler>(),
+  shellOpenPath: vi.fn(),
+  sendEvent: vi.fn(),
+  listSessions: vi.fn(),
+  loadSessionTranscript: vi.fn(),
+  deleteSession: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  ipcMain: {
+    handle: (channel: string, handler: Handler) => h.handlers.set(channel, handler),
+    on: (channel: string, handler: Handler) => h.listeners.set(channel, handler),
+  },
+  shell: { openPath: h.shellOpenPath },
+}))
+vi.mock('../../main/analytics', () => ({ sendEvent: h.sendEvent }))
+vi.mock('./sessionFiles', () => ({
+  listSessions: h.listSessions,
+  loadSessionTranscript: h.loadSessionTranscript,
+  deleteSession: h.deleteSession,
+}))
+vi.mock('../../main/runtime/runtimeManager', () => ({
+  runtimes: { resolve: vi.fn() },
+}))
+vi.mock('./customModels', () => ({
+  readCustomOpenAI: vi.fn(),
+  saveCustomOpenAI: vi.fn(),
+}))
+
+import { registerAgentHandlers } from './ipcAgent'
+import {
+  AGENT_CREATE,
+  AGENT_DELETE_SESSION,
+  AGENT_LIST_SESSIONS,
+  AGENT_LOAD_SESSION_MESSAGES,
+  AGENT_PROMPT,
+} from '../../shared/ipc-channels'
+import type { AgentManager } from './agentManager'
+import type { AuthManager } from './authManager'
+
+function makeManager(): AgentManager {
+  return {
+    create: vi.fn(async () => {}),
+    disposeForWebContents: vi.fn(),
+    prompt: vi.fn(async () => {}),
+  } as unknown as AgentManager
+}
+
+function makeSender(id: number): { sender: FakeSender; destroy: () => void } {
+  let destroyed: (() => void) | undefined
+  const sender: FakeSender = {
+    id,
+    once: vi.fn((event: string, callback: () => void) => {
+      if (event === 'destroyed') destroyed = callback
+    }),
+  }
+  return { sender, destroy: () => destroyed?.() }
+}
+
+function invoke(channel: string, sender: FakeSender, ...args: unknown[]): unknown {
+  const handler = h.handlers.get(channel)
+  if (!handler) throw new Error(`No handler registered for ${channel}`)
+  return handler({ sender }, ...args)
+}
+
+beforeEach(() => {
+  h.handlers.clear()
+  h.listeners.clear()
+  h.sendEvent.mockReset()
+  h.listSessions.mockReset()
+  h.loadSessionTranscript.mockReset()
+  h.deleteSession.mockReset()
+})
+
+describe('agent IPC ownership and session routing', () => {
+  it('hooks each owner window once and disposes all of its sessions when destroyed', async () => {
+    const manager = makeManager()
+    registerAgentHandlers({} as AuthManager, manager)
+    const owner = makeSender(42)
+
+    await expect(invoke(AGENT_CREATE, owner.sender, { panelId: 'one', cwd: '/work' })).resolves.toEqual({ ok: true })
+    await expect(invoke(AGENT_CREATE, owner.sender, { panelId: 'two', cwd: '/work' })).resolves.toEqual({ ok: true })
+
+    expect(owner.sender.once).toHaveBeenCalledTimes(1)
+    expect(owner.sender.once).toHaveBeenCalledWith('destroyed', expect.any(Function))
+    expect(manager.create).toHaveBeenCalledTimes(2)
+
+    owner.destroy()
+    expect(manager.disposeForWebContents).toHaveBeenCalledOnce()
+    expect(manager.disposeForWebContents).toHaveBeenCalledWith(42)
+  })
+
+  it('releases destroyed sender ids so a replacement sender with the same id gets cleanup ownership', async () => {
+    const manager = makeManager()
+    registerAgentHandlers({} as AuthManager, manager)
+    const first = makeSender(7)
+    await invoke(AGENT_CREATE, first.sender, { panelId: 'first', cwd: '/work' })
+    first.destroy()
+
+    const replacement = makeSender(7)
+    await invoke(AGENT_CREATE, replacement.sender, { panelId: 'replacement', cwd: '/work' })
+
+    expect(replacement.sender.once).toHaveBeenCalledOnce()
+    replacement.destroy()
+    expect(manager.disposeForWebContents).toHaveBeenNthCalledWith(1, 7)
+    expect(manager.disposeForWebContents).toHaveBeenNthCalledWith(2, 7)
+  })
+
+  it('returns create failures as serializable results without rejecting IPC', async () => {
+    const manager = makeManager()
+    vi.mocked(manager.create).mockRejectedValueOnce(new Error('provider unavailable'))
+    registerAgentHandlers({} as AuthManager, manager)
+    const owner = makeSender(3)
+
+    await expect(invoke(AGENT_CREATE, owner.sender, { panelId: 'one', cwd: '/work' })).resolves.toEqual({
+      ok: false,
+      error: 'provider unavailable',
+    })
+  })
+
+  it('short-circuits empty session arguments and delegates non-empty paths unchanged', async () => {
+    const manager = makeManager()
+    registerAgentHandlers({} as AuthManager, manager)
+    const owner = makeSender(1).sender
+    h.listSessions.mockResolvedValue([{ id: 'session' }])
+    h.loadSessionTranscript.mockResolvedValue([{ type: 'user', text: 'hello' }])
+
+    await expect(invoke(AGENT_LIST_SESSIONS, owner, '')).resolves.toEqual([])
+    await expect(invoke(AGENT_LOAD_SESSION_MESSAGES, owner, '')).resolves.toEqual([])
+    await expect(invoke(AGENT_DELETE_SESSION, owner, '')).resolves.toBeUndefined()
+    expect(h.listSessions).not.toHaveBeenCalled()
+    expect(h.loadSessionTranscript).not.toHaveBeenCalled()
+    expect(h.deleteSession).not.toHaveBeenCalled()
+
+    await expect(invoke(AGENT_LIST_SESSIONS, owner, 'cate-runtime://server/work')).resolves.toEqual([{ id: 'session' }])
+    await expect(invoke(AGENT_LOAD_SESSION_MESSAGES, owner, 'cate-runtime://server/session.jsonl')).resolves.toEqual([
+      { type: 'user', text: 'hello' },
+    ])
+    await invoke(AGENT_DELETE_SESSION, owner, 'cate-runtime://server/session.jsonl')
+
+    expect(h.listSessions).toHaveBeenCalledWith('cate-runtime://server/work')
+    expect(h.loadSessionTranscript).toHaveBeenCalledWith('cate-runtime://server/session.jsonl')
+    expect(h.deleteSession).toHaveBeenCalledWith('cate-runtime://server/session.jsonl')
+  })
+
+  it('routes prompts and records only anonymous message metadata', async () => {
+    const manager = makeManager()
+    registerAgentHandlers({} as AuthManager, manager)
+    const owner = makeSender(1).sender
+    const images = [{ mimeType: 'image/png', data: 'secret-image-data' }]
+
+    await invoke(AGENT_PROMPT, owner, 'panel-1', 'do not log this prompt', images)
+
+    expect(manager.prompt).toHaveBeenCalledWith('panel-1', 'do not log this prompt', images)
+    expect(h.sendEvent).toHaveBeenCalledWith('agent_message_sent', {
+      kind: 'prompt', chars: 22, has_images: true,
+    })
+    expect(JSON.stringify(h.sendEvent.mock.calls)).not.toContain('do not log this prompt')
+    expect(JSON.stringify(h.sendEvent.mock.calls)).not.toContain('secret-image-data')
+  })
+})

--- a/src/agent/main/sessionFiles.test.ts
+++ b/src/agent/main/sessionFiles.test.ts
@@ -13,15 +13,19 @@ import { deleteSession, listSessions, loadSessionTranscript } from './sessionFil
 import { formatLocator } from '../../main/runtime/locator'
 import type { Runtime } from '../../main/runtime/types'
 
+const norm = (value: string): string => value.replace(/\\/g, '/')
+
 function runtimeWithFiles(files: Record<string, string>, id = 'local'): Runtime {
+  const normalizedFiles = new Map(Object.entries(files).map(([filePath, content]) => [norm(filePath), content]))
   return {
     id,
     file: {
       readFile: vi.fn(async (filePath: string) => {
-        if (!(filePath in files)) throw new Error(`missing: ${filePath}`)
-        return files[filePath]
+        const content = normalizedFiles.get(norm(filePath))
+        if (content == null) throw new Error(`missing: ${filePath}`)
+        return content
       }),
-      readDir: vi.fn(async () => Object.keys(files).map((filePath) => ({
+      readDir: vi.fn(async () => [...normalizedFiles.keys()].map((filePath) => ({
         name: filePath.slice(filePath.lastIndexOf('/') + 1),
         path: filePath,
         isDirectory: false,

--- a/src/agent/main/sessionFiles.test.ts
+++ b/src/agent/main/sessionFiles.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  resolve: vi.fn(),
+}))
+
+vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/tmp') } }))
+vi.mock('../../main/runtime/runtimeManager', () => ({
+  runtimes: { resolve: h.resolve },
+}))
+
+import { deleteSession, listSessions, loadSessionTranscript } from './sessionFiles'
+import { formatLocator } from '../../main/runtime/locator'
+import type { Runtime } from '../../main/runtime/types'
+
+function runtimeWithFiles(files: Record<string, string>, id = 'local'): Runtime {
+  return {
+    id,
+    file: {
+      readFile: vi.fn(async (filePath: string) => {
+        if (!(filePath in files)) throw new Error(`missing: ${filePath}`)
+        return files[filePath]
+      }),
+      readDir: vi.fn(async () => Object.keys(files).map((filePath) => ({
+        name: filePath.slice(filePath.lastIndexOf('/') + 1),
+        path: filePath,
+        isDirectory: false,
+      }))),
+      remove: vi.fn(async () => {}),
+    },
+  } as unknown as Runtime
+}
+
+const sessionPath = '/work/.cate/pi-agent/sessions/--work--/session.jsonl'
+
+beforeEach(() => {
+  h.resolve.mockReset()
+})
+
+describe('loadSessionTranscript', () => {
+  it('replays persisted messages while tolerating malformed and unknown entries', async () => {
+    const transcript = [
+      '{not-json',
+      JSON.stringify({ type: 'model_change', modelId: 'model-before-message' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'user-entry',
+        timestamp: '2026-07-15T10:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'hello' }, { type: 'image', data: 'ignored' }] },
+      }),
+      JSON.stringify({
+        type: 'message',
+        timestamp: '2026-07-15T10:01:00.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'reasoning' },
+            { type: 'text', text: 'answer' },
+          ],
+          usage: { input: 7, output: 3, cacheRead: 'bad', cacheWrite: 2, cost: { total: 0.04 } },
+          stopReason: 'stop',
+        },
+      }),
+      JSON.stringify({ type: 'compaction' }),
+      JSON.stringify({ type: 'message', message: { role: 'toolResult', toolCallId: 'orphan', content: 'ignored' } }),
+      JSON.stringify({ type: 'message', message: { role: 'bashExecution', command: 'npm test' } }),
+      JSON.stringify({ type: 'future_entry', value: 1 }),
+    ].join('\n')
+    h.resolve.mockReturnValue(runtimeWithFiles({ [sessionPath]: transcript }))
+
+    const messages = await loadSessionTranscript(sessionPath)
+
+    expect(messages).toHaveLength(4)
+    expect(messages[0]).toMatchObject({
+      type: 'user', text: 'hello', entryId: 'user-entry', createdAt: Date.parse('2026-07-15T10:00:00.000Z'),
+    })
+    expect(messages[1]).toMatchObject({
+      type: 'assistant',
+      text: 'answer',
+      thinking: 'reasoning',
+      model: 'model-before-message',
+      streaming: false,
+      stopReason: 'stop',
+      usage: { input: 7, output: 3, cacheRead: 0, cacheWrite: 2, total: 0.04 },
+    })
+    expect(messages[2]).toMatchObject({ type: 'system', text: 'Context compacted.', kind: 'info' })
+    expect(messages[3]).toMatchObject({ type: 'system', text: 'bash: npm test', kind: 'info' })
+  })
+
+  it('merges tool results and normalizes persisted subagent details for renderer replay', async () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', id: 'call-1', name: 'subagent', arguments: { task: 'inspect' } }],
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          content: [{ type: 'text', text: 'completed' }],
+          details: {
+            mode: 'parallel',
+            results: [
+              null,
+              {
+                agent: 'reviewer',
+                agentSource: 'project',
+                task: 'inspect',
+                exitCode: 0,
+                messages: [{
+                  role: 'assistant',
+                  content: [
+                    { type: 'toolCall', name: 'read', arguments: { path: 'a.ts' } },
+                    { type: 'text', text: 'first' },
+                    { type: 'text', text: 'final' },
+                  ],
+                }],
+                usage: { input: 4, output: 5, cacheRead: 1, cacheWrite: 2, cost: 0.01, turns: 3 },
+                model: 'test-model',
+                step: 2,
+              },
+            ],
+          },
+        },
+      }),
+    ].join('\n')
+    h.resolve.mockReturnValue(runtimeWithFiles({ [sessionPath]: transcript }))
+
+    const messages = await loadSessionTranscript(sessionPath)
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({
+      type: 'tool',
+      toolCallId: 'call-1',
+      name: 'subagent',
+      args: { task: 'inspect' },
+      status: 'success',
+      result: 'completed',
+      subagent: {
+        mode: 'parallel',
+        results: [{
+          agent: 'reviewer',
+          agentSource: 'project',
+          task: 'inspect',
+          exitCode: 0,
+          parts: [
+            { type: 'toolCall', toolCall: { name: 'read', args: { path: 'a.ts' } } },
+            { type: 'text', text: 'first' },
+            { type: 'text', text: 'final' },
+          ],
+          finalText: 'final',
+          usage: { input: 4, output: 5, cacheRead: 1, cacheWrite: 2, cost: 0.01, turns: 3 },
+          model: 'test-model',
+          step: 2,
+        }],
+      },
+    })
+  })
+
+  it('records failed tool results as errors with a stable fallback message', async () => {
+    const transcript = [
+      JSON.stringify({
+        type: 'message',
+        message: { role: 'assistant', content: [{ type: 'toolCall', id: 'failed', name: 'bash', arguments: {} }] },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: { role: 'toolResult', toolCallId: 'failed', content: [], isError: true },
+      }),
+    ].join('\n')
+    h.resolve.mockReturnValue(runtimeWithFiles({ [sessionPath]: transcript }))
+
+    expect(await loadSessionTranscript(sessionPath)).toMatchObject([{
+      type: 'tool', toolCallId: 'failed', status: 'error', error: 'Tool reported an error', result: undefined,
+    }])
+  })
+})
+
+describe('session listing and deletion safety', () => {
+  it('summarizes valid files, ignores unreadable/invalid sessions, and sorts newest first', async () => {
+    const dir = '/work/.cate/pi-agent/sessions/--work--'
+    const files = {
+      [`${dir}/older.jsonl`]: [
+        JSON.stringify({ type: 'session', id: 'older', cwd: '/work', timestamp: '2026-07-14T09:00:00Z' }),
+        JSON.stringify({ type: 'message', message: { role: 'user', content: '  First\n prompt  ' } }),
+        JSON.stringify({ type: 'model_change', provider: 'openai', modelId: 'old-model' }),
+        JSON.stringify({ type: 'session_info', sessionName: 'Renamed session' }),
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: [] } }),
+      ].join('\n'),
+      [`${dir}/newer.jsonl`]: [
+        JSON.stringify({ type: 'session', id: 'newer', cwd: '/work', timestamp: '2026-07-15T09:00:00Z' }),
+        JSON.stringify({ type: 'message', message: { role: 'user', content: 'Newest prompt' } }),
+      ].join('\n'),
+      [`${dir}/invalid.jsonl`]: JSON.stringify({ type: 'message', message: { role: 'user', content: 'no header' } }),
+    }
+    const runtime = runtimeWithFiles(files)
+    h.resolve.mockReturnValue(runtime)
+
+    const sessions = await listSessions('/work')
+
+    expect(sessions.map((session) => session.id)).toEqual(['newer', 'older'])
+    expect(sessions[0]).toMatchObject({ title: 'Newest prompt', named: false, messageCount: 1 })
+    expect(sessions[1]).toMatchObject({
+      title: 'Renamed session', named: true, messageCount: 2, lastModel: { provider: 'openai', model: 'old-model' },
+    })
+  })
+
+  it('rejects reads and deletes outside the pi sessions directory before resolving a runtime', async () => {
+    await expect(loadSessionTranscript('/work/notes.jsonl')).rejects.toThrow('not a pi session file')
+    await expect(deleteSession('/work/.cate/pi-agent/sessions/readme.txt')).rejects.toThrow('not a pi session file')
+    expect(h.resolve).not.toHaveBeenCalled()
+  })
+
+  it('routes a remote delete to its owning runtime using the decoded host path', async () => {
+    const remotePath = '/srv/work/.cate/pi-agent/sessions/--srv-work--/remote.jsonl'
+    const runtime = runtimeWithFiles({}, 'server-1')
+    h.resolve.mockReturnValue(runtime)
+
+    await deleteSession(formatLocator({ runtimeId: 'server-1', path: remotePath }))
+
+    expect(h.resolve).toHaveBeenCalledWith('server-1')
+    expect(runtime.file.remove).toHaveBeenCalledWith(remotePath)
+  })
+})

--- a/src/main/runtime/transports/sshTransport.test.ts
+++ b/src/main/runtime/transports/sshTransport.test.ts
@@ -1,0 +1,223 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sshModule = vi.hoisted(() => ({ makeClient: vi.fn() }))
+
+vi.mock('ssh2', () => ({
+  Client: class {
+    constructor() { return sshModule.makeClient() }
+  },
+}))
+vi.mock('../sshKnownHosts', () => ({
+  hostKeyId: vi.fn(),
+  verifyAndPinHostKey: vi.fn(),
+}))
+vi.mock('../../logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+vi.mock('../runtimeArtifacts', () => ({
+  ensureLocalTarball: vi.fn(),
+  isRuntimeDevMode: () => false,
+  isRuntimeTarget: (target: string) => ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64'].includes(target),
+  localTarballIfPresent: () => null,
+  releaseUrl: () => 'https://example.invalid/runtime.tgz',
+  tarballHash: vi.fn(),
+  localRuntimeBundlePath: () => null,
+}))
+
+import { SshTransport } from './sshTransport'
+
+type ConnectMode = 'ready' | 'authentication-error'
+
+class FakeChannel extends EventEmitter {
+  stderr = new EventEmitter()
+  write = vi.fn()
+  close = vi.fn()
+}
+
+let connectMode: ConnectMode
+let launchError: Error | null
+let probeStreamError: Error | null
+let clients: FakeSshClient[]
+
+class FakeSshClient extends EventEmitter {
+  connectOptions: Record<string, unknown> | null = null
+  launchChannel = new FakeChannel()
+  end = vi.fn()
+  exec = vi.fn((command: string, optionsOrCallback: unknown, maybeCallback?: (err: unknown, stream?: FakeChannel) => void) => {
+    const callback = (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as (err: unknown, stream?: FakeChannel) => void
+    if (typeof optionsOrCallback !== 'function') {
+      if (launchError) callback(launchError)
+      else callback(null, this.launchChannel)
+      return
+    }
+
+    const channel = new FakeChannel()
+    callback(null, channel)
+    queueMicrotask(() => {
+      if (probeStreamError && command.startsWith('uname -s')) {
+        channel.emit('error', probeStreamError)
+        return
+      }
+      const stdout = command.startsWith('uname -s')
+        ? 'Linux\nx86_64\nglibc 2.37\n'
+        : command === 'echo $HOME'
+          ? '/home/tester\n'
+          : command.includes('/.ok')
+            ? '3.0.0\n'
+            : ''
+      if (stdout) channel.emit('data', Buffer.from(stdout))
+      channel.emit('close', 0)
+    })
+  })
+
+  connect(options: Record<string, unknown>): void {
+    this.connectOptions = options
+    if (connectMode === 'authentication-error') {
+      queueMicrotask(() => this.emit('error', new Error('All configured authentication methods failed')))
+      return
+    }
+    const verifier = options.hostVerifier as (key: string, callback: (valid: boolean) => void) => void
+    verifier('aabbcc', (valid) => {
+      queueMicrotask(() => {
+        if (valid) this.emit('ready')
+        else this.emit('error', new Error('Host denied by verifier'))
+      })
+    })
+  }
+}
+
+function makeTransport(verifyHostKey = vi.fn().mockResolvedValue(undefined)): SshTransport {
+  return new SshTransport({
+    host: 'server.example',
+    user: 'alice',
+    root: "/srv/O'Reilly project",
+    id: 'runtime-ssh',
+    privateKey: 'private-key',
+    passphrase: 'secret',
+    agentSock: '/tmp/agent.sock',
+    exclusions: ['node_modules', '.git'],
+    idleSuspend: true,
+    verifyHostKey,
+  })
+}
+
+beforeEach(() => {
+  connectMode = 'ready'
+  launchError = null
+  probeStreamError = null
+  clients = []
+  sshModule.makeClient.mockReset().mockImplementation(() => {
+    const client = new FakeSshClient()
+    clients.push(client)
+    return client
+  })
+})
+
+describe('SshTransport connection lifecycle', () => {
+  it('verifies the host key, forwards connection options, and probes the target', async () => {
+    const verifyHostKey = vi.fn().mockResolvedValue(undefined)
+    const transport = makeTransport(verifyHostKey)
+
+    await expect(transport.isInstalled('3.0.0')).resolves.toBe(true)
+
+    expect(clients).toHaveLength(1)
+    expect(clients[0].connectOptions).toEqual(expect.objectContaining({
+      host: 'server.example',
+      port: 22,
+      username: 'alice',
+      privateKey: 'private-key',
+      passphrase: 'secret',
+      agent: '/tmp/agent.sock',
+      keepaliveInterval: 15000,
+      readyTimeout: 20000,
+      hostHash: 'sha256',
+    }))
+    expect(verifyHostKey).toHaveBeenCalledWith('aabbcc')
+    expect(clients[0].exec).toHaveBeenCalledWith(
+      'uname -s; uname -m; (ldd --version 2>&1 | head -n1) || true',
+      expect.any(Function),
+    )
+    expect(clients[0].exec).toHaveBeenCalledWith('echo $HOME', expect.any(Function))
+  })
+
+  it('surfaces authentication failures from ssh2', async () => {
+    connectMode = 'authentication-error'
+    const transport = makeTransport()
+
+    await expect(transport.isInstalled('3.0.0')).rejects.toThrow('All configured authentication methods failed')
+  })
+
+  it('surfaces the host-key rejection instead of ssh2 generic verifier failure', async () => {
+    const verifyHostKey = vi.fn().mockRejectedValue(new Error('Host key changed'))
+    const transport = makeTransport(verifyHostKey)
+
+    await expect(transport.isInstalled('3.0.0')).rejects.toThrow('Host key changed')
+    expect(verifyHostKey).toHaveBeenCalledWith('aabbcc')
+  })
+
+  it('rejects a channel error during platform probing rather than hanging', async () => {
+    probeStreamError = new Error('connection dropped')
+    const transport = makeTransport()
+
+    await expect(transport.isInstalled('3.0.0')).rejects.toThrow('connection dropped')
+  })
+
+  it('disposes the connection idempotently and reconnects on the next operation', async () => {
+    const transport = makeTransport()
+    await transport.isInstalled('3.0.0')
+    const first = clients[0]
+
+    await transport.dispose()
+    await transport.dispose()
+    expect(first.end).toHaveBeenCalledTimes(1)
+
+    await transport.isInstalled('3.0.0')
+    expect(clients).toHaveLength(2)
+  })
+})
+
+describe('SshTransport runtime channel', () => {
+  it('quotes launch arguments and forwards frames and lifecycle events', async () => {
+    const transport = makeTransport()
+    await transport.isInstalled('3.0.0')
+    const client = clients[0]
+
+    const channel = await transport.launch()
+
+    const launchCall = client.exec.mock.calls.find(([, options]) => typeof options !== 'function')
+    expect(launchCall).toBeDefined()
+    expect(launchCall?.[0]).toBe(
+      "'/home/tester/.cate/runtime/3.0.0/linux-x64/runtime/bin/node' " +
+      "'/home/tester/.cate/runtime/3.0.0/linux-x64/runtime.cjs' " +
+      "--root '/srv/O'\\''Reilly project' --id 'runtime-ssh' " +
+      "--exclude 'node_modules,.git' --idle-suspend",
+    )
+    expect(launchCall?.[1]).toEqual({ pty: false })
+
+    channel.write('{"id":1}\n')
+    expect(client.launchChannel.write).toHaveBeenCalledWith('{"id":1}\n')
+
+    const data = vi.fn()
+    const stderr = vi.fn()
+    const close = vi.fn()
+    channel.onData(data)
+    channel.onStderr?.(stderr)
+    channel.onClose(close)
+    client.launchChannel.emit('data', Buffer.from('response\n'))
+    client.launchChannel.stderr.emit('data', Buffer.from('diagnostic'))
+    client.launchChannel.emit('close', 9)
+    expect(data.mock.calls[0][0].toString()).toBe('response\n')
+    expect(stderr.mock.calls[0][0].toString()).toBe('diagnostic')
+    expect(close).toHaveBeenCalledWith({ code: 9 })
+
+    channel.kill()
+    expect(client.launchChannel.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects launch when SSH command forwarding fails', async () => {
+    const transport = makeTransport()
+    await transport.isInstalled('3.0.0')
+    launchError = new Error('administratively prohibited')
+
+    await expect(transport.launch()).rejects.toThrow('administratively prohibited')
+  })
+})

--- a/src/main/runtime/transports/wslTransport.test.ts
+++ b/src/main/runtime/transports/wslTransport.test.ts
@@ -1,0 +1,140 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const processMocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+  execFileP: vi.fn(),
+}))
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process')
+  Object.defineProperty(processMocks.execFile, Symbol.for('nodejs.util.promisify.custom'), {
+    value: processMocks.execFileP,
+    configurable: true,
+  })
+  return { ...actual, spawn: processMocks.spawn, execFile: processMocks.execFile }
+})
+vi.mock('../../logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+vi.mock('../runtimeArtifacts', () => ({
+  ensureLocalTarball: vi.fn(),
+  isRuntimeDevMode: () => false,
+  isRuntimeTarget: (target: string) => ['linux-x64', 'linux-arm64'].includes(target),
+  localTarballIfPresent: () => null,
+  releaseUrl: () => 'https://example.invalid/runtime.tgz',
+  tarballHash: vi.fn(),
+  localRuntimeBundlePath: () => null,
+}))
+
+import { WslTransport } from './wslTransport'
+
+class FakeChild extends EventEmitter {
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+  kill = vi.fn(() => true)
+}
+
+function execResult(stdout = '', stderr = ''): { stdout: string; stderr: string } {
+  return { stdout, stderr }
+}
+
+beforeEach(() => {
+  processMocks.spawn.mockReset()
+  processMocks.execFileP.mockReset().mockImplementation(async (_file: string, args: string[]) => {
+    if (args.includes('uname')) return execResult('x86_64\n')
+    if (args.includes('echo $HOME')) return execResult('/home/tester\n')
+    return execResult('')
+  })
+})
+
+describe('WslTransport', () => {
+  it('constructs distro-scoped probe commands and caches platform/home discovery', async () => {
+    const transport = new WslTransport({ distro: 'Ubuntu-24.04', root: '/work', id: 'runtime-1' })
+
+    await expect(transport.isInstalled('1.2.3')).resolves.toBe(false)
+    await expect(transport.isInstalled('1.2.3')).resolves.toBe(false)
+
+    expect(processMocks.execFileP.mock.calls.filter(([, args]) => args.includes('uname'))).toHaveLength(1)
+    expect(processMocks.execFileP.mock.calls.filter(([, args]) => args.includes('echo $HOME'))).toHaveLength(1)
+    for (const [file, args] of processMocks.execFileP.mock.calls) {
+      expect(file).toBe('wsl.exe')
+      expect(args.slice(0, 3)).toEqual(['-d', 'Ubuntu-24.04', '-e'])
+    }
+    expect(processMocks.execFileP).toHaveBeenCalledWith('wsl.exe', [
+      '-d', 'Ubuntu-24.04', '-e', 'sh', '-c',
+      expect.stringContaining("'/home/tester/.cate/runtime/1.2.3/linux-x64'/runtime/bin/node"),
+    ])
+  })
+
+  it('forwards frames and process events, with all daemon launch arguments kept as argv', async () => {
+    const child = new FakeChild()
+    processMocks.spawn.mockReturnValue(child)
+    const transport = new WslTransport({
+      distro: 'Ubuntu',
+      root: "/work/it's safe",
+      id: 'runtime-2',
+      exclusions: ['node_modules', '.git'],
+      idleSuspend: true,
+    })
+    await transport.isInstalled('2.0.0')
+
+    const channel = await transport.launch()
+
+    expect(processMocks.spawn).toHaveBeenCalledWith('wsl.exe', [
+      '-d', 'Ubuntu', '-e',
+      '/home/tester/.cate/runtime/2.0.0/linux-x64/runtime/bin/node',
+      '/home/tester/.cate/runtime/2.0.0/linux-x64/runtime.cjs',
+      '--root', "/work/it's safe",
+      '--id', 'runtime-2',
+      '--exclude', 'node_modules,.git',
+      '--idle-suspend',
+    ], { stdio: ['pipe', 'pipe', 'pipe'] })
+
+    const writes: Buffer[] = []
+    child.stdin.on('data', (chunk) => writes.push(chunk))
+    channel.write('{"id":1}\n')
+    expect(Buffer.concat(writes).toString()).toBe('{"id":1}\n')
+
+    const data = vi.fn()
+    const stderr = vi.fn()
+    const close = vi.fn()
+    channel.onData(data)
+    channel.onStderr?.(stderr)
+    channel.onClose(close)
+    child.stdout.write('response\n')
+    child.stderr.write('diagnostic')
+    child.emit('close', 17)
+    expect(data.mock.calls[0][0].toString()).toBe('response\n')
+    expect(stderr.mock.calls[0][0].toString()).toBe('diagnostic')
+    expect(close).toHaveBeenCalledWith({ code: 17 })
+
+    channel.kill()
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    child.exitCode = 17
+    expect(() => channel.write('late\n')).toThrow('Runtime stdin is closed')
+  })
+
+  it('dispose kills the active child once and is idempotent', async () => {
+    const child = new FakeChild()
+    processMocks.spawn.mockReturnValue(child)
+    const transport = new WslTransport({ distro: 'Ubuntu', root: '/work', id: 'runtime-3' })
+    await transport.launch()
+
+    await transport.dispose()
+    await transport.dispose()
+
+    expect(child.kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects unsupported distro architectures before launch', async () => {
+    processMocks.execFileP.mockResolvedValueOnce(execResult('riscv64\n'))
+    const transport = new WslTransport({ distro: 'Experimental', root: '/work', id: 'runtime-4' })
+
+    await expect(transport.isInstalled('1.0.0')).rejects.toThrow('Unsupported WSL arch: "riscv64"')
+    expect(processMocks.spawn).not.toHaveBeenCalled()
+  })
+})

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -1,0 +1,129 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ElectronAPI } from '../shared/electron-api'
+import {
+  DIALOG_SAVE_FILE,
+  DIALOG_TERMINAL_LINK_OPEN,
+  MENU_POPUP_BAR_ITEM,
+  TERMINAL_DATA,
+  TERMINAL_RESIZE,
+} from '../shared/ipc-channels'
+
+type IpcListener = (event: unknown, ...args: unknown[]) => void
+
+const electron = vi.hoisted(() => {
+  const listeners = new Map<string, Set<IpcListener>>()
+  const on = vi.fn((channel: string, listener: IpcListener) => {
+    const channelListeners = listeners.get(channel) ?? new Set<IpcListener>()
+    channelListeners.add(listener)
+    listeners.set(channel, channelListeners)
+  })
+  const removeListener = vi.fn((channel: string, listener: IpcListener) => {
+    listeners.get(channel)?.delete(listener)
+  })
+
+  return {
+    exposeInMainWorld: vi.fn(),
+    getPathForFile: vi.fn(),
+    invoke: vi.fn(),
+    listeners,
+    on,
+    removeListener,
+    send: vi.fn(),
+    sendSync: vi.fn(),
+    setZoomFactor: vi.fn(),
+  }
+})
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: electron.exposeInMainWorld },
+  ipcRenderer: {
+    invoke: electron.invoke,
+    on: electron.on,
+    removeListener: electron.removeListener,
+    send: electron.send,
+    sendSync: electron.sendSync,
+  },
+  webFrame: { setZoomFactor: electron.setZoomFactor },
+  webUtils: { getPathForFile: electron.getPathForFile },
+}))
+
+let api: ElectronAPI
+
+function emit(channel: string, ...args: unknown[]): void {
+  for (const listener of [...(electron.listeners.get(channel) ?? [])]) {
+    listener({ sender: 'main' }, ...args)
+  }
+}
+
+beforeAll(async () => {
+  await import('./index')
+  api = electron.exposeInMainWorld.mock.calls[0][1] as ElectronAPI
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('electronAPI preload bridge', () => {
+  it('forwards invoke arguments and returns the original IPC promise', () => {
+    const ipcResult = Promise.resolve('done')
+    electron.invoke.mockReturnValueOnce(ipcResult)
+
+    const result = api.terminalResize('terminal-1', 120, 40)
+
+    expect(electron.invoke).toHaveBeenCalledWith(TERMINAL_RESIZE, 'terminal-1', 120, 40)
+    expect(result).toBe(ipcResult)
+  })
+
+  it('keeps transformed dialog and menu payloads on their wire contracts', () => {
+    api.saveFileDialog()
+    api.promptTerminalLinkOpen('https://example.test/docs')
+    api.popupAppMenu(2, 18, 34)
+
+    expect(electron.invoke.mock.calls).toEqual([
+      [DIALOG_SAVE_FILE, {}],
+      [DIALOG_TERMINAL_LINK_OPEN, { url: 'https://example.test/docs' }],
+      [MENU_POPUP_BAR_ITEM, { index: 2, x: 18, y: 34 }],
+    ])
+  })
+
+  it('isolates subscriptions and removes only the listener being unsubscribed', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const unsubscribeFirst = api.onTerminalData(first)
+    const unsubscribeSecond = api.onTerminalData(second)
+
+    emit(TERMINAL_DATA, 'terminal-1', 'hello')
+    expect(first).toHaveBeenCalledWith('terminal-1', 'hello')
+    expect(second).toHaveBeenCalledWith('terminal-1', 'hello')
+
+    unsubscribeFirst()
+    emit(TERMINAL_DATA, 'terminal-1', ' again')
+
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).toHaveBeenLastCalledWith('terminal-1', ' again')
+    expect(electron.listeners.get(TERMINAL_DATA)).toHaveLength(1)
+
+    unsubscribeSecond()
+    expect(electron.listeners.get(TERMINAL_DATA)).toHaveLength(0)
+  })
+
+  it('delegates dropped-file path lookup to Electron webUtils', () => {
+    const file = { name: 'notes.txt' } as File
+    electron.getPathForFile.mockReturnValue('/tmp/notes.txt')
+
+    expect(api.getPathForFile(file)).toBe('/tmp/notes.txt')
+    expect(electron.getPathForFile).toHaveBeenCalledWith(file)
+  })
+
+  it.each([
+    [0.25, 0.5],
+    [1.25, 1.25],
+    [3, 2],
+    [Number.NaN, 1],
+  ])('clamps UI scale %s to %s', (input, expected) => {
+    api.setUiScale(input)
+
+    expect(electron.setZoomFactor).toHaveBeenCalledWith(expected)
+  })
+})

--- a/src/renderer/panels/BrowserPanel.component.test.tsx
+++ b/src/renderer/panels/BrowserPanel.component.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.hoisted(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null),
+  })
+})
+
+const portalMocks = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+}))
+
+vi.mock('../lib/portalRegistry', () => ({ portalRegistry: portalMocks }))
+vi.mock('../ui/Tooltip', () => ({ Tooltip: ({ children }: { children: React.ReactNode }) => children }))
+vi.mock('./UrlSuggestions', () => ({ UrlSuggestions: () => null }))
+vi.mock('./StartPage', () => ({ StartPage: () => <div>Start page</div> }))
+vi.mock('./BrowserMenu', () => ({ BrowserMenu: () => null }))
+vi.mock('./BrowserSettingsPopover', () => ({ BrowserSettingsPopover: () => null }))
+vi.mock('./BrowserTabStrip', () => ({ BrowserTabStrip: () => null }))
+vi.mock('./BrowserBookmarksSidebar', () => ({ BrowserBookmarksSidebar: () => null }))
+
+import BrowserPanel from './BrowserPanel'
+import { useAppStore } from '../stores/appStore'
+import { useBrowserStore } from '../stores/browserStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import type { BrowserTab } from '../../shared/types'
+
+const initialAppState = useAppStore.getState()
+const initialBrowserState = useBrowserStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+
+const updatePanelTitle = vi.fn()
+const updateBrowserActiveTabUrl = vi.fn()
+const updatePanelTabs = vi.fn()
+const updatePanelProxy = vi.fn()
+const recordVisit = vi.fn()
+const unsubscribeShortcut = vi.fn()
+const onBrowserShortcut = vi.fn(() => unsubscribeShortcut)
+const browserSetProxy = vi.fn<(partition: string, proxyUrl: string) => Promise<void>>(async () => undefined)
+
+let host: HTMLDivElement
+let root: Root
+
+function mount(options?: { proxyUrl?: string; tabs?: BrowserTab[]; activeTabId?: string }): void {
+  const tabs = options?.tabs ?? [{ id: 'tab-1', url: 'https://initial.example', title: 'Initial' }]
+  act(() => {
+    root.render(
+      <BrowserPanel
+        panelId="browser-1"
+        workspaceId="ws-1"
+        nodeId="node-1"
+        proxyUrl={options?.proxyUrl}
+        tabs={tabs}
+        activeTabId={options?.activeTabId ?? tabs[0].id}
+      />,
+    )
+  })
+}
+
+function event(type: string, fields: Record<string, unknown> = {}): Event {
+  return Object.assign(new Event(type), fields)
+}
+
+function installWebviewMethods(webview: HTMLElement) {
+  const methods = {
+    loadURL: vi.fn(),
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    reload: vi.fn(),
+    reloadIgnoringCache: vi.fn(),
+    canGoBack: vi.fn(() => true),
+    canGoForward: vi.fn(() => false),
+    isLoading: vi.fn(() => false),
+    getURL: vi.fn(() => 'https://navigated.example/page'),
+    getTitle: vi.fn(() => 'Navigated title'),
+    getWebContentsId: vi.fn(() => 42),
+    executeJavaScript: vi.fn(async () => undefined),
+  }
+  Object.assign(webview, methods)
+  return methods
+}
+
+async function flush(): Promise<void> {
+  await act(async () => { await Promise.resolve() })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  useAppStore.setState({
+    updatePanelTitle,
+    updateBrowserActiveTabUrl,
+    updatePanelTabs,
+    updatePanelProxy,
+  })
+  useBrowserStore.setState({
+    bookmarks: [],
+    recordVisit,
+    toggleBookmark: vi.fn(),
+    querySuggestions: vi.fn(() => []),
+  })
+  useSettingsStore.setState({
+    browserHomepage: 'https://home.example',
+    browserSearchEngine: 'google',
+    browserNewTabBehavior: 'startPage',
+    browserShowTabSidebar: false,
+    setSetting: vi.fn(),
+  })
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    onBrowserShortcut,
+    browserSetProxy,
+    webviewScreenshot: vi.fn(async () => null),
+    browserClearData: vi.fn(async () => undefined),
+    showContextMenu: vi.fn(async () => null),
+  }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  useAppStore.setState(initialAppState, true)
+  useBrowserStore.setState(initialBrowserState, true)
+  useSettingsStore.setState(initialSettingsState, true)
+})
+
+describe('BrowserPanel component', () => {
+  it('persists a completed navigation, records history, and updates navigation controls', () => {
+    mount()
+    const webview = host.querySelector('webview') as HTMLElement
+    const methods = installWebviewMethods(webview)
+
+    act(() => {
+      webview.dispatchEvent(event('did-navigate', { url: 'https://navigated.example/page' }))
+    })
+
+    expect(updateBrowserActiveTabUrl).toHaveBeenCalledWith(
+      'ws-1',
+      'browser-1',
+      'https://navigated.example/page',
+    )
+    expect(recordVisit).toHaveBeenCalledWith('https://navigated.example/page', 'Navigated title')
+    expect((host.querySelector('input') as HTMLInputElement).value).toBe('https://navigated.example/page')
+    expect((host.querySelector('button[aria-label="Back"]') as HTMLButtonElement).disabled).toBe(false)
+    expect((host.querySelector('button[aria-label="Forward"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(updatePanelTabs).toHaveBeenLastCalledWith(
+      'ws-1',
+      'browser-1',
+      [{ id: 'tab-1', url: 'https://navigated.example/page', title: 'Navigated title' }],
+      'tab-1',
+    )
+    expect(methods.canGoBack).toHaveBeenCalled()
+  })
+
+  it('ignores subframe failures but surfaces a main-frame failure with a working retry', () => {
+    mount()
+    const webview = host.querySelector('webview') as HTMLElement
+    const methods = installWebviewMethods(webview)
+
+    act(() => {
+      webview.dispatchEvent(event('did-fail-load', {
+        errorCode: -105,
+        errorDescription: 'Tracker failed',
+        isMainFrame: false,
+      }))
+    })
+    expect(host.textContent).not.toContain('Tracker failed')
+
+    act(() => {
+      webview.dispatchEvent(event('did-fail-load', {
+        errorCode: -105,
+        errorDescription: 'DNS lookup failed',
+        isMainFrame: true,
+      }))
+    })
+    expect(host.textContent).toContain('DNS lookup failed')
+
+    const retry = Array.from(host.querySelectorAll('button')).find((button) => button.textContent === 'Try Again')
+    expect(retry).toBeTruthy()
+    act(() => retry!.click())
+    expect(methods.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for proxy configuration before attaching the webview', async () => {
+    let releaseProxy!: () => void
+    browserSetProxy.mockReturnValueOnce(new Promise<void>((resolve) => { releaseProxy = resolve }))
+
+    mount({ proxyUrl: ' http://proxy.example:8080 ' })
+
+    expect(host.querySelector('webview')).toBeNull()
+    expect(browserSetProxy).toHaveBeenCalledTimes(1)
+    expect(browserSetProxy.mock.calls[0][0]).toMatch(/^persist:browser-proxy-/)
+    expect(browserSetProxy.mock.calls[0][1]).toBe(' http://proxy.example:8080 ')
+
+    await act(async () => {
+      releaseProxy()
+      await Promise.resolve()
+    })
+    const webview = host.querySelector('webview')
+    expect(webview).toBeTruthy()
+    expect(webview?.getAttribute('partition')).toMatch(/^persist:browser-proxy-/)
+  })
+
+  it('unregisters the guest and subscriptions, and removes webview listeners on unmount', async () => {
+    mount()
+    const webview = host.querySelector('webview') as HTMLElement
+    installWebviewMethods(webview)
+    act(() => webview.dispatchEvent(event('dom-ready')))
+    expect(portalMocks.register).toHaveBeenCalledWith('browser-1', webview)
+
+    act(() => root.unmount())
+    expect(portalMocks.unregister).toHaveBeenCalledWith('browser-1')
+    expect(unsubscribeShortcut).toHaveBeenCalledTimes(1)
+
+    const persistedCalls = updateBrowserActiveTabUrl.mock.calls.length
+    act(() => webview.dispatchEvent(event('did-navigate', { url: 'https://late.example' })))
+    expect(updateBrowserActiveTabUrl).toHaveBeenCalledTimes(persistedCalls)
+
+    root = createRoot(host)
+    await flush()
+  })
+})

--- a/src/renderer/panels/DocumentPanel.component.test.tsx
+++ b/src/renderer/panels/DocumentPanel.component.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.hoisted(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null),
+  })
+})
+
+const pdfMocks = vi.hoisted(() => ({
+  getDocument: vi.fn(),
+}))
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: pdfMocks.getDocument,
+}))
+
+import DocumentPanel from './DocumentPanel'
+import { useAppStore } from '../stores/appStore'
+import type { PanelState, WorkspaceState } from '../../shared/types'
+
+const initialAppState = useAppStore.getState()
+
+let host: HTMLDivElement
+let root: Root
+let fsReadBinary: ReturnType<typeof vi.fn>
+let shellShowInFolder: ReturnType<typeof vi.fn>
+
+function workspace(filePath?: string, documentType?: PanelState['documentType']): WorkspaceState {
+  return {
+    id: 'ws-1',
+    name: 'Workspace',
+    color: '#000',
+    rootPath: '/workspace',
+    panels: {
+      'document-1': {
+        id: 'document-1',
+        type: 'document',
+        title: 'Document',
+        filePath,
+        documentType,
+      } as PanelState,
+    },
+  }
+}
+
+function mount(): void {
+  act(() => {
+    root.render(<DocumentPanel panelId="document-1" workspaceId="ws-1" />)
+  })
+}
+
+async function flush(): Promise<void> {
+  await act(async () => { await Promise.resolve() })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  fsReadBinary = vi.fn()
+  shellShowInFolder = vi.fn()
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    fsReadBinary,
+    shellShowInFolder,
+  }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('DocumentPanel component', () => {
+  it('loads binary data for the owning workspace and trusts magic bytes over stale persisted type', async () => {
+    useAppStore.setState({ workspaces: [workspace('/workspace/photo.png', 'pdf')], selectedWorkspaceId: 'ws-1' })
+    fsReadBinary.mockResolvedValue(Uint8Array.from([0x89, 0x50, 0x4e, 0x47]).buffer)
+
+    mount()
+    expect(host.textContent).toContain('Loading photo.png…')
+    await flush()
+
+    expect(fsReadBinary).toHaveBeenCalledWith('/workspace/photo.png', 'ws-1')
+    const image = host.querySelector('img')
+    expect(image?.alt).toBe('photo.png')
+    expect(image?.getAttribute('src')).toBe('data:image/png;base64,iVBORw==')
+    expect(pdfMocks.getDocument).not.toHaveBeenCalled()
+  })
+
+  it('offers Finder recovery for a failed local file and forwards the workspace id', async () => {
+    useAppStore.setState({ workspaces: [workspace('/workspace/missing.pdf', 'pdf')], selectedWorkspaceId: 'ws-1' })
+    fsReadBinary.mockRejectedValue(new Error('Permission denied'))
+
+    mount()
+    await flush()
+
+    expect(host.textContent).toContain('Permission denied')
+    const button = Array.from(host.querySelectorAll('button')).find((candidate) => candidate.textContent === 'Show in Finder')
+    expect(button).toBeTruthy()
+    act(() => button!.click())
+    expect(shellShowInFolder).toHaveBeenCalledWith('/workspace/missing.pdf', 'ws-1')
+  })
+
+  it('does not offer a local Finder action for a remote document', async () => {
+    useAppStore.setState({
+      workspaces: [workspace('cate-runtime://srv_1/home/me/missing.pdf', 'pdf')],
+      selectedWorkspaceId: 'ws-1',
+    })
+    fsReadBinary.mockRejectedValue(new Error('Remote unavailable'))
+
+    mount()
+    await flush()
+
+    expect(host.textContent).toContain('Remote unavailable')
+    expect(host.textContent).not.toContain('Show in Finder')
+  })
+
+  it('ignores an obsolete read when the panel file changes before it resolves', async () => {
+    let resolveFirst!: (value: ArrayBuffer) => void
+    const first = new Promise<ArrayBuffer>((resolve) => { resolveFirst = resolve })
+    fsReadBinary
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(Uint8Array.from([0xff, 0xd8, 0xff, 0x00]).buffer)
+    useAppStore.setState({ workspaces: [workspace('/workspace/first.png', 'image')], selectedWorkspaceId: 'ws-1' })
+    mount()
+
+    act(() => {
+      useAppStore.setState({ workspaces: [workspace('/workspace/second.jpg', 'image')] })
+    })
+    await flush()
+    expect(host.querySelector('img')?.alt).toBe('second.jpg')
+
+    await act(async () => {
+      resolveFirst(Uint8Array.from([0x25, 0x50, 0x44, 0x46]).buffer)
+      await first
+    })
+    expect(host.querySelector('img')?.alt).toBe('second.jpg')
+    expect(pdfMocks.getDocument).not.toHaveBeenCalled()
+  })
+
+  it('destroys an in-flight PDF loading task on unmount', async () => {
+    const destroy = vi.fn(async () => undefined)
+    pdfMocks.getDocument.mockReturnValue({
+      promise: new Promise(() => {}),
+      destroy,
+    })
+    useAppStore.setState({ workspaces: [workspace('/workspace/report.pdf', 'pdf')], selectedWorkspaceId: 'ws-1' })
+    fsReadBinary.mockResolvedValue(Uint8Array.from([0x25, 0x50, 0x44, 0x46]).buffer)
+
+    mount()
+    await flush()
+    expect(pdfMocks.getDocument).toHaveBeenCalledTimes(1)
+
+    act(() => root.unmount())
+    expect(destroy).toHaveBeenCalledTimes(1)
+    root = createRoot(host)
+  })
+})

--- a/src/renderer/panels/PanelHost.test.tsx
+++ b/src/renderer/panels/PanelHost.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const registryMocks = vi.hoisted(() => ({
+  getPanelDef: vi.fn(),
+  renderPanelComponent: vi.fn(),
+}))
+
+vi.mock('./registry', () => registryMocks)
+vi.mock('./PanelSuspense', () => ({
+  PanelSuspense: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+import { PanelHost } from './PanelHost'
+import type { PanelRenderContext } from './registry'
+import type { PanelState } from '../../shared/types'
+
+let host: HTMLDivElement
+let root: Root
+
+function panel(id: string, type: PanelState['type']): PanelState {
+  return { id, type, title: id } as PanelState
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  registryMocks.getPanelDef.mockReturnValue({ canLiveOnCanvas: true })
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('PanelHost', () => {
+  it('renders nothing for a missing panel record', () => {
+    act(() => {
+      root.render(<PanelHost panelId="missing" panels={{}} workspaceId="ws-1" />)
+    })
+
+    expect(host.innerHTML).toBe('')
+    expect(registryMocks.renderPanelComponent).not.toHaveBeenCalled()
+  })
+
+  it('blocks a nested panel type that cannot live on a canvas', () => {
+    registryMocks.getPanelDef.mockReturnValue({ canLiveOnCanvas: false })
+    const panels = { nested: panel('nested', 'canvas') }
+
+    act(() => {
+      root.render(
+        <PanelHost
+          panelId="nested"
+          panels={panels}
+          workspaceId="ws-1"
+          allowCanvas={false}
+        />,
+      )
+    })
+
+    expect(host.innerHTML).toBe('')
+    expect(registryMocks.renderPanelComponent).not.toHaveBeenCalled()
+  })
+
+  it('routes workspace, node, and zoom context through a nested canvas render', () => {
+    const panels = {
+      canvas: panel('canvas', 'canvas'),
+      child: panel('child', 'editor'),
+    }
+    registryMocks.renderPanelComponent.mockImplementation((record: PanelState, context: PanelRenderContext) => {
+      if (record.id === 'canvas') {
+        return <div>{context.renderPanelContent?.('child', 'child-node', 2)}</div>
+      }
+      return <span>Child editor</span>
+    })
+
+    act(() => {
+      root.render(
+        <PanelHost
+          panelId="canvas"
+          panels={panels}
+          workspaceId="ws-1"
+          nodeId="canvas-node"
+          zoomLevel={0.75}
+        />,
+      )
+    })
+
+    expect(host.textContent).toBe('Child editor')
+    expect(registryMocks.renderPanelComponent).toHaveBeenCalledTimes(2)
+    expect(registryMocks.renderPanelComponent.mock.calls[0][1]).toMatchObject({
+      workspaceId: 'ws-1',
+      nodeId: 'canvas-node',
+      zoomLevel: 0.75,
+    })
+    expect(registryMocks.renderPanelComponent.mock.calls[1][1]).toMatchObject({
+      workspaceId: 'ws-1',
+      nodeId: 'child-node',
+      zoomLevel: 2,
+    })
+  })
+})

--- a/src/renderer/settings/UpdatesSettings.test.tsx
+++ b/src/renderer/settings/UpdatesSettings.test.tsx
@@ -1,0 +1,49 @@
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS } from '../../shared/types'
+import { useSettingsStore } from '../stores/settingsStore'
+import { UpdatesSettings } from './UpdatesSettings'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('UpdatesSettings', () => {
+  let host: HTMLDivElement
+  let root: Root
+  let settingsSet: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    settingsSet = vi.fn(async () => {})
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      writable: true,
+      value: { settingsSet },
+    })
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, _loaded: true })
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+  })
+
+  it('persists the beta-build toggle through the settings IPC contract', () => {
+    act(() => root.render(<UpdatesSettings />))
+    const toggle = host.querySelector('button')
+    expect(toggle).not.toBeNull()
+
+    act(() => toggle?.click())
+
+    expect(useSettingsStore.getState().betaUpdatesEnabled).toBe(true)
+    expect(settingsSet).toHaveBeenCalledTimes(1)
+    expect(settingsSet).toHaveBeenCalledWith('betaUpdatesEnabled', true)
+  })
+})

--- a/src/renderer/stores/settingsStore.test.tsx
+++ b/src/renderer/stores/settingsStore.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppSettings } from '../../shared/types'
+import { DEFAULT_SETTINGS } from '../../shared/types'
+
+type ReloadCallback = (settings: Partial<AppSettings>) => void
+
+function createSettingsAPI() {
+  let reloadCallback: ReloadCallback | undefined
+  const api = {
+    settingsGet: vi.fn(),
+    settingsSet: vi.fn(async () => {}),
+    settingsGetAll: vi.fn(async (): Promise<Partial<AppSettings>> => ({})),
+    settingsReset: vi.fn(async () => {}),
+    onSettingsReloaded: vi.fn((callback: ReloadCallback) => {
+      reloadCallback = callback
+      return vi.fn()
+    }),
+  }
+  return { api, getReloadCallback: () => reloadCallback }
+}
+
+async function loadStore() {
+  vi.resetModules()
+  return import('./settingsStore')
+}
+
+describe('settingsStore', () => {
+  let harness: ReturnType<typeof createSettingsAPI>
+
+  beforeEach(() => {
+    harness = createSettingsAPI()
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      writable: true,
+      value: harness.api,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+  })
+
+  it('hydrates known settings once and projects subsequent main-process reloads', async () => {
+    harness.api.settingsGetAll.mockResolvedValue({
+      editorFontSize: 18,
+      browserSearchEngine: 'brave',
+      unknownSetting: 'ignored',
+    } as Partial<AppSettings>)
+    const { useSettingsStore } = await loadStore()
+
+    const firstLoad = useSettingsStore.getState().loadSettings()
+    const secondLoad = useSettingsStore.getState().loadSettings()
+    expect(secondLoad).toBe(firstLoad)
+    await firstLoad
+
+    expect(harness.api.settingsGetAll).toHaveBeenCalledTimes(1)
+    expect(harness.api.onSettingsReloaded).toHaveBeenCalledTimes(1)
+    expect(useSettingsStore.getState()).toMatchObject({
+      editorFontSize: 18,
+      browserSearchEngine: 'brave',
+      warnBeforeQuit: DEFAULT_SETTINGS.warnBeforeQuit,
+      _loaded: true,
+    })
+    expect((useSettingsStore.getState() as unknown as Record<string, unknown>).unknownSetting).toBeUndefined()
+
+    harness.getReloadCallback()?.({
+      editorFontSize: 21,
+      unknownSetting: 'still ignored',
+    } as Partial<AppSettings>)
+
+    expect(useSettingsStore.getState().editorFontSize).toBe(21)
+    expect((useSettingsStore.getState() as unknown as Record<string, unknown>).unknownSetting).toBeUndefined()
+  })
+
+  it('finishes loading with defaults when the initial IPC read fails', async () => {
+    harness.api.settingsGetAll.mockRejectedValue(new Error('settings unavailable'))
+    const { useSettingsStore } = await loadStore()
+
+    await expect(useSettingsStore.getState().loadSettings()).resolves.toBeUndefined()
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      editorFontSize: DEFAULT_SETTINGS.editorFontSize,
+      warnBeforeQuit: DEFAULT_SETTINGS.warnBeforeQuit,
+      _loaded: true,
+    })
+    expect(harness.api.onSettingsReloaded).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates optimistically and persists single-setting and all-setting resets', async () => {
+    const { useSettingsStore } = await loadStore()
+    useSettingsStore.setState({ _loaded: true })
+
+    useSettingsStore.getState().setSetting('editorFontSize', 20)
+    expect(useSettingsStore.getState().editorFontSize).toBe(20)
+    expect(harness.api.settingsSet).toHaveBeenCalledWith('editorFontSize', 20)
+
+    useSettingsStore.getState().resetSetting('editorFontSize')
+    expect(useSettingsStore.getState().editorFontSize).toBe(DEFAULT_SETTINGS.editorFontSize)
+    expect(harness.api.settingsReset).toHaveBeenCalledWith('editorFontSize')
+
+    useSettingsStore.setState({ warnBeforeQuit: true, browserHomepage: 'https://example.test' })
+    useSettingsStore.getState().resetAll()
+    expect(useSettingsStore.getState()).toMatchObject({
+      warnBeforeQuit: DEFAULT_SETTINGS.warnBeforeQuit,
+      browserHomepage: DEFAULT_SETTINGS.browserHomepage,
+      _loaded: true,
+    })
+    expect(harness.api.settingsReset).toHaveBeenLastCalledWith()
+  })
+
+  it('keeps optimistic state when persistence rejects without leaking the rejection', async () => {
+    harness.api.settingsSet.mockRejectedValue(new Error('disk full'))
+    harness.api.settingsReset.mockRejectedValue(new Error('disk full'))
+    const { useSettingsStore } = await loadStore()
+
+    useSettingsStore.getState().setSetting('warnBeforeQuit', true)
+    await Promise.resolve()
+    expect(useSettingsStore.getState().warnBeforeQuit).toBe(true)
+
+    useSettingsStore.getState().resetSetting('editorFontSize')
+    useSettingsStore.getState().resetAll()
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(useSettingsStore.getState().warnBeforeQuit).toBe(DEFAULT_SETTINGS.warnBeforeQuit)
+    expect(useSettingsStore.getState().editorFontSize).toBe(DEFAULT_SETTINGS.editorFontSize)
+    expect(harness.api.settingsSet).toHaveBeenCalledWith('warnBeforeQuit', true)
+    expect(harness.api.settingsReset).toHaveBeenCalledWith('editorFontSize')
+    expect(harness.api.settingsReset).toHaveBeenCalledWith()
+  })
+})

--- a/src/renderer/stores/useParallelWork.test.tsx
+++ b/src/renderer/stores/useParallelWork.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const h = vi.hoisted(() => {
+  // appStore's import graph initializes the optional worktree territory canvas.
+  // jsdom logs for every getContext call unless the API is stubbed locally.
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null),
+  })
+  return { refresh: vi.fn() }
+})
+
+vi.mock('./gitStatusStore', () => ({
+  gitStatusStore: { refresh: h.refresh },
+}))
+
+vi.mock('./useWorktreeActions', () => ({
+  useWorktreeActions: () => ({
+    createWorktree: vi.fn(),
+    checkoutPr: vi.fn(),
+  }),
+}))
+
+import { useAppStore } from './appStore'
+import { useSettingsStore } from './settingsStore'
+import { useParallelWork, type UseParallelWork, type WorktreeStatus } from './useParallelWork'
+import type { JoinedWorktree } from './useWorktrees'
+
+const ROOT = '/repo'
+const WS = 'ws-1'
+const worktree: JoinedWorktree = {
+  id: 'wt-feature',
+  path: '/repo/.cate/worktrees/feature',
+  branch: 'feature',
+  label: 'Feature',
+  color: '#abcdef',
+  isPrimary: false,
+  isCurrent: false,
+  isOrphan: false,
+}
+
+let host: HTMLDivElement
+let root: Root
+let actions: UseParallelWork
+let setError: ReturnType<typeof vi.fn<(value: string | null) => void>>
+let setBusy: ReturnType<typeof vi.fn<(value: string | null) => void>>
+const initialAppState = useAppStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+
+function Probe(): React.ReactElement {
+  actions = useParallelWork(ROOT, WS, 'main', { setError, setBusy })
+  return <div />
+}
+
+function workspace() {
+  return useAppStore.getState().workspaces.find((ws) => ws.id === WS)!
+}
+
+function status(overrides: Partial<WorktreeStatus> = {}): WorktreeStatus {
+  return {
+    branch: 'feature',
+    dirty: false,
+    ahead: 0,
+    behind: 0,
+    staged: 0,
+    unstaged: 0,
+    untracked: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  h.refresh.mockReset()
+  setError = vi.fn()
+  setBusy = vi.fn()
+  useSettingsStore.setState({
+    ...initialSettingsState,
+    closeWorktreePanelsOnDelete: true,
+  }, true)
+  useAppStore.setState({
+    ...initialAppState,
+    workspaces: [{
+      id: WS,
+      name: 'Repo',
+      color: '',
+      rootPath: ROOT,
+      worktrees: [
+        { id: 'primary', path: ROOT, color: '#112233' },
+        { id: worktree.id, path: worktree.path, color: '#abcdef' },
+      ],
+      panels: {},
+    }],
+    selectedWorkspaceId: WS,
+  }, true)
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    gitWorktreeStatus: vi.fn().mockResolvedValue(status()),
+    gitWorktreeRemove: vi.fn().mockResolvedValue(undefined),
+    gitBranchDelete: vi.fn().mockResolvedValue(undefined),
+  }
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root.render(<Probe />))
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  useAppStore.setState(initialAppState, true)
+  useSettingsStore.setState(initialSettingsState, true)
+})
+
+describe('useParallelWork handleDelete', () => {
+  it('uses fresh dirty status for confirmation and force-removes disk and store state', async () => {
+    vi.mocked(window.electronAPI.gitWorktreeStatus).mockResolvedValueOnce(status({ dirty: true, ahead: 2 }))
+
+    await act(async () => {
+      await actions.handleDelete(worktree)
+    })
+
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('unsaved changes here will be lost'))
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('2 unpublished commit(s) will be lost'))
+    expect(window.electronAPI.gitWorktreeRemove).toHaveBeenCalledWith(
+      ROOT,
+      worktree.path,
+      { force: true },
+      WS,
+    )
+    expect(window.electronAPI.gitBranchDelete).toHaveBeenCalledWith(ROOT, 'feature', true, WS)
+    expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(false)
+    expect(h.refresh).toHaveBeenCalledWith(ROOT)
+    expect(setBusy.mock.calls).toEqual([[worktree.id], [null]])
+  })
+
+  it('preserves renderer state and reports the error when disk removal fails', async () => {
+    vi.mocked(window.electronAPI.gitWorktreeRemove).mockRejectedValueOnce(new Error('worktree locked'))
+
+    await act(async () => {
+      await actions.handleDelete(worktree)
+    })
+
+    expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(true)
+    expect(window.electronAPI.gitBranchDelete).not.toHaveBeenCalled()
+    expect(h.refresh).not.toHaveBeenCalled()
+    expect(setError).toHaveBeenCalledWith('worktree locked')
+    expect(setBusy.mock.calls).toEqual([[worktree.id], [null]])
+  })
+
+  it('finishes store removal but reports a partial failure when branch deletion fails', async () => {
+    vi.mocked(window.electronAPI.gitBranchDelete).mockRejectedValueOnce(new Error('branch protected'))
+
+    await act(async () => {
+      await actions.handleDelete(worktree)
+    })
+
+    expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(false)
+    expect(setError).toHaveBeenCalledWith('Removed, but branch feature could not be deleted: branch protected')
+    expect(h.refresh).toHaveBeenCalledWith(ROOT)
+  })
+
+  it('does not remove anything when the user cancels', async () => {
+    vi.mocked(window.confirm).mockReturnValueOnce(false)
+
+    await act(async () => {
+      await actions.handleDelete(worktree)
+    })
+
+    expect(window.electronAPI.gitWorktreeRemove).not.toHaveBeenCalled()
+    expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(true)
+    expect(setBusy).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/stores/useWorktreeActions.test.tsx
+++ b/src/renderer/stores/useWorktreeActions.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const h = vi.hoisted(() => {
+  // appStore's import graph initializes the optional worktree territory canvas.
+  // jsdom logs for every getContext call unless the API is stubbed locally.
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null),
+  })
+  return {
+    refresh: vi.fn(),
+    newWorktreeId: vi.fn(() => 'wt-test'),
+  }
+})
+
+vi.mock('./gitStatusStore', () => ({
+  gitStatusStore: { refresh: h.refresh },
+}))
+
+vi.mock('../lib/worktreeSync', () => ({
+  newWorktreeId: h.newWorktreeId,
+}))
+
+import { useAppStore } from './appStore'
+import { useSettingsStore } from './settingsStore'
+import { useWorktreeActions, type WorktreeActions } from './useWorktreeActions'
+
+const ROOT = '/repo/'
+const WS = 'ws-1'
+
+let host: HTMLDivElement
+let root: Root
+let actions: WorktreeActions
+const initialAppState = useAppStore.getState()
+const initialSettingsState = useSettingsStore.getState()
+
+function Probe(): React.ReactElement {
+  actions = useWorktreeActions(ROOT, WS)
+  return <div />
+}
+
+function workspace() {
+  return useAppStore.getState().workspaces.find((ws) => ws.id === WS)!
+}
+
+beforeEach(() => {
+  h.refresh.mockReset()
+  h.newWorktreeId.mockReset().mockReturnValue('wt-test')
+  useAppStore.setState({
+    ...initialAppState,
+    workspaces: [{
+      id: WS,
+      name: 'Repo',
+      color: '',
+      rootPath: '/repo',
+      panels: {},
+      worktrees: [{ id: 'primary', path: '/repo', color: '#112233' }],
+    }],
+    selectedWorkspaceId: WS,
+  }, true)
+  useSettingsStore.setState({
+    ...initialSettingsState,
+    worktreeSymlinkPaths: [' node_modules ', '', ' .env.local '],
+  }, true)
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    gitWorktreeAdd: vi.fn().mockResolvedValue(undefined),
+    gitWorktreeAddFromPr: vi.fn(),
+  }
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => root.render(<Probe />))
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  useAppStore.setState(initialAppState, true)
+  useSettingsStore.setState(initialSettingsState, true)
+})
+
+describe('useWorktreeActions', () => {
+  it('creates a sanitized branch, then registers and refreshes its worktree', async () => {
+    await act(async () => {
+      await actions.createWorktree('  Fix login bug!  ', 'origin/release')
+    })
+
+    expect(window.electronAPI.gitWorktreeAdd).toHaveBeenCalledWith(
+      ROOT,
+      'Fix-login-bug',
+      '/repo/.cate/worktrees/Fix-login-bug',
+      {
+        createBranch: true,
+        baseRef: 'origin/release',
+        symlinkPaths: ['node_modules', '.env.local'],
+      },
+      WS,
+    )
+    expect(workspace().worktrees).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'wt-test',
+        path: '/repo/.cate/worktrees/Fix-login-bug',
+        label: 'Fix login bug!',
+      }),
+    ]))
+    expect(workspace().additionalRoots).toContain('/repo/.cate/worktrees/Fix-login-bug')
+    expect(h.refresh).toHaveBeenCalledWith(ROOT)
+  })
+
+  it('does not mutate renderer state when creating the worktree fails', async () => {
+    const failure = new Error('branch already exists')
+    vi.mocked(window.electronAPI.gitWorktreeAdd).mockRejectedValueOnce(failure)
+
+    await expect(actions.createWorktree('feature')).rejects.toBe(failure)
+
+    expect(workspace().worktrees).toHaveLength(1)
+    expect(workspace().additionalRoots).toBeUndefined()
+    expect(h.refresh).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty sanitized name before invoking git', async () => {
+    await expect(actions.createWorktree(' !!! ')).rejects.toThrow('Please enter a name')
+
+    expect(window.electronAPI.gitWorktreeAdd).not.toHaveBeenCalled()
+    expect(h.refresh).not.toHaveBeenCalled()
+  })
+
+  it('checks out a PR with a collision-resistant path and trusts the returned path', async () => {
+    vi.mocked(window.electronAPI.gitWorktreeAddFromPr).mockResolvedValueOnce({
+      path: '/runtime/repo/.cate/worktrees/pr-42-fork-feature',
+      branch: 'fork-feature',
+    })
+    const pr = {
+      number: 42,
+      title: 'Feature',
+      headRefName: 'fork/feature',
+      author: 'contributor',
+      isFork: true,
+    }
+
+    await act(async () => {
+      await actions.checkoutPr(pr)
+    })
+
+    expect(window.electronAPI.gitWorktreeAddFromPr).toHaveBeenCalledWith(
+      ROOT,
+      42,
+      '/repo/.cate/worktrees/pr-42-fork-feature',
+      { symlinkPaths: ['node_modules', '.env.local'] },
+      WS,
+    )
+    expect(workspace().worktrees).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'wt-test',
+        path: '/runtime/repo/.cate/worktrees/pr-42-fork-feature',
+        label: '#42 fork/feature',
+      }),
+    ]))
+    expect(workspace().additionalRoots).toContain('/runtime/repo/.cate/worktrees/pr-42-fork-feature')
+    expect(h.refresh).toHaveBeenCalledWith(ROOT)
+  })
+})

--- a/src/skills/main/skillPath.ts
+++ b/src/skills/main/skillPath.ts
@@ -1,0 +1,9 @@
+/** Split a bundle-relative file path, rejecting paths that can escape its root. */
+export function skillPathSegments(relPath: string): string[] {
+  const segments = relPath.split(/[\\/]/)
+  const isAbsolute = /^[\\/]/.test(relPath) || /^[a-zA-Z]:[\\/]/.test(relPath)
+  if (isAbsolute || segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new Error(`Unsafe skill file path: ${relPath}`)
+  }
+  return segments
+}

--- a/src/skills/main/skillStore.test.ts
+++ b/src/skills/main/skillStore.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-skill-store-'))
+
+vi.mock('electron', () => ({ app: { getPath: () => userData } }))
+
+import { cache, has, read, remove } from './skillStore'
+
+beforeEach(() => {
+  fs.rmSync(path.join(userData, 'skills-store'), { recursive: true, force: true })
+  fs.rmSync(path.join(userData, 'outside.md'), { force: true })
+})
+
+afterAll(() => {
+  fs.rmSync(userData, { recursive: true, force: true })
+})
+
+describe('skillStore', () => {
+  it('round-trips nested text and binary files under a sanitized skill key', async () => {
+    const binary = Buffer.from([0xff, 0x00, 0xfe])
+    await cache('owner/repo:demo', [
+      { relPath: 'SKILL.md', text: 'skill body' },
+      { relPath: 'references/guide.md', text: 'guide' },
+      { relPath: 'assets/icon.bin', base64: binary.toString('base64') },
+    ])
+
+    expect(await has('owner/repo:demo')).toBe(true)
+    expect(await read('owner/repo:demo')).toEqual(expect.arrayContaining([
+      { relPath: 'SKILL.md', text: 'skill body' },
+      { relPath: 'references/guide.md', text: 'guide' },
+      { relPath: 'assets/icon.bin', base64: binary.toString('base64') },
+    ]))
+    expect(fs.existsSync(path.join(userData, 'skills-store', 'owner_repo_demo', 'SKILL.md'))).toBe(true)
+  })
+
+  it('re-caching replaces stale files and remove drops the entry', async () => {
+    await cache('demo', [
+      { relPath: 'SKILL.md', text: 'old' },
+      { relPath: 'stale.md', text: 'stale' },
+    ])
+    await cache('demo', [{ relPath: 'SKILL.md', text: 'new' }])
+
+    expect(await read('demo')).toEqual([{ relPath: 'SKILL.md', text: 'new' }])
+    expect(fs.existsSync(path.join(userData, 'skills-store', 'demo', 'stale.md'))).toBe(false)
+
+    await remove('demo')
+    expect(await has('demo')).toBe(false)
+    expect(await read('demo')).toBeNull()
+  })
+
+  it('rejects traversal before deleting an existing good cache entry', async () => {
+    await cache('demo', [{ relPath: 'SKILL.md', text: 'known-good' }])
+
+    await expect(cache('demo', [
+      { relPath: 'SKILL.md', text: 'replacement' },
+      { relPath: '../../outside.md', text: 'escaped' },
+    ])).rejects.toThrow('Unsafe skill file path')
+
+    expect(await read('demo')).toEqual([{ relPath: 'SKILL.md', text: 'known-good' }])
+    expect(fs.existsSync(path.join(userData, 'outside.md'))).toBe(false)
+  })
+})

--- a/src/skills/main/skillStore.ts
+++ b/src/skills/main/skillStore.ts
@@ -11,6 +11,7 @@ import { app } from 'electron'
 import fs from 'fs/promises'
 import path from 'path'
 import type { SkillFile } from './githubCrawl'
+import { skillPathSegments } from './skillPath'
 
 function storeRoot(): string {
   return path.join(app.getPath('userData'), 'skills-store')
@@ -66,10 +67,13 @@ export async function read(skillId: string): Promise<SkillFile[] | null> {
 /** Cache a skill's files (used when promoting a skill to global). */
 export async function cache(skillId: string, files: SkillFile[]): Promise<void> {
   const dir = skillDir(skillId)
+  // Validate before removing an existing good cache entry. Skill bundles can
+  // come from remote sources and must never write outside their cache root.
+  const writes = files.map((file) => ({ file, segments: skillPathSegments(file.relPath) }))
   await fs.rm(dir, { recursive: true, force: true })
   await fs.mkdir(dir, { recursive: true })
-  for (const f of files) {
-    const abs = path.join(dir, ...f.relPath.split('/'))
+  for (const { file: f, segments } of writes) {
+    const abs = path.join(dir, ...segments)
     await fs.mkdir(path.dirname(abs), { recursive: true })
     if (f.text != null) await fs.writeFile(abs, f.text, 'utf-8')
     else if (f.base64 != null) await fs.writeFile(abs, Buffer.from(f.base64, 'base64'))

--- a/src/skills/main/skillsInstaller.test.ts
+++ b/src/skills/main/skillsInstaller.test.ts
@@ -112,7 +112,8 @@ describe('skillsInstaller workspace manifest', () => {
 
     expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('name: demo-skill')
     expect(files.get(`${WS}/.codex/skills/demo-skill/references/guide.md`)).toBe('guide')
-    expect(manifest().skills).toEqual([
+    const skills = manifest().skills.map((skill) => ({ ...skill, path: norm(skill.path) }))
+    expect(skills).toEqual([
       expect.objectContaining({ targetId: 'claude-code', path: '/claude' }),
       expect.objectContaining({ skillId: entry().id, targetId: 'codex', path: `${WS}/.codex/skills/demo-skill/SKILL.md` }),
     ])

--- a/src/skills/main/skillsInstaller.test.ts
+++ b/src/skills/main/skillsInstaller.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SkillEntry } from '../../shared/skills'
+
+const resolve = vi.hoisted(() => vi.fn())
+const store = vi.hoisted(() => ({
+  read: vi.fn(),
+  has: vi.fn(),
+  cache: vi.fn(),
+  remove: vi.fn(),
+}))
+const saved = vi.hoisted(() => ({ addSaved: vi.fn(), removeSaved: vi.fn() }))
+const fetchSkillFiles = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+vi.mock('../../main/logger', () => ({ default: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }))
+vi.mock('../../main/runtime/runtimeManager', () => ({ runtimes: { resolve } }))
+vi.mock('./skillStore', () => store)
+vi.mock('./savedSkills', () => saved)
+vi.mock('./skillSources', () => ({ getToken: () => 'token' }))
+vi.mock('./githubCrawl', () => ({ fetchSkillFiles }))
+
+import { install, uninstall, writeSkillToWorkspace } from './skillsInstaller'
+
+const WS = '/workspace'
+const MANIFEST = `${WS}/.cate/skills.json`
+const norm = (value: string): string => value.replace(/\\/g, '/')
+
+let files: Map<string, string>
+let dirs: Set<string>
+let removeError: Error | null
+let removed: string[]
+
+function makeRuntime() {
+  return {
+    file: {
+      readFile: async (file: string) => {
+        const value = files.get(norm(file))
+        if (value == null) throw new Error(`ENOENT: ${file}`)
+        return value
+      },
+      writeFile: async (file: string, content: string) => {
+        files.set(norm(file), content)
+        return file
+      },
+      writeBinary: async (file: string, content: Buffer) => {
+        files.set(norm(file), content.toString('base64'))
+        return file
+      },
+      mkdir: async (dir: string) => { dirs.add(norm(dir)) },
+      remove: async (target: string) => {
+        removed.push(norm(target))
+        if (removeError) throw removeError
+        files.delete(norm(target))
+      },
+    },
+  }
+}
+
+function entry(): SkillEntry {
+  return {
+    id: 'owner/repo/demo',
+    name: 'Demo Skill',
+    description: 'demo',
+    tags: [],
+    format: 'skill-md',
+    source: { repo: 'owner/repo', ref: 'main', path: 'skills/demo' },
+    provenance: 'curated',
+    sourceId: 'owner/repo',
+  }
+}
+
+function manifest(): { skills: Array<{ skillId: string; targetId: string; path: string }>; seeded?: string[] } {
+  return JSON.parse(files.get(MANIFEST) ?? '{"skills":[]}')
+}
+
+beforeEach(() => {
+  files = new Map()
+  dirs = new Set([WS])
+  removed = []
+  removeError = null
+  resolve.mockReset().mockReturnValue(makeRuntime())
+  store.read.mockReset().mockResolvedValue(null)
+  store.has.mockReset().mockResolvedValue(false)
+  store.cache.mockReset().mockResolvedValue(undefined)
+  store.remove.mockReset().mockResolvedValue(undefined)
+  saved.addSaved.mockReset()
+  saved.removeSaved.mockReset()
+  fetchSkillFiles.mockReset().mockResolvedValue([])
+})
+
+describe('skillsInstaller workspace manifest', () => {
+  it('replaces only the matching target entry and preserves seed markers', async () => {
+    files.set(MANIFEST, JSON.stringify({
+      skills: [
+        { skillId: entry().id, name: 'old', targetId: 'codex', path: '/old', origin: 'local' },
+        { skillId: entry().id, name: 'Demo Skill', targetId: 'claude-code', path: '/claude', origin: 'local' },
+      ],
+      seeded: ['cate/cate-cli:cate-agent'],
+    }))
+
+    await writeSkillToWorkspace({
+      skillId: entry().id,
+      name: entry().name,
+      targetId: 'codex',
+      cwd: WS,
+      origin: 'local',
+      files: [
+        { relPath: 'SKILL.md', text: '---\nname: wrong\n---\nbody' },
+        { relPath: 'references/guide.md', text: 'guide' },
+      ],
+    })
+
+    expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('name: demo-skill')
+    expect(files.get(`${WS}/.codex/skills/demo-skill/references/guide.md`)).toBe('guide')
+    expect(manifest().skills).toEqual([
+      expect.objectContaining({ targetId: 'claude-code', path: '/claude' }),
+      expect.objectContaining({ skillId: entry().id, targetId: 'codex', path: `${WS}/.codex/skills/demo-skill/SKILL.md` }),
+    ])
+    expect(manifest().seeded).toEqual(['cate/cate-cli:cate-agent'])
+  })
+
+  it('removes the manifest entry even when deleting the installed files fails', async () => {
+    files.set(MANIFEST, JSON.stringify({
+      skills: [
+        { skillId: entry().id, name: entry().name, targetId: 'codex', path: '/codex', origin: 'local' },
+        { skillId: entry().id, name: entry().name, targetId: 'claude-code', path: '/claude', origin: 'local' },
+      ],
+      seeded: ['keep-me'],
+    }))
+    removeError = new Error('locked')
+
+    await uninstall(entry().id, entry().name, 'codex', WS)
+
+    expect(removed).toEqual([`${WS}/.codex/skills/demo-skill`])
+    expect(manifest().skills).toEqual([expect.objectContaining({ targetId: 'claude-code' })])
+    expect(manifest().seeded).toEqual(['keep-me'])
+  })
+
+  it('rejects traversal paths before changing the workspace or manifest', async () => {
+    files.set(MANIFEST, JSON.stringify({ skills: [], seeded: ['keep-me'] }))
+    const beforeDirs = new Set(dirs)
+
+    await expect(writeSkillToWorkspace({
+      skillId: entry().id,
+      name: entry().name,
+      targetId: 'codex',
+      cwd: WS,
+      origin: 'local',
+      files: [
+        { relPath: 'SKILL.md', text: 'body' },
+        { relPath: '../../outside.md', text: 'escaped' },
+      ],
+    })).rejects.toThrow('Unsafe skill file path')
+
+    expect(dirs).toEqual(beforeDirs)
+    expect(files.get(MANIFEST)).toBe(JSON.stringify({ skills: [], seeded: ['keep-me'] }))
+    expect(files.has(`${WS}/.codex/outside.md`)).toBe(false)
+  })
+})
+
+describe('skillsInstaller resolution cache', () => {
+  it('uses saved bytes without fetching from GitHub', async () => {
+    store.read.mockResolvedValue([{ relPath: 'SKILL.md', text: 'cached' }])
+
+    await install(entry(), 'codex', WS)
+
+    expect(store.read).toHaveBeenCalledWith(entry().id)
+    expect(fetchSkillFiles).not.toHaveBeenCalled()
+    expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('cached')
+  })
+
+  it('fetches only when the saved cache is empty', async () => {
+    fetchSkillFiles.mockResolvedValue([{ relPath: 'SKILL.md', text: 'remote' }])
+
+    await install(entry(), 'codex', WS)
+
+    expect(fetchSkillFiles).toHaveBeenCalledWith(entry().source, 'token')
+    expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('remote')
+  })
+})

--- a/src/skills/main/skillsInstaller.ts
+++ b/src/skills/main/skillsInstaller.ts
@@ -23,6 +23,7 @@ import * as savedSkills from './savedSkills'
 import { getToken } from './skillSources'
 import { slugifySkillName, type InstalledSkill, type SkillEntry, type SkillTargetId } from '../../shared/skills'
 import { fetchSkillFiles, type SkillFile } from './githubCrawl'
+import { skillPathSegments } from './skillPath'
 
 // ---------------------------------------------------------------------------
 // Manifest (<workspace>/.cate/skills.json)
@@ -133,10 +134,12 @@ export async function writeSkillToWorkspace(args: WriteSkillArgs): Promise<Write
   let installedHostPath: string
 
   if (info.layout === 'folder') {
+    // Validate the complete bundle before creating directories or writing files,
+    // so a malformed source cannot escape (or partially modify) the skill root.
+    const bundle = files.map((file) => ({ file, segments: skillPathSegments(file.relPath) }))
     const dir = hostJoin(runtimeId, root, slug)
     await mkdirp(runtime, runtimeId, hostCwd, dir)
-    for (const f of files) {
-      const segs = f.relPath.split('/')
+    for (const { file: f, segments: segs } of bundle) {
       const target = hostJoin(runtimeId, dir, ...segs)
       if (segs.length > 1) {
         await mkdirp(runtime, runtimeId, hostCwd, hostJoin(runtimeId, dir, ...segs.slice(0, -1)))

--- a/src/skills/main/skillsRegistry.test.ts
+++ b/src/skills/main/skillsRegistry.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SkillEntry, SkillSource } from '../../shared/skills'
+
+const crawl = vi.hoisted(() => ({ listSkillsInRepo: vi.fn(), rawText: vi.fn() }))
+const sourceState = vi.hoisted(() => ({ sources: [] as SkillSource[], token: undefined as string | undefined }))
+const logger = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn() }))
+
+vi.mock('./githubCrawl', () => crawl)
+vi.mock('./skillSources', () => ({
+  listSources: () => sourceState.sources,
+  getToken: () => sourceState.token,
+}))
+vi.mock('../../main/logger', () => ({ default: logger }))
+
+import { getMergedIndex, refresh } from './skillsRegistry'
+
+function skill(id: string, repo: string, path: string, provenance: 'curated' | 'user'): SkillEntry {
+  return {
+    id,
+    name: id,
+    description: id,
+    tags: [],
+    format: 'skill-md',
+    source: { repo, ref: 'main', path },
+    provenance,
+    sourceId: repo,
+  }
+}
+
+beforeEach(() => {
+  refresh()
+  sourceState.sources = [{ id: 'user-source', repo: 'user/repo' }]
+  sourceState.token = 'github-token'
+  crawl.listSkillsInRepo.mockReset().mockResolvedValue([])
+  crawl.rawText.mockReset()
+  logger.info.mockReset()
+  logger.warn.mockReset()
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+describe('skillsRegistry cache and merge behavior', () => {
+  it('deduplicates repo paths case-insensitively with curated metadata winning', async () => {
+    const curated = skill('curated-copy', 'Owner/Repo', 'skills/demo', 'curated')
+    const duplicate = skill('user-copy', 'owner/repo', 'skills/demo', 'user')
+    const userOnly = skill('user-only', 'user/repo', 'skills/only', 'user')
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ skills: [curated] }) } as Response)
+    crawl.listSkillsInRepo.mockResolvedValue([duplicate, userOnly])
+
+    const first = await getMergedIndex()
+    const second = await getMergedIndex()
+
+    expect(first).toEqual([expect.objectContaining({ id: 'curated-copy', provenance: 'curated' }), userOnly])
+    expect(second).toEqual(first)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(crawl.listSkillsInRepo).toHaveBeenCalledTimes(1)
+    expect(crawl.listSkillsInRepo).toHaveBeenCalledWith(sourceState.sources[0], 'github-token')
+  })
+
+  it('refresh invalidates both curated and user caches', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ skills: [] }) } as Response)
+
+    await getMergedIndex()
+    await getMergedIndex()
+    refresh()
+    await getMergedIndex()
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(crawl.listSkillsInRepo).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to the bundled curated index and isolates a failed user source', async () => {
+    sourceState.sources = [
+      { id: 'broken', repo: 'broken/repo' },
+      { id: 'working', repo: 'working/repo' },
+    ]
+    vi.mocked(fetch).mockRejectedValue(new Error('offline'))
+    const live = skill('live', 'working/repo', 'skills/live', 'user')
+    crawl.listSkillsInRepo.mockImplementation(async (source: SkillSource) => {
+      if (source.id === 'broken') throw new Error('rate limited')
+      return [live]
+    })
+
+    const merged = await getMergedIndex()
+
+    expect(merged).toContainEqual(live)
+    expect(merged.some((entry) => entry.provenance === 'curated')).toBe(true)
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('curated index unavailable'),
+      expect.stringContaining('offline'),
+    )
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('live crawl failed'),
+      'broken/repo',
+      expect.any(Error),
+    )
+  })
+})

--- a/src/test/piTuiStub.ts
+++ b/src/test/piTuiStub.ts
@@ -1,0 +1,8 @@
+class Component {
+  addChild(_child: unknown): void {}
+}
+
+export class Container extends Component {}
+export class Markdown extends Component {}
+export class Spacer extends Component {}
+export class Text extends Component {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
       'electron-log/renderer': path.resolve(__dirname, 'src/test/electronLogStub.ts'),
       'electron-log/main': path.resolve(__dirname, 'src/test/electronLogStub.ts'),
       'electron-log': path.resolve(__dirname, 'src/test/electronLogStub.ts'),
+      // The vendored subagent extension runs inside pi, where pi-tui is
+      // available. Unit tests exercise its orchestration without that runtime.
+      '@earendil-works/pi-tui': path.resolve(__dirname, 'src/test/piTuiStub.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- add 79 regression tests across agent extensions, agent sessions and IPC, skills, panel components, settings, worktree workflows, the preload bridge, and SSH/WSL transports
- cover lifecycle, routing, persistence, failure, cleanup, concurrency, and platform-specific behavior at previously untested seams
- reject unsafe skill bundle paths before cache or workspace mutation

## Why

A coverage audit found several high-risk systems with no behavioral regression tests or only helper-level coverage. The new suites protect their public contracts without broad production refactors.

The skills tests exposed a concrete path-safety bug: remote skill bundles could contain absolute or parent-relative paths, allowing writes outside the intended root or partial replacement of a known-good cache. Bundle paths are now validated completely before any filesystem mutation.

## Impact

This improves confidence in agent tooling, session replay, skill installation, browser/document panels, settings persistence, worktree operations, IPC bridging, and remote transport behavior. Valid skill installation behavior is unchanged; malformed bundle paths now fail safely.

## Validation

- `npm test`: 2,679 passed, 5 skipped
- `npm run typecheck`
- ESLint on all changed TypeScript files
- `git diff --check`
