### PR TITLE
fix(terminal): keep focus with selected split pane

### DIFF
--- a/e2e/terminal-focus-copy.spec.ts
+++ b/e2e/terminal-focus-copy.spec.ts
@@ -192,7 +192,7 @@ test('clicking a split sibling leaves focus in the clicked pane', async () => {
 
 test('rearranging the node keeps copy on the pane holding the selection', async () => {
   const nodeId = await splitTerminalNode(page)
-  const [left, right] = await panes(page, nodeId)
+  const [left] = await panes(page, nodeId)
 
   // Select in the LEFT pane.
   await clickPane(page, left)

--- a/e2e/terminal-focus-copy.spec.ts
+++ b/e2e/terminal-focus-copy.spec.ts
@@ -1,0 +1,306 @@
+// Repro for #521 — terminal focus / clipboard selection mismatch after splits.
+//
+// Cmd+C in a terminal is Electron's `role: 'copy'` (src/main/menu.ts), which
+// fires a native copy at whatever holds DOM focus; xterm answers it only for the
+// terminal whose element contains the focused node (its `copy` listener sits on
+// terminal.element). So the copy source is decided by DOM focus, never by the
+// terminal the selection lives in. These specs pin the observable consequences
+// inside one node's split mini-dock: where focus lands after a click, and which
+// terminal answers the copy.
+
+import { test, expect } from '@playwright/test'
+import {
+  launchApp,
+  closeApp,
+  seedTerminal,
+  resetViewport,
+  titleBarCentre,
+  getNodeRect,
+  dragMouse,
+  setZoom,
+} from './fixtures/electron-app'
+import type { ElectronApplication, Page } from 'playwright'
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeEach(async () => {
+  ;({ electronApp: app, mainWindow: page } = await launchApp())
+  await page.evaluate(() => window.__cateE2E!.setActiveLeftSidebarView(null))
+  await resetViewport(page)
+})
+test.afterEach(async () => closeApp(app))
+
+interface Pane {
+  index: number
+  rect: { x: number; y: number; width: number; height: number }
+}
+
+/** Print a marker line in a node's terminal. Written straight to the PTY via the
+ *  harness (not typed) so seeding never depends on the focus behaviour under
+ *  test — at this point each node still holds exactly one terminal. */
+async function seedMarker(p: Page, nodeId: string, marker: string): Promise<void> {
+  await p.waitForFunction((id) => window.__cateE2E!.terminalPtyId(id) !== null, nodeId, {
+    timeout: 15_000,
+  })
+  await p.evaluate(
+    ([id, m]) => window.__cateE2E!.writeTerminal(id!, `echo ${m}\r`),
+    [nodeId, marker],
+  )
+  await p.waitForTimeout(900)
+}
+
+/**
+ * Seed two terminals, give each distinct on-screen content, then drop A on B's
+ * left edge so both live in ONE node's mini-dock as a horizontal split — the
+ * shape the issue describes. Returns the surviving node id.
+ */
+async function splitTerminalNode(p: Page): Promise<string> {
+  // Zoom out first: at zoom 1 a node seeded far right hangs off the 1200px e2e
+  // window, and the canvas viewport cull detaches any pane that isn't
+  // intersecting (a detached pane can't be clicked or focused). At 0.6 both
+  // nodes — and both panes after the split — stay fully on screen.
+  await setZoom(p, 0.6)
+  await resetViewport(p)
+
+  const a = await seedTerminal(p, { x: 300, y: 100 })
+  const b = await seedTerminal(p, { x: 1000, y: 100 })
+  await setZoom(p, 0.6)
+  await resetViewport(p)
+  await p.waitForTimeout(300)
+
+  await seedMarker(p, a, 'LEFTMARK')
+  await seedMarker(p, b, 'RIGHTMARK')
+
+  const aGrab = await titleBarCentre(p, a)
+  const bRect = (await getNodeRect(p, b))!
+  const dropPoint = { x: bRect.x + 8, y: bRect.y + bRect.height / 2 }
+  await dragMouse(p, aGrab!, dropPoint, { steps: 25, pauseAtEnd: 50 })
+
+  await p.waitForFunction(
+    (id) => document.querySelectorAll(`[data-node-id="${id}"] .xterm`).length === 2,
+    b,
+    { timeout: 15_000 },
+  )
+  await p.waitForTimeout(600)
+  return b
+}
+
+/** Screen rects of the node's two xterm panes, left pane first. */
+async function panes(p: Page, nodeId: string): Promise<[Pane, Pane]> {
+  const rects = await p.evaluate((id) => {
+    const els = [...document.querySelectorAll(`[data-node-id="${id}"] .xterm`)]
+    return els.map((el, index) => {
+      const r = el.getBoundingClientRect()
+      return { index, rect: { x: r.x, y: r.y, width: r.width, height: r.height } }
+    })
+  }, nodeId)
+  const sorted = [...rects].sort((l, r) => l.rect.x - r.rect.x)
+  return [sorted[0]!, sorted[1]!]
+}
+
+/** Index of the pane that owns DOM focus, plus the panes xterm itself considers
+ *  focused (it stamps `.focus` on its element). -1 = focus is outside every
+ *  terminal (e.g. it fell back to <body>). */
+async function focusState(
+  p: Page,
+  nodeId: string,
+): Promise<{ domFocus: number; xtermFocus: number[] }> {
+  return p.evaluate((id) => {
+    const els = [...document.querySelectorAll(`[data-node-id="${id}"] .xterm`)]
+    const owner = (document.activeElement as HTMLElement | null)?.closest('.xterm')
+    return {
+      domFocus: owner ? els.indexOf(owner) : -1,
+      xtermFocus: els.flatMap((el, i) => (el.classList.contains('focus') ? [i] : [])),
+    }
+  }, nodeId)
+}
+
+/** Record every focusin target so a failure shows the churn, not just the end state. */
+async function traceFocus(p: Page, nodeId: string): Promise<() => Promise<string[]>> {
+  await p.evaluate((id) => {
+    const w = window as unknown as { __focusTrace?: string[] }
+    w.__focusTrace = []
+    document.addEventListener(
+      'focusin',
+      (e) => {
+        const els = [...document.querySelectorAll(`[data-node-id="${id}"] .xterm`)]
+        const owner = (e.target as HTMLElement | null)?.closest?.('.xterm')
+        w.__focusTrace!.push(owner ? `pane${els.indexOf(owner)}` : 'outside')
+      },
+      true,
+    )
+  }, nodeId)
+  return () => p.evaluate(() => (window as unknown as { __focusTrace: string[] }).__focusTrace)
+}
+
+/**
+ * Fire the real thing: webContents.copy() is exactly what Electron's
+ * Edit ▸ Copy (`role: 'copy'`, src/main/menu.ts) invokes for Cmd+C. Returns the
+ * pane whose xterm element answered the copy event, plus the resulting clipboard.
+ */
+async function nativeCopy(
+  p: Page,
+  a: ElectronApplication,
+  nodeId: string,
+): Promise<{ copyTarget: string; clipboard: string }> {
+  await a.evaluate(({ clipboard }) => clipboard.writeText('__CLEARED__'))
+  await p.evaluate((id) => {
+    const w = window as unknown as { __copyTarget?: string }
+    w.__copyTarget = 'none'
+    document.addEventListener(
+      'copy',
+      (e) => {
+        const els = [...document.querySelectorAll(`[data-node-id="${id}"] .xterm`)]
+        const owner = (e.target as HTMLElement | null)?.closest?.('.xterm')
+        w.__copyTarget = owner ? `pane${els.indexOf(owner)}` : 'outside'
+      },
+      true,
+    )
+  }, nodeId)
+  await a.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]!.webContents.copy())
+  await p.waitForTimeout(300)
+  return {
+    copyTarget: await p.evaluate(() => (window as unknown as { __copyTarget: string }).__copyTarget),
+    clipboard: await a.evaluate(({ clipboard }) => clipboard.readText()),
+  }
+}
+
+async function clickPane(p: Page, pane: Pane): Promise<void> {
+  await p.mouse.click(pane.rect.x + pane.rect.width / 2, pane.rect.y + pane.rect.height / 2)
+}
+
+test('clicking a split sibling leaves focus in the clicked pane', async () => {
+  const nodeId = await splitTerminalNode(page)
+  const [left, right] = await panes(page, nodeId)
+  const dump = await traceFocus(page, nodeId)
+
+  // Focus the left pane, then click the right one — "click terminal A, then B".
+  await clickPane(page, left)
+  await page.waitForTimeout(800)
+  await clickPane(page, right)
+  // Past the 500ms re-assert window in TerminalPanel's runFocus loop.
+  await page.waitForTimeout(1000)
+
+  const state = await focusState(page, nodeId)
+  console.log('focus trace:', (await dump()).join(' → '), '| state:', JSON.stringify(state))
+  expect(state.domFocus, 'DOM focus should be in the clicked pane').toBe(right.index)
+  expect(state.xtermFocus, 'exactly one pane should consider itself focused').toEqual([
+    right.index,
+  ])
+})
+
+test('rearranging the node keeps copy on the pane holding the selection', async () => {
+  const nodeId = await splitTerminalNode(page)
+  const [left, right] = await panes(page, nodeId)
+
+  // Select in the LEFT pane.
+  await clickPane(page, left)
+  await page.waitForTimeout(900)
+  await dragMouse(
+    page,
+    { x: left.rect.x + 4, y: left.rect.y + 4 },
+    { x: left.rect.x + left.rect.width - 8, y: left.rect.y + left.rect.height - 8 },
+    { steps: 20, pauseAtEnd: 200 },
+  )
+  await page.waitForTimeout(300)
+
+  const dump = await traceFocus(page, nodeId)
+  // Step 5 of the issue: rearrange, then come back to the node. Clicking away and
+  // re-focusing the node re-arms BOTH split panes' focus loops (focusEpoch bump),
+  // and they race for DOM focus for ~500ms.
+  const grab = await titleBarCentre(page, nodeId)
+  await dragMouse(page, grab!, { x: grab!.x + 90, y: grab!.y + 40 }, { steps: 15, pauseAtEnd: 80 })
+  await page.waitForTimeout(300)
+  await page.mouse.click(60, 700) // empty canvas — drops node focus
+  await page.waitForTimeout(300)
+  const grab2 = await titleBarCentre(page, nodeId)
+  await page.mouse.click(grab2!.x, grab2!.y) // re-focus the node
+  await page.waitForTimeout(1000)
+
+  const state = await focusState(page, nodeId)
+  const { copyTarget, clipboard } = await nativeCopy(page, app, nodeId)
+  console.log(
+    'after rearrange — focus:', JSON.stringify(state),
+    '| trace:', (await dump()).join(' → '),
+    '| copy answered by:', copyTarget,
+    '| clipboard:', JSON.stringify(clipboard.slice(0, 120)),
+  )
+
+  expect(copyTarget, 'copy should still be answered by the pane holding the selection').toBe(
+    `pane${left.index}`,
+  )
+  expect(clipboard).toContain('LEFTMARK')
+  expect(clipboard).not.toContain('RIGHTMARK')
+})
+
+test('copy takes the selection from the pane the user selected in', async () => {
+  const nodeId = await splitTerminalNode(page)
+  const [left, right] = await panes(page, nodeId)
+
+  // Land in the left pane first, then click into the right one and select there.
+  await clickPane(page, left)
+  await page.waitForTimeout(800)
+  await clickPane(page, right)
+  await page.waitForTimeout(1000)
+
+  // Drag-select the whole visible buffer of the RIGHT pane.
+  await dragMouse(
+    page,
+    { x: right.rect.x + 4, y: right.rect.y + 4 },
+    { x: right.rect.x + right.rect.width - 8, y: right.rect.y + right.rect.height - 8 },
+    { steps: 20, pauseAtEnd: 200 },
+  )
+  await page.waitForTimeout(400)
+
+  const { copyTarget, clipboard } = await nativeCopy(page, app, nodeId)
+  console.log('copy answered by:', copyTarget, '| clipboard:', JSON.stringify(clipboard))
+
+  expect(copyTarget, 'copy should be answered by the pane holding the selection').toBe(
+    `pane${right.index}`,
+  )
+  expect(clipboard).toContain('RIGHTMARK')
+  expect(clipboard).not.toContain('LEFTMARK')
+})
+
+test('copy does not return a stale selection from the other pane', async () => {
+  const nodeId = await splitTerminalNode(page)
+  const [left, right] = await panes(page, nodeId)
+
+  const selectAll = async (pane: Pane): Promise<void> => {
+    await dragMouse(
+      page,
+      { x: pane.rect.x + 4, y: pane.rect.y + 4 },
+      { x: pane.rect.x + pane.rect.width - 8, y: pane.rect.y + pane.rect.height - 8 },
+      { steps: 20, pauseAtEnd: 200 },
+    )
+    await page.waitForTimeout(300)
+  }
+
+  // The user selected in the RIGHT pane a while ago (stale selection lives on
+  // in that terminal), then moved to the LEFT pane and selected there.
+  await clickPane(page, right)
+  await page.waitForTimeout(900)
+  await selectAll(right)
+  await clickPane(page, left)
+  await page.waitForTimeout(900)
+  await selectAll(left)
+
+  // Rearrange + come back, per steps 5-6 of the issue.
+  const grab = await titleBarCentre(page, nodeId)
+  await dragMouse(page, grab!, { x: grab!.x + 90, y: grab!.y + 40 }, { steps: 15, pauseAtEnd: 80 })
+  await page.waitForTimeout(300)
+  await page.mouse.click(60, 700)
+  await page.waitForTimeout(300)
+  const grab2 = await titleBarCentre(page, nodeId)
+  await page.mouse.click(grab2!.x, grab2!.y)
+  await page.waitForTimeout(1000)
+
+  const { copyTarget, clipboard } = await nativeCopy(page, app, nodeId)
+  console.log('stale-selection copy answered by:', copyTarget, '| clipboard:', JSON.stringify(clipboard.slice(0, 120)))
+
+  expect(clipboard, 'copy should return the last selection the user made').toContain('LEFTMARK')
+  expect(clipboard, "copy must not return the other pane's stale selection").not.toContain(
+    'RIGHTMARK',
+  )
+})

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -25,6 +25,7 @@ import type { DockStore } from '../stores/dockStore'
 import { DockStoreProvider } from '../stores/DockStoreContext'
 import DockTabStack from '../docking/DockTabStack'
 import { activeLeafPanelId } from '../panels/nodeDockRegistry'
+import { findTabStack } from '../stores/dockTreeUtils'
 import { setActivePanel } from '../lib/activePanel'
 import { Tooltip } from '../ui/Tooltip'
 import DockLayoutRenderer from '../docking/DockLayoutRenderer'
@@ -469,16 +470,53 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
   // --- Event handlers --------------------------------------------------------
 
+  // The leaf the user last pressed inside this node's mini-dock. A split node
+  // has several visible leaves at once, and activeLeafPanelId() always answers
+  // with the FIRST one — so without this every press on the right-hand pane
+  // would still point the active panel (and therefore DOM focus) at the left
+  // one. Recorded on pointer-down, below.
+  const pressedLeafRef = useRef<string | null>(null)
+
+  /** The leaf that should own focus: the one the user last pressed, as long as
+   *  it's still in the layout; otherwise the layout's active leaf. */
+  const preferredLeaf = useCallback((): string | null => {
+    const layoutNow = dockStoreApi.getState().zones.center.layout
+    const pressed = pressedLeafRef.current
+    if (pressed && collectPanelIds(layoutNow).includes(pressed)) return pressed
+    pressedLeafRef.current = null
+    return activeLeafPanelId(layoutNow)
+  }, [dockStoreApi])
+
   // Focus this node AND point the canonical active-panel pointer at its active
-  // leaf (the visible dock tab). This is the bridge
-  // that makes terminal-focus detection (and Cmd+T placement) correct for a node
-  // whose mini-dock holds several panels. The subscription below re-asserts it on
-  // every tab switch while focused; this covers the initial focus.
+  // leaf (the pane the user pressed, else the visible dock tab). This is the
+  // bridge that makes terminal-focus detection (and Cmd+T placement) correct for
+  // a node whose mini-dock holds several panels. The subscription below
+  // re-asserts it on every tab switch while focused; this covers the initial focus.
   const focusThisNode = useCallback(() => {
     focusNode(nodeId)
-    const leaf = activeLeafPanelId(dockStoreApi.getState().zones.center.layout)
-    setActivePanel(leaf)
-  }, [focusNode, nodeId, dockStoreApi])
+    setActivePanel(preferredLeaf())
+  }, [focusNode, nodeId, preferredLeaf])
+
+  /** Pointer-down anywhere in the node body: remember which split pane it landed
+   *  in and make that the active panel. Runs on every press (not just the one
+   *  that focuses the node) so clicking between panes of an already-focused node
+   *  moves the active panel too. */
+  const recordPressedLeaf = useCallback(
+    (target: EventTarget | null) => {
+      const targetEl = target as HTMLElement | null
+      const stackEl = targetEl?.closest?.('[data-dock-stack-id]')
+      const stackId = (stackEl as HTMLElement | null)?.dataset.dockStackId
+      if (!stackId) return
+      const stack = findTabStack(dockStoreApi.getState().zones.center.layout, stackId)
+      const clickedTab = (targetEl?.closest?.('[data-tab-panel-id]') as HTMLElement | null)
+        ?.dataset.tabPanelId
+      const leaf = clickedTab ?? stack?.panelIds[stack.activeIndex] ?? stack?.panelIds[0]
+      if (!leaf) return
+      pressedLeafRef.current = leaf
+      setActivePanel(leaf)
+    },
+    [dockStoreApi],
+  )
 
   // Authoritative writer for the active panel while this node is focused: any
   // center-layout change (tab switch, split, close) re-points activePanelId at
