### PR TITLE
Keep the "hooks off" nudge honest; pin the process-scan blind spot to #480

### DIFF
--- a/src/renderer/hooks/useMissingAgentHookNotice.ts
+++ b/src/renderer/hooks/useMissingAgentHookNotice.ts
@@ -8,11 +8,25 @@ import type { AgentHookAgentState } from '../../shared/agentHooks'
 // Detector for "a supported agent CLI is running in this terminal, but Cate's
 // hooks aren't installed for it here." Agent state/name now come exclusively
 // from hooks; when a repo has no injected hook file the agent runs invisibly to
-// Cate. This nudges the user to Settings → Agent Hooks. It reuses the same two
-// facts the rest of the app already owns — the process-scan child name
-// (matched against the agent registry) and the per-workspace injection readout
-// (agentHooksInspect) — so it auto-clears the moment the agent exits or a hook
-// file gets injected.
+// Cate. This nudges the user to Settings → Agent Hooks. It reuses three facts
+// the rest of the app already owns — the process-scan child name (matched
+// against the agent registry), the hook-anchored presence flag, and the
+// per-workspace injection readout (agentHooksInspect) — so it auto-clears the
+// moment the agent exits, starts posting hooks, or a hook file gets injected.
+//
+// The presence flag is what keeps this HONEST. `agentHooksInspect(rootPath)`
+// only answers "is a hook file present in THIS workspace root" — it says
+// nothing about whether hooks actually fire. Hooks configured elsewhere
+// (~/.claude, an agent cwd ≠ rootPath) fire fine yet leave rootPath's file
+// absent, which would false-positive the nudge. `agentPresent` is set by a real
+// hook post (agentPresence.ts), so gating on !agentPresent means "no hook has
+// spoken for this terminal" — the actual condition worth nudging about.
+//
+// Blind spot (inherited from the process scan, see process.ts / #480): under
+// tmux/screen/setsid the agent is detached from the pty's subtree, so the scan
+// yields no processName and the nudge simply doesn't show. That fails safe (no
+// false nudge) and matches the accepted "hooks that never fire aren't detected"
+// gap — the fix there is the same as everywhere: install the hooks.
 //
 // Returns the agent's display name while the notice should show, else null.
 export function useMissingAgentHookNotice(
@@ -32,6 +46,14 @@ export function useMissingAgentHookNotice(
   })
   const agent = useMemo(() => (processName ? matchAgentDef(processName) : null), [processName])
 
+  // Hook-anchored presence: true once a real hook post has been attributed to
+  // this terminal (agentPresence.ts). If hooks are speaking, they own the name
+  // and state — there is nothing to nudge about, regardless of whether a hook
+  // file happens to live in rootPath.
+  const agentPresent = useStatusStore((s) =>
+    ptyId ? (s.workspaces[workspaceId]?.terminals[ptyId]?.agentPresent ?? false) : false,
+  )
+
   // Re-inspect the workspace's live hook files when the running agent changes or
   // the user edits this workspace's injection overrides in Settings (a respawn
   // then rewrites the files).
@@ -50,6 +72,8 @@ export function useMissingAgentHookNotice(
   }, [agent, rootPath, overrides])
 
   if (!agent) return null
+  // Hooks are already firing for this terminal — nothing to nudge.
+  if (agentPresent) return null
   // Only show once the inspect confirms the hook file is absent — an unknown
   // (not-yet-inspected) agent must not flash the chip.
   if (injectedById[agent.id] !== false) return null

--- a/src/runtime/capabilities/process.ts
+++ b/src/runtime/capabilities/process.ts
@@ -112,9 +112,21 @@ function isShellProcess(name: string): boolean {
  *  under a launcher (grok's npm wrapper execs a versioned binary, etc.), so it
  *  isn't always the direct child. This is the process-scan detection the tab
  *  title and the "hooks off" nudge key on — complementary to the hook-anchored
- *  presence (agentPresence.ts), which still owns running/finished STATE and
- *  survives tmux/setsid detaching the agent from this tree. Falls back to the
- *  first non-shell direct child for the generic indicator (dev servers, vim). */
+ *  presence (agentPresence.ts), which still owns running/finished STATE.
+ *
+ *  BLIND SPOT (deliberate, see #480 / agentPresence.ts header): this is a
+ *  DOWNWARD walk of the pty's OWN tree, so it is structurally blind wherever the
+ *  agent is detached from that tree — tmux/screen panes hang off the
+ *  multiplexer server, setsid/nohup daemonize. That is exactly why presence and
+ *  STATE are hook-anchored, not scan-anchored: hooks don't care about topology.
+ *  The two features that key on this scan (clean tab title, "hooks off" nudge)
+ *  therefore degrade to "no clean name / no nudge" under tmux — never a wrong
+ *  state, and the hook path still delivers the tab name + full state there. The
+ *  nudge additionally gates on hook-anchored presence so it can't fire when
+ *  hooks ARE working (see useMissingAgentHookNotice).
+ *
+ *  Falls back to the first non-shell direct child for the generic indicator
+ *  (dev servers, vim). */
 function activityForPid(shellPid: number, tree: ProcTree): TerminalActivity {
   for (const pid of descendantsOf(shellPid, tree)) {
     const name = tree.nameByPid.get(pid)


### PR DESCRIPTION
Follow-up to df67903, which keyed two things on the re-added pty-subtree scan: the clean tab title and the new "Agent hooks off" chip.

**Nudge could false-positive.** It fired whenever `agentHooksInspect(rootPath)` found no hook file in the workspace root, but that only checks for a file there, not whether hooks fire. Hooks in `~/.claude` (or an agent cwd that is not rootPath) work fine yet leave rootPath's file absent, so the chip claimed "hooks off" while hooks were running. Now gated on `agentPresent`, which only a real hook post sets.

**Docs only:** the subtree walk is downward, so it is blind under tmux/setsid where the agent is detached from the pty tree - the #480 case. Added a blind-spot note in `process.ts` and a pointer from the nudge hook so the scan does not silently contradict the hooks-only design. Both features degrade to "no name / no chip" there, never a wrong state.

Still no nudge for tmux users on a hookless agent - same accepted #480 gap. typecheck + lint green.