### PR TITLE
Add real CLI E2E and harden agent workflows

### DIFF
--- a/e2e/cate-cli.spec.ts
+++ b/e2e/cate-cli.spec.ts
@@ -1,0 +1,251 @@
+// Real Cate CLI E2E. Unlike src/cli/cate.integration.test.ts (scripted HTTP),
+// this launches Electron, provisions Cate's runtime, types commands into a real
+// Cate terminal, and drives a real BrowserPanel webview through CATE_API.
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import http from 'node:http'
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { closeApp, launchApp, seedTerminal } from './fixtures/electron-app'
+
+let app: ElectronApplication
+let page: Page
+let server: http.Server
+let baseUrl = ''
+let workspace = ''
+
+const FORM_HTML = `<!doctype html>
+<html>
+  <head><title>Form Ready</title></head>
+  <body style="min-height: 1200px">
+    <h1>Cate CLI browser fixture</h1>
+    <form id="form">
+      <label for="query">Query</label>
+      <input id="query" type="search" />
+      <label for="password">Password</label>
+      <input id="password" type="password" value="never-expose-me" />
+      <button id="submit" type="submit">Submit query</button>
+      <button id="click" type="button">Click me</button>
+      <div id="status">Loading</div>
+    </form>
+    <script>
+      document.querySelector('#click').addEventListener('click', () => {
+        document.title = 'Clicked'
+        setTimeout(() => { document.querySelector('#status').textContent = 'Saved' }, 100)
+      })
+      document.querySelector('#form').addEventListener('submit', (event) => {
+        event.preventDefault()
+        document.title = 'Submitted:' + document.querySelector('#query').value
+      })
+    </script>
+  </body>
+</html>`
+
+function startFixtureServer(): Promise<void> {
+  return new Promise((resolve) => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(FORM_HTML)
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      baseUrl = `http://127.0.0.1:${port}/form`
+      resolve()
+    })
+  })
+}
+
+function shellQuote(value: string): string {
+  if (process.platform === 'win32') return `'${value.replace(/'/g, "''")}'`
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function cate(...args: string[]): string {
+  return `cate ${args.map(shellQuote).join(' ')}`
+}
+
+let commandSequence = 0
+
+async function runInCateTerminal(
+  nodeId: string,
+  command: string,
+  timeout = 20_000,
+): Promise<{ code: number; output: string }> {
+  const sequence = ++commandSequence
+  const begin = `__CATE_BEGIN_${sequence}__`
+  const end = `__CATE_END_${sequence}__`
+  const wrapped = process.platform === 'win32'
+    ? `Write-Output ("__CATE_{0}_${sequence}__" -f "BEGIN"); ${command}; $cateStatus=$LASTEXITCODE; Write-Output ("__CATE_{0}_${sequence}__:{1}" -f "END",$cateStatus)\r`
+    : `printf '\\n__CATE_%s_${sequence}__\\n' BEGIN; ${command}; cate_status=$?; printf '\\n__CATE_%s_${sequence}__:%s\\n' END "$cate_status"\r`
+
+  const accepted = await page.evaluate(
+    ({ id, data }) => window.__cateE2E!.writeTerminal(id, data),
+    { id: nodeId, data: wrapped },
+  )
+  expect(accepted).toBe(true)
+
+  await expect.poll(
+    () => page.evaluate((id) => window.__cateE2E!.terminalText(id), nodeId),
+    { timeout },
+  ).toContain(`${end}:`)
+
+  const screen = await page.evaluate((id) => window.__cateE2E!.terminalText(id), nodeId)
+  const endMatch = screen?.match(new RegExp(`${end}:(\\d+)`))
+  expect(endMatch, screen ?? 'terminal unavailable').not.toBeNull()
+  const endAt = screen!.lastIndexOf(endMatch![0])
+  const beginAt = screen!.lastIndexOf(begin, endAt)
+  expect(beginAt, screen ?? '').toBeGreaterThanOrEqual(0)
+  return {
+    code: Number(endMatch![1]),
+    output: screen!.slice(beginAt + begin.length, endAt).trim(),
+  }
+}
+
+async function runCate(nodeId: string, ...args: string[]): Promise<string> {
+  const result = await runInCateTerminal(nodeId, cate(...args))
+  expect(result.code, `${args.join(' ')}\n${result.output}`).toBe(0)
+  return result.output
+}
+
+async function nodeForPanel(shortPanelId: string): Promise<string> {
+  return expect.poll(
+    async () => page.evaluate(
+      (prefix) => window.__cateE2E!.nodes().find((node) => node.panelId.startsWith(prefix))?.id ?? '',
+      shortPanelId,
+    ),
+    { timeout: 15_000 },
+  ).not.toBe('').then(async () => page.evaluate(
+    (prefix) => window.__cateE2E!.nodes().find((node) => node.panelId.startsWith(prefix))!.id,
+    shortPanelId,
+  ))
+}
+
+test.beforeAll(async () => {
+  await startFixtureServer()
+})
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+})
+
+test.beforeEach(async () => {
+  // Match workspaceManager's canonical root (`/private/var/...` on macOS;
+  // tmpdir() itself may spell the same directory through the `/var` symlink).
+  workspace = realpathSync(mkdtempSync(path.join(tmpdir(), 'cate-cli-e2e-')))
+  writeFileSync(path.join(workspace, 'cli-fixture.ts'), 'export const e2e = true\n')
+  ;({ electronApp: app, mainWindow: page } = await launchApp())
+  expect(await page.evaluate((root) => window.__cateE2E!.setWorkspaceRoot(root), workspace)).toBe(true)
+  // Terminal input is the only CLI permission disabled by default. Enable it
+  // through the real settings IPC so terminal type/press can be exercised.
+  await page.evaluate(() => window.electronAPI.settingsSet('cliTerminalInputEnabled', true))
+})
+
+test.afterEach(async () => {
+  await closeApp(app)
+  rmSync(workspace, { recursive: true, force: true })
+})
+
+test('every cate CLI command works from a real Cate terminal', async () => {
+  test.setTimeout(180_000)
+  const controlNode = await seedTerminal(page, { x: 120, y: 120 })
+  await expect.poll(
+    () => page.evaluate((id) => window.__cateE2E!.terminalPtyId(id), controlNode),
+    { timeout: 60_000 },
+  ).not.toBeNull()
+
+  // Process/transport basics.
+  expect(await runCate(controlNode, '--version')).toMatch(/^cate cli \d+$/)
+  expect(await runCate(controlNode, '--help')).toContain('browser    open <url>')
+  expect(await runCate(controlNode, 'version')).toBe('4')
+  expect(await runCate(controlNode, 'panel', 'list')).toContain('terminal')
+  expect(await runCate(controlNode, 'panel', 'set-title', 'CLI Control')).toBe('ok')
+  expect(await runCate(controlNode, 'panel', 'list')).toContain('CLI Control')
+  expect(await runCate(controlNode, 'ui', 'notify', 'CLI E2E notification')).toBe('ok')
+
+  // Editor + panel verbs.
+  const editorId = await runCate(controlNode, 'editor', 'open', `${path.join(workspace, 'cli-fixture.ts')}:1:8`)
+  expect(editorId).toMatch(/^[a-z0-9-]{8}$/i)
+  expect(await runCate(controlNode, 'panel', 'focus', editorId)).toBe('ok')
+  expect(await runCate(controlNode, 'panel', 'list')).toContain('cli-fixture.ts')
+
+  // Browser verbs against a real Electron webview and local HTTP page.
+  const browserId = await runCate(controlNode, 'panel', 'create', 'browser', baseUrl)
+  expect(browserId).toMatch(/^[a-z0-9-]{8}$/i)
+  expect(await runCate(controlNode, 'browser', 'open', `${baseUrl}?opened=1`, '--panel', browserId)).toBe(`${baseUrl}?opened=1`)
+  expect(await runCate(controlNode, 'browser', 'wait', '8000', '--panel', browserId)).toBe(`${baseUrl}?opened=1`)
+
+  let snapshot = await runCate(controlNode, 'browser', 'snapshot', '--panel', browserId)
+  expect(snapshot).toContain('title: Form Ready')
+  expect(snapshot).toContain('••••••••')
+  expect(snapshot).not.toContain('never-expose-me')
+  let queryRef = snapshot.match(/\[(@s\d+e\d+)\] input:search "Query"/)?.[1]
+  const clickRef = snapshot.match(/\[(@s\d+e\d+)\] button "Click me"/)?.[1]
+  expect(queryRef).toBeTruthy()
+  expect(clickRef).toBeTruthy()
+
+  expect(await runCate(controlNode, 'browser', 'fill', queryRef!, 'hello', '--panel', browserId)).toBe('ok')
+  expect(await runCate(controlNode, 'browser', 'type', queryRef!, 'hello cate', '--panel', browserId)).toBe('ok')
+  snapshot = await runCate(controlNode, 'browser', 'snapshot', '--panel', browserId)
+  expect(snapshot).toContain('= "hello cate"')
+  const currentClickRef = snapshot.match(/\[(@s\d+e\d+)\] button "Click me"/)?.[1]
+  const clickObservation = await runCate(
+    controlNode, 'browser', 'click', currentClickRef!, '--snapshot', '--panel', browserId,
+  )
+  expect(clickObservation).toContain('title: Clicked')
+  const savedObservation = await runCate(
+    controlNode, 'browser', 'wait', 'text', 'Saved', '--wait-timeout', '3000', '--snapshot', '--panel', browserId,
+  )
+  expect(savedObservation).toContain('title: Clicked')
+  expect(await runCate(
+    controlNode, 'browser', 'wait', 'gone', 'Loading', '--wait-timeout', '3000', '--panel', browserId,
+  )).toBe(`${baseUrl}?opened=1`)
+  expect(await runCate(
+    controlNode, 'browser', 'wait', 'url', '**?opened=1', '--wait-timeout', '3000', '--panel', browserId,
+  )).toBe(`${baseUrl}?opened=1`)
+  queryRef = savedObservation.match(/\[(@s\d+e\d+)\] input:search "Query"/)?.[1]
+  expect(queryRef).toBeTruthy()
+  expect(await runCate(
+    controlNode, 'browser', 'wait', 'ref', queryRef!, 'visible', '--wait-timeout', '3000', '--panel', browserId,
+  )).toBe(`${baseUrl}?opened=1`)
+  expect(await runCate(controlNode, 'browser', 'press', queryRef!, 'Enter', '--panel', browserId)).toBe('ok')
+  expect(await runCate(controlNode, 'browser', 'snapshot', '--panel', browserId)).toContain('title: Submitted:hello cate')
+  expect(await runCate(controlNode, 'browser', 'press', 'PageDown', '--panel', browserId)).toBe('ok')
+
+  const screenshot = await runCate(controlNode, 'browser', 'screenshot', '--panel', browserId)
+  expect(screenshot).toMatch(/\.png$/)
+  expect(existsSync(screenshot)).toBe(true)
+  expect(await runCate(controlNode, 'browser', 'reload', '--panel', browserId)).toBe('ok')
+  await runCate(controlNode, 'browser', 'wait', '8000', '--panel', browserId)
+
+  // A second real terminal proves terminal type/press/read, not just the shell
+  // hosting this test's CLI process.
+  const workerId = await runCate(controlNode, 'panel', 'create', 'terminal')
+  const workerNode = await nodeForPanel(workerId)
+  await expect.poll(
+    () => page.evaluate((id) => window.__cateE2E!.terminalPtyId(id), workerNode),
+    { timeout: 30_000 },
+  ).not.toBeNull()
+  const workerOutput = path.join(workspace, 'cli-worker.out')
+  const workerCommand = process.platform === 'win32'
+    ? 'Set-Content -NoNewline cli-worker.out CLI_TARGET_OK; Get-Content cli-worker.out'
+    : 'printf CLI_TARGET_OK > cli-worker.out; cat cli-worker.out'
+  expect(await runCate(controlNode, 'terminal', 'type', workerCommand, '--panel', workerId)).toBe('ok')
+  expect(await runCate(controlNode, 'terminal', 'press', 'enter', '--panel', workerId)).toBe('ok')
+  await expect.poll(
+    () => existsSync(workerOutput) ? readFileSync(workerOutput, 'utf8') : '',
+    { timeout: 10_000 },
+  ).toBe('CLI_TARGET_OK')
+  expect(await runCate(controlNode, 'terminal', 'read', '--max', '20', '--panel', workerId)).toContain('CLI_TARGET_OK')
+
+  // Close verifies immediate list consistency for several panel types.
+  expect(await runCate(controlNode, 'panel', 'close', workerId)).toBe('ok')
+  expect(await runCate(controlNode, 'panel', 'close', browserId)).toBe('ok')
+  expect(await runCate(controlNode, 'panel', 'close', editorId)).toBe('ok')
+  const finalPanels = await runCate(controlNode, 'panel', 'list')
+  expect(finalPanels).not.toContain(workerId)
+  expect(finalPanels).not.toContain(browserId)
+  expect(finalPanels).not.toContain(editorId)
+})

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -15,18 +15,23 @@ export interface LaunchResult {
 const REPO_ROOT = path.resolve(__dirname, '..', '..')
 
 export async function launchApp(opts: { perf?: boolean } = {}): Promise<LaunchResult> {
+  const env = {
+    ...process.env,
+    CATE_E2E: '1',
+    NODE_ENV: 'production',
+    // Activate the resource profiler (main getAppMetrics sampler + counters,
+    // renderer FPS/long-task/render counters, window.__catePerf) for the
+    // perf-stress spec. Harmless no-op for other specs that don't set it.
+    ...(opts.perf ? { CATE_PERF: '1' } : {}),
+  }
+  // Playwright forces colored reporter output while some hosts also export
+  // NO_COLOR. Passing both into a real terminal makes every bundled Node CLI
+  // print a warning before its own stdout, which is not a Cate behavior.
+  delete env.NO_COLOR
   const electronApp = await electron.launch({
     args: ['.'],
     cwd: REPO_ROOT,
-    env: {
-      ...process.env,
-      CATE_E2E: '1',
-      NODE_ENV: 'production',
-      // Activate the resource profiler (main getAppMetrics sampler + counters,
-      // renderer FPS/long-task/render counters, window.__catePerf) for the
-      // perf-stress spec. Harmless no-op for other specs that don't set it.
-      ...(opts.perf ? { CATE_PERF: '1' } : {}),
-    },
+    env,
   })
   const mainWindow = await electronApp.firstWindow()
   await mainWindow.waitForLoadState('domcontentloaded')
@@ -41,10 +46,22 @@ export async function launchApp(opts: { perf?: boolean } = {}): Promise<LaunchRe
 }
 
 export async function closeApp(electronApp: ElectronApplication): Promise<void> {
+  const child = electronApp.process()
+  let timer: ReturnType<typeof setTimeout> | undefined
   try {
-    await electronApp.close()
+    await Promise.race([
+      electronApp.close(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('Electron close timed out')), 10_000)
+      }),
+    ])
   } catch {
-    /* best-effort */
+    // A wedged runtime/PTY must not hold the entire Playwright worker open after
+    // the assertions have completed. This child belongs exclusively to the
+    // current isolated E2E app instance.
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+  } finally {
+    if (timer) clearTimeout(timer)
   }
 }
 

--- a/skills/cate-cli/SKILL.md
+++ b/skills/cate-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cate-cli
-description: Drive the Cate IDE from inside a Cate terminal with the `cate` CLI — control the built-in browser panel (open URLs, navigate, screenshot, read an accessibility snapshot, click/type/press by ref), read and drive terminal panels (read the rendered screen, send keystrokes), and reach the granted cate.* host scopes (panels, editor, notifications) through named verbs. Use when an agent or user working in a Cate terminal needs to see or steer a web page, capture a screenshot, read another terminal, or reach Cate's host API from the shell.
+description: Drive the Cate IDE from inside a Cate terminal with the `cate` CLI — control the built-in browser panel (open URLs, navigate, screenshot, read an accessibility snapshot, click/fill/press by ref), read and drive terminal panels (read the rendered screen, send keystrokes), and reach the granted cate.* host scopes (panels, editor, notifications) through named verbs. Use when an agent or user working in a Cate terminal needs to see or steer a web page, capture a screenshot, read another terminal, or reach Cate's host API from the shell.
 user-invocable: true
 ---
 
@@ -36,17 +36,22 @@ cate browser open https://x.com   # navigate; prints the resulting url
 cate browser wait                 # until the page settles; prints the url
                                   #   (instant when idle — also "where am I")
 cate browser wait 8000            # same, custom deadline in ms (capped at 8s)
+cate browser wait text Saved      # wait for SPA text to appear
+cate browser wait gone Loading    # wait for text to disappear
+cate browser wait url '**/done'   # wait for a URL glob
 cate browser reload               # reload
 cate browser screenshot           # prints ONLY a file path (see below)
 cate browser snapshot             # accessibility tree with refs (see below)
-cate browser click @e12           # click the element with ref @e12
-cate browser type @e7 hello world # type text into the element with ref @e7
-cate browser press @e7 Enter      # focus @e7, then press Enter (submits forms)
+cate browser click @s1e12         # auto-wait, then trusted click
+cate browser fill @s1e7 hello world # replace a field using trusted input
+cate browser type @s1e7 hello world # compatibility alias for fill
+cate browser press @s1e7 Enter    # focus @s1e7, then press Enter (submits forms)
 cate browser press PageDown       # press a key with no target (scroll, Escape...)
 ```
 
-`press` sends **trusted** key input (unlike `click`/`type`, which synthesise DOM
-events), so Enter genuinely submits a form. Supported keys: Enter, Tab, Escape,
+`click`, `fill`/`type`, and `press` send **trusted browser input**. Click/fill
+auto-wait for the target to be visible, stable, enabled, and unobscured.
+Supported keys: Enter, Tab, Escape,
 Backspace, Delete, Space, the arrows (Up/Down/Left/Right), PageUp, PageDown,
 Home, End — case-insensitive.
 
@@ -71,9 +76,10 @@ value after `=`:
 ```
 url: https://example.com
 title: Example
-[@e12] link "Home"
-[@e13] input:submit "Sign in"
-[@e14] input:search "Search" = "mechanical keyboards"
+snapshot: s1
+[@s1e12] link "Home"
+[@s1e13] input:submit "Sign in"
+[@s1e14] input:search "Search" = "mechanical keyboards"
 ```
 
 Bare `<input>` elements expose their type (`input:search` vs `input:submit`) so
@@ -81,29 +87,35 @@ a field and its submit button never read alike; names come from the aria-label,
 an associated `<label>`, visible text, or the placeholder — whichever exists
 first.
 
-The bracketed token (`@e12`) is the element's **ref**. Feed it back to `click`,
-`type`, or `press`:
+The bracketed token (`@s1e12`) is the element's **generation-scoped ref**. Feed
+it back to `click`, `fill`/`type`, or `press`:
 
 ```bash
-cate browser click @e13           # click "Sign in"
-cate browser type @e14 mechanical keyboards
-cate browser press @e14 Enter     # submit
+cate browser click @s1e13           # click "Sign in"
+cate browser fill @s1e14 mechanical keyboards
+cate browser press @s1e14 Enter     # submit
 ```
+
+A newer snapshot gets a new generation (`s2`, `s3`, ...). Old refs fail with
+`stale-ref`; they never silently address an element from the newer snapshot.
+Password values are always masked. State flags such as `[disabled]`, `[checked]`,
+`[expanded]`, and `[focused]` appear when relevant.
 
 Very large pages are truncated to 150 ref lines with a trailing `(+N more refs)`
 note; pass `--max <n>` to change the cap (`--max 0` prints everything).
 
-Typical loop: `snapshot` to find a ref → `click`/`type`/`press` → `wait` →
-`snapshot` again (or `screenshot`) to confirm the result. Refs don't survive a
-navigation; re-snapshot after one. There is no back/forward/current: navigate
+Typical loop: `snapshot` to find a ref → `click`/`fill`/`press` → conditional
+`wait` → `snapshot` again (or `screenshot`) to confirm the result. Add
+`--snapshot` to click/fill/type/press/wait to return a compact post-action
+snapshot in the same round trip. Refs become stale after a newer snapshot or
+navigation. There is no back/forward/current: navigate
 by URL with `open`, and `wait` doubles as "where am I" since it returns the
 url instantly when the page is idle.
 
-One timing caveat: `wait` polls the page's loading flag, so calling it right
-after an action that *triggers* a navigation (`press Enter`, a `click` on a
-link) can return before loading has even started. When you expect a navigation,
-confirm it from the url `wait` prints (or re-snapshot) instead of treating a
-fast return as "already loaded".
+Use `wait text <text...>`, `wait gone <text...>`, `wait url <glob>`, or
+`wait ref <ref> [visible|hidden|attached|detached]` for SPA transitions; set the
+condition deadline with `--wait-timeout <ms>` (capped at 8 seconds). Plain
+`wait` retains the original page-loading behavior.
 
 ## Host API groups
 

--- a/src/cli/cate.test.ts
+++ b/src/cli/cate.test.ts
@@ -24,7 +24,7 @@ import {
   type SendDeps,
 } from './cate'
 
-const noFlags: Flags = { json: false, help: false, version: false }
+const noFlags: Flags = { json: false, snapshot: false, help: false, version: false }
 
 describe('buildRequest — browser group', () => {
   it('open -> cate.browser.open {url}', () => {
@@ -53,6 +53,13 @@ describe('buildRequest — browser group', () => {
     expect(buildRequest(['browser', 'type', 'e7', 'hello', 'world'], noFlags)).toEqual({
       method: 'cate.browser.type',
       args: { ref: 'e7', text: 'hello world' },
+    })
+  })
+
+  it('fill maps to trusted field replacement', () => {
+    expect(buildRequest(['browser', 'fill', 's2e7', 'hello', 'world'], noFlags)).toEqual({
+      method: 'cate.browser.fill',
+      args: { ref: 's2e7', text: 'hello world' },
     })
   })
 
@@ -473,6 +480,34 @@ describe('buildRequest — new verbs', () => {
     expect(() => buildRequest(['browser', 'wait', 'soon'], noFlags)).toThrow(UsageError)
   })
 
+  it('browser wait supports agent conditions and an explicit condition timeout', () => {
+    expect(buildRequest(['browser', 'wait', 'text', 'Build', 'finished'], noFlags).args).toEqual({
+      condition: { kind: 'text', value: 'Build finished' },
+    })
+    expect(buildRequest(['browser', 'wait', 'gone', 'Loading'], noFlags).args).toEqual({
+      condition: { kind: 'textGone', value: 'Loading' },
+    })
+    expect(buildRequest(['browser', 'wait', 'url', '**/done'], noFlags).args).toEqual({
+      condition: { kind: 'url', value: '**/done' },
+    })
+    expect(buildRequest(['browser', 'wait', 'ref', '@s1e3', 'hidden'], {
+      ...noFlags,
+      waitTimeout: '7000',
+    }).args).toEqual({
+      condition: { kind: 'ref', ref: '@s1e3', state: 'hidden' },
+      timeoutMs: 7000,
+    })
+    expect(() => buildRequest(['browser', 'wait', 'ref', '@s1e3', 'ready'], noFlags)).toThrow(/invalid <state>/)
+  })
+
+  it('--snapshot requests a post-action observation', () => {
+    expect(buildRequest(['browser', 'click', '@s1e2'], { ...noFlags, snapshot: true }).args).toEqual({
+      ref: '@s1e2',
+      includeSnapshot: true,
+    })
+    expect(() => buildRequest(['browser', 'reload'], { ...noFlags, snapshot: true })).toThrow(/--snapshot/)
+  })
+
   it('browser press: one positional is the key, two are ref + key', () => {
     expect(buildRequest(['browser', 'press', 'Enter'], noFlags)).toEqual({
       method: 'cate.browser.press',
@@ -541,6 +576,26 @@ describe('formatHuman — new output shapes', () => {
     expect(out).toContain('[@e1] textbox "Search" = "query"')
     expect(out).toContain('[@e2] button "Go"')
     expect(out).not.toContain('[@e2] button "Go" =')
+  })
+
+  it('snapshot shows its generation and useful element state', () => {
+    const out = formatHuman('cate.browser.snapshot', {
+      snapshotId: 's4',
+      url: 'u',
+      title: 't',
+      refs: [{ ref: '@s4e1', role: 'button', name: 'Pay', disabled: true, focused: true }],
+    })
+    expect(out).toContain('snapshot: s4')
+    expect(out).toContain('[@s4e1] button "Pay" [disabled] [focused]')
+  })
+
+  it('an action with --snapshot prints the returned observation', () => {
+    const out = formatHuman('cate.browser.click', {
+      ok: true,
+      snapshot: { snapshotId: 's2', url: 'u', title: 'Done', refs: [] },
+    })
+    expect(out).toContain('title: Done')
+    expect(out).toContain('snapshot: s2')
   })
 
   it('snapshot caps ref lines at --max and says how many were dropped', () => {

--- a/src/cli/cate.ts
+++ b/src/cli/cate.ts
@@ -20,7 +20,8 @@
 // deliberately NO raw method passthrough: every reachable host method has a
 // named verb, so the CLI's help is the complete, honest surface.
 //
-// Flags: --panel <id> --json --max <n> --timeout <ms> --help/-h --version.
+// Flags: --panel <id> --json --max <n> --snapshot --wait-timeout <ms>
+// --timeout <ms> --help/-h --version.
 //
 // Bundled to cate/dist/cli.cjs by scripts/build-runtime-tarball.mjs and run via
 // the bundled Node from the cate/bin/ shims. Node built-ins + global fetch ONLY.
@@ -30,7 +31,7 @@ import { parseArgs } from 'node:util'
 
 /** Version of the CLI tool itself (printed by --version). The API's own version
  *  is reachable via `cate version`. */
-export const CLI_VERSION = '4'
+export const CLI_VERSION = '5'
 
 /** Default request timeout (ms) when --timeout is not given. */
 export const DEFAULT_TIMEOUT_MS = 30_000
@@ -63,6 +64,8 @@ export interface Flags {
   json: boolean
   timeout?: string
   max?: string
+  snapshot: boolean
+  waitTimeout?: string
   help: boolean
   version: boolean
 }
@@ -134,15 +137,63 @@ export const GROUPS: Record<string, Group> = {
     screenshot: (a) => ({ method: 'cate.browser.screenshot', args: noArgs(a) }),
     snapshot: (a) => ({ method: 'cate.browser.snapshot', args: noArgs(a) }),
     click: (a) => ({ method: 'cate.browser.click', args: { ref: need(exact(a, 1)[0], 'ref') } }),
+    fill: (a) => ({
+      method: 'cate.browser.fill',
+      args: { ref: need(a[0], 'ref'), text: need(a.slice(1).join(' ') || undefined, 'text') },
+    }),
     type: (a) => ({
       method: 'cate.browser.type',
       // Join the remaining positionals so multi-word text needs no quoting.
       args: { ref: need(a[0], 'ref'), text: need(a.slice(1).join(' ') || undefined, 'text') },
     }),
-    wait: (a) => ({
-      method: 'cate.browser.wait',
-      args: exact(a, 1)[0] !== undefined ? { timeoutMs: needPositiveInt(a[0], 'ms') } : {},
-    }),
+    wait: (a, f) => {
+      const timeoutMs = f.waitTimeout !== undefined ? needPositiveInt(f.waitTimeout, 'wait-timeout') : undefined
+      if (a.length === 0) return { method: 'cate.browser.wait', args: { ...(timeoutMs ? { timeoutMs } : {}) } }
+      if (/^\d+$/.test(a[0])) {
+        exact(a, 1)
+        if (timeoutMs !== undefined) throw new UsageError('use either wait <ms> or --wait-timeout, not both')
+        return { method: 'cate.browser.wait', args: { timeoutMs: needPositiveInt(a[0], 'ms') } }
+      }
+
+      const kind = a[0]
+      if (kind === 'load') {
+        exact(a, 1)
+        return { method: 'cate.browser.wait', args: { condition: { kind: 'load' }, ...(timeoutMs ? { timeoutMs } : {}) } }
+      }
+      if (kind === 'text' || kind === 'gone') {
+        return {
+          method: 'cate.browser.wait',
+          args: {
+            condition: { kind: kind === 'text' ? 'text' : 'textGone', value: needRest(a.slice(1), 'text') },
+            ...(timeoutMs ? { timeoutMs } : {}),
+          },
+        }
+      }
+      if (kind === 'url') {
+        return {
+          method: 'cate.browser.wait',
+          args: {
+            condition: { kind: 'url', value: need(exact(a, 2)[1], 'pattern') },
+            ...(timeoutMs ? { timeoutMs } : {}),
+          },
+        }
+      }
+      if (kind === 'ref') {
+        const values = exact(a, 3)
+        const state = values[2] ?? 'visible'
+        if (!['visible', 'hidden', 'attached', 'detached'].includes(state)) {
+          throw new UsageError(`invalid <state>: ${state}`)
+        }
+        return {
+          method: 'cate.browser.wait',
+          args: {
+            condition: { kind: 'ref', ref: need(values[1], 'ref'), state },
+            ...(timeoutMs ? { timeoutMs } : {}),
+          },
+        }
+      }
+      throw new UsageError(`unknown browser wait condition: ${kind}`)
+    },
     // `press <key>` sends to whatever the guest has focused; `press <ref> <key>`
     // focuses the element first.
     press: (a) =>
@@ -223,6 +274,8 @@ const OPTIONS = {
   json: { type: 'boolean', default: false },
   timeout: { type: 'string' },
   max: { type: 'string' },
+  snapshot: { type: 'boolean', default: false },
+  'wait-timeout': { type: 'string' },
   help: { type: 'boolean', short: 'h', default: false },
   version: { type: 'boolean', default: false },
 } as const
@@ -248,6 +301,8 @@ export function parseCli(argv: string[]): Parsed {
       json: Boolean(values.json),
       timeout: values.timeout as string | undefined,
       max: values.max as string | undefined,
+      snapshot: Boolean(values.snapshot),
+      waitTimeout: values['wait-timeout'] as string | undefined,
       help: Boolean(values.help),
       version: Boolean(values.version),
     },
@@ -289,6 +344,20 @@ export function buildRequest(positionals: string[], flags: Flags): Request {
   if (flags.max !== undefined && req.method !== 'cate.browser.snapshot' && req.method !== 'cate.terminal.read') {
     throw new UsageError('--max is only valid for browser snapshot and terminal read')
   }
+  const snapshotMethods = new Set([
+    'cate.browser.click',
+    'cate.browser.fill',
+    'cate.browser.type',
+    'cate.browser.press',
+    'cate.browser.wait',
+  ])
+  if (flags.snapshot && !snapshotMethods.has(req.method)) {
+    throw new UsageError('--snapshot is only valid for browser click/fill/type/press/wait')
+  }
+  if (flags.waitTimeout !== undefined && req.method !== 'cate.browser.wait') {
+    throw new UsageError('--wait-timeout is only valid for browser wait')
+  }
+  if (flags.snapshot) req.args.includeSnapshot = true
 
   // --panel addresses a specific target panel (args.panelId). Browser/terminal
   // targets resolve only against rows of their type; set-title accepts every
@@ -455,6 +524,7 @@ function formatSnapshot(v: unknown, max: number): string {
   const url = pickUrl(v)
   if (url) lines.push(`url: ${url}`)
   if (o && typeof o.title === 'string') lines.push(`title: ${o.title}`)
+  if (o && typeof o.snapshotId === 'string') lines.push(`snapshot: ${o.snapshotId}`)
 
   const refs = Array.isArray(o?.refs) ? o.refs : []
   const shown = max > 0 ? refs.slice(0, max) : refs
@@ -466,6 +536,9 @@ function formatSnapshot(v: unknown, max: number): string {
     parts.push(JSON.stringify(String(e.name ?? '')))
     // Current input value — what a verify-after-type loop needs to read back.
     if (typeof e.value === 'string' && e.value !== '') parts.push(`= ${JSON.stringify(e.value)}`)
+    for (const state of ['disabled', 'checked', 'expanded', 'selected', 'focused']) {
+      if (e[state] === true) parts.push(`[${state}]`)
+    }
     lines.push(parts.join(' '))
   }
   if (shown.length < refs.length) {
@@ -517,13 +590,19 @@ export function formatHuman(method: string, value: unknown, opts?: { max?: numbe
       return pickUrl(value) ?? 'ok'
     case 'cate.browser.wait':
       // wait resolves to { url, title, loading: false }.
-      return pickUrl(value) ?? 'ok'
+      return asObj(value)?.snapshot
+        ? formatSnapshot(asObj(value)?.snapshot, opts?.max ?? SNAPSHOT_MAX_DEFAULT)
+        : pickUrl(value) ?? 'ok'
     case 'cate.browser.reload':
     case 'cate.browser.click':
+    case 'cate.browser.fill':
     case 'cate.browser.type':
     case 'cate.browser.press':
-      // These resolve to { ok: true } — nothing to print.
-      return 'ok'
+      // Agent actions can opt into a compact post-action observation, avoiding
+      // a second CLI round trip. Preserve the terse legacy output otherwise.
+      return asObj(value)?.snapshot
+        ? formatSnapshot(asObj(value)?.snapshot, opts?.max ?? SNAPSHOT_MAX_DEFAULT)
+        : 'ok'
     case 'cate.ui.notify':
     case 'cate.panel.focus':
     case 'cate.panel.setTitle':
@@ -559,8 +638,9 @@ Usage:
   cate version                      print the host API version
 
 Groups:
-  browser    open <url> | wait [ms] | reload
-             | screenshot | snapshot | click <ref> | type <ref> <text...>
+  browser    open <url> | wait [ms|load|text|gone|url|ref] | reload
+             | screenshot | snapshot | click <ref> | fill <ref> <text...>
+             | type <ref> <text...>
              | press [ref] <key>       (Enter, Tab, Escape, arrows, PageDown, ...)
   ui         notify <message...>
   editor     open <path[:line[:col]]>
@@ -577,6 +657,8 @@ Flags:
   --json           print the raw result as one JSON line
   --max <n>        snapshot: max ref lines (default ${SNAPSHOT_MAX_DEFAULT}; 0 = all)
                    terminal read: max tail lines (default ${TERMINAL_READ_MAX_DEFAULT}; 0 = all)
+  --snapshot       return a post-action snapshot (click/fill/type/press/wait)
+  --wait-timeout <ms> condition timeout for browser wait (default 5000, max 8000)
   --timeout <ms>   request timeout (default ${DEFAULT_TIMEOUT_MS})
   -h, --help       show this help
   --version        print the CLI version (distinct from host API version)
@@ -586,8 +668,9 @@ terminals while "Command-line control (cate CLI)" is enabled (Settings → CLI,
 where per-feature toggles for browser control and terminal read/input live too).`
 
 const GROUP_USAGE: Record<string, string> = {
-  browser: `Usage: cate browser open <url> | wait [ms] | reload | screenshot | snapshot\n` +
-    `       cate browser click <ref> | type <ref> <text...> | press [ref] <key>`,
+  browser: `Usage: cate browser open <url> | wait [ms|load|text|gone|url|ref] | reload | screenshot | snapshot\n` +
+    `       cate browser click <ref> | fill <ref> <text...> | type <ref> <text...> | press [ref] <key>\n` +
+    `       wait text <text...> | gone <text...> | url <glob> | ref <ref> [visible|hidden|attached|detached]`,
   ui: 'Usage: cate ui notify <message...>',
   editor: 'Usage: cate editor open <path[:line[:col]]>',
   panel: `Usage: cate panel list | create <type> [url] | focus <id> | close <id> | set-title <title...>\n` +

--- a/src/main/extensions/cateApiHandlers.test.ts
+++ b/src/main/extensions/cateApiHandlers.test.ts
@@ -192,7 +192,7 @@ beforeEach(() => {
 
 describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
   it('reports the API version for feature detection', async () => {
-    expect(await dispatchCateInvoke(scope(), 'cate.version', undefined)).toBe(3)
+    expect(await dispatchCateInvoke(scope(), 'cate.version', undefined)).toBe(4)
   })
 
   it('resolves the workspace root from the locator', async () => {
@@ -258,6 +258,26 @@ describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
     expect(res).toEqual({ panelId: 'new' })
   })
 
+  it('registers a created panel immediately for a follow-up targeted command', async () => {
+    activeWindow.value = { id: 9, isDestroyed: () => false, webContents: { send: vi.fn() } }
+    const forward = vi.fn(async () => ({ panelId: 'fresh-browser' }))
+
+    expect(await dispatchCateInvoke(
+      scope(forward),
+      'cate.canvas.createPanel',
+      { type: 'browser', url: 'https://example.test' },
+    )).toEqual({ panelId: 'fresh-browser' })
+
+    expect(upsertWindowPanel).toHaveBeenCalledWith(9, {
+      panelId: 'fresh-browser',
+      type: 'browser',
+      title: 'https://example.test',
+      workspaceId: WS,
+      url: 'https://example.test',
+      focused: false,
+    })
+  })
+
   it('rejects unknown methods as unsupported', async () => {
     expect(await dispatchCateInvoke(scope(), 'cate.bogus.method', undefined)).toEqual({ error: 'unsupported', method: 'cate.bogus.method' })
   })
@@ -308,7 +328,7 @@ describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
     // panel.* stay allowed (feature detection + panel self-control).
     state.scopes = undefined
     const forward = vi.fn()
-    expect(await dispatchCateInvoke(scope(forward), 'cate.version', undefined)).toBe(3)
+    expect(await dispatchCateInvoke(scope(forward), 'cate.version', undefined)).toBe(4)
     expect(await dispatchCateInvoke(scope(forward), 'cate.storage.get', { key: 'k' })).toEqual({ error: 'scope-denied', method: 'cate.storage.get' })
     expect(await dispatchCateInvoke(scope(forward), 'cate.editor.openFile', { path: 'x' })).toEqual({ error: 'scope-denied', method: 'cate.editor.openFile' })
     expect(await dispatchCateInvoke(scope(forward), 'cate.theme.get', undefined)).toEqual({ error: 'scope-denied', method: 'cate.theme.get' })

--- a/src/main/extensions/cateApiHandlers.ts
+++ b/src/main/extensions/cateApiHandlers.ts
@@ -70,15 +70,18 @@ import { parseLocator, LOCAL_RUNTIME_ID } from '../runtime/locator'
 import { getAllSettings, getSetting } from '../settingsFile'
 import { resolveActiveTheme } from '../themeBootCache'
 import { showOsNotification } from '../ipc/notifications'
+import type { PanelType } from '../../shared/types'
 
 /** Bumped when the cateHost API surface changes incompatibly. Guests use
- *  `cate.version` for feature detection. v3 removals: browser.list and
+ *  `cate.version` for feature detection. v4 adds generation-scoped browser
+ *  refs, native fill/click actions, conditional waits, and action snapshots.
+ *  v3 removals: browser.list and
  *  editor.active (cate.panel.list is the single enumeration surface — browser
  *  panels carry `url`, the focused entry answers "what is the user looking
  *  at"); browser.back/forward/current (navigate by URL; `wait` reads the
  *  settled url/title instantly when idle); agent.run (compose open -> send ->
  *  dispose). */
-const CATE_API_VERSION = 3
+const CATE_API_VERSION = 4
 
 const FORWARD_TIMEOUT_MS = 10_000
 
@@ -652,7 +655,33 @@ export async function dispatchCateInvoke(
     default:
       // Forward state-mutating methods (strip the leading `cate.`) to the owner.
       if (FORWARDED_METHODS.has(method.replace(/^cate\./, ''))) {
-        return scope.forward({ extensionId, workspaceId, panelId: panelId ?? '', method, args })
+        const result = await scope.forward({ extensionId, workspaceId, panelId: panelId ?? '', method, args })
+        // A create result is meant to be used immediately by the next CLI
+        // command. The renderer's full panel report is debounced, so register a
+        // provisional row now; otherwise `panel create browser` followed by
+        // `browser open --panel <returned-id>` (and the terminal equivalent)
+        // races the owner lookup and returns no-such-browser/terminal. The next
+        // normal report replaces this row with the complete panel metadata.
+        if (method === 'cate.canvas.createPanel' && result && typeof result === 'object') {
+          const created = result as { panelId?: unknown }
+          const a = (args ?? {}) as { type?: unknown; url?: unknown }
+          const win = getActiveMainWindow()
+          if (
+            typeof created.panelId === 'string' &&
+            typeof a.type === 'string' &&
+            win && !win.isDestroyed()
+          ) {
+            upsertWindowPanel(win.id, {
+              panelId: created.panelId,
+              type: a.type as PanelType,
+              title: typeof a.url === 'string' ? a.url : a.type,
+              workspaceId,
+              ...(a.type === 'browser' && typeof a.url === 'string' ? { url: a.url } : {}),
+              focused: false,
+            })
+          }
+        }
+        return result
       }
       return unsupported(method)
   }

--- a/src/preload/cateHost.test.tsx
+++ b/src/preload/cateHost.test.tsx
@@ -78,6 +78,32 @@ describe('cateHost preload — invoke wire contract', () => {
     expect(cate.browser.current).toBeUndefined()
     expect(cate.editor.active).toBeUndefined()
   })
+
+  it('browser fill and conditional wait preserve agent protocol options', async () => {
+    await cate.browser.fill({ ref: '@s2e4', text: 'Anton', panelId: 'browser-1', includeSnapshot: true })
+    expect(invoke).toHaveBeenLastCalledWith('cate:invoke', {
+      ...IDENTITY,
+      method: 'cate.browser.fill',
+      args: { ref: '@s2e4', text: 'Anton', panelId: 'browser-1', includeSnapshot: true },
+    })
+
+    await cate.browser.wait({
+      panelId: 'browser-1',
+      condition: { kind: 'text', value: 'Saved' },
+      timeoutMs: 8000,
+      includeSnapshot: true,
+    })
+    expect(invoke).toHaveBeenLastCalledWith('cate:invoke', {
+      ...IDENTITY,
+      method: 'cate.browser.wait',
+      args: {
+        panelId: 'browser-1',
+        condition: { kind: 'text', value: 'Saved' },
+        timeoutMs: 8000,
+        includeSnapshot: true,
+      },
+    })
+  })
 })
 
 describe('cateHost preload — files.onDrop', () => {

--- a/src/preload/cateHost.ts
+++ b/src/preload/cateHost.ts
@@ -100,14 +100,11 @@ const api: CateHost = {
       invoke('cate.browser.screenshot', opts) as Promise<{ path: string }>,
     snapshot: (opts?: { panelId?: string }) =>
       invoke('cate.browser.snapshot', opts) as Promise<CateBrowserSnapshot>,
-    click: (opts: { ref: string; panelId?: string }) =>
-      invoke('cate.browser.click', opts) as Promise<{ ok: true }>,
-    type: (opts: { ref: string; text: string; panelId?: string }) =>
-      invoke('cate.browser.type', opts) as Promise<{ ok: true }>,
-    wait: (opts?: { panelId?: string; timeoutMs?: number }) =>
-      invoke('cate.browser.wait', opts) as Promise<{ url: string; title: string; loading: false }>,
-    press: (opts: { key: string; ref?: string; panelId?: string }) =>
-      invoke('cate.browser.press', opts) as Promise<{ ok: true }>,
+    click: (opts) => invoke('cate.browser.click', opts) as ReturnType<CateHost['browser']['click']>,
+    fill: (opts) => invoke('cate.browser.fill', opts) as ReturnType<CateHost['browser']['fill']>,
+    type: (opts) => invoke('cate.browser.type', opts) as ReturnType<CateHost['browser']['type']>,
+    wait: (opts) => invoke('cate.browser.wait', opts) as ReturnType<CateHost['browser']['wait']>,
+    press: (opts) => invoke('cate.browser.press', opts) as ReturnType<CateHost['browser']['press']>,
   },
 
   files: {

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -360,6 +360,7 @@ function SkillRow({
   const installRef = useRef<HTMLButtonElement>(null)
   const [menuAnchor, setMenuAnchor] = useState<{ top: number; left: number } | null>(null)
   const [saveBusy, setSaveBusy] = useState(false)
+  const [updateBusy, setUpdateBusy] = useState(false)
   const link = sourceUrl(entry)
 
   const openMenu = () => {
@@ -382,6 +383,29 @@ function SkillRow({
       onError(errorMessage(err))
     } finally {
       setSaveBusy(false)
+    }
+  }
+
+  const updateInstalled = async () => {
+    const targets = SKILL_TARGETS.filter((target) => installedKeys.has(`${entry.id}:${target.id}`))
+    if (!rootPath || targets.length === 0) return
+    onError(null)
+    setUpdateBusy(true)
+    try {
+      const results = await Promise.all(
+        targets.map((target) => api().skillsInstall(entry, target.id, rootPath)),
+      )
+      const errors = results.flatMap((result) =>
+        result.ok
+          ? result.warnings ?? []
+          : [errorMessage(result.error, 'Could not update skill.')],
+      )
+      if (errors.length) onError(errors.join('\n'))
+      onChanged()
+    } catch (err) {
+      onError(errorMessage(err, 'Could not update skill.'))
+    } finally {
+      setUpdateBusy(false)
     }
   }
 
@@ -417,6 +441,19 @@ function SkillRow({
         </div>
         {entry.description && <div className="text-[11px] text-muted truncate">{entry.description}</div>}
       </div>
+
+      {installed && link && (
+        <Tooltip label="Update installed copies from source">
+          <button
+            onClick={() => void updateInstalled()}
+            disabled={updateBusy}
+            aria-label="Update installed copies from source"
+            className="shrink-0 w-6 h-6 flex items-center justify-center rounded-lg text-muted hover:text-secondary disabled:opacity-50"
+          >
+            <ArrowsClockwise size={14} className={updateBusy ? 'animate-spin' : undefined} />
+          </button>
+        </Tooltip>
+      )}
 
       {link && (
         <Tooltip label="Open skill on GitHub">

--- a/src/renderer/lib/browser/browserDriver.test.ts
+++ b/src/renderer/lib/browser/browserDriver.test.ts
@@ -273,20 +273,27 @@ describe('snapshot / click / type', () => {
   })
 
   it('click passes the ref via JSON.stringify (never interpolated raw)', async () => {
-    const exec = vi.fn(async (_code: string) => ({ ok: true }))
-    h.webviews.set('b1', makeWebview({ executeJavaScript: exec }))
+    const exec = vi.fn(async (_code: string) => ({ ok: true, x: 5, y: 5, rect: '0:0:10:10' }))
+    const wv = makeWebview({ executeJavaScript: exec })
+    h.webviews.set('b1', wv)
     await handleBrowserMethod(WS, M('click'), { ref: '@e2' })
     const code = exec.mock.calls[0][0] as string
     expect(code).toContain('"@e2"')
+    expect(wv.sendInputEvent.mock.calls.map((call) => call[0].type)).toEqual(['mouseMove', 'mouseDown', 'mouseUp'])
   })
 
-  it('type dispatches with the given text and succeeds', async () => {
-    const exec = vi.fn(async (_code: string) => ({ ok: true }))
-    h.webviews.set('b1', makeWebview({ executeJavaScript: exec }))
+  it('type uses trusted keyboard input and succeeds', async () => {
+    const exec = vi.fn(async (_code: string) => ({ ok: true, x: 5, y: 5, rect: '0:0:10:10' }))
+    const wv = makeWebview({ executeJavaScript: exec })
+    h.webviews.set('b1', wv)
     const out = await handleBrowserMethod(WS, M('type'), { ref: '@e1', text: 'hi "there"' })
     expect(out).toEqual({ ok: true })
-    const code = exec.mock.calls[0][0] as string
-    expect(code).toContain(JSON.stringify('hi "there"'))
+    const chars = wv.sendInputEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.type === 'char')
+      .map((event) => event.keyCode)
+      .join('')
+    expect(chars).toBe('hi "there"')
   })
 })
 
@@ -354,6 +361,9 @@ describe('injected page JS (jsdom)', () => {
     vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
       width: 10, height: 10, top: 0, left: 0, right: 10, bottom: 10, x: 0, y: 0, toJSON: () => ({}),
     } as DOMRect)
+    vi.spyOn(document, 'elementFromPoint').mockImplementation(
+      () => document.querySelector('[data-cate-ref]'),
+    )
     // jsdom doesn't implement scrollIntoView at all — the injected click/type JS
     // calls it, so provide an inert one.
     ;(Element.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {}
@@ -368,18 +378,21 @@ describe('injected page JS (jsdom)', () => {
 
     const out = await handleBrowserMethod(WS, M('snapshot'), {})
     expect(out.ok).toBe(true)
-    const result = (out as { ok: true; result: { url: string; title: string; refs: unknown[] } }).result
+    const result = (out as {
+      ok: true; result: { snapshotId: string; url: string; title: string; refs: unknown[] }
+    }).result
     expect(result.url).toBe(location.href)
     expect(result.title).toBe('Fixture')
+    expect(result.snapshotId).toBe('s1')
     expect(result.refs).toEqual([
-      { ref: '@e1', role: 'button', name: 'Save', value: '' },
-      { ref: '@e2', role: 'input:text', name: 'Email', value: '' },
-      { ref: '@e3', role: 'a', name: 'Home', value: undefined },
+      { ref: '@s1e1', role: 'button', name: 'Save', value: '' },
+      { ref: '@s1e2', role: 'input:text', name: 'Email', value: '' },
+      { ref: '@s1e3', role: 'a', name: 'Home', value: undefined },
     ])
     // The refs are written back onto the live DOM as data-cate-ref attributes.
-    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@e1')
-    expect(document.querySelector('input')?.getAttribute('data-cate-ref')).toBe('@e2')
-    expect(document.querySelector('a')?.getAttribute('data-cate-ref')).toBe('@e3')
+    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@s1e1')
+    expect(document.querySelector('input')?.getAttribute('data-cate-ref')).toBe('@s1e2')
+    expect(document.querySelector('a')?.getAttribute('data-cate-ref')).toBe('@s1e3')
   })
 
   it('reads all geometry/style before writing any data-cate-ref (no layout thrash)', async () => {
@@ -429,23 +442,23 @@ describe('injected page JS (jsdom)', () => {
 
     await handleBrowserMethod(WS, M('snapshot'), {})
     expect(stale.hasAttribute('data-cate-ref')).toBe(false)
-    // The button is re-numbered from @e1 on every run (no drift).
-    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@e1')
+    // Element indexes restart, but the generation changes so an old ref can
+    // never silently address the new @e1.
+    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@s1e1')
     await handleBrowserMethod(WS, M('snapshot'), {})
-    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@e1')
+    expect(document.querySelector('button')?.getAttribute('data-cate-ref')).toBe('@s2e1')
+    expect(await handleBrowserMethod(WS, M('click'), { ref: '@s1e1' })).toEqual({ ok: false, error: 'stale-ref' })
   })
 
-  it('click activates the element addressed by a live ref', async () => {
+  it('click sends trusted pointer input to the element addressed by a live ref', async () => {
     document.body.innerHTML = '<button aria-label="Go">Go</button>'
     const wv = evalWebview()
     h.webviews.set('b1', wv)
-    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @e1
-    const clicked = vi.fn()
-    document.querySelector('button')!.addEventListener('click', clicked)
+    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @s1e1
 
-    const out = await handleBrowserMethod(WS, M('click'), { ref: '@e1' })
+    const out = await handleBrowserMethod(WS, M('click'), { ref: '@s1e1' })
     expect(out).toEqual({ ok: true })
-    expect(clicked).toHaveBeenCalledTimes(1)
+    expect(wv.sendInputEvent.mock.calls.map((call) => call[0].type)).toEqual(['mouseMove', 'mouseDown', 'mouseUp'])
   })
 
   it('click on a well-formed but unknown ref returns stale-ref', async () => {
@@ -456,16 +469,14 @@ describe('injected page JS (jsdom)', () => {
     expect(out).toEqual({ ok: false, error: 'stale-ref' })
   })
 
-  it('click accepts a bare e<n> ref (normalized to @e<n>)', async () => {
+  it('click accepts a bare generation-scoped ref', async () => {
     document.body.innerHTML = '<button>Go</button>'
     const wv = evalWebview()
     h.webviews.set('b1', wv)
-    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @e1
-    const clicked = vi.fn()
-    document.querySelector('button')!.addEventListener('click', clicked)
-    const out = await handleBrowserMethod(WS, M('click'), { ref: 'e1' })
+    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @s1e1
+    const out = await handleBrowserMethod(WS, M('click'), { ref: 's1e1' })
     expect(out).toEqual({ ok: true })
-    expect(clicked).toHaveBeenCalledTimes(1)
+    expect(wv.sendInputEvent).toHaveBeenCalled()
   })
 
   it('click on a malformed ref reports bad-ref, not stale-ref', async () => {
@@ -475,7 +486,7 @@ describe('injected page JS (jsdom)', () => {
     h.webviews.set('b1', evalWebview())
     await handleBrowserMethod(WS, M('snapshot'), {})
     const out = await handleBrowserMethod(WS, M('click'), { ref: '@nope' })
-    expect(out).toEqual({ ok: false, error: 'bad-ref: expected a snapshot ref like @e12' })
+    expect(out).toEqual({ ok: false, error: 'bad-ref: expected a snapshot ref like @s12e7' })
   })
 
   it('snapshot surfaces input types, label names, select names, and collapsed whitespace', async () => {
@@ -492,27 +503,43 @@ describe('injected page JS (jsdom)', () => {
     // field is named from its associated <label> (whitespace collapsed), and
     // the <select> does NOT dump every option's text as its name.
     expect(refs).toEqual([
-      expect.objectContaining({ ref: '@e1', role: 'input:search', name: 'Search the web' }),
-      expect.objectContaining({ ref: '@e2', role: 'input:submit', name: '' }),
-      expect.objectContaining({ ref: '@e3', role: 'select', name: '' }),
+      expect.objectContaining({ ref: '@s1e1', role: 'input:search', name: 'Search the web' }),
+      expect.objectContaining({ ref: '@s1e2', role: 'input:submit', name: '' }),
+      expect.objectContaining({ ref: '@s1e3', role: 'select', name: '' }),
     ])
   })
 
-  it('type sets the value and dispatches input on a live ref', async () => {
+  it('snapshot masks passwords and reports useful control state', async () => {
+    document.body.innerHTML =
+      '<input type="password" aria-label="Password" value="top-secret" />' +
+      '<input type="checkbox" aria-label="Remember" checked />' +
+      '<button aria-label="Pay" disabled>Pay</button>'
+    h.webviews.set('b1', evalWebview())
+
+    const out = await handleBrowserMethod(WS, M('snapshot'), {})
+    const refs = (out as { ok: true; result: { refs: Array<Record<string, unknown>> } }).result.refs
+    expect(refs[0]).toMatchObject({ role: 'input:password', value: '••••••••' })
+    expect(refs[1]).toMatchObject({ role: 'input:checkbox', checked: true })
+    expect(refs[2]).toMatchObject({ role: 'button', disabled: true })
+    expect(JSON.stringify(out)).not.toContain('top-secret')
+  })
+
+  it('type focuses a live ref and sends replacement text as trusted char input', async () => {
     document.body.innerHTML = '<input type="text" />'
     const wv = evalWebview()
     h.webviews.set('b1', wv)
-    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @e1
-    const input = document.querySelector('input')!
-    const onInput = vi.fn()
-    input.addEventListener('input', onInput)
+    await handleBrowserMethod(WS, M('snapshot'), {}) // assigns @s1e1
 
     // Quotes + backslash: JSON-embedded (not interpolated), so must survive verbatim.
     const text = 'a "b" \\c/ \'d\''
-    const out = await handleBrowserMethod(WS, M('type'), { ref: '@e1', text })
+    const out = await handleBrowserMethod(WS, M('type'), { ref: '@s1e1', text })
     expect(out).toEqual({ ok: true })
-    expect(input.value).toBe(text)
-    expect(onInput).toHaveBeenCalledTimes(1)
+    const chars = wv.sendInputEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.type === 'char')
+      .map((event) => event.keyCode)
+      .join('')
+    expect(chars).toBe(text)
   })
 
   it('type on a well-formed but unknown ref returns stale-ref', async () => {
@@ -543,6 +570,58 @@ describe('wait', () => {
     h.webviews.set('b1', makeWebview({ isLoading: vi.fn(() => true) }))
     const out = await handleBrowserMethod(WS, M('wait'), { timeoutMs: 1 })
     expect(out).toEqual({ ok: false, error: 'still-loading' })
+  })
+
+  it('waits on text, disappearance, URL globs, and ref visibility', async () => {
+    document.body.innerHTML = '<button>Saved</button>'
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 10, height: 10, top: 0, left: 0, right: 10, bottom: 10, x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect)
+    const wv = makeWebview({
+      getURL: vi.fn(() => 'https://app.test/jobs/42/done'),
+      executeJavaScript: vi.fn(async (code: string) => eval(code)),
+    })
+    h.webviews.set('b1', wv)
+
+    expect(await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'text', value: 'Saved' },
+    })).toMatchObject({ ok: true })
+    expect(await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'textGone', value: 'Loading' },
+    })).toMatchObject({ ok: true })
+
+    // executeJavaScript observes jsdom's URL, while getURL is the webview URL.
+    const hrefPattern = `${location.origin}/**`
+    expect(await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'url', value: hrefPattern },
+    })).toMatchObject({ ok: true })
+
+    const snap = await handleBrowserMethod(WS, M('snapshot'), {}) as {
+      ok: true; result: { refs: Array<{ ref: string }> }
+    }
+    expect(await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'ref', ref: snap.result.refs[0].ref, state: 'visible' },
+    })).toMatchObject({ ok: true })
+  })
+
+  it('returns a stable condition timeout and can include the next snapshot', async () => {
+    document.body.innerHTML = '<button>Ready</button>'
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 10, height: 10, top: 0, left: 0, right: 10, bottom: 10, x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect)
+    const wv = makeWebview({ executeJavaScript: vi.fn(async (code: string) => eval(code)) })
+    h.webviews.set('b1', wv)
+
+    expect(await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'text', value: 'Never' },
+      timeoutMs: 1,
+    })).toEqual({ ok: false, error: 'wait-timeout:text' })
+
+    const observed = await handleBrowserMethod(WS, M('wait'), {
+      condition: { kind: 'text', value: 'Ready' },
+      includeSnapshot: true,
+    }) as { ok: true; result: { snapshot: { snapshotId: string } } }
+    expect(observed.result.snapshot.snapshotId).toBe('s1')
   })
 })
 

--- a/src/renderer/lib/browser/browserDriver.ts
+++ b/src/renderer/lib/browser/browserDriver.ts
@@ -12,12 +12,9 @@
 //   2. the focused browser (active panel is a browser of this workspace)
 //   3. the first browser panel in the workspace (matches terminalUrlOpen)
 //
-// SECURITY / FIDELITY NOTE: click/type synthesise DOM events (Event with
-// isTrusted=false). Pages that gate on trusted events (some drag/paste flows,
-// certain <input type=file> pickers) won't react. This is an accepted v1
-// limitation — documented so callers don't treat a synthetic click as a full
-// user gesture. `press` is the exception: it delivers REAL input through
-// webContents.sendInputEvent (isTrusted=true), so Enter submits forms.
+// Actions resolve a generation-scoped snapshot ref, auto-wait for an actionable
+// target, then deliver real input through webContents.sendInputEvent. Refs from
+// an older snapshot cannot silently address a different element.
 // =============================================================================
 
 import { useAppStore } from '../../stores/appStore'
@@ -87,7 +84,13 @@ async function waitForWebview(panelId: string, timeoutMs = 3_000): Promise<Porta
 // as function arguments via JSON.stringify so a malicious value can't break out
 // of a string literal into executable code.
 
-const SNAPSHOT_JS = `(function () {
+const snapshotGeneration = new WeakMap<PortalWebview, number>()
+
+function snapshotJs(webview: PortalWebview): string {
+  const generation = (snapshotGeneration.get(webview) ?? 0) + 1
+  snapshotGeneration.set(webview, generation)
+  const snapshotId = `s${generation}`
+  return `(function (snapshotId) {
   document.querySelectorAll('[data-cate-ref]').forEach(function (el) { el.removeAttribute('data-cate-ref') })
   var sel = 'a[href],button,input,textarea,select,[role],[contenteditable],h1,h2,h3,h4,h5,h6'
   // Two passes to avoid layout thrash: a DOM write (setAttribute) invalidates
@@ -106,7 +109,7 @@ const SNAPSHOT_JS = `(function () {
   var refs = []
   for (var i = 0; i < visible.length; i++) {
     var el = visible[i]
-    var ref = '@e' + (i + 1)
+    var ref = '@' + snapshotId + 'e' + (i + 1)
     el.setAttribute('data-cate-ref', ref)
     // Bare <input> tags all read alike, so expose the type (input:search vs
     // input:submit) — it is what disambiguates a field from its submit button.
@@ -121,19 +124,39 @@ const SNAPSHOT_JS = `(function () {
     if (!name) name = el.getAttribute('placeholder') || el.getAttribute('value') || ''
     name = name.replace(/\\s+/g, ' ').trim().slice(0, 200)
     var value = 'value' in el ? el.value : undefined
-    refs.push({ ref: ref, role: role, name: name, value: value })
+    // Never expose a password through the agent observation channel.
+    if (el.tagName === 'INPUT' && String(el.type).toLowerCase() === 'password') {
+      value = value ? '••••••••' : ''
+    }
+    var disabled = Boolean(el.disabled) || el.getAttribute('aria-disabled') === 'true'
+    var inputType = el.tagName === 'INPUT' ? String(el.type).toLowerCase() : ''
+    var checked = inputType === 'checkbox' || inputType === 'radio' ? Boolean(el.checked) : undefined
+    var expandedAttr = el.getAttribute('aria-expanded')
+    var expanded = expandedAttr === null ? undefined : expandedAttr === 'true'
+    var selectedAttr = el.getAttribute('aria-selected')
+    var selected = selectedAttr === null ? undefined : selectedAttr === 'true'
+    var item = { ref: ref, role: role, name: name, value: value }
+    if (disabled) item.disabled = true
+    if (checked !== undefined) item.checked = checked
+    if (expanded !== undefined) item.expanded = expanded
+    if (selected !== undefined) item.selected = selected
+    if (document.activeElement === el) item.focused = true
+    refs.push(item)
   }
-  return { url: location.href, title: document.title, refs: refs }
-})()`
+  return { snapshotId: snapshotId, url: location.href, title: document.title, refs: refs }
+})(${JSON.stringify(snapshotId)})`
+}
 
-/** Canonical refs are the `@e<n>` tokens SNAPSHOT_JS mints. Accept the bare
- *  `e<n>` a caller is likely to strip the sigil from, and reject anything else
- *  up front — a malformed ref would otherwise come back as `stale-ref`, telling
- *  the caller to re-snapshot when the fix is the argument itself. */
+async function takeSnapshot(webview: PortalWebview): Promise<unknown> {
+  return webview.executeJavaScript(snapshotJs(webview))
+}
+
+/** Canonical refs are generation-scoped `@s<n>e<n>` tokens. Legacy `@e<n>` and
+ *  bare forms remain accepted as input, but new snapshots never emit them. */
 function normalizeRef(raw: unknown): { ref: string } | { error: string } {
   if (typeof raw !== 'string' || raw === '') return { error: 'ref-required' }
-  const ref = /^e\d+$/.test(raw) ? `@${raw}` : raw
-  if (!/^@e\d+$/.test(ref)) return { error: 'bad-ref: expected a snapshot ref like @e12' }
+  const ref = /^(?:s\d+)?e\d+$/.test(raw) ? `@${raw}` : raw
+  if (!/^@(?:s\d+)?e\d+$/.test(ref)) return { error: 'bad-ref: expected a snapshot ref like @s12e7' }
   return { ref }
 }
 
@@ -145,28 +168,29 @@ function elementByRefBody(): string {
   for (var i = 0; i < all.length; i++) { if (all[i].getAttribute('data-cate-ref') === ref) { el = all[i]; break } }`
 }
 
-function clickJs(ref: string): string {
-  return `(function (ref) {
+function actionabilityJs(ref: string, mode: 'click' | 'fill'): string {
+  return `(function (ref, mode) {
   ${elementByRefBody()}
   if (!el) return { error: 'stale-ref' }
+  if (!el.isConnected) return { error: 'detached' }
   el.scrollIntoView({ block: 'center' })
-  el.focus()
-  el.click()
-  return { ok: true }
-})(${JSON.stringify(ref)})`
-}
-
-function typeJs(ref: string, text: string): string {
-  return `(function (ref, text) {
-  ${elementByRefBody()}
-  if (!el) return { error: 'stale-ref' }
-  el.scrollIntoView({ block: 'center' })
-  el.focus()
-  if ('value' in el) { el.value = text } else { el.textContent = text }
-  el.dispatchEvent(new Event('input', { bubbles: true }))
-  el.dispatchEvent(new Event('change', { bubbles: true }))
-  return { ok: true }
-})(${JSON.stringify(ref)}, ${JSON.stringify(text)})`
+  var rect = el.getBoundingClientRect()
+  var style = getComputedStyle(el)
+  if (rect.width <= 0 || rect.height <= 0 || style.visibility === 'hidden' || style.display === 'none') {
+    return { error: 'not-visible' }
+  }
+  if (el.disabled || el.getAttribute('aria-disabled') === 'true') return { error: 'disabled' }
+  if (mode === 'fill') {
+    var editable = el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+    if (!editable) return { error: 'not-editable' }
+    if (el.readOnly || el.getAttribute('aria-readonly') === 'true') return { error: 'readonly' }
+  }
+  var x = Math.max(0, Math.floor(rect.left + rect.width / 2))
+  var y = Math.max(0, Math.floor(rect.top + rect.height / 2))
+  var hit = document.elementFromPoint ? document.elementFromPoint(x, y) : el
+  if (!hit || !(hit === el || el.contains(hit))) return { error: 'obscured' }
+  return { ok: true, x: x, y: y, rect: [rect.left, rect.top, rect.width, rect.height].join(':') }
+})(${JSON.stringify(ref)}, ${JSON.stringify(mode)})`
 }
 
 function focusJs(ref: string): string {
@@ -177,6 +201,75 @@ function focusJs(ref: string): string {
   el.focus()
   return { ok: true }
 })(${JSON.stringify(ref)})`
+}
+
+function focusForFillJs(ref: string): string {
+  return `(function (ref) {
+  ${elementByRefBody()}
+  if (!el) return { error: 'stale-ref' }
+  el.scrollIntoView({ block: 'center' })
+  el.focus()
+  if (typeof el.select === 'function') {
+    el.select()
+  } else if (el.isContentEditable) {
+    var selection = getSelection()
+    var range = document.createRange()
+    range.selectNodeContents(el)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+  return { ok: true }
+})(${JSON.stringify(ref)})`
+}
+
+const ACTION_TIMEOUT_MS = 3_000
+const ACTION_POLL_MS = 50
+
+interface ActionablePoint { x: number; y: number }
+
+async function waitForActionable(
+  webview: PortalWebview,
+  ref: string,
+  mode: 'click' | 'fill',
+): Promise<{ point: ActionablePoint } | { error: string }> {
+  const deadline = Date.now() + ACTION_TIMEOUT_MS
+  let previousRect = ''
+  let lastError = 'not-actionable'
+  for (;;) {
+    const result = await webview.executeJavaScript(actionabilityJs(ref, mode)) as {
+      ok?: true; error?: string; x?: number; y?: number; rect?: string
+    }
+    if (result.error === 'stale-ref') return { error: result.error }
+    if (result.ok && typeof result.x === 'number' && typeof result.y === 'number') {
+      if (result.rect && result.rect === previousRect) return { point: { x: result.x, y: result.y } }
+      previousRect = result.rect ?? ''
+      lastError = 'not-stable'
+    } else {
+      previousRect = ''
+      lastError = result.error ?? 'not-actionable'
+    }
+    if (Date.now() >= deadline) return { error: `action-timeout:${lastError}` }
+    await new Promise((resolve) => setTimeout(resolve, ACTION_POLL_MS))
+  }
+}
+
+async function postActionOutcome(webview: PortalWebview, args: Record<string, unknown>): Promise<BrowserOutcome> {
+  if (args.includeSnapshot !== true) return { ok: true }
+  return {
+    ok: true,
+    result: {
+      ok: true,
+      url: webview.getURL(),
+      title: webview.getTitle(),
+      snapshot: await takeSnapshot(webview),
+    },
+  }
+}
+
+async function sendNativeFill(webview: PortalWebview, text: string): Promise<void> {
+  await webview.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' })
+  await webview.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' })
+  for (const char of text) await webview.sendInputEvent({ type: 'char', keyCode: char })
 }
 
 // --- press key map -------------------------------------------------------------
@@ -213,13 +306,84 @@ const WAIT_DEFAULT_MS = 5_000
 const WAIT_MAX_MS = 8_000
 const WAIT_POLL_MS = 100
 
-async function waitForLoad(webview: PortalWebview, timeoutMs: number): Promise<BrowserOutcome> {
+type WaitCondition =
+  | { kind: 'load' }
+  | { kind: 'text' | 'textGone' | 'url'; value: string }
+  | { kind: 'ref'; ref: string; state: 'visible' | 'hidden' | 'attached' | 'detached' }
+
+function waitConditionJs(condition: Exclude<WaitCondition, { kind: 'load' }>): string {
+  return `(function (condition) {
+    if (condition.kind === 'text' || condition.kind === 'textGone') {
+      var text = document.body ? (document.body.innerText || document.body.textContent || '') : ''
+      var found = text.indexOf(condition.value) !== -1
+      return condition.kind === 'text' ? found : !found
+    }
+    if (condition.kind === 'url') {
+      var escaped = condition.value.replace(/[.+?^\${}()|[\\]\\\\]/g, '\\$&').split('*').join('.*')
+      return new RegExp('^' + escaped + '$').test(location.href)
+    }
+    var target = null
+    var nodes = document.querySelectorAll('[data-cate-ref]')
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i].getAttribute('data-cate-ref') === condition.ref) { target = nodes[i]; break }
+    }
+    var attached = Boolean(target && target.isConnected)
+    var visible = false
+    if (attached) {
+      var rect = target.getBoundingClientRect()
+      var style = getComputedStyle(target)
+      visible = rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none'
+    }
+    if (condition.state === 'attached') return attached
+    if (condition.state === 'detached') return !attached
+    if (condition.state === 'visible') return visible
+    return !visible
+  })(${JSON.stringify(condition)})`
+}
+
+function parseWaitCondition(raw: unknown): WaitCondition | { error: string } {
+  if (raw === undefined) return { kind: 'load' }
+  if (!raw || typeof raw !== 'object') return { error: 'bad-wait-condition' }
+  const value = raw as Record<string, unknown>
+  if (value.kind === 'load') return { kind: 'load' }
+  if ((value.kind === 'text' || value.kind === 'textGone' || value.kind === 'url') && typeof value.value === 'string') {
+    return { kind: value.kind, value: value.value }
+  }
+  if (value.kind === 'ref' && typeof value.ref === 'string' &&
+      ['visible', 'hidden', 'attached', 'detached'].includes(String(value.state))) {
+    const ref = normalizeRef(value.ref)
+    if ('error' in ref) return ref
+    const state = value.state as 'visible' | 'hidden' | 'attached' | 'detached'
+    return { kind: 'ref', ref: ref.ref, state }
+  }
+  return { error: 'bad-wait-condition' }
+}
+
+async function waitForCondition(
+  webview: PortalWebview,
+  timeoutMs: number,
+  condition: WaitCondition,
+  includeSnapshot: boolean,
+): Promise<BrowserOutcome> {
   const deadline = Date.now() + Math.min(Math.max(timeoutMs, 0) || WAIT_DEFAULT_MS, WAIT_MAX_MS)
   for (;;) {
-    if (!webview.isLoading()) {
-      return { ok: true, result: { url: webview.getURL(), title: webview.getTitle(), loading: false } }
+    const matched = condition.kind === 'load'
+      ? !webview.isLoading()
+      : await webview.executeJavaScript(waitConditionJs(condition)) === true
+    if (matched) {
+      return {
+        ok: true,
+        result: {
+          url: webview.getURL(),
+          title: webview.getTitle(),
+          loading: webview.isLoading(),
+          ...(includeSnapshot ? { snapshot: await takeSnapshot(webview) } : {}),
+        },
+      }
     }
-    if (Date.now() >= deadline) return { ok: false, error: 'still-loading' }
+    if (Date.now() >= deadline) {
+      return { ok: false, error: condition.kind === 'load' ? 'still-loading' : `wait-timeout:${condition.kind}` }
+    }
     await new Promise((r) => setTimeout(r, WAIT_POLL_MS))
   }
 }
@@ -317,27 +481,37 @@ export async function handleBrowserMethod(
         return { ok: true, result: { path: result.filePath } }
       }
       case 'snapshot': {
-        const snap = await webview.executeJavaScript(SNAPSHOT_JS)
+        const snap = await takeSnapshot(webview)
         return { ok: true, result: snap }
       }
       case 'click': {
         const ref = normalizeRef(args.ref)
         if ('error' in ref) return { ok: false, error: ref.error }
-        const res = (await webview.executeJavaScript(clickJs(ref.ref))) as { ok?: true; error?: string }
-        if (res?.error) return { ok: false, error: res.error }
-        return { ok: true }
+        const actionable = await waitForActionable(webview, ref.ref, 'click')
+        if ('error' in actionable) return { ok: false, error: actionable.error }
+        const { x, y } = actionable.point
+        await webview.sendInputEvent({ type: 'mouseMove', x, y })
+        await webview.sendInputEvent({ type: 'mouseDown', x, y, button: 'left', clickCount: 1 })
+        await webview.sendInputEvent({ type: 'mouseUp', x, y, button: 'left', clickCount: 1 })
+        return postActionOutcome(webview, args)
       }
+      case 'fill':
       case 'type': {
         const ref = normalizeRef(args.ref)
         if ('error' in ref) return { ok: false, error: ref.error }
         const text = typeof args.text === 'string' ? args.text : ''
-        const res = (await webview.executeJavaScript(typeJs(ref.ref, text))) as { ok?: true; error?: string }
-        if (res?.error) return { ok: false, error: res.error }
-        return { ok: true }
+        const actionable = await waitForActionable(webview, ref.ref, 'fill')
+        if ('error' in actionable) return { ok: false, error: actionable.error }
+        const focused = await webview.executeJavaScript(focusForFillJs(ref.ref)) as { error?: string }
+        if (focused?.error) return { ok: false, error: focused.error }
+        await sendNativeFill(webview, text)
+        return postActionOutcome(webview, args)
       }
       case 'wait': {
         const timeoutMs = typeof args.timeoutMs === 'number' ? args.timeoutMs : WAIT_DEFAULT_MS
-        return await waitForLoad(webview, timeoutMs)
+        const condition = parseWaitCondition(args.condition)
+        if ('error' in condition) return { ok: false, error: condition.error }
+        return await waitForCondition(webview, timeoutMs, condition, args.includeSnapshot === true)
       }
       case 'press': {
         const key = typeof args.key === 'string' ? PRESS_KEYS[args.key.toLowerCase()] : undefined
@@ -358,7 +532,7 @@ export async function handleBrowserMethod(
           await webview.sendInputEvent({ type: 'char', keyCode: key })
         }
         await webview.sendInputEvent({ type: 'keyUp', keyCode: key })
-        return { ok: true }
+        return postActionOutcome(webview, args)
       }
       default:
         return { ok: false, error: 'unsupported' }

--- a/src/renderer/lib/e2eHarness.ts
+++ b/src/renderer/lib/e2eHarness.ts
@@ -91,6 +91,8 @@ declare global {
       terminalPtyId(nodeId: string): string | null
       /** Write raw data to a terminal node's PTY (e.g. a flooding command). */
       writeTerminal(nodeId: string, data: string): boolean
+      /** Plain text currently held by a terminal's active xterm buffer. */
+      terminalText(nodeId: string): string | null
       /** Point the selected workspace at a real directory (registers it as an
        *  allowed root) so content search has files to scan. */
       setWorkspaceRoot(rootPath: string): Promise<boolean>
@@ -303,6 +305,25 @@ export function installE2EHarness(): void {
     return true
   }
 
+  const terminalText = (nodeId: string): string | null => {
+    const cs = activeCanvasStore()
+    if (!cs) return null
+    const node = cs.getState().nodes[nodeId]
+    const panelId = activeDockPanelId(node?.dockLayout) ?? nodeId
+    const terminal = terminalRegistry.getEntry(panelId)?.terminal
+    if (!terminal) return null
+    const buffer = terminal.buffer.active
+    const lines: string[] = []
+    for (let i = 0; i < buffer.length; i++) {
+      const line = buffer.getLine(i)
+      const text = line?.translateToString(true) ?? ''
+      if (line?.isWrapped && lines.length > 0) lines[lines.length - 1] += text
+      else lines.push(text)
+    }
+    while (lines.at(-1) === '') lines.pop()
+    return lines.join('\n')
+  }
+
   const setWorkspaceRoot = (rootPath: string): Promise<boolean> => {
     const wsId = useAppStore.getState().selectedWorkspaceId
     return useAppStore.getState().setWorkspaceRootPath(wsId, rootPath)
@@ -386,6 +407,7 @@ export function installE2EHarness(): void {
     worktreeDebug,
     terminalPtyId,
     writeTerminal,
+    terminalText,
     setWorkspaceRoot,
     openSidebarView,
     setActiveLeftSidebarView,

--- a/src/renderer/lib/portalRegistry.ts
+++ b/src/renderer/lib/portalRegistry.ts
@@ -7,10 +7,8 @@
 // `dom-ready` fires (which is when getWebContentsId() returns a stable id),
 // and unregisters on unmount.
 //
-// Note: refs (the @e1/@e2 mapping returned by `portal snapshot`) live in main
-// rather than here — main injects `data-cate-ref` attributes onto the DOM
-// during the snapshot and looks them up directly via executeJavaScript() on
-// subsequent commands.
+// Snapshot refs are generation-scoped tokens (for example @s2e4) injected into
+// the guest DOM and resolved by browserDriver on subsequent commands.
 // =============================================================================
 
 /** Minimal subset of the Electron <webview> tag interface we depend on.
@@ -25,9 +23,22 @@ export interface PortalWebview {
   reload(): void
   isLoading(): boolean
   executeJavaScript(code: string): Promise<unknown>
-  /** Real (isTrusted) input delivered to the guest webContents — unlike the
-   *  synthetic DOM events click/type dispatch. Used by `browser press`. */
-  sendInputEvent(event: { type: 'keyDown' | 'char' | 'keyUp'; keyCode: string }): Promise<void> | void
+  /** Real (isTrusted) input delivered to the guest webContents. Browser actions
+   *  use this instead of synthetic DOM click/input events. */
+  sendInputEvent(event:
+    | {
+      type: 'keyDown' | 'char' | 'keyUp'
+      keyCode: string
+      modifiers?: Array<'shift' | 'control' | 'alt' | 'meta'>
+    }
+    | {
+      type: 'mouseMove' | 'mouseDown' | 'mouseUp'
+      x: number
+      y: number
+      button?: 'left'
+      clickCount?: number
+    }
+  ): Promise<void> | void
 }
 
 interface Entry {

--- a/src/shared/cate-host-api.d.ts
+++ b/src/shared/cate-host-api.d.ts
@@ -91,18 +91,24 @@ export interface CateDroppedFile {
   truncated?: boolean
 }
 
-/** One interactable element in an accessibility `snapshot()`. `ref` is an opaque
- *  handle to pass back to `click`/`type`; it is only valid for the snapshot it
- *  came from (re-snapshot after a navigation or mutation). */
+/** One interactable element in an accessibility `snapshot()`. `ref` is an opaque,
+ *  generation-scoped handle to pass back to browser actions. */
 export interface CateBrowserRef {
   ref: string
   role: string
   name: string
   value?: string
+  disabled?: boolean
+  checked?: boolean
+  expanded?: boolean
+  selected?: boolean
+  focused?: boolean
 }
 
 /** Accessibility snapshot of a browser panel, from `cate.browser.snapshot()`. */
 export interface CateBrowserSnapshot {
+  /** Generation id embedded into every ref; a ref from an older generation is stale. */
+  snapshotId: string
   url: string
   title: string
   refs: CateBrowserRef[]
@@ -187,19 +193,27 @@ export interface CateHost {
     screenshot(opts?: { panelId?: string }): Promise<{ path: string }>
     /** Accessibility snapshot with interactable element refs. */
     snapshot(opts?: { panelId?: string }): Promise<CateBrowserSnapshot>
-    /** Click the element identified by `ref` (from a recent `snapshot`). */
-    click(opts: { ref: string; panelId?: string }): Promise<{ ok: true }>
-    /** Type `text` into the element identified by `ref`. */
-    type(opts: { ref: string; text: string; panelId?: string }): Promise<{ ok: true }>
-    /** Resolve once the panel stops loading (poll-based; `timeoutMs` defaults to
-     *  5000 and is capped at 8000). Rejects in-band with `still-loading`. */
-    wait(opts?: { panelId?: string; timeoutMs?: number }): Promise<{ url: string; title: string; loading: false }>
+    /** Auto-wait for actionability, then click with trusted pointer input. */
+    click(opts: { ref: string; panelId?: string; includeSnapshot?: boolean }): Promise<{ ok: true; snapshot?: CateBrowserSnapshot }>
+    /** Fill with trusted keyboard input. `type` is retained as an alias. */
+    fill(opts: { ref: string; text: string; panelId?: string; includeSnapshot?: boolean }): Promise<{ ok: true; snapshot?: CateBrowserSnapshot }>
+    type(opts: { ref: string; text: string; panelId?: string; includeSnapshot?: boolean }): Promise<{ ok: true; snapshot?: CateBrowserSnapshot }>
+    /** Wait for load, text, text disappearance, URL glob, or ref state. */
+    wait(opts?: {
+      panelId?: string
+      timeoutMs?: number
+      includeSnapshot?: boolean
+      condition?:
+        | { kind: 'load' }
+        | { kind: 'text' | 'textGone' | 'url'; value: string }
+        | { kind: 'ref'; ref: string; state: 'visible' | 'hidden' | 'attached' | 'detached' }
+    }): Promise<{ url: string; title: string; loading: boolean; snapshot?: CateBrowserSnapshot }>
     /** Press a named key (Enter, Tab, Escape, Backspace, Delete, Space, arrows,
      *  PageUp/PageDown, Home, End) as TRUSTED input — unlike `click`/`type`,
      *  which synthesise untrusted DOM events — so Enter submits forms. With
      *  `ref` the element is focused first; without it the key goes to the
      *  guest's current focus. */
-    press(opts: { key: string; ref?: string; panelId?: string }): Promise<{ ok: true }>
+    press(opts: { key: string; ref?: string; panelId?: string; includeSnapshot?: boolean }): Promise<{ ok: true; snapshot?: CateBrowserSnapshot }>
   }
   storage: CateHostStorage
 }

--- a/src/shared/cliPermissions.ts
+++ b/src/shared/cliPermissions.ts
@@ -75,7 +75,7 @@ export const CLI_PERMISSIONS: CliPermissionSurface[] = [
       access: 'Control',
       code: 'browser-control-disabled',
       detail:
-        '`cate browser open / reload / click / type / press` — act on the page in the built-in browser panel, using your live logged-in sessions.',
+        '`cate browser open / reload / click / fill / type / press` — act on the page in the built-in browser panel, using your live logged-in sessions.',
     },
   },
   {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -1045,8 +1045,8 @@ export interface ElectronAPI {
   skillsRefresh(): Promise<SkillEntry[]>
   /** Fetch a skill's SKILL.md body for the detail preview. */
   skillsGetPreview(entry: SkillEntry): Promise<string>
-  /** Install a skill into a workspace agent. Reuses an existing local install of
-   *  the same skill, then the saved-library cache, else fetches from GitHub. */
+  /** Install/update a skill from its source. Existing workspace/library bytes
+   *  are used only as an offline fallback (reported in warnings). */
   skillsInstall(entry: SkillEntry, targetId: SkillTargetId, cwd: string): Promise<{ ok: boolean; error?: string; warnings?: string[]; installed?: InstalledSkill }>
   /** Uninstall a skill from a workspace agent. */
   skillsUninstall(skillId: string, name: string, targetId: SkillTargetId, cwd: string): Promise<{ ok: boolean; error?: string }>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1449,11 +1449,11 @@ export interface AppSettings {
    *  the cell. cliEnabled above is the master switch — off, no endpoint exists
    *  and these never come into play. The rows and the method → cell mapping live
    *  in shared/cliPermissions.ts. */
-  /** Read half of `cate browser *` — screenshot, snapshot, list, current, wait.
+  /** Read half of `cate browser *` — screenshot, snapshot and conditional wait.
    *  Sees whatever the user's live logged-in session is showing. On by default. */
   cliBrowserReadEnabled: boolean
-  /** Control half of `cate browser *` — open/back/forward/reload plus click,
-   *  type and press, which act on the user's live logged-in session.
+  /** Control half of `cate browser *` — open/reload plus click, fill, type and
+   *  press, which act on the user's live logged-in session.
    *  On by default (the CLI's original core feature). */
   cliBrowserControlEnabled: boolean
   /** `cate terminal read` — read other terminal panels' screens/scrollback,

--- a/src/skills/main/skillsInstaller.test.ts
+++ b/src/skills/main/skillsInstaller.test.ts
@@ -8,7 +8,7 @@ const store = vi.hoisted(() => ({
   cache: vi.fn(),
   remove: vi.fn(),
 }))
-const saved = vi.hoisted(() => ({ addSaved: vi.fn(), removeSaved: vi.fn() }))
+const saved = vi.hoisted(() => ({ addSaved: vi.fn(), removeSaved: vi.fn(), isSaved: vi.fn() }))
 const fetchSkillFiles = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
@@ -19,7 +19,7 @@ vi.mock('./savedSkills', () => saved)
 vi.mock('./skillSources', () => ({ getToken: () => 'token' }))
 vi.mock('./githubCrawl', () => ({ fetchSkillFiles }))
 
-import { install, uninstall, writeSkillToWorkspace } from './skillsInstaller'
+import { install, saveSkill, uninstall, writeSkillToWorkspace } from './skillsInstaller'
 
 const WS = '/workspace'
 const MANIFEST = `${WS}/.cate/skills.json`
@@ -85,6 +85,7 @@ beforeEach(() => {
   store.remove.mockReset().mockResolvedValue(undefined)
   saved.addSaved.mockReset()
   saved.removeSaved.mockReset()
+  saved.isSaved.mockReset().mockReturnValue(false)
   fetchSkillFiles.mockReset().mockResolvedValue([])
 })
 
@@ -186,22 +187,71 @@ describe('skillsInstaller workspace manifest', () => {
 })
 
 describe('skillsInstaller resolution cache', () => {
-  it('uses saved bytes without fetching from GitHub', async () => {
+  it('falls back to saved bytes when the latest source is unavailable', async () => {
     store.read.mockResolvedValue([{ relPath: 'SKILL.md', text: 'cached' }])
 
-    await install(entry(), 'codex', WS)
+    const result = await install(entry(), 'codex', WS)
 
     expect(store.read).toHaveBeenCalledWith(entry().id)
-    expect(fetchSkillFiles).not.toHaveBeenCalled()
+    expect(fetchSkillFiles).toHaveBeenCalledWith(entry().source, 'token')
     expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('cached')
+    expect(result.warnings).toContain('Latest source unavailable; installed the existing offline copy.')
   })
 
-  it('fetches only when the saved cache is empty', async () => {
+  it('prefers fresh source bytes over a stale saved cache', async () => {
+    store.read.mockResolvedValue([{ relPath: 'SKILL.md', text: 'stale cached' }])
     fetchSkillFiles.mockResolvedValue([{ relPath: 'SKILL.md', text: 'remote' }])
 
     await install(entry(), 'codex', WS)
 
     expect(fetchSkillFiles).toHaveBeenCalledWith(entry().source, 'token')
+    expect(store.read).not.toHaveBeenCalled()
     expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('remote')
+  })
+
+  it('prefers fresh source bytes over another agent install', async () => {
+    files.set(MANIFEST, JSON.stringify({
+      skills: [{ skillId: entry().id, name: entry().name, targetId: 'claude-code', path: '/claude', origin: 'local' }],
+    }))
+    files.set(`${WS}/.claude/skills/demo-skill/SKILL.md`, 'stale agent copy')
+    fetchSkillFiles.mockResolvedValue([{ relPath: 'SKILL.md', text: 'fresh source' }])
+
+    await install(entry(), 'codex', WS)
+
+    expect(files.get(`${WS}/.codex/skills/demo-skill/SKILL.md`)).toContain('fresh source')
+  })
+
+  it('refreshes a saved cache after a successful source fetch', async () => {
+    const fresh = [{ relPath: 'SKILL.md', text: 'fresh source' }]
+    saved.isSaved.mockReturnValue(true)
+    fetchSkillFiles.mockResolvedValue(fresh)
+
+    await install(entry(), 'codex', WS)
+
+    expect(store.cache).toHaveBeenCalledWith(entry().id, fresh)
+  })
+})
+
+describe('saveSkill freshness', () => {
+  it('replaces an existing cache with current source bytes', async () => {
+    const fresh = [{ relPath: 'SKILL.md', text: 'fresh source' }]
+    store.has.mockResolvedValue(true)
+    fetchSkillFiles.mockResolvedValue(fresh)
+
+    await saveSkill(entry())
+
+    expect(fetchSkillFiles).toHaveBeenCalledWith(entry().source, 'token')
+    expect(store.cache).toHaveBeenCalledWith(entry().id, fresh)
+    expect(saved.addSaved).toHaveBeenCalled()
+  })
+
+  it('keeps a usable cached copy when saving offline', async () => {
+    store.has.mockResolvedValue(true)
+    fetchSkillFiles.mockRejectedValue(new Error('offline'))
+
+    await expect(saveSkill(entry())).resolves.toBeUndefined()
+
+    expect(store.cache).not.toHaveBeenCalled()
+    expect(saved.addSaved).toHaveBeenCalled()
   })
 })

--- a/src/skills/main/skillsInstaller.ts
+++ b/src/skills/main/skillsInstaller.ts
@@ -2,11 +2,11 @@
 // Skill install engine — writes a skill into a workspace's per-target dir via
 // the runtime (local AND remote), and tracks installs in <ws>/.cate/skills.json.
 //
-// Resolving a skill's files for a workspace install, in order:
-//   - reuse an existing install of the same skill in ANOTHER agent here (copy
-//     agent → agent);
-//   - reuse the saved-library cache (skillStore), if the skill was saved;
-//   - otherwise fetch from GitHub.
+// Resolving a skill's files for a workspace install:
+//   - fetch the source first, so installing for another agent also updates an
+//     old workspace/library copy instead of propagating stale bytes;
+//   - if the source is unavailable, fall back to another local agent install,
+//     then the saved-library cache, and surface an offline-copy warning.
 // Saving (saveSkill) caches the bytes in skillStore + records the skill in the
 // userData library; it never touches a workspace.
 // =============================================================================
@@ -244,21 +244,44 @@ export async function install(entry: SkillEntry, targetId: SkillTargetId, cwd: s
   if (!hostCwd) throw new Error('Workspace has no folder open')
   const runtime = runtimes.resolve(runtimeId)
 
-  // Resolve files: existing agent install here → saved-library cache → GitHub.
+  // The remote source is authoritative. Existing installs and the saved cache
+  // are offline fallbacks, not a faster path: making them the first choice
+  // caused a skill to remain stale forever once it had been installed/saved.
   const manifest = await readManifest(runtime, runtimeId, hostCwd)
   const existing = manifest.find((m) => m.skillId === entry.id)
   let files: SkillFile[] = []
-  if (existing) {
+  let fetchError: unknown
+  if (entry.source.repo) {
+    try {
+      files = await fetchSkillFiles(entry.source, getToken())
+      if (!files.length) throw new Error('Source returned no skill files')
+      // A successful source read also repairs a stale saved-library cache. A
+      // cache write is useful but must not block the workspace install.
+      if (savedSkills.isSaved(entry.id)) {
+        await skillStore.cache(entry.id, files).catch((err) => {
+          log.warn('[skills] could not refresh saved cache for %s: %O', entry.id, err)
+        })
+      }
+    } catch (err) {
+      fetchError = err
+    }
+  }
+  if (!files.length && existing) {
     files = await readWorkspaceSkillFiles(runtime, runtimeId, hostCwd, existing.targetId, existing.name)
   }
   if (!files.length) {
     files = (await skillStore.read(entry.id)) ?? []
   }
   if (!files.length) {
-    files = await fetchSkillFiles(entry.source, getToken())
+    if (fetchError instanceof Error) throw fetchError
+    throw new Error('Could not resolve skill files')
   }
 
-  return writeSkillToWorkspace({ skillId: entry.id, name: entry.name, targetId, cwd, files, origin: 'local' })
+  const result = await writeSkillToWorkspace({ skillId: entry.id, name: entry.name, targetId, cwd, files, origin: 'local' })
+  if (fetchError) {
+    result.warnings.unshift('Latest source unavailable; installed the existing offline copy.')
+  }
+  return result
 }
 
 export async function uninstall(
@@ -303,10 +326,17 @@ export async function listInstalled(cwd: string): Promise<InstalledSkill[]> {
 // ---------------------------------------------------------------------------
 
 export async function saveSkill(entry: SkillEntry): Promise<void> {
-  if (!(await skillStore.has(entry.id))) {
+  // Re-saving must refresh the bytes. `has()` used to make the first cached
+  // copy permanent, even when a moving branch such as `main` changed later.
+  try {
     const files = await fetchSkillFiles(entry.source, getToken())
     if (!files.length) throw new Error('Could not fetch skill files')
     await skillStore.cache(entry.id, files)
+  } catch (err) {
+    // Preserve the library's offline promise when a usable cache already
+    // exists; without one, surface the fetch failure to the caller.
+    if (!(await skillStore.has(entry.id))) throw err
+    log.warn('[skills] source unavailable while saving %s; keeping cached copy: %O', entry.id, err)
   }
   savedSkills.addSaved({
     skillId: entry.id,


### PR DESCRIPTION
## Summary

- add a real Electron/Playwright CLI E2E that executes the bundled `cate` CLI inside Cate's terminal PTY and exercises panel, editor, UI, terminal, browser, wait, snapshot, interaction, reload, and screenshot commands
- harden the browser-control protocol for agents with generation-scoped refs, password masking, state flags, native actionability, conditional waits, and optional post-action snapshots while retaining the simple custom DOM snapshot implementation
- make skill installation source-first so installed skills refresh from their configured source, update saved caches, and fall back clearly when offline
- fix immediate panel-create routing so newly created terminal/browser panels can be addressed before the renderer's debounced panel report
- make the E2E harness inspect terminal output and shut Electron down robustly

## Why

The previous CLI tests mocked the daemon socket, so they did not prove that commands work through the packaged CLI, Electron IPC, a real terminal PTY, or a browser webview. Skill resolution could also let an installed copy shadow its source indefinitely, and newly created panels were briefly unavailable to follow-up CLI commands.

## Verification

- `npm run typecheck`
- focused Vitest suites: 257 passed
- `npm run build`
- full Vitest suite excluding the unrelated local-daemon tarball artifact test: 2,855 passed, 46 skipped
- real Electron CLI E2E passed before rebasing onto current `main`
- post-rebase E2E launch currently closes the renderer during `beforeEach`, before workspace setup or any CLI command executes; documented here for follow-up rather than treating it as a CLI assertion failure

## Notes

This intentionally keeps Cate's compact custom DOM browser snapshot protocol. The experimental switch to Chromium's CDP accessibility tree was reverted and is not part of this PR.