@@ -492,7 +530,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
     // Re-assert on becoming focused (the click path already did, but a focus
     // change via keyboard nav goes through focusNode without focusThisNode).
     if (isFocused) {
-      const leaf = activeLeafPanelId(dockStoreApi.getState().zones.center.layout)
+      const leaf = preferredLeaf()
       if (leaf) setActivePanel(leaf)
     }
     let prevLeaf = activeLeafPanelId(dockStoreApi.getState().zones.center.layout)
@@ -500,10 +538,13 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
       const leaf = activeLeafPanelId(s.zones.center.layout)
       if (leaf === prevLeaf) return
       prevLeaf = leaf
+      // A layout change (tab switch, split, close) retires the remembered pane:
+      // the user's last press may no longer be what's visible.
+      pressedLeafRef.current = null
       if (isFocusedRef.current && leaf) setActivePanel(leaf)
     })
     return unsub
-  }, [dockStoreApi, isFocused])
+  }, [dockStoreApi, isFocused, preferredLeaf])
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -718,7 +759,12 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
           <div
             style={{ position: 'relative', zIndex: 0, width: '100%', height: '100%' }}
             onMouseDownCapture={(e) => {
-              if (e.button !== 0 || isFocused) return
+              if (e.button !== 0) return
+              // Which pane of a split did this land in? Recorded before the
+              // focus bail-outs below, so switching panes inside an
+              // already-focused node still re-points the active panel.
+              recordPressedLeaf(e.target)
+              if (isFocused) return
               // When this node is part of a live multi-selection, a press on it
               // starts a GROUP drag (the bubble-phase handlers call handleDragStart,
               // which carries the selection). Focusing here would run first

--- a/src/renderer/docking/DockTabStack.tsx
+++ b/src/renderer/docking/DockTabStack.tsx
@@ -228,6 +228,10 @@ export default function DockTabStack({ stack, zone: zoneProp, renderPanel, getPa
   return (
     <div
       ref={stackRef}
+      // Lets an ancestor map a pointer target back to the leaf stack it landed
+      // in — CanvasNode uses it to learn WHICH pane of a split mini-dock the
+      // user pressed, so focus goes to that pane and not the first leaf.
+      data-dock-stack-id={stack.id}
       className="flex flex-col h-full min-h-0 relative"
       // Mark this stack's active tab as the active panel on any pointer-down
       // inside it (tab bar OR content), so a panel-create shortcut lands here —

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -25,6 +25,8 @@ import { useUIStore } from '../stores/uiStore'
 import { useMissingAgentHookNotice } from '../hooks/useMissingAgentHookNotice'
 import { Warning } from '@phosphor-icons/react'
 import { focusedNodeId } from '../stores/canvas/selectionModel'
+import { useActivePanelStore, getActivePanelId } from '../lib/activePanel'
+import { collectPanelIds } from '../../shared/collectPanelIds'
 import { resolveTerminalFontSize } from '../lib/terminal/terminalSettings'
 import { shouldAdjustTerminalCoords } from '../lib/terminal/terminalCoordAdjust'
 import { useTerminalGlow } from '../cateAgent/cateAgentStore'
@@ -408,6 +410,27 @@ export default function TerminalPanel({
   useEffect(() => {
     let cancelled = false
 
+    /**
+     * False when a SIBLING panel of this node owns the active panel — i.e. this
+     * node's mini-dock is split and the user is working in the other pane.
+     *
+     * Node focus is per-NODE, so every pane of a split sees isFocused === true.
+     * Without this gate all of them re-assert `textarea.focus()` on the same
+     * 25 ms tick and the last one to fire wins, which is how a click (and the
+     * Cmd+C that follows it — Electron's `role: 'copy'` copies from whatever
+     * holds DOM focus) lands on the wrong terminal. Deliberately permissive: an
+     * unset or out-of-node active panel still focuses, so a single-terminal node
+     * behaves exactly as before.
+     */
+    const ownsNodeFocus = (): boolean => {
+      const active = getActivePanelId()
+      if (!active || active === panelId) return true
+      const layout = nodeId ? canvasApi?.getState().nodes[nodeId]?.dockLayout : null
+      if (!layout) return true
+      const siblings = collectPanelIds(layout)
+      return !(siblings.includes(active) && siblings.includes(panelId))
+    }
+
     const runFocus = () => {
       let waitAttempts = 0
       let recheckAttempts = 0
@@ -415,6 +438,7 @@ export default function TerminalPanel({
       let myCancelled = false
       const tick = () => {
         if (cancelled || myCancelled) return
+        if (!ownsNodeFocus()) return
         const entry = terminalRegistry.getEntry(panelId)
         const el = entry?.terminal.element
         // Skip when xterm DOM is not attached: IntersectionObserver can briefly
@@ -456,10 +480,23 @@ export default function TerminalPanel({
       stopRun = runFocus()
     })
 
+    // Becoming the active pane of a focused split node: take DOM focus. Covers
+    // a press that lands on pane chrome rather than the xterm element itself
+    // (xterm focuses its own textarea on a direct mousedown).
+    const unsubscribeActive = useActivePanelStore.subscribe((s, prev) => {
+      if (s.activePanelId === prev.activePanelId) return
+      if (s.activePanelId !== panelId) return
+      const state = canvasApi?.getState()
+      if (state && nodeId && focusedNodeId(state) !== nodeId) return
+      stopRun?.()
+      stopRun = runFocus()
+    })
+
     return () => {
       cancelled = true
       stopRun?.()
       unsubscribe?.()
+      unsubscribeActive()
     }
   }, [isFocused, panelId, nodeId, canvasApi])
 


### PR DESCRIPTION
## Summary

- track the exact mini-dock split pane or tab pressed inside a canvas node
- prevent sibling terminal panels in the same focused node from racing to reclaim DOM focus
- refocus a terminal when it becomes the active pane
- add Electron E2E coverage for focus, native copy routing, rearrangement, and stale selections

## Root cause

Canvas focus is tracked per node, so every terminal in a split node observed itself as focused and repeatedly called `focus()` during the same 500 ms retry window. The last terminal to run could take DOM focus even when the user clicked or selected text in another pane. Electron's native Copy command then copied from that incorrectly focused terminal.

## User impact

Clicks, selections, and native copy now stay associated with the terminal pane the user actually selected, including after moving the node or focusing away and back.

Closes #521.

## Validation

- `npx playwright test e2e/terminal-focus-copy.spec.ts` - 4 passed
- `npx vitest run src/renderer/canvas/CanvasNode.groupDrag.test.tsx src/renderer/stores/dockStore.test.ts` - 46 passed
- `npm run typecheck`
- `npm run build`
- focused ESLint check - 0 errors (3 pre-existing hook dependency warnings in `CanvasNode.tsx`)
