### PR TITLE
chore(release): bump version to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.5.1'
+export const RUNTIME_VERSION = '1.5.2'


### PR DESCRIPTION
Bumps package.json, package-lock.json and the generated runtime version to 1.5.2.

Since v1.5.1: unified agent-CLI hook system (status, needs-input, session restore), cate CLI permission matrix and settings section, url mode for extension panels, dock tab bar chrome for detached windows, README rewrite and translation sync.

Tests: `npm test` green (2852 passed).