### PR TITLE
Keep moved panels alive when closing a canvas

### DIFF
--- a/src/renderer/lib/canvas/confirmCloseCanvas.test.ts
+++ b/src/renderer/lib/canvas/confirmCloseCanvas.test.ts
@@ -6,6 +6,7 @@ const state = {
 }
 const closePanel = vi.fn()
 const addNode = vi.fn()
+const finalizeRemoveNode = vi.fn()
 const canvasNodes: Record<string, {
   id: string
   origin: { x: number; y: number }
@@ -18,7 +19,7 @@ vi.mock('../../stores/appStore', () => ({
 
 vi.mock('../../stores/canvasStore', () => ({
   getOrCreateCanvasStoreForPanel: () => ({
-    getState: () => ({ nodes: canvasNodes, addNode }),
+    getState: () => ({ nodes: canvasNodes, addNode, finalizeRemoveNode }),
   }),
 }))
 
@@ -52,6 +53,8 @@ describe('confirmCloseCanvas', () => {
   beforeEach(() => {
     closePanel.mockReset()
     addNode.mockReset()
+    addNode.mockReturnValue('target-node')
+    finalizeRemoveNode.mockReset()
     confirmCloseCanvasDialog.mockReset()
     ;(globalThis as unknown as { window: { electronAPI: unknown } }).window = {
       electronAPI: { confirmCloseCanvas: confirmCloseCanvasDialog },
@@ -108,6 +111,7 @@ describe('confirmCloseCanvas', () => {
 
     expect(proceed).toBe(true)
     expect(addNode).toHaveBeenCalledWith('term1', 'terminal', { x: 0, y: 0 })
+    expect(finalizeRemoveNode).toHaveBeenCalledWith('n0')
     expect(closePanel).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/lib/canvas/confirmCloseCanvas.ts
+++ b/src/renderer/lib/canvas/confirmCloseCanvas.ts
@@ -32,12 +32,16 @@ export async function confirmCloseCanvas(
   // each canvas node's dockLayout.
   const sourceStore = getOrCreateCanvasStoreForPanel(canvasPanelId)
   const sourceNodes = Object.values(sourceStore.getState().nodes)
-  const contained: Array<{ panelId: string; origin: { x: number; y: number } }> = []
+  const contained: Array<{
+    panelId: string
+    nodeId: string
+    origin: { x: number; y: number }
+  }> = []
   for (const node of sourceNodes) {
     // Read the live mini-dock layout when the node is mounted (the resolver
     // falls back to the persisted node.dockLayout projection otherwise).
     for (const pid of collectPanelIds(getNodeDockLayout(canvasPanelId, node.id))) {
-      if (ws.panels[pid]) contained.push({ panelId: pid, origin: node.origin })
+      if (ws.panels[pid]) contained.push({ panelId: pid, nodeId: node.id, origin: node.origin })
     }
   }
 
@@ -75,16 +79,31 @@ export async function confirmCloseCanvas(
     const targetCanvasId = canvasPanelIds.find((id) => id !== canvasPanelId)
     if (!targetCanvasId) return true // defensive — shouldn't happen when !isLast
     const targetStore = getOrCreateCanvasStoreForPanel(targetCanvasId)
+    const addedTargetNodeIds: string[] = []
 
-    for (const { panelId, origin } of contained) {
-      const panel = ws.panels[panelId]
-      if (!panel) continue
-      // Re-home each panel as its own fresh node on the target canvas. This
-      // preserves spatial position but flattens any nested dock layouts into
-      // individual nodes — a deliberate simplification over deep layout copy.
-      try {
-        targetStore.getState().addNode(panelId, panel.type, origin)
-      } catch { /* swallow and continue */ }
+    try {
+      for (const { panelId, origin } of contained) {
+        const panel = ws.panels[panelId]
+        if (!panel) continue
+        // Re-home each panel as its own fresh node on the target canvas. This
+        // preserves spatial position but flattens any nested dock layouts into
+        // individual nodes — a deliberate simplification over deep layout copy.
+        const nodeId = targetStore.getState().addNode(panelId, panel.type, origin)
+        if (!nodeId) throw new Error(`Failed to move panel ${panelId}`)
+        addedTargetNodeIds.push(nodeId)
+      }
+    } catch {
+      for (const nodeId of addedTargetNodeIds) {
+        targetStore.getState().finalizeRemoveNode(nodeId)
+      }
+      return false
+    }
+
+    // Closing a canvas tears down every panel it still owns. Drop the source
+    // nodes immediately so the caller's closePanel(canvasPanelId) cannot also
+    // tear down the children that now belong to the target canvas.
+    for (const nodeId of new Set(contained.map(({ nodeId }) => nodeId))) {
+      sourceStore.getState().finalizeRemoveNode(nodeId)
     }
     return true
   }

--- a/src/renderer/stores/appStore/closePanel.lifecycle.test.ts
+++ b/src/renderer/stores/appStore/closePanel.lifecycle.test.ts
@@ -96,6 +96,7 @@ import {
   getOrCreateCanvasStoreForPanel,
   peekCanvasStoreForPanel,
 } from '../canvasStore'
+import { closePanelWithConfirm } from '../../lib/closePanelWithConfirm'
 import { removePanelFromWindow } from '../../lib/panels/removePanelFromWindow'
 import { setActivePanel, getActivePanelId } from '../../lib/activePanel'
 import type { DockLayoutNode, PanelState } from '../../../shared/types'
@@ -268,6 +269,29 @@ describe('closePanel — happy path', () => {
 // ---------------------------------------------------------------------------
 
 describe('closePanel — canvas with children', () => {
+  it('keeps a moved child panel and PTY alive when its source canvas closes', async () => {
+    const { wsId, canvasId: targetCanvas } = makeWorkspace(`move-${testSeq}`)
+    const sourceCanvas = useAppStore.getState().createCanvas(wsId)
+    const childTerm = useAppStore.getState().createTerminal(
+      wsId, undefined, undefined,
+      { target: 'canvas', canvasPanelId: sourceCanvas, position: { x: 20, y: 30 } },
+    )
+    spawnPty(childTerm, wsId)
+    const confirmCloseCanvas = vi.fn(async () => 'move' as const)
+    Object.assign(window.electronAPI, { confirmCloseCanvas })
+
+    await closePanelWithConfirm(wsId, sourceCanvas)
+
+    expect(confirmCloseCanvas).toHaveBeenCalledWith({ panelCount: 1, isLast: false })
+    expect(panelsOf(wsId)[sourceCanvas]).toBeUndefined()
+    expect(panelsOf(wsId)[childTerm]).toBeDefined()
+    expect(h.entries.has(childTerm)).toBe(true)
+    expect(h.ptyKill).not.toHaveBeenCalled()
+    expect(
+      getOrCreateCanvasStoreForPanel(targetCanvas).getState().nodeForPanel(childTerm),
+    ).toBeTruthy()
+  })
+
   it('recursively disposes child node panels AND mini-dock tab panels, then releases the canvas store', () => {
     const { wsId } = makeWorkspace(`cv-${testSeq}`)
     const canvas2 = useAppStore.getState().createCanvas(wsId)


### PR DESCRIPTION
Keep moved panels and terminal sessions alive when their source canvas closes.

Closes #530