### PR TITLE
Catalog: filter by category, search, pagination

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -25,6 +25,7 @@ Cate only standardizes how it serves/launches an extension and a small reverse A
 {
   "id": "acme.example",
   "name": "Example",
+  "category": "development",
   "panels": [
     { "id": "main", "label": "Example", "icon": "...", "defaultSize": { "width": 600, "height": 400 } }
   ],
@@ -34,6 +35,19 @@ Cate only standardizes how it serves/launches an extension and a small reverse A
   "cateApi": ["workspace.read", "editor.write", "storage"]
 }
 ```
+
+`category` is the functional grouping Settings → Extensions filters the catalog by. It answers "what do I use this for?", never "how is it built" — the url/frontend/server split is invisible to users. The list is deliberately short (a 20-category catalog filters no better than none), and anything unrecognised or missing falls back to **Other**:
+
+| id | label | typical extensions |
+| --- | --- | --- |
+| `ai` | AI | agent tooling, MCP, model/usage viewers |
+| `development` | Development | editors, code tooling, dev servers |
+| `data` | Data | databases, query/table browsers |
+| `design` | Design | diagrams, whiteboards, visual editors |
+| `productivity` | Productivity | issues, docs, notes, planning |
+| `communication` | Communication | chat, mail, meetings |
+| `sales` | Sales & CRM | CRM and pipeline tools |
+| `other` | Other | fallback |
 
 `server`, `url` and `frontend` are all **optional**, and a manifest normally declares exactly one. Mode precedence when several are present is **`server` > `url` > `frontend`** (a mixed manifest still loads; the extra fields are simply ignored):
 

--- a/skills/cate-extension/SKILL.md
+++ b/skills/cate-extension/SKILL.md
@@ -79,6 +79,7 @@ is always at the artifact root.
   "id": "acme.example",
   "name": "Example",
   "version": "1.0.0",
+  "category": "development",
   "description": "One-line catalog description.",
   "frontend": "dist/index.html",
   "panels": [
@@ -95,6 +96,7 @@ is always at the artifact root.
 | `id` | Required. Must match `^[A-Za-z0-9][A-Za-z0-9._-]*$` (it becomes a filesystem path). Convention: `publisher.name`, e.g. `cate.mermaid`. Invalid id rejects the whole manifest. |
 | `name` | Display name; falls back to `id`. |
 | `version` | SemVer-ish, must match `^[A-Za-z0-9][A-Za-z0-9.+_-]*$` or it is silently dropped (treated as `0.0.0`). The artifact is `<id>-<version>.tgz`; **bump it for every published change**. |
+| `category` | Functional group the catalog filters by: `ai`, `development`, `data`, `design`, `productivity`, `communication`, `sales`, `other`. Pick by what the extension is *for*, not how it is built. Missing or unknown files it under **Other**; the catalog build rejects an unknown value. |
 | `panels` | Required, non-empty. Every panel needs non-empty `id` and `label` or the whole manifest is rejected. `icon` is an inline SVG string. `defaultSize` needs both numbers. |
 | `frontend` | Entry HTML for frontend-only extensions. Ignored when `server` is present (the server serves its own frontend). |
 | `server` | Optional; makes the extension server-backed. `command` required; `readyPath` defaults to `/health`, `portEnv` to `PORT`. |

--- a/src/renderer/settings/ExtensionsSettings.test.tsx
+++ b/src/renderer/settings/ExtensionsSettings.test.tsx
@@ -1,0 +1,111 @@
+// =============================================================================
+// Catalog browsing: category filter, search, and pagination. The catalog can
+// hold far more entries than fit on screen, so these three are what makes it
+// navigable — a regression here silently hides extensions from users.
+// =============================================================================
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useExtensionsStore } from '../stores/extensionsStore'
+import type { ExtensionCategory, ExtensionListEntry } from '../../shared/extensions'
+import { ExtensionsSettings } from './ExtensionsSettings'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function entry(name: string, category?: ExtensionCategory, description = ''): ExtensionListEntry {
+  return {
+    manifest: { id: `acme.${name.toLowerCase()}`, name, category, panels: [{ id: 'main', label: name }] },
+    enabled: false,
+    source: 'catalog',
+    rootDir: '',
+    installed: false,
+    description,
+  }
+}
+
+/** Visible catalog row names, in order. */
+function rowNames(host: HTMLElement): string[] {
+  return Array.from(host.querySelectorAll('.border-subtle > div > div > span:first-of-type')).map(
+    (el) => el.textContent ?? '',
+  )
+}
+
+/** A button by its text, whitespace-insensitive (chips render label+count with
+ *  no separating text node, so "Design 1" and "Design1" are the same button). */
+function button(host: HTMLElement, text: string): HTMLButtonElement | undefined {
+  const want = text.replace(/\s+/g, '')
+  return Array.from(host.querySelectorAll('button')).find(
+    (b) => (b.textContent ?? '').replace(/\s+/g, '') === want,
+  )
+}
+
+describe('ExtensionsSettings — catalog browsing', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      writable: true,
+      value: {
+        extensionList: vi.fn(async () => []),
+        extensionCatalogSources: vi.fn(async () => ['https://example.com/catalog.json']),
+        onExtensionsChanged: vi.fn(),
+      },
+    })
+    // 12 AI entries (two pages) plus one design entry to filter down to.
+    const entries = [
+      ...Array.from({ length: 12 }, (_, i) => entry(`Ai${String(i + 1).padStart(2, '0')}`, 'ai')),
+      entry('Sketch', 'design', 'a whiteboard'),
+    ]
+    useExtensionsStore.setState({ entries, refresh: async () => {} })
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+    act(() => root.render(<ExtensionsSettings />))
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useExtensionsStore.setState({ entries: [] })
+  })
+
+  it('shows at most one page of rows and pages through the rest', () => {
+    expect(rowNames(host)).toHaveLength(10)
+    expect(rowNames(host)[0]).toBe('Ai01')
+
+    act(() => button(host, '2')?.click())
+    // 13 entries, 10 per page -> 3 on the last page.
+    expect(rowNames(host)).toEqual(['Ai11', 'Ai12', 'Sketch'])
+  })
+
+  it('filters by category and drops the pager when one page is left', () => {
+    act(() => button(host, 'Design 1')?.click())
+    expect(rowNames(host)).toEqual(['Sketch'])
+    expect(button(host, '2')).toBeUndefined()
+
+    act(() => button(host, 'All 13')?.click())
+    expect(rowNames(host)).toHaveLength(10)
+  })
+
+  it('searches name and description, and resets to the first page', () => {
+    act(() => button(host, '2')?.click())
+    const input = host.querySelector<HTMLInputElement>('input[placeholder="Search extensions…"]')!
+
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, 'whiteboard')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(rowNames(host)).toEqual(['Sketch'])
+  })
+
+  it('files an uncategorised extension under Other', () => {
+    act(() => useExtensionsStore.setState({ entries: [entry('Loose')] }))
+    act(() => button(host, 'Other 1')?.click())
+    expect(rowNames(host)).toEqual(['Loose'])
+  })
+})

--- a/src/renderer/settings/ExtensionsSettings.tsx
+++ b/src/renderer/settings/ExtensionsSettings.tsx
@@ -4,8 +4,10 @@
 //
 // Three subsections:
 //   1. Catalog — browse catalog entries; install (download), enable/disable, and
-//      manage installed ones (update / reinstall / remove). Opening an
-//      extension's panels happens from the canvas toolbar, not here.
+//      manage installed ones (update / reinstall / remove). Browsing is filtered
+//      by functional category (manifest `category`), narrowed by a search box,
+//      and paginated at CATALOG_PAGE_SIZE rows. Opening an extension's panels
+//      happens from the canvas toolbar, not here.
 //   2. Sideloaded — local dev folders added via "Add local folder…", removable.
 //   3. Catalog sources — view/add/remove catalog source URLs and refresh.
 //
@@ -16,13 +18,19 @@
 // Styling mirrors SkillsSettings.
 // =============================================================================
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
-import { Plus, Trash, CircleNotch, ArrowsClockwise, ArrowCircleUp, Warning, CaretRight } from '@phosphor-icons/react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Plus, Trash, CircleNotch, ArrowsClockwise, ArrowCircleUp, Warning, CaretRight, CaretLeft } from '@phosphor-icons/react'
 import { SettingRow, SearchableBlock, SecondaryButton, Toggle, TextInput } from './SettingsComponents'
 import { Tooltip } from '../ui/Tooltip'
 import { errorMessage } from '../lib/errorMessage'
 import { useExtensionsStore, ensureExtensionsStarted } from '../stores/extensionsStore'
-import type { ExtensionListEntry } from '../../shared/extensions'
+import {
+  EXTENSION_CATEGORIES,
+  extensionCategoryLabel,
+  resolveExtensionCategory,
+  type ExtensionCategory,
+  type ExtensionListEntry,
+} from '../../shared/extensions'
 
 const api = () => window.electronAPI
 
@@ -43,6 +51,78 @@ const PERMISSION_LABELS: Record<string, string> = {
   files: 'Receive dropped files',
   'files.drop': 'Receive dropped files',
 }
+
+/** How many catalog rows one page shows. The catalog is browsed, not scanned —
+ *  a wall of every extension buries the ones a user is looking for. */
+const CATALOG_PAGE_SIZE = 10
+
+/** One category filter chip (also used for the "All" pseudo-category). */
+const CategoryChip = ({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string
+  count: number
+  active: boolean
+  onClick: () => void
+}) => (
+  <button
+    onClick={onClick}
+    aria-pressed={active}
+    className={`shrink-0 text-[11px] px-2 py-0.5 rounded-full border ${
+      active
+        ? 'border-transparent bg-accent text-white'
+        : 'border-subtle bg-surface-2 text-muted hover:text-primary hover:bg-hover'
+    }`}
+  >
+    {label}
+    <span className="ml-1 text-[10px] opacity-60">{count}</span>
+  </button>
+)
+
+/** Numbered pager: ‹ 1 2 3 ›. Rendered only when there is more than one page. */
+const Pager = ({
+  page,
+  pageCount,
+  onPage,
+}: {
+  page: number
+  pageCount: number
+  onPage: (page: number) => void
+}) => (
+  <div className="flex items-center justify-center gap-1 py-1">
+    <button
+      aria-label="Previous page"
+      onClick={() => onPage(page - 1)}
+      disabled={page === 0}
+      className="p-1 rounded text-muted hover:text-primary disabled:opacity-30"
+    >
+      <CaretLeft size={11} />
+    </button>
+    {Array.from({ length: pageCount }, (_, i) => (
+      <button
+        key={i}
+        onClick={() => onPage(i)}
+        aria-current={i === page ? 'page' : undefined}
+        className={`min-w-[20px] text-[11px] px-1.5 py-0.5 rounded ${
+          i === page ? 'bg-surface-3 text-primary' : 'text-muted hover:text-primary hover:bg-hover'
+        }`}
+      >
+        {i + 1}
+      </button>
+    ))}
+    <button
+      aria-label="Next page"
+      onClick={() => onPage(page + 1)}
+      disabled={page >= pageCount - 1}
+      className="p-1 rounded text-muted hover:text-primary disabled:opacity-30"
+    >
+      <CaretRight size={11} />
+    </button>
+  </div>
+)
 
 /** A small muted icon button (reinstall / remove / remove source).
  *  Hoisted to module scope so it isn't redefined on every ExtensionsSettings
@@ -159,6 +239,10 @@ export function ExtensionsSettings() {
   // permissions) is expanded. Keyed by `source:id` so a sideloaded copy of a
   // catalog extension can't collide.
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  // Catalog browse state: free-text query, category filter, and current page.
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState<ExtensionCategory | 'all'>('all')
+  const [page, setPage] = useState(0)
 
   const toggleExpanded = (key: string) =>
     setExpanded((prev) => {
@@ -304,8 +388,42 @@ export function ExtensionsSettings() {
     // removeCatalogSource refreshes the catalog, which broadcasts; store updates.
   }
 
-  const catalogEntries = entries.filter((e) => e.source === 'catalog')
+  const catalogEntries = useMemo(() => entries.filter((e) => e.source === 'catalog'), [entries])
   const sideloadEntries = entries.filter((e) => e.source === 'sideload')
+
+  // ---------------------------------------------------------------------------
+  // Catalog browse — category chips, search, pagination
+  // ---------------------------------------------------------------------------
+
+  /** How many catalog entries fall under each category (chips show the count and
+   *  categories nobody ships are hidden rather than rendered as empty chips). */
+  const categoryCounts = useMemo(() => {
+    const counts = new Map<ExtensionCategory, number>()
+    for (const entry of catalogEntries) {
+      const c = resolveExtensionCategory(entry.manifest)
+      counts.set(c, (counts.get(c) ?? 0) + 1)
+    }
+    return counts
+  }, [catalogEntries])
+
+  const filteredCatalog = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return catalogEntries.filter((entry) => {
+      if (category !== 'all' && resolveExtensionCategory(entry.manifest) !== category) return false
+      if (!q) return true
+      const haystack = `${entry.manifest.name} ${entry.manifest.id} ${entry.description ?? ''}`
+      return haystack.toLowerCase().includes(q)
+    })
+  }, [catalogEntries, category, query])
+
+  const pageCount = Math.max(1, Math.ceil(filteredCatalog.length / CATALOG_PAGE_SIZE))
+  // Clamp instead of resetting in an effect: a shrinking result set (a refresh
+  // that drops entries) must not leave us rendering a page past the end.
+  const currentPage = Math.min(page, pageCount - 1)
+  const pagedCatalog = filteredCatalog.slice(
+    currentPage * CATALOG_PAGE_SIZE,
+    currentPage * CATALOG_PAGE_SIZE + CATALOG_PAGE_SIZE,
+  )
 
   // ---------------------------------------------------------------------------
   // Shared rows
@@ -366,7 +484,14 @@ export function ExtensionsSettings() {
         version={version}
         open={open}
         onToggleExpand={() => toggleExpanded(key)}
-        middle={<span className="flex-1 min-w-0 text-[11px] text-muted truncate">{description}</span>}
+        middle={
+          <>
+            <span className="shrink-0 text-[10px] text-muted px-1.5 py-0.5 rounded bg-surface-3">
+              {extensionCategoryLabel(resolveExtensionCategory(m))}
+            </span>
+            <span className="flex-1 min-w-0 text-[11px] text-muted truncate">{description}</span>
+          </>
+        }
         actions={
           !entry.installed ? (
             <SecondaryButton onClick={() => void install(entry)} disabled={inFlight}>
@@ -427,9 +552,56 @@ export function ExtensionsSettings() {
         </div>
 
         {catalogEntries.length > 0 ? (
-          <div className="my-2 rounded-lg border border-subtle overflow-hidden">
-            {catalogEntries.map(renderCatalogRow)}
-          </div>
+          <>
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              <CategoryChip
+                label="All"
+                count={catalogEntries.length}
+                active={category === 'all'}
+                onClick={() => {
+                  setCategory('all')
+                  setPage(0)
+                }}
+              />
+              {EXTENSION_CATEGORIES.filter((c) => (categoryCounts.get(c.id) ?? 0) > 0).map((c) => (
+                <CategoryChip
+                  key={c.id}
+                  label={c.label}
+                  count={categoryCounts.get(c.id) ?? 0}
+                  active={category === c.id}
+                  onClick={() => {
+                    setCategory(c.id)
+                    setPage(0)
+                  }}
+                />
+              ))}
+            </div>
+
+            <div className="mt-2">
+              <TextInput
+                value={query}
+                onChange={(value) => {
+                  setQuery(value)
+                  setPage(0)
+                }}
+                placeholder="Search extensions…"
+                layoutClassName="w-full px-2"
+              />
+            </div>
+
+            {pagedCatalog.length > 0 ? (
+              <>
+                <div className="my-2 rounded-lg border border-subtle overflow-hidden">
+                  {pagedCatalog.map(renderCatalogRow)}
+                </div>
+                {pageCount > 1 && (
+                  <Pager page={currentPage} pageCount={pageCount} onPage={setPage} />
+                )}
+              </>
+            ) : (
+              <p className="text-[11px] text-muted px-1 py-2">No extensions match this filter.</p>
+            )}
+          </>
         ) : refreshing || initialLoad ? (
           <p className="text-[11px] text-muted px-1 py-2">Loading catalog…</p>
         ) : sources.length === 0 ? (

--- a/src/shared/extensions.test.ts
+++ b/src/shared/extensions.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
-import { normalizeManifest } from './extensions'
+import {
+  EXTENSION_CATEGORIES,
+  extensionCategoryLabel,
+  normalizeManifest,
+  resolveExtensionCategory,
+} from './extensions'
 
 // A minimal valid manifest body, parameterised by id/version, so each test can
 // vary only the field under scrutiny.
@@ -37,6 +42,33 @@ describe('normalizeManifest — id validation', () => {
 
   it('rejects ids containing a NUL byte', () => {
     expect(normalizeManifest(manifest({ id: 'a\u0000b' }))).toBeNull()
+  })
+})
+
+describe('normalizeManifest — category validation', () => {
+  it('keeps every known category id', () => {
+    for (const { id } of EXTENSION_CATEGORIES) {
+      expect(normalizeManifest(manifest({ category: id }))?.category).toBe(id)
+    }
+  })
+
+  it('drops an unknown or non-string category, filing it under Other', () => {
+    for (const category of ['frontend', 'url', '', 42, null, {}]) {
+      const m = normalizeManifest(manifest({ category }))
+      expect(m).not.toBeNull()
+      expect(m?.category).toBeUndefined()
+      expect(resolveExtensionCategory(m ?? undefined)).toBe('other')
+    }
+  })
+
+  it('resolves a missing manifest/category to other', () => {
+    expect(resolveExtensionCategory(undefined)).toBe('other')
+    expect(resolveExtensionCategory(normalizeManifest(manifest()) ?? undefined)).toBe('other')
+  })
+
+  it('labels known ids and falls back to the raw id', () => {
+    expect(extensionCategoryLabel('sales')).toBe('Sales & CRM')
+    expect(extensionCategoryLabel('nope')).toBe('nope')
   })
 })
 
@@ -157,6 +189,12 @@ describe.skipIf(!fs.existsSync(EXTENSIONS_DIR))('shipped manifests on disk', () 
       expect(m, `${id}/manifest.json failed to normalize`).not.toBeNull()
       expect(m?.id).toBe(id)
       expect(m?.panels.length).toBeGreaterThan(0)
+      // A declared category must be one we know — a typo would silently demote
+      // the extension to "Other" in the catalog UI. Absence is fine: the
+      // catalog repo is a separate PR that lands after this one.
+      if (parsed.category !== undefined) {
+        expect(m?.category, `${id}/manifest.json has an unknown category`).toBe(parsed.category)
+      }
     }
   })
 

--- a/src/shared/extensions.ts
+++ b/src/shared/extensions.ts
@@ -16,6 +16,50 @@ export const DEFAULT_READY_PATH = '/health'
 export const DEFAULT_PORT_ENV = 'PORT'
 
 // -----------------------------------------------------------------------------
+// Categories
+// -----------------------------------------------------------------------------
+
+/**
+ * The functional categories an extension can declare, in display order.
+ *
+ * Deliberately few and broad: a category answers "what do I use this for?", not
+ * "how is it built" (url / frontend / server — that is an implementation detail
+ * the user never sees). Keeping the list short is the point — a catalog with 20
+ * categories filters no better than one with none. Anything that doesn't fit
+ * falls back to `other` rather than growing the list.
+ */
+export const EXTENSION_CATEGORIES = [
+  { id: 'ai', label: 'AI' },
+  { id: 'development', label: 'Development' },
+  { id: 'data', label: 'Data' },
+  { id: 'design', label: 'Design' },
+  { id: 'productivity', label: 'Productivity' },
+  { id: 'communication', label: 'Communication' },
+  { id: 'sales', label: 'Sales & CRM' },
+  { id: 'other', label: 'Other' },
+] as const
+
+export type ExtensionCategory = (typeof EXTENSION_CATEGORIES)[number]['id']
+
+/** Used when a manifest declares no category, or one we don't recognise. */
+export const DEFAULT_EXTENSION_CATEGORY: ExtensionCategory = 'other'
+
+/** True if `value` is one of the known category ids. */
+export function isExtensionCategory(value: unknown): value is ExtensionCategory {
+  return EXTENSION_CATEGORIES.some((c) => c.id === value)
+}
+
+/** Human label for a category id (falls back to the raw id). */
+export function extensionCategoryLabel(id: string): string {
+  return EXTENSION_CATEGORIES.find((c) => c.id === id)?.label ?? id
+}
+
+/** The category to file a manifest under — always a known id. */
+export function resolveExtensionCategory(manifest: ExtensionManifest | undefined): ExtensionCategory {
+  return manifest?.category ?? DEFAULT_EXTENSION_CATEGORY
+}
+
+// -----------------------------------------------------------------------------
 // Manifest shape
 // -----------------------------------------------------------------------------
 
@@ -36,6 +80,7 @@ export interface ExtensionManifest {
   id: string                    // e.g. "acme.example"
   name: string
   version?: string
+  category?: ExtensionCategory  // functional grouping in the catalog UI
   panels: ExtensionPanelDef[]
   frontend?: string             // entry html for frontend-only (ignored when server/url present)
   server?: ExtensionServerSpec
@@ -189,6 +234,9 @@ export function normalizeManifest(parsed: unknown): ExtensionManifest | null {
   // manifest; downstream code falls back to '0.0.0'. An unsafe version must
   // never reach a path.
   if (isSafeVersion(parsed.version)) manifest.version = parsed.version
+  // An unknown category is dropped rather than kept: the UI files it under
+  // "Other" instead of inventing a filter chip from untrusted catalog text.
+  if (isExtensionCategory(parsed.category)) manifest.category = parsed.category
   if (nonEmptyString(parsed.frontend)) manifest.frontend = parsed.frontend
 
   const server = normalizeServer(parsed.server)


### PR DESCRIPTION
Catalog in settings was a flat list of everything. Now:

- manifests can declare a `category` (ai, development, data, design, productivity, communication, sales, other)
- category chips with counts, search over name/id/description, 10 rows per page with a numbered pager
- unknown or missing category falls back to Other, so nothing disappears

Categories are functional, not technical: url/frontend/server is invisible to users. Kept the list short on purpose.

Catalog side (tagging the actual extensions): 0-AI-UG/cate-extensions PR follows.