### PR TITLE
fix(runtime): content-key local install dirs so builds stop deleting each other

### DIFF
--- a/src/main/extensions/extension-daemon.e2e.test.ts
+++ b/src/main/extensions/extension-daemon.e2e.test.ts
@@ -46,14 +46,14 @@ const EXT_VERSION = '2.0.0'
 
 describe.skipIf(!hasTarball)('extension install/serve over a real daemon subprocess', () => {
   let mgr: RuntimeManager
-  let installDir: string
+  let installRoot: string
   let workspace: string
   let hostExtRoot: string
   let entry: CatalogEntry
   let runtime: Runtime
 
   beforeAll(async () => {
-    installDir = await fs.mkdtemp(path.join(process.cwd(), 'cate-exte2e-install-'))
+    installRoot = await fs.mkdtemp(path.join(process.cwd(), 'cate-exte2e-install-'))
     workspace = await fs.realpath(await fs.mkdtemp(path.join(process.cwd(), 'cate-exte2e-ws-')))
     // The daemon resolves its extensions root from CATE_EXTENSIONS_ROOT (env),
     // pointed at a temp dir so the test never touches the real ~/.cate.
@@ -82,7 +82,8 @@ describe.skipIf(!hasTarball)('extension install/serve over a real daemon subproc
       root: workspace,
       id: 'srv_e2e',
       tarballPath,
-      installDir,
+      installRoot,
+      target: target!,
       env: { ...process.env, CATE_EXTENSIONS_ROOT: hostExtRoot },
     })
     // install=true extracts the tarball before launch; the daemon then runs from
@@ -92,7 +93,7 @@ describe.skipIf(!hasTarball)('extension install/serve over a real daemon subproc
 
   afterAll(async () => {
     await mgr?.disposeAll()
-    for (const dir of [installDir, workspace, hostExtRoot, h.userData]) {
+    for (const dir of [installRoot, workspace, hostExtRoot, h.userData]) {
       await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
     }
     await fs.rm(path.join(process.cwd(), `cate.e2e-${EXT_VERSION}.tgz`), { force: true }).catch(() => {})

--- a/src/main/runtime/local-daemon-tarball.test.ts
+++ b/src/main/runtime/local-daemon-tarball.test.ts
@@ -22,18 +22,19 @@ const hasTarball = !!tarballPath && existsSync(tarballPath)
 
 describe.skipIf(!hasTarball)('local daemon from the real tarball', () => {
   let mgr: RuntimeManager
+  let installRoot: string
   let installDir: string
   let workspace: string
 
   beforeAll(async () => {
-    installDir = await fs.mkdtemp(path.join(process.cwd(), 'cate-local-install-'))
+    installRoot = await fs.mkdtemp(path.join(process.cwd(), 'cate-local-install-'))
     workspace = await fs.realpath(await fs.mkdtemp(path.join(process.cwd(), 'cate-local-ws-')))
     await fs.writeFile(path.join(workspace, 'hello.ts'), 'export const x = 1\n')
   }, 60_000)
 
   afterAll(async () => {
     await mgr?.disposeAll()
-    await fs.rm(installDir, { recursive: true, force: true })
+    await fs.rm(installRoot, { recursive: true, force: true })
     await fs.rm(workspace, { recursive: true, force: true })
   })
 
@@ -43,11 +44,16 @@ describe.skipIf(!hasTarball)('local daemon from the real tarball', () => {
       root: workspace,
       id: 'srv_localtarball',
       tarballPath,
-      installDir,
+      installRoot,
+      target: target!,
     })
 
     // install=true so connect() runs bootstrap (extracts the tarball) before launch.
     const runtime = await mgr.connect('srv_localtarball', transport, { install: true })
+
+    // The install landed in a content-keyed dir under the root.
+    installDir = (await transport.installDir())!
+    expect(path.dirname(installDir)).toBe(installRoot)
 
     // The daemon ran from the extracted tarball's own node.
     expect(existsSync(path.join(installDir, 'runtime.cjs'))).toBe(true)

--- a/src/main/runtime/transports/localInstall.test.ts
+++ b/src/main/runtime/transports/localInstall.test.ts
@@ -1,0 +1,148 @@
+// =============================================================================
+// Local runtime provisioning: content-keyed install dirs + atomic swap.
+//
+// Regression cover for the bug where a packaged Cate and a dev build, both at
+// the same RUNTIME_VERSION but with different daemon tarballs, shared ONE
+// install dir (~/.cate/runtime/<version>/<target>). Each app read the other's
+// `.ok` marker as stale, `rm -rf`d the live directory and re-extracted 110MB
+// of node into it. For the minutes that took, <installDir>/runtime/bin/node
+// did not exist — and that exact path is embedded in every agent hook bridge
+// wrapper, so every hook that fired in the window died with
+// "no such file or directory".
+//
+// Real tar, real dirs, tiny fake tarballs — no mocks.
+// =============================================================================
+
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { LocalSubprocessTransport } from './localTransport'
+import type { RuntimeTarget } from '../runtimeArtifacts'
+import { RUNTIME_VERSION } from '../../../runtime/version'
+
+const execFileP = promisify(execFile)
+const TARGET: RuntimeTarget = 'linux-x64' // fixed, so the layout assertions are host-independent
+const nodeName = process.platform === 'win32' ? 'node.exe' : 'node'
+
+let root: string
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-local-install-'))
+})
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true })
+})
+
+/** A minimal but structurally real runtime tarball: the two files isInstalled
+ *  probes, with `body` as their content so a swap is detectable byte-wise. */
+async function makeTarball(name: string, body: string): Promise<string> {
+  const stage = path.join(root, `stage-${name}`)
+  await fs.mkdir(path.join(stage, 'runtime', 'bin'), { recursive: true })
+  await fs.writeFile(path.join(stage, 'runtime', 'bin', nodeName), body)
+  await fs.writeFile(path.join(stage, 'runtime.cjs'), body)
+  const tgz = path.join(root, `${name}.tgz`)
+  await execFileP('tar', ['-czf', tgz, '-C', stage, '.'])
+  return tgz
+}
+
+function transportFor(tarballPath: string, installRoot: string): LocalSubprocessTransport {
+  return new LocalSubprocessTransport({ root, id: 'srv_test', tarballPath, installRoot, target: TARGET })
+}
+
+async function nodeBytes(installDir: string): Promise<string> {
+  return fs.readFile(path.join(installDir, 'runtime', 'bin', nodeName), 'utf-8')
+}
+
+describe('content-keyed install dirs', () => {
+  test('two different builds of the SAME version never share a directory', async () => {
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const a = transportFor(await makeTarball('a', 'DAEMON-A'), installRoot)
+    const b = transportFor(await makeTarball('b', 'DAEMON-B'), installRoot)
+
+    const dirA = await a.installDir()
+    const dirB = await b.installDir()
+
+    expect(dirA).toBeTruthy()
+    expect(dirB).toBeTruthy()
+    expect(dirA).not.toBe(dirB)
+    // Both still live under <version>/, keyed by target so the layout stays legible.
+    expect(path.dirname(dirA!)).toBe(installRoot)
+    expect(path.basename(dirA!).startsWith(`${TARGET}-`)).toBe(true)
+  })
+
+  test('the same tarball always resolves to the same directory', async () => {
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const tgz = await makeTarball('a', 'DAEMON-A')
+    expect(await transportFor(tgz, installRoot).installDir())
+      .toBe(await transportFor(tgz, installRoot).installDir())
+  })
+
+  test('provisioning build B leaves build A fully intact and runnable', async () => {
+    // THE regression: this is the sequence that deleted the node binary out
+    // from under a running daemon (and every agent hook bridge pointing at it).
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const a = transportFor(await makeTarball('a', 'DAEMON-A'), installRoot)
+    const b = transportFor(await makeTarball('b', 'DAEMON-B'), installRoot)
+
+    await a.bootstrap(RUNTIME_VERSION)
+    const dirA = (await a.installDir())!
+    expect(await nodeBytes(dirA)).toBe('DAEMON-A')
+
+    await b.bootstrap(RUNTIME_VERSION)
+    const dirB = (await b.installDir())!
+
+    expect(await nodeBytes(dirA)).toBe('DAEMON-A') // untouched
+    expect(await nodeBytes(dirB)).toBe('DAEMON-B')
+    expect(await a.isInstalled(RUNTIME_VERSION)).toBe(true)
+    expect(await b.isInstalled(RUNTIME_VERSION)).toBe(true)
+  })
+
+  test('an already-provisioned install is not re-extracted', async () => {
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const a = transportFor(await makeTarball('a', 'DAEMON-A'), installRoot)
+    await a.bootstrap(RUNTIME_VERSION)
+    const dir = (await a.installDir())!
+
+    // A local edit survives a no-op bootstrap; a re-extract would erase it.
+    await fs.writeFile(path.join(dir, 'sentinel'), 'x')
+    await a.bootstrap(RUNTIME_VERSION)
+    expect(existsSync(path.join(dir, 'sentinel'))).toBe(true)
+  })
+})
+
+describe('atomic swap', () => {
+  test('a failed extraction leaves the previous install complete', async () => {
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const tgz = await makeTarball('a', 'DAEMON-A')
+    const a = transportFor(tgz, installRoot)
+    await a.bootstrap(RUNTIME_VERSION)
+    const dir = (await a.installDir())!
+
+    // Same path, now garbage: a forced re-provision must fail WITHOUT leaving
+    // the install dir emptied or half-populated.
+    await fs.writeFile(tgz, 'not a tarball')
+    await expect(a.bootstrap(RUNTIME_VERSION, true)).rejects.toThrow()
+
+    expect(existsSync(path.join(dir, 'runtime', 'bin', nodeName))).toBe(true)
+    expect(await nodeBytes(dir)).toBe('DAEMON-A')
+    expect(existsSync(path.join(dir, 'runtime.cjs'))).toBe(true)
+  })
+
+  test('a forced re-provision swaps the tree in whole and leaves no staging dirs', async () => {
+    const installRoot = path.join(root, 'runtime', RUNTIME_VERSION)
+    const a = transportFor(await makeTarball('a', 'DAEMON-A'), installRoot)
+    await a.bootstrap(RUNTIME_VERSION)
+    const dir = (await a.installDir())!
+
+    await a.bootstrap(RUNTIME_VERSION, true)
+    expect(await nodeBytes(dir)).toBe('DAEMON-A')
+
+    // No `.staging-*` / `.retired-*` leftovers next to the install.
+    const siblings = await fs.readdir(installRoot)
+    expect(siblings).toEqual([path.basename(dir)])
+  })
+})

--- a/src/main/runtime/transports/localTransport.ts
+++ b/src/main/runtime/transports/localTransport.ts
@@ -12,7 +12,7 @@
 
 import { spawn, execFile, type ChildProcess } from 'child_process'
 import { existsSync, readFileSync } from 'fs'
-import { mkdir, rm, writeFile } from 'fs/promises'
+import { mkdir, rename, rm, writeFile } from 'fs/promises'
 import { promisify } from 'util'
 import os from 'os'
 import path from 'path'
@@ -34,9 +34,12 @@ export interface LocalSubprocessOptions {
   /** Direct mode: explicit node + bundle, no provisioning (tests). */
   nodePath?: string
   bundlePath?: string
-  /** Provisioned mode: extract this tarball into installDir, then run its node. */
+  /** Provisioned mode: extract this tarball into a content-keyed dir under
+   *  `installRoot` (see localInstallRoot / installDir), then run its node. */
   tarballPath?: string
-  installDir?: string
+  installRoot?: string
+  /** The tarball's target — the readable half of the install dir's name. */
+  target?: RuntimeTarget
 }
 
 /** node binary inside an extracted tarball. Unified layout: runtime/bin/node on
@@ -48,15 +51,27 @@ function tarballNode(installDir: string): string {
     : path.join(installDir, 'runtime', 'bin', 'node')
 }
 
-/** Where the local host's runtime tarball is extracted, keyed by version +
- *  target (mirrors the remote `~/.cate/runtime/<ver>/<target>` layout). */
-export function localInstallDir(target: RuntimeTarget): string {
-  return path.join(os.homedir(), '.cate', 'runtime', RUNTIME_VERSION, target)
+/** Where this version's local installs live: `~/.cate/runtime/<ver>` (mirrors
+ *  the remote layout one level up). The install dirs INSIDE it are content-keyed
+ *  — see `installDir`. */
+export function localInstallRoot(): string {
+  return path.join(os.homedir(), '.cate', 'runtime', RUNTIME_VERSION)
+}
+
+/** Best-effort cleanup of a staging/retired tree. A retired tree can still be
+ *  open in a running daemon — on POSIX unlinking it is fine, on Windows it can
+ *  fail with EBUSY. Either way the leftover is inert and the NEXT bootstrap
+ *  clears it, so a failure here must not fail provisioning. */
+async function discard(dir: string): Promise<void> {
+  try {
+    await rm(dir, { recursive: true, force: true })
+  } catch { /* still in use (win32) — harmless, retried on the next bootstrap */ }
 }
 
 export class LocalSubprocessTransport implements RuntimeTransport {
   readonly kind = 'local'
   private child: ChildProcess | null = null
+  private tarballHashPromise: Promise<string> | null = null
 
   constructor(private readonly opts: LocalSubprocessOptions) {}
 
@@ -79,22 +94,47 @@ export class LocalSubprocessTransport implements RuntimeTransport {
       ...opts,
       id: opts.id ?? 'local',
       tarballPath,
-      installDir: localInstallDir(target),
+      installRoot: localInstallRoot(),
+      target,
     })
   }
 
-  /** Freshness marker stored in `.ok`: version + the tarball's content hash, so a
-   *  rebuilt daemon at the SAME version (dev iteration: `npm run runtime:tarball`
-   *  with new runtime.cjs/rg/pi) re-provisions instead of running stale bytes.
+  /** Short content hash of our tarball, computed once. */
+  private async hash(): Promise<string> {
+    this.tarballHashPromise ??= tarballHash(this.opts.tarballPath!)
+    return this.tarballHashPromise
+  }
+
+  /**
+   * Where this transport's tarball installs to: `<installRoot>/<target>-<hash>`.
+   * Null in direct mode.
+   *
+   * CONTENT-KEYED on purpose. Keying by version alone put a packaged Cate and a
+   * dev build — same RUNTIME_VERSION, different daemon bytes — in one directory,
+   * where each read the other's `.ok` as stale and `rm -rf`d a tree the other
+   * app's daemon was running from. Every agent hook bridge wrapper embeds
+   * `<installDir>/runtime/bin/node`, so hooks fired during the re-extract died
+   * with "no such file or directory". Distinct builds now install side by side
+   * and nothing ever deletes a live install.
+   */
+  async installDir(): Promise<string | null> {
+    const { installRoot, tarballPath, target } = this.opts
+    if (!installRoot || !tarballPath || !target) return null
+    return path.join(installRoot, `${target}-${await this.hash()}`)
+  }
+
+  /** Freshness marker stored in `.ok`: version + the tarball's content hash.
+   *  Now that the dir name carries the hash this is a COMPLETION marker (the
+   *  last thing written before the swap) plus a self-describing breadcrumb.
    *  Mirrors SshTransport's `version:hash` marker. */
   private async marker(version: string): Promise<string> {
-    return `${version}:${await tarballHash(this.opts.tarballPath!)}`
+    return `${version}:${await this.hash()}`
   }
 
   /** Provisioned mode only: true when the install dir holds THIS tarball's bytes. */
   async isInstalled(version: string): Promise<boolean> {
-    const { installDir, tarballPath } = this.opts
-    if (!installDir || !tarballPath) return true // direct mode: nothing to install
+    const installDir = await this.installDir()
+    if (!installDir) return true // direct mode: nothing to install
     const ok = path.join(installDir, '.ok')
     if (
       !existsSync(tarballNode(installDir)) ||
@@ -106,20 +146,46 @@ export class LocalSubprocessTransport implements RuntimeTransport {
     return readFileSync(ok, 'utf-8').trim() === (await this.marker(version))
   }
 
-  /** Provisioned mode only: extract the tarball into the install dir. */
+  /**
+   * Provisioned mode only: extract the tarball into the install dir.
+   *
+   * Extraction goes to a staging sibling and is swapped in with rename(2), so
+   * the install dir is either the old complete tree or the new one — never a
+   * half-extracted one. A daemon already running out of the old tree keeps its
+   * inodes across the swap, and anything resolving the path (agent hook
+   * bridges) finds a complete install at every instant. A failed extract leaves
+   * the previous install untouched.
+   */
   async bootstrap(version: string, force?: boolean): Promise<void> {
-    const { installDir, tarballPath } = this.opts
+    const { tarballPath } = this.opts
+    const installDir = await this.installDir()
     if (!installDir || !tarballPath) return // direct mode: bundle ships with the app
     if (!force && (await this.isInstalled(version))) return
-    await rm(installDir, { recursive: true, force: true })
-    await mkdir(installDir, { recursive: true })
-    await execFileP('tar', ['-xzf', tarballPath, '-C', installDir])
-    await writeFile(path.join(installDir, '.ok'), await this.marker(version))
+
+    const staging = `${installDir}.staging-${process.pid}`
+    const retired = `${installDir}.retired-${process.pid}`
+    await mkdir(path.dirname(installDir), { recursive: true })
+    await rm(staging, { recursive: true, force: true })
+    await mkdir(staging, { recursive: true })
+    try {
+      await execFileP('tar', ['-xzf', tarballPath, '-C', staging])
+      await writeFile(path.join(staging, '.ok'), await this.marker(version))
+      // Two renames, not one: POSIX has no atomic directory swap. The gap where
+      // installDir is absent is a single syscall wide (vs. the minutes a full
+      // re-extract took), and only opens when a tree is already there — the
+      // common fresh-hash path is one rename with no gap at all.
+      if (existsSync(installDir)) await rename(installDir, retired)
+      await rename(staging, installDir)
+    } finally {
+      await discard(staging)
+      await discard(retired)
+    }
   }
 
   async launch(): Promise<RuntimeChannel> {
-    const nodePath = this.opts.nodePath ?? tarballNode(this.opts.installDir!)
-    const bundlePath = this.opts.bundlePath ?? path.join(this.opts.installDir!, 'runtime.cjs')
+    const installDir = await this.installDir()
+    const nodePath = this.opts.nodePath ?? tarballNode(installDir!)
+    const bundlePath = this.opts.bundlePath ?? path.join(installDir!, 'runtime.cjs')
     const args = [bundlePath, '--root', this.opts.root, '--id', this.opts.id]
     if (this.opts.exclusions?.length) args.push('--exclude', this.opts.exclusions.join(','))
     if (this.opts.idleSuspend) args.push('--idle-suspend')

--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -37,6 +37,7 @@ function tmpDir(sub: string): string {
 function makeCap(
   deps: {
     hooksDir?: string
+    nodePath?: string
     interruptPollMs?: number
     onPost?: (post: { terminalId: string; agentId: string; pid?: number }) => void | Promise<void>
   } = {},
@@ -252,6 +253,30 @@ describe('agentHooks capability', () => {
     // production it is the agent CLI (or its sh hook-command layer), which is
     // what the presence tracker walks up from.
     expect(posts).toEqual([{ terminalId: 'rpty-bridge', agentId: 'codex', pid: process.pid }])
+  })
+
+  test.skipIf(!posix)('the wrapper exits silently when its node binary is gone', async () => {
+    // A hook failure must never surface into the user's agent turn. The wrapper
+    // embeds an absolute node path, and that path CAN go missing — a runtime
+    // re-provision used to delete and re-extract the very tree it points into,
+    // and the raw exec error landed in the agent transcript as
+    // "cannot execute: No such file or directory".
+    const cap = makeCap({ nodePath: path.join(tmpDir('no-node'), 'runtime', 'bin', 'node') })
+    const events = collect(cap)
+    const { dir } = await cap.endpoint()
+    const env = await cap.envForPty('rpty-nonode', { PATH: '/usr/bin:/bin' })
+
+    const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((resolve) => {
+      let err = ''
+      const child = execFile(path.join(dir, 'cate-hook-bridge-claude-code'), [], { env, timeout: 15_000 })
+      child.stderr!.on('data', (chunk) => { err += String(chunk) })
+      child.on('close', (c) => resolve({ code: c, stderr: err }))
+      child.stdin!.end(JSON.stringify({ hook_event_name: 'SessionStart', cwd: '/w' }))
+    })
+
+    expect(code, 'a missing node must not fail the hook').toBe(0)
+    expect(stderr, 'and must not print anything the agent would show the user').toBe('')
+    expect(events).toEqual([])
   })
 
   // Cross-vendor guard. grok scans .claude/settings.local.json (and

--- a/src/runtime/capabilities/agentHooks.ts
+++ b/src/runtime/capabilities/agentHooks.ts
@@ -100,6 +100,10 @@ export interface AgentHooksCapability {
 export interface AgentHooksDeps {
   /** Override the stable hooks dir (tests). Default: ~/.cate/agent-hooks. */
   hooksDir?: string
+  /** The node binary the bridge wrappers exec. Default: this daemon's own
+   *  (process.execPath). Tests point it at a missing path to exercise the
+   *  wrapper's fail-soft guard. */
+  nodePath?: string
   /** Poll cadence (ms) of the interrupt transcript tail-watch. Default 600 —
    *  well under the "a moment after the user hit Esc" tolerance, and it only
    *  ticks while a false-on-interrupt turn is actually in flight. Tests lower
@@ -422,6 +426,7 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
 
     const secret = randomBytes(32).toString('hex')
     const contexts = new Map<AgentId, HookInjectionContext>()
+    const nodePath = deps.nodePath ?? process.execPath
 
     for (const agent of AGENTS) {
       // Per-agent bridge wrapper: hook configs get ONE command path with no
@@ -432,11 +437,19 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
       // + packaged app) flip-flop it between their node paths. Benign: both
       // are working node binaries, and codex's hook trust keys on the wrapper
       // PATH (via hooks.json), which never changes.
+      //
+      // The exec is GUARDED on the binary still being there. That path lives
+      // in a provisioned runtime install, and an install can be replaced under
+      // a running daemon; without the guard, sh reports "cannot execute: No
+      // such file or directory" straight into the user's agent transcript. A
+      // hook that cannot run must degrade to a silent no-op, like BRIDGE_JS's
+      // always-exit-0 contract.
       const wrapper = path.join(dir, `cate-hook-bridge-${agent.id}${process.platform === 'win32' ? '.cmd' : ''}`)
       if (process.platform === 'win32') {
-        await writeFile(wrapper, `@echo off\r\n"${process.execPath}" "${bridgeJs}" "${agent.id}" %*\r\n`)
+        await writeFile(wrapper, `@echo off\r\nif not exist "${nodePath}" exit /b 0\r\n"${nodePath}" "${bridgeJs}" "${agent.id}" %*\r\n`)
       } else {
-        await writeFile(wrapper, `#!/bin/sh\nexec ${shQuote(process.execPath)} ${shQuote(bridgeJs)} ${shQuote(agent.id)} "$@"\n`)
+        const q = shQuote(nodePath)
+        await writeFile(wrapper, `#!/bin/sh\n[ -x ${q} ] || exit 0\nexec ${q} ${shQuote(bridgeJs)} ${shQuote(agent.id)} "$@"\n`)
         await chmod(wrapper, 0o755)
       }
 


### PR DESCRIPTION
Hooks were dying in the packaged build with:

```
cate-hook-bridge-claude-code: line 2: ~/.cate/runtime/1.5.3/darwin-arm64/runtime/bin/node:
cannot execute: No such file or directory
```

## Cause

A packaged Cate and a dev build share one `RUNTIME_VERSION` but ship different daemon tarballs. Both provision into `~/.cate/runtime/<version>/<target>`, and `isInstalled()` keys freshness on the tarball's content hash in `.ok`. So each app read the other's install as stale, `rm -rf`'d the live directory and re-extracted 110MB of node into it. On my machine:

```
16:00:59  bridge wrapper written -> .../1.5.3/darwin-arm64/runtime/bin/node
16:05:53  node binary reappears           (rm -rf + re-extract happened here)
16:07:08  .ok written
```

Every agent hook bridge wrapper embeds that node path, so every hook that fired in the gap failed. Not dev-only: a prod re-download at an unchanged version, or any rebuilt tarball, wipes a live directory the same way.

## Fix

- Install dirs are keyed by tarball content: `<version>/<target>-<hash>`. Distinct builds sit side by side and nothing deletes a live install. The hash is now computed once per transport instead of on every `isInstalled` call.
- Extraction stages into a sibling and swaps in with `rename(2)`, so the install dir is always either the old complete tree or the new one. A failed extract leaves the previous install untouched.
- The bridge wrapper guards its exec on the node binary existing and exits 0 otherwise, matching `BRIDGE_JS`'s own never-fail-a-turn contract.

`LocalSubprocessOptions` swaps `installDir` for `installRoot` + `target`; the resolved dir is available as `await transport.installDir()`.

## Tests

New `src/main/runtime/transports/localInstall.test.ts` (real tar, real dirs, tiny fake tarballs), written first, all 6 red before the change:

- two builds of the same version never share a directory
- the same tarball always resolves to the same directory
- **provisioning build B leaves build A intact and runnable** (the regression)
- an already-provisioned install is not re-extracted
- a failed extraction leaves the previous install complete
- a forced re-provision swaps whole and leaves no staging dirs

Plus one in `agentHooks.test.ts`: the wrapper exits 0 with empty stderr when its node binary is gone.

Full suite green (2836 passed). `local-daemon-tarball.test.ts` and `extension-daemon.e2e.test.ts` updated to the new option shape; both provision and boot the real daemon fine. The former then fails on an unrelated workspace-allowlist check, identically on main.

## Not done

Pre-existing `<version>/<target>` dirs are left on disk. They are inert, and deleting them is the exact hazard this fixes. Nothing has ever pruned old runtime versions (13 dirs, ~1.4GB here); worth a separate age-based sweep.