### PR TITLE
docs: trim the README to the landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,36 @@ We would rather say "not yet" in a one paragraph issue than decline a polished P
 
 ## Development Setup
 
-1. Fork and clone the repo
-2. Install dependencies: `npm install`
-3. Start the dev server: `npm run dev`
-
 ### Prerequisites
 
-- Node.js >= 18
-- npm >= 9
-- Python 3 + C++ compiler (for `node-pty` native module)
+- [Bun](https://bun.sh): package manager and script runner.
+- [Node.js](https://nodejs.org/) 20 or 22 LTS (see `.nvmrc`) on your PATH. The build scripts run under it; the runtime daemon bundles its own Node 22.
+- **Linux only:** `node-pty` ships prebuilt binaries for macOS and Windows, but not Linux, so it compiles from source there. Install Python 3 and a C++ toolchain:
+  - Debian/Ubuntu: `sudo apt install build-essential python3`
+  - Fedora/RHEL: `sudo dnf install @development-tools gcc-c++ make python3`
+  - Arch: `sudo pacman -S base-devel python`
+
+Fork and clone the repo, then one command installs dependencies and builds the local runtime daemon:
+
+```bash
+git clone https://github.com/<you>/cate.git
+cd cate
+bun run setup
+```
+
+### Scripts
+
+```bash
+bun run dev          # dev server with hot reload
+bun run typecheck
+bun run lint
+bun run test         # unit tests (vitest)
+bun run test:e2e     # Playwright integration tests
+bun run build        # production build
+bun run package      # package for distribution (:mac, :win, :linux)
+```
+
+Packaged binaries land in `release/`. The runtime daemon is rebuilt by `bun run runtime:tarball` (re-run it after changing anything under `src/runtime/`).
 
 ## Making Changes
 
@@ -59,11 +80,10 @@ We would rather say "not yet" in a one paragraph issue than decline a polished P
 2. Make your changes
 3. Run the checks before you push:
    ```bash
-   npm run typecheck
-   npm run test:unit
-   npm run build
-   npm run typecheck
-   npm run lint
+   bun run typecheck
+   bun run lint
+   bun run test
+   bun run build
    ```
 4. Commit with a clear message following [Conventional Commits](https://www.conventionalcommits.org/):
    ```
@@ -77,7 +97,7 @@ We would rather say "not yet" in a one paragraph issue than decline a polished P
 - **Link the issue** the PR resolves (`Closes #123`).
 - **Describe what changed and why.** The "why" matters more than the "what".
 - **Include screenshots or a short clip for any UI change.**
-- **Make sure `npm run typecheck`, `npm run test:unit`, `npm run build`, and `npm run lint` all pass.**
+- **Make sure `bun run typecheck`, `bun run lint`, `bun run test`, and `bun run build` all pass.**
 - **Add or update tests** when you change behavior.
 - **Don't bundle unrelated changes.** No drive-by reformatting, dependency bumps, or refactors mixed into a feature PR.
 - Expect review feedback. A few rounds of back and forth is normal and is not a sign anything is wrong.
@@ -90,7 +110,7 @@ We would rather say "not yet" in a one paragraph issue than decline a polished P
 
 ## Project Structure
 
-See the [Architecture section](README.md#architecture) in the README and [`CLAUDE.md`](CLAUDE.md) for detailed guidance on the codebase.
+See [`docs/architecture.md`](docs/architecture.md) and [`CLAUDE.md`](CLAUDE.md) for detailed guidance on the codebase.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@
   <img src="assets/demo-canvas.gif" alt="Cate demo" width="900" />
 </p>
 
-Cate is a desktop IDE built on an infinite canvas, made for running many terminals and coding agents at once. Run Claude Code, Codex, or any agent CLI in a Cate terminal and the canvas becomes mission control: every terminal shows whether its agent is working, finished, or waiting on you, and Cate sends a notification the moment one needs input. Spin up parallel git worktrees with one click and each gets its own colored territory on the canvas, so five agents on five branches stay five visibly separate workstreams instead of a pile of tabs.
+Run Claude Code, Codex, or any agent CLI in a Cate terminal and the canvas becomes mission control: every terminal shows whether its agent is working, finished, or waiting on you, and Cate notifies you the moment one needs input. One click spins up a git worktree with its own colored territory on the canvas, so five agents on five branches stay five visibly separate workstreams instead of a pile of tabs.
 
-Around that core is a full IDE: Monaco editors, embedded browsers, document viewers, git tooling, and an in-app agent chat. Float panels anywhere on the canvas, dock them into tabs and splits, or detach them into their own OS windows. Cate restores the whole layout when you reopen the folder.
-
-**Getting started:** open a folder and it becomes a workspace. Right-click to add panels, press `Cmd+K` for the command palette, drag panels onto the dock to build tabs and splits. No config files.
+Open a folder and it becomes a workspace. No config files.
 
 ## Install
 
@@ -49,98 +47,23 @@ brew install --cask cate
 
 ## What's inside
 
-- **Agent-aware terminals.** Cate hooks the agent CLIs it supports (Claude Code, Codex, Cursor, Grok, OpenCode, Pi), so the agent itself reports turn start, turn end, and permission prompts. That drives the panel's running / waiting / finished state and the notification you get when one needs an answer. An agent that posts no hooks shows no status.
-- **Agent sessions survive restarts.** The hook stream carries each CLI's session id. Reopen the project and terminals return with their scrollback, and the agent is reattached with its own resume command. A stale id falls back to a plain shell rather than resuming the wrong conversation.
-- **Worktrees for parallel branches.** Type what you're working on and Cate creates a worktree and branch, based on a local or remote branch or an open PR. Each gets a color that follows it through the sidebar, dock tabs, and a territory drawn behind its panels on the canvas.
-- **Panels on a canvas or in a dock.** Terminals, Monaco editors, browsers, PDF/image/DOCX viewers, extension webviews, nested canvases. Float them on the canvas, dock them into tabs and splits, or drag them into their own window. Layout persists per project.
-- **Git and search.** Source-control sidebar for staging, commits, branches, stash, and history across multiple repos; git badges in the file tree; side-by-side diffs. Ripgrep search over the workspace, and `Cmd+K` for commands, panels, and files.
-- **A CLI agents can call.** In a Cate terminal, `cate` drives a browser panel (`open`, `screenshot`, `snapshot`, `click`, `type`), reads another terminal, opens files, manages panels. Settings → CLI gates each surface separately for Read and Control.
-- **Local and remote are the same path.** One runtime daemon serves every workspace. Point Cate at a host over SSH or WSL and terminals, git, search, and agents run there; editors, browser, and canvas stay local.
+- **Agent-aware terminals.** Claude Code, Codex, Cursor, Grok, OpenCode and Pi report turn start, turn end, and permission prompts, so each panel shows running / waiting / finished and pings you when it needs an answer.
+- **Agent sessions survive restarts.** Reopen the project and terminals come back with their scrollback, each agent reattached with its own resume command.
+- **Worktrees for parallel branches.** Type what you're working on and Cate creates the worktree and branch, off a local branch, a remote branch, or an open PR.
+- **Panels on a canvas or in a dock.** Terminals, Monaco editors, browsers, PDF/image/DOCX viewers, extension webviews, nested canvases. Float, dock into tabs and splits, or detach into their own window. Layout persists per project.
+- **Git and search.** Multi-repo source control, git badges in the file tree, side-by-side diffs, ripgrep search, and `Cmd+K` for commands, panels, and files.
+- **A CLI agents can call.** In a Cate terminal, `cate` drives a browser panel, reads another terminal, opens files, manages panels.
+- **Local and remote are the same path.** Point Cate at a host over SSH or WSL and terminals, git, search, and agents run there; editors, browser, and canvas stay local.
+
+Press `Cmd+K` for everything else. All shortcuts are listed in [docs/shortcuts.md](docs/shortcuts.md) and rebindable in Settings.
 
 ## Extensions
 
 Cate has an extension system for third-party panels (MCP servers, diagrams, and more), each served in its own isolated webview. Browse and build them in the companion repo: [0-AI-UG/cate-extensions](https://github.com/0-AI-UG/cate-extensions).
 
-## Keyboard shortcuts
-
-macOS shown below; on Windows/Linux use `Ctrl` in place of `Cmd`.
-
-| Panels & files | | View & navigation | |
-|---|---|---|---|
-| New terminal | `Cmd+T` | Command palette | `Cmd+K` |
-| New editor | `Cmd+Shift+E` | Search everything | `Cmd+Shift+F` |
-| New browser | `Cmd+Shift+B` | Toggle sidebar | `Cmd+B` |
-| New agent | `Cmd+Shift+A` | Toggle file explorer | `Cmd+Shift+X` |
-| New canvas | `Cmd+Shift+C` | Toggle minimap | `Cmd+Shift+M` |
-| New file | `Cmd+N` | Focus next / previous panel | `Ctrl+Tab` / `Ctrl+Shift+Tab` |
-| Save file | `Cmd+S` | Move between panels | `Cmd+←↑↓→` |
-| Close panel | `Cmd+W` | Delete focused panel | `Cmd+Backspace` |
-
-| Canvas | |
-|---|---|
-| Zoom in / out | `Cmd+=` / `Cmd+-` |
-| Reset zoom | `Cmd+0` |
-| Zoom to fit / selection | `Cmd+1` / `Cmd+2` |
-| Auto-layout canvas | `Cmd+Shift+L` |
-| Pan canvas | `Shift+←↑↓→` |
-| Toggle select / hand tool | `Shift+Space` |
-| Undo / redo | `Cmd+Z` / `Cmd+Shift+Z` |
-
-Every shortcut is rebindable in Settings.
-
-## Build from source
-
-For contributors. Use the release above otherwise.
-
-**Prerequisites:**
-- [Bun](https://bun.sh): package manager and script runner.
-- [Node.js](https://nodejs.org/) 20 or 22 LTS (see `.nvmrc`) on your PATH. The build scripts run under it; the runtime daemon bundles its own Node 22.
-- **Linux only:** `node-pty` ships prebuilt binaries for macOS and Windows, but not Linux, so it compiles from source there. Install Python 3 and a C++ toolchain:
-  - Debian/Ubuntu: `sudo apt install build-essential python3`
-  - Fedora/RHEL: `sudo dnf install @development-tools gcc-c++ make python3`
-  - Arch: `sudo pacman -S base-devel python`
-
-Fresh clone, one command sets everything up (installs dependencies and builds the local runtime daemon):
-
-```bash
-git clone https://github.com/0-AI-UG/cate.git
-cd cate
-bun run setup
-```
-
-Then:
-
-```bash
-bun run dev          # dev server with hot reload
-bun run typecheck
-bun run test         # unit tests (vitest)
-bun run test:e2e     # Playwright integration tests
-bun run build        # production build
-bun run package      # package for distribution (:mac, :win, :linux)
-```
-
-Packaged binaries land in `release/`. The runtime daemon is rebuilt by `bun run runtime:tarball` (re-run it after changing anything under `src/runtime/`).
-
-## Architecture
-
-```text
-src/
-├── agent/      # Embedded Pi coding-agent: process manager, auth, marketplace, panel UI
-├── cli/        # The `cate` CLI available inside Cate terminals (browser control, panels, editor)
-├── main/       # Electron main process: IPC, workspaces, windows, updater, security
-├── preload/    # Context-isolated IPC bridge
-├── renderer/   # React 18 app: canvas, docking, panels, sidebar, stores, hooks
-├── runtime/    # Runtime daemon for remote (SSH) workspaces: terminals, agents, search
-└── shared/     # IPC channels and shared types
-```
-
-Cate runs all IPC through a context-isolated preload bridge. Filesystem access is scoped to registered workspace roots, browser panels disable node integration, and terminals can't spawn outside approved directories.
-
-**Stack:** Electron 41, React 18, Zustand 5, Monaco 0.52, xterm.js 5.5 + node-pty 1.0, Tailwind 3.4, electron-vite, electron-builder, electron-updater, Sentry. PDFs and DOCX via pdf.js and mammoth, git via simple-git, file watching via `@parcel/watcher` and chokidar. The embedded coding agent is built on `@earendil-works/pi`, shipped as an on-demand runtime alongside the app.
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Release-by-release history lives in the [CHANGELOG](CHANGELOG.md).
+Build-from-source instructions and the contribution workflow are in [CONTRIBUTING.md](CONTRIBUTING.md). Codebase layout and stack in [docs/architecture.md](docs/architecture.md). Release history in the [CHANGELOG](CHANGELOG.md).
 
 ## Star history
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# Architecture
+
+```text
+src/
+├── agent/      # Embedded Pi coding-agent: process manager, auth, marketplace, panel UI
+├── cli/        # The `cate` CLI available inside Cate terminals (browser control, panels, editor)
+├── main/       # Electron main process: IPC, workspaces, windows, updater, security
+├── preload/    # Context-isolated IPC bridge
+├── renderer/   # React 18 app: canvas, docking, panels, sidebar, stores, hooks
+├── runtime/    # Runtime daemon for remote (SSH) workspaces: terminals, agents, search
+└── shared/     # IPC channels and shared types
+```
+
+See [`CLAUDE.md`](../CLAUDE.md) for detailed guidance on the codebase: coordinate system, panel system, state stores, and persisted state.
+
+## Security model
+
+Cate runs all IPC through a context-isolated preload bridge. Filesystem access is scoped to registered workspace roots, browser panels disable node integration, and terminals can't spawn outside approved directories.
+
+The `cate` CLI is gated per surface in Settings → CLI, separately for Read and Control.
+
+## Agent terminals
+
+Cate hooks the agent CLIs it supports (Claude Code, Codex, Cursor, Grok, OpenCode, Pi) so the agent itself reports turn start, turn end, and permission prompts. That drives the panel's running / waiting / finished state and the notification when one needs an answer. An agent that posts no hooks shows no status.
+
+The hook stream also carries each CLI's session id, which is what makes a terminal resumable across restarts. A stale id falls back to a plain shell rather than resuming the wrong conversation.
+
+Worktree colors follow a branch through the sidebar, dock tabs, and the territory drawn behind its panels on the canvas.
+
+## Stack
+
+Electron 41, React 18, Zustand 5, Monaco 0.52, xterm.js 5.5 + node-pty 1.0, Tailwind 3.4, electron-vite, electron-builder, electron-updater, Sentry. PDFs and DOCX via pdf.js and mammoth, git via simple-git, file watching via `@parcel/watcher` and chokidar. The embedded coding agent is built on `@earendil-works/pi`, shipped as an on-demand runtime alongside the app.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,24 @@
+# Keyboard shortcuts
+
+macOS shown below; on Windows/Linux use `Ctrl` in place of `Cmd`. Every shortcut is rebindable in Settings, and `Cmd+K` opens the command palette if you'd rather search for the action.
+
+| Panels & files | | View & navigation | |
+|---|---|---|---|
+| New terminal | `Cmd+T` | Command palette | `Cmd+K` |
+| New editor | `Cmd+Shift+E` | Search everything | `Cmd+Shift+F` |
+| New browser | `Cmd+Shift+B` | Toggle sidebar | `Cmd+B` |
+| New agent | `Cmd+Shift+A` | Toggle file explorer | `Cmd+Shift+X` |
+| New canvas | `Cmd+Shift+C` | Toggle minimap | `Cmd+Shift+M` |
+| New file | `Cmd+N` | Focus next / previous panel | `Ctrl+Tab` / `Ctrl+Shift+Tab` |
+| Save file | `Cmd+S` | Move between panels | `Cmd+←↑↓→` |
+| Close panel | `Cmd+W` | Delete focused panel | `Cmd+Backspace` |
+
+| Canvas | |
+|---|---|
+| Zoom in / out | `Cmd+=` / `Cmd+-` |
+| Reset zoom | `Cmd+0` |
+| Zoom to fit / selection | `Cmd+1` / `Cmd+2` |
+| Auto-layout canvas | `Cmd+Shift+L` |
+| Pan canvas | `Shift+←↑↓→` |
+| Toggle select / hand tool | `Shift+Space` |
+| Undo / redo | `Cmd+Z` / `Cmd+Shift+Z` |


### PR DESCRIPTION
The README was carrying four audiences at once. Most of it was for people who already decided to use Cate.

- Build from source moves to CONTRIBUTING, which needed the fix anyway: it still said `npm install` and Node >= 18, and referenced a `test:unit` script that does not exist.
- Shortcut tables move to `docs/shortcuts.md`. They are all rebindable and discoverable via Cmd+K.
- Source tree, security model and stack move to `docs/architecture.md`, plus the agent-hook details that were cluttering the feature bullets.
- Intro cut from two dense paragraphs to three sentences, feature bullets down to one line each.

README goes from 151 to 80 lines.

Not done here: the de/fr/zh-CN READMEs still have the old structure and will drift.