### PR TITLE
Fix terminal rendering artifacts

### DIFF
--- a/src/renderer/docking/useDockTabActions.rename.test.tsx
+++ b/src/renderer/docking/useDockTabActions.rename.test.tsx
@@ -13,9 +13,11 @@ import { act } from 'react'
 
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
+const resetRendering = vi.hoisted(() => vi.fn())
+
 vi.mock('../lib/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
 vi.mock('../lib/terminal/terminalRegistry', () => ({
-  terminalRegistry: { entries: () => [], panelIdForPty: () => null, ptyIdForPanel: () => null, has: () => false, getEntry: () => undefined, dispose: vi.fn(), release: vi.fn(), disposeWorkspace: vi.fn() },
+  terminalRegistry: { entries: () => [], panelIdForPty: () => null, ptyIdForPanel: () => null, has: () => false, getEntry: () => undefined, dispose: vi.fn(), release: vi.fn(), disposeWorkspace: vi.fn(), resetRendering },
 }))
 vi.mock('../../agent/renderer/agentSessionRegistry', () => ({
   disposeAgentPanel: vi.fn(),
@@ -43,6 +45,7 @@ const Harness: React.FC = () => {
     zone: 'center',
     dockStoreApi: dockStore,
     workspaceId: 'ws-rename',
+    getPanelProp: () => ({ id: 'p1', type: 'terminal', title: 'Agent · foo' }) as never,
   })
   return null
 }
@@ -54,6 +57,7 @@ const initialAppState = useAppStore.getState()
 
 beforeEach(() => {
   renamePanelByUser.mockClear()
+  resetRendering.mockClear()
   useAppStore.setState({ renamePanelByUser } as never)
   host = document.createElement('div')
   document.body.appendChild(host)
@@ -107,5 +111,30 @@ describe('useDockTabActions — commitRename seed regression', () => {
     act(() => { api.current!.beginRename('p1', 'Custom') })
     act(() => { api.current!.commitRename('p1') })
     expect(renamePanelByUser).not.toHaveBeenCalled()
+  })
+
+  it('offers terminal rendering recovery and resets only the selected panel', async () => {
+    const showContextMenu = vi.fn(
+      async (items: import('../../shared/electron-api').NativeContextMenuItem[]) => {
+        expect(items).toContainEqual({
+          id: 'reset-terminal-rendering',
+          label: 'Reset Terminal Rendering',
+        })
+        return 'reset-terminal-rendering'
+      },
+    )
+    Object.defineProperty(window.electronAPI, 'showContextMenu', {
+      configurable: true,
+      value: showContextMenu,
+    })
+
+    await act(async () => {
+      await api.current!.handleTabContextMenu({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as never, 'p1')
+    })
+
+    expect(resetRendering).toHaveBeenCalledWith('p1')
   })
 })

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -195,6 +195,12 @@ export function useDockTabActions(params: DockTabActionsParams) {
       const hasRight = idx >= 0 && idx < stack.panelIds.length - 1
       const panel = getPanelLocal(panelId)
       const menu: NativeContextMenuItem[] = [
+        ...(panel?.type === 'terminal'
+          ? [
+              { id: 'reset-terminal-rendering', label: 'Reset Terminal Rendering' },
+              { type: 'separator' },
+            ] as NativeContextMenuItem[]
+          : []),
         { id: 'rename', label: 'Rename' },
         { type: 'separator' },
         { id: 'close', label: 'Close', accelerator: 'Cmd+W' },
@@ -209,6 +215,11 @@ export function useDockTabActions(params: DockTabActionsParams) {
       ]
       const id = await window.electronAPI.showContextMenu(menu)
       switch (id) {
+        case 'reset-terminal-rendering': {
+          const { terminalRegistry } = await import('../lib/terminal/terminalRegistry')
+          terminalRegistry.resetRendering(panelId)
+          break
+        }
         case 'rename':
           if (panel) beginRename(panelId, panel.title)
           break

--- a/src/renderer/lib/terminal/terminalDom.ts
+++ b/src/renderer/lib/terminal/terminalDom.ts
@@ -99,6 +99,29 @@ export function forceWebglRepaint(): void {
 }
 
 /**
+ * Recover a visibly corrupted terminal without restarting its PTY.
+ *
+ * Silent glyph-atlas corruption does not always fire WebGL's context-loss
+ * event, so users need an explicit escape hatch. Dispose only this panel's GPU
+ * renderer and keep it on xterm's DOM renderer for the rest of the session;
+ * the terminal buffer, scrollback, and running process all remain untouched.
+ * Repaint the other terminals too because their WebGL renderers may share the
+ * atlas that became corrupt.
+ */
+export function resetRendering(panelId: string): void {
+  const entry = registry.get(panelId)
+  if (!entry) return
+
+  webglDisabledPanels.add(panelId)
+  if (entry.webglAddon) {
+    try { entry.webglAddon.dispose() } catch { /* ignore */ }
+    entry.webglAddon = null
+  }
+  releaseWebglGrant(panelId)
+  forceWebglRepaint()
+}
+
+/**
  * Create the WebGL renderer for a granted panel and swap it in for xterm's DOM
  * renderer. No-op if the entry is gone or already on WebGL. On context loss the
  * panel falls back to the DOM renderer for the rest of the session and returns

--- a/src/renderer/lib/terminal/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.test.ts
@@ -728,6 +728,35 @@ describe('WebGL glyph-atlas resync on a shared-config change', () => {
   })
 })
 
+describe('manual terminal rendering recovery', () => {
+  it('falls back to the DOM renderer without replacing the terminal or its PTY', async () => {
+    const { registry } = await import('./registryState')
+    const { terminalRegistry } = await import('./terminalRegistry')
+    const disposeWebgl = vi.fn()
+    const refresh = vi.fn()
+    const terminal = { rows: 24, refresh }
+    const entry = {
+      terminal,
+      webglAddon: { dispose: disposeWebgl, clearTextureAtlas: vi.fn() },
+      ptyId: 'pty-recovery',
+    }
+    registry.set('panel-recovery', entry as never)
+
+    try {
+      terminalRegistry.resetRendering('panel-recovery')
+
+      expect(disposeWebgl).toHaveBeenCalledTimes(1)
+      expect(entry.webglAddon).toBeNull()
+      expect(registry.get('panel-recovery')?.terminal).toBe(terminal)
+      expect(registry.get('panel-recovery')?.ptyId).toBe('pty-recovery')
+      expect(refresh).toHaveBeenCalledTimes(1)
+      expect(window.electronAPI.terminalKill).not.toHaveBeenCalled()
+    } finally {
+      registry.delete('panel-recovery')
+    }
+  })
+})
+
 describe('process-wide WebGL context grant lifecycle', () => {
   async function mountAndAttach(panelId: string): Promise<{
     terminalRegistry: typeof import('./terminalRegistry').terminalRegistry
@@ -778,5 +807,17 @@ describe('process-wide WebGL context grant lifecycle', () => {
     terminalRegistry.dispose('panel-release')
 
     expect(webglReleaseGrant).toHaveBeenCalledWith('panel-release')
+  })
+
+  it('releases the grant and stays on the DOM renderer after a manual reset', async () => {
+    const { terminalRegistry, container } = await mountAndAttach('panel-reset')
+
+    terminalRegistry.resetRendering('panel-reset')
+
+    expect(terminalRegistry.getEntry('panel-reset')?.webglAddon).toBeNull()
+    expect(webglReleaseGrant).toHaveBeenCalledWith('panel-reset')
+
+    document.body.removeChild(container)
+    terminalRegistry.dispose('panel-reset')
   })
 })

--- a/src/renderer/lib/terminal/terminalRegistry.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.ts
@@ -23,7 +23,7 @@ import {
   setPendingTransfer,
   setPendingRestore,
 } from './terminalLifecycle'
-import { attach, detach, fit, restoreScroll } from './terminalDom'
+import { attach, detach, fit, resetRendering, restoreScroll } from './terminalDom'
 import { findNext, findPrevious, clearSearch } from './terminalSearch'
 import { serializeTerminalState } from './scrollbackCapture'
 import {
@@ -55,6 +55,7 @@ export const terminalRegistry = {
   disposeWorkspace,
   release,
   fit,
+  resetRendering,
   restoreScroll,
   setPendingTransfer,
   setPendingRestore,

--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -270,6 +270,7 @@ describe('agentHooks capability', () => {
       let err = ''
       const child = execFile(path.join(dir, 'cate-hook-bridge-claude-code'), [], { env, timeout: 15_000 })
       child.stderr!.on('data', (chunk) => { err += String(chunk) })
+      child.stdin!.on('error', () => { /* wrapper may exit before reading stdin */ })
       child.on('close', (c) => resolve({ code: c, stderr: err }))
       child.stdin!.end(JSON.stringify({ hook_event_name: 'SessionStart', cwd: '/w' }))
     })


### PR DESCRIPTION
Adds a safe renderer reset for garbled terminals without restarting the PTY.