### PR TITLE
Make agent setup work across worktrees

### DIFF
--- a/src/agent/main/agentManager.test.ts
+++ b/src/agent/main/agentManager.test.ts
@@ -11,7 +11,8 @@ vi.mock('../../main/windowRegistry', () => ({ broadcastToAll: vi.fn() }))
 vi.mock('../../main/windowPanels', () => ({ getWindowPanels: () => [] }))
 vi.mock('../../main/runtime/runtimeManager', () => ({ runtimes: { resolve: vi.fn() } }))
 vi.mock('../../main/runtime/locator', () => ({
-  parseLocator: vi.fn(() => ({ runtimeId: 'local', path: '/ws' })),
+  parseLocator: vi.fn((path: string) => ({ runtimeId: 'local', path })),
+  formatLocator: vi.fn(({ path }: { path: string }) => path),
 }))
 vi.mock('./piRpcClient', () => ({ PiRpcClient: vi.fn() }))
 vi.mock('./installSubagents', () => ({ installSubagentExtension: vi.fn() }))
@@ -28,11 +29,59 @@ vi.mock('./agentDir', () => ({
   hostJoin: vi.fn((_rt: string, ...segs: string[]) => segs.join('/')),
 }))
 vi.mock('./customModels', () => ({ mirrorModelsToWorkspace: vi.fn() }))
+vi.mock('../../skills/main/skillsMirror', () => ({ syncWorkspaceSkills: vi.fn() }))
+vi.mock('../../main/extensions/workspaceCateApi', () => ({
+  workspaceCateApi: { ensureEndpoint: vi.fn().mockResolvedValue(null) },
+}))
+vi.mock('../../main/workspaceStateStore', () => ({ isProjectTrusted: vi.fn(() => false) }))
 
 import { AgentManager } from './agentManager'
 import type { AuthManager } from './authManager'
+import { runtimes } from '../../main/runtime/runtimeManager'
+import { PiRpcClient } from './piRpcClient'
+import { prepareAgentDir } from './agentDir'
+import { syncWorkspaceSkills } from '../../skills/main/skillsMirror'
 
 const fakeAuthManager = { setOnChange: vi.fn() } as unknown as AuthManager
+
+describe('AgentManager worktree skill preparation', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('mirrors base-workspace skills before preparing and starting a worktree agent', async () => {
+    const runtime = { agent: { ensurePi: vi.fn().mockResolvedValue(undefined) } }
+    vi.mocked(runtimes.resolve).mockReturnValue(runtime as never)
+    const client = {
+      start: vi.fn().mockResolvedValue(undefined),
+      onEvent: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+    }
+    vi.mocked(PiRpcClient).mockImplementation(() => client as never)
+    vi.mocked(syncWorkspaceSkills).mockResolvedValue({
+      copied: [],
+      updated: [],
+      removed: [],
+      preserved: [],
+      warnings: [],
+    })
+
+    const manager = new AgentManager(fakeAuthManager)
+    await manager.create(
+      {
+        panelId: 'panel-worktree',
+        workspaceId: 'workspace-1',
+        workspaceRoot: '/repo/base',
+        cwd: '/repo/worktree',
+      },
+      { id: 4, isDestroyed: () => false, send: vi.fn() } as never,
+    )
+
+    expect(syncWorkspaceSkills).toHaveBeenCalledWith('/repo/base', '/repo/worktree')
+    expect(vi.mocked(syncWorkspaceSkills).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(prepareAgentDir).mock.invocationCallOrder[0],
+    )
+    expect(client.start).toHaveBeenCalledOnce()
+  })
+})
 
 function makeManager() {
   const mgr = new AgentManager(fakeAuthManager)

--- a/src/agent/main/agentManager.ts
+++ b/src/agent/main/agentManager.ts
@@ -40,6 +40,8 @@ import { installAskUserExtension } from './installAskUser'
 import { installCateAgentToolsExtension } from './installCateAgentTools'
 import { installMcpAdapter } from './installMcpAdapter'
 import { isProjectTrusted } from '../../main/workspaceStateStore'
+import { syncWorkspaceSkills } from '../../skills/main/skillsMirror'
+import { resolveWorktreeContext } from '../../main/worktreeContext'
 import { hostAgentDir, prepareAgentDir, watchWorkspaceAuth, pushSharedToWorkspace, type AgentDirVariant } from './agentDir'
 import { mirrorModelsToWorkspace } from './customModels'
 import { authManager, type AuthManager } from './authManager'
@@ -154,6 +156,17 @@ export class AgentManager {
       // runtime isn't connected — surfaced as a start error).
       const { runtimeId, path: cwd } = parseLocator(opts.cwd)
       const runtime = runtimes.resolve(runtimeId)
+
+      // The workspace manifest is canonical; materialize its managed skills in
+      // this checkout before pi discovers project skills on startup.
+      try {
+        const worktree = resolveWorktreeContext(opts.workspaceRoot ?? opts.cwd, opts.cwd)
+        if (worktree) {
+          await syncWorkspaceSkills(worktree.base.locator, worktree.checkout.locator)
+        }
+      } catch (err) {
+        log.warn('[agentManager] worktree skill sync failed for %s: %O', opts.panelId, err)
+      }
 
       // The Cate Agent's headless sessions live in an ISOLATED per-workspace pi
       // dir (.cate/pi-agent-cate-agent) so their transcripts never show up in — or get

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -13,6 +13,10 @@ import { parseLocator, formatLocator } from '../runtime/locator'
 import type { FileAccessContext, VcsHost } from '../runtime/types'
 import { resolveLocator } from '../runtime/runtimeManager'
 import { windowFromEvent } from '../windowRegistry'
+import log from '../logger'
+import { getWorkspaceInfo } from '../workspaceManager'
+import { syncWorkspaceSkills } from '../../skills/main/skillsMirror'
+import { resolveWorktreeContext } from '../worktreeContext'
 import {
   GIT_IS_REPO,
   GIT_FIND_REPOS,
@@ -58,6 +62,22 @@ import {
 function vcsFor(locator: string): { vcs: VcsHost; path: string; runtimeId: string } {
   const { runtime, path, runtimeId } = resolveLocator(locator)
   return { vcs: runtime.vcs, path, runtimeId }
+}
+
+async function syncNewWorktreeSkills(
+  workspaceId: string | undefined,
+  fallbackBaseCwd: string,
+  targetCwd: string,
+): Promise<void> {
+  const baseCwd = (workspaceId && getWorkspaceInfo(workspaceId)?.rootPath) || fallbackBaseCwd
+  const worktree = resolveWorktreeContext(baseCwd, targetCwd)
+  if (!worktree) return
+  try {
+    await syncWorkspaceSkills(worktree.base.locator, worktree.checkout.locator)
+  } catch (err) {
+    // Worktree creation succeeded; a later terminal/agent launch retries.
+    log.warn('[git] new worktree skill sync failed: %O', err)
+  }
 }
 
 /** Decode a worktree-path argument (a locator built by the renderer from the
@@ -160,7 +180,9 @@ export function registerHandlers(): void {
       const { vcs, path, runtimeId } = vcsFor(repoCwd)
       const target = worktreeTargetPath(runtimeId, targetPath)
       const res = await vcs.worktreeAdd(path, branch, target, options, { ownerWindowId: windowFromEvent(event)?.id, scopeId: workspaceId })
-      return { ...res, path: formatLocator({ runtimeId, path: res.path }) }
+      const locator = formatLocator({ runtimeId, path: res.path })
+      await syncNewWorktreeSkills(workspaceId, repoCwd, locator)
+      return { ...res, path: locator }
     },
   )
 
@@ -177,7 +199,9 @@ export function registerHandlers(): void {
       const { vcs, path, runtimeId } = vcsFor(repoCwd)
       const target = worktreeTargetPath(runtimeId, targetPath)
       const res = await vcs.worktreeAddFromPr(path, prNumber, target, options, { ownerWindowId: windowFromEvent(event)?.id, scopeId: workspaceId })
-      return { ...res, path: formatLocator({ runtimeId, path: res.path }) }
+      const locator = formatLocator({ runtimeId, path: res.path })
+      await syncNewWorktreeSkills(workspaceId, repoCwd, locator)
+      return { ...res, path: locator }
     },
   )
 

--- a/src/main/ipc/gitSkillsMirror.test.ts
+++ b/src/main/ipc/gitSkillsMirror.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GIT_WORKTREE_ADD, GIT_WORKTREE_ADD_FROM_PR } from '../../shared/ipc-channels'
+
+const state = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  worktreeAdd: vi.fn(),
+  worktreeAddFromPr: vi.fn(),
+  sync: vi.fn(),
+  getWorkspaceInfo: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      state.handlers.set(channel, handler)
+    }),
+  },
+}))
+vi.mock('../runtime/runtimeManager', () => ({
+  resolveLocator: vi.fn(() => ({
+    runtimeId: 'local',
+    path: '/repo',
+    runtime: {
+      vcs: {
+        worktreeAdd: state.worktreeAdd,
+        worktreeAddFromPr: state.worktreeAddFromPr,
+      },
+    },
+  })),
+}))
+vi.mock('../windowRegistry', () => ({ windowFromEvent: () => ({ id: 7 }) }))
+vi.mock('../workspaceManager', () => ({ getWorkspaceInfo: state.getWorkspaceInfo }))
+vi.mock('../../skills/main/skillsMirror', () => ({ syncWorkspaceSkills: state.sync }))
+vi.mock('../logger', () => ({ default: { warn: vi.fn() } }))
+
+import { registerHandlers } from './git'
+
+describe('git worktree skill mirroring', () => {
+  beforeEach(() => {
+    state.handlers.clear()
+    state.worktreeAdd.mockReset().mockResolvedValue({
+      path: '/repo/.cate/worktrees/feature',
+      branch: 'feature',
+    })
+    state.worktreeAddFromPr.mockReset().mockResolvedValue({
+      path: '/repo/.cate/worktrees/pr-12',
+      branch: 'pr-12',
+    })
+    state.sync.mockReset().mockResolvedValue({
+      copied: [],
+      updated: [],
+      removed: [],
+      preserved: [],
+      warnings: [],
+    })
+    state.getWorkspaceInfo.mockReset().mockReturnValue({ rootPath: '/repo/base' })
+    registerHandlers()
+  })
+
+  it('hydrates a newly-created worktree from the logical workspace root', async () => {
+    const result = await state.handlers.get(GIT_WORKTREE_ADD)!(
+      {},
+      '/repo',
+      'feature',
+      '/repo/.cate/worktrees/feature',
+      { createBranch: true },
+      'workspace-1',
+    )
+
+    expect(state.sync).toHaveBeenCalledWith('/repo/base', '/repo/.cate/worktrees/feature')
+    expect(result).toMatchObject({ path: '/repo/.cate/worktrees/feature', branch: 'feature' })
+  })
+
+  it('hydrates a PR worktree through the same path', async () => {
+    await state.handlers.get(GIT_WORKTREE_ADD_FROM_PR)!(
+      {},
+      '/repo',
+      12,
+      '/repo/.cate/worktrees/pr-12',
+      undefined,
+      'workspace-1',
+    )
+
+    expect(state.sync).toHaveBeenCalledWith('/repo/base', '/repo/.cate/worktrees/pr-12')
+  })
+})

--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -76,16 +76,29 @@ const cateApi = vi.hoisted(() => ({ ensureEndpoint: vi.fn() }))
 vi.mock('../extensions/workspaceCateApi', () => ({
   workspaceCateApi: { ensureEndpoint: cateApi.ensureEndpoint },
 }))
+const workspaceInfo = vi.hoisted(() => ({
+  get: vi.fn<(id: string) => { rootPath: string } | undefined>(() => undefined),
+}))
+vi.mock('../workspaceManager', () => ({ getWorkspaceInfo: workspaceInfo.get }))
+const skillsSync = vi.hoisted(() => ({ run: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../../skills/main/skillsMirror', () => ({ syncWorkspaceSkills: skillsSync.run }))
 
 // A fake runtime whose process.create is the hoisted spy, so the instant-exit
 // tests can drive onData/onExit deterministically through the real spawnTerminal.
 vi.mock('../runtime/runtimeManager', () => ({
   runtimes: {
-    resolve: () => ({ validateCwd: (p: string) => p, process: { create: diag.ptyCreate } }),
+    resolve: () => ({
+      validateCwd: (p: string) => p,
+      validatePathStrict: (p: string) => Promise.resolve(p),
+      process: { create: diag.ptyCreate },
+    }),
     disposeAll: () => Promise.resolve(),
   },
 }))
-vi.mock('../runtime/locator', () => ({ parseLocator: (cwd: string) => ({ runtimeId: 'local', path: cwd }) }))
+vi.mock('../runtime/locator', () => ({
+  parseLocator: (cwd: string) => ({ runtimeId: 'local', path: cwd }),
+  formatLocator: ({ path }: { path: string }) => path,
+}))
 
 // --- terminalLifecycle (renderer) deps, stubbed so getOrCreate/dispose run
 //     without a real xterm/DOM/store stack. registryState is left REAL so the
@@ -474,6 +487,27 @@ describe('CATE_API env injection into spawned terminals', () => {
 
     expect(cateApi.ensureEndpoint).toHaveBeenCalledWith('ws-1')
     expect(env).toEqual({ CATE_API: 'http://127.0.0.1:9876', CATE_TOKEN: 'tok-abc' })
+  })
+
+  it('passes the base workspace cwd as the agent hook auto reference', async () => {
+    cateApi.ensureEndpoint.mockResolvedValue(null)
+    workspaceInfo.get.mockReturnValueOnce({ rootPath: '/repo/base' })
+    diag.ptyCreate.mockResolvedValue({ id: 'pty-hooks', pid: 123, shell: '/bin/zsh' })
+    const mod = await import('./terminal')
+    mod.registerHandlers()
+
+    await handlers.get('terminal:create')!(
+      {},
+      { cols: 80, rows: 24, cwd: '/repo/worktree', workspaceId: 'ws-1' },
+    )
+
+    expect(workspaceInfo.get).toHaveBeenCalledWith('ws-1')
+    expect(skillsSync.run).toHaveBeenCalledWith('/repo/base', '/repo/worktree')
+    expect(diag.ptyCreate.mock.calls[0][0]).toMatchObject({
+      cwd: '/repo/worktree',
+      scopeId: 'ws-1',
+      workspaceBaseCwd: '/repo/base',
+    })
   })
 
   it('injects CATE_PANEL_ID when the PTY belongs to a Cate terminal panel', async () => {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -45,6 +45,9 @@ import { runtimes } from '../runtime/runtimeManager'
 import type { Runtime } from '../runtime/types'
 import { createStringDispatcher } from './batchedDispatcher'
 import { workspaceCateApi } from '../extensions/workspaceCateApi'
+import { getWorkspaceInfo } from '../workspaceManager'
+import { syncWorkspaceSkills } from '../../skills/main/skillsMirror'
+import { resolveWorktreeContext, validateWorktreeContext } from '../worktreeContext'
 
 // Set true during app shutdown so PTY data/exit callbacks no-op instead of
 // calling into a torn-down JS environment.
@@ -323,6 +326,24 @@ async function spawnTerminal(
   const agentHookConfig = options.workspaceId
     ? getSetting('agentHookInjection')[options.workspaceId]
     : undefined
+  const workspaceRoot = options.workspaceId
+    ? getWorkspaceInfo(options.workspaceId)?.rootPath
+    : undefined
+  const unresolvedWorktree = workspaceRoot && options.cwd
+    ? resolveWorktreeContext(workspaceRoot, options.cwd)
+    : undefined
+  const worktree = unresolvedWorktree && options.workspaceId
+    ? await validateWorktreeContext(unresolvedWorktree, runtime, ownerWindowId, options.workspaceId)
+    : undefined
+  // Existing or externally-created worktrees may predate Cate's eager mirror
+  // triggers. Hydrate managed skills before the shell can launch an agent.
+  if (worktree) {
+    try {
+      await syncWorkspaceSkills(worktree.base.locator, worktree.checkout.locator)
+    } catch (err) {
+      log.warn('[terminal] worktree skill sync failed: %O', err)
+    }
+  }
   const handle = await runtime.process.create(
     {
       cols: options.cols,
@@ -332,6 +353,7 @@ async function spawnTerminal(
       env: cateApiEnv,
       agentHooks: true,
       agentHookConfig,
+      workspaceBaseCwd: worktree?.base.path,
       // The workspace whose root this cwd lives under — the daemon validates
       // against this scope, so a project outside the daemon's own root still
       // gets a terminal.

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -54,6 +54,10 @@ export interface PtyCreateOptions {
    *  agentHooks; gates the workspace FILE writes, not the ambient env. Rides
    *  the same opts pass-through as `env`, so it reaches a remote host. */
   agentHookConfig?: AgentHookConfig
+  /** Runtime-absolute canonical workspace checkout for a linked-worktree cwd.
+   *  Runtime features may read it as shared workspace context, but writes stay
+   *  scoped to `cwd`. The daemon validates it against `scopeId` before spawn. */
+  workspaceBaseCwd?: string
 }
 
 export interface PtyHandle {

--- a/src/main/worktreeContext.test.ts
+++ b/src/main/worktreeContext.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { formatLocator } from './runtime/locator'
+import {
+  listWorktreeCheckouts,
+  resolveWorktreeContext,
+  validateWorktreeContext,
+} from './worktreeContext'
+
+describe('worktreeContext', () => {
+  it('resolves base and checkout paths on the same runtime', () => {
+    const base = formatLocator({ runtimeId: 'server-1', path: '/repo' })
+    const checkout = formatLocator({ runtimeId: 'server-1', path: '/repo-feature' })
+
+    expect(resolveWorktreeContext(base, checkout)).toEqual({
+      runtimeId: 'server-1',
+      base: { locator: base, path: '/repo' },
+      checkout: { locator: checkout, path: '/repo-feature' },
+    })
+  })
+
+  it('rejects paths from different runtimes', () => {
+    const base = formatLocator({ runtimeId: 'server-1', path: '/repo' })
+    const checkout = formatLocator({ runtimeId: 'server-2', path: '/repo-feature' })
+
+    expect(resolveWorktreeContext(base, checkout)).toBeUndefined()
+  })
+
+  it('validates base and checkout against one workspace scope', async () => {
+    const validatePathStrict = vi.fn(async (path: string) => `/safe${path}`)
+    const context = resolveWorktreeContext('/repo', '/repo-feature')!
+
+    const result = await validateWorktreeContext(
+      context,
+      { validatePathStrict },
+      7,
+      'workspace-1',
+    )
+
+    expect(validatePathStrict).toHaveBeenNthCalledWith(1, '/repo', 7, 'workspace-1')
+    expect(validatePathStrict).toHaveBeenNthCalledWith(2, '/repo-feature', 7, 'workspace-1')
+    expect(result.base).toEqual({ locator: '/safe/repo', path: '/safe/repo' })
+    expect(result.checkout).toEqual({
+      locator: '/safe/repo-feature',
+      path: '/safe/repo-feature',
+    })
+  })
+
+  it('lists non-bare checkouts on the base runtime', async () => {
+    const worktreeList = vi.fn().mockResolvedValue([
+      { path: '/repo', branch: 'main', isBare: false },
+      { path: '/repo-feature', branch: 'feature', isBare: false },
+      { path: '/repo.git', branch: '(unknown)', isBare: true },
+    ])
+    const base = formatLocator({ runtimeId: 'server-1', path: '/repo' })
+
+    const result = await listWorktreeCheckouts(
+      base,
+      { vcs: { worktreeList } as never },
+      { ownerWindowId: 7, scopeId: 'workspace-1' },
+    )
+
+    expect(worktreeList).toHaveBeenCalledWith('/repo', {
+      ownerWindowId: 7,
+      scopeId: 'workspace-1',
+    })
+    expect(result).toEqual([
+      formatLocator({ runtimeId: 'server-1', path: '/repo' }),
+      formatLocator({ runtimeId: 'server-1', path: '/repo-feature' }),
+    ])
+  })
+})

--- a/src/main/worktreeContext.ts
+++ b/src/main/worktreeContext.ts
@@ -1,0 +1,68 @@
+import { formatLocator, parseLocator } from './runtime/locator'
+import type { FileAccessContext, Runtime } from './runtime/types'
+
+interface WorktreeLocation {
+  locator: string
+  path: string
+}
+
+export interface WorktreeContext {
+  runtimeId: string
+  base: WorktreeLocation
+  checkout: WorktreeLocation
+}
+
+/** Resolve a workspace's canonical checkout and active checkout on one runtime. */
+export function resolveWorktreeContext(
+  baseLocator: string,
+  checkoutLocator: string,
+): WorktreeContext | undefined {
+  const base = parseLocator(baseLocator)
+  const checkout = parseLocator(checkoutLocator)
+  if (!base.path || !checkout.path || base.runtimeId !== checkout.runtimeId) return undefined
+
+  return {
+    runtimeId: base.runtimeId,
+    base: { locator: formatLocator(base), path: base.path },
+    checkout: { locator: formatLocator(checkout), path: checkout.path },
+  }
+}
+
+/** Validate both sides of a worktree context against the same workspace scope. */
+export async function validateWorktreeContext(
+  context: WorktreeContext,
+  runtime: Pick<Runtime, 'validatePathStrict'>,
+  ownerWindowId: number | undefined,
+  scopeId: string,
+): Promise<WorktreeContext> {
+  const [basePath, checkoutPath] = await Promise.all([
+    runtime.validatePathStrict(context.base.path, ownerWindowId, scopeId),
+    runtime.validatePathStrict(context.checkout.path, ownerWindowId, scopeId),
+  ])
+
+  return {
+    runtimeId: context.runtimeId,
+    base: {
+      locator: formatLocator({ runtimeId: context.runtimeId, path: basePath }),
+      path: basePath,
+    },
+    checkout: {
+      locator: formatLocator({ runtimeId: context.runtimeId, path: checkoutPath }),
+      path: checkoutPath,
+    },
+  }
+}
+
+/** List every non-bare checkout as a locator on the canonical checkout's runtime. */
+export async function listWorktreeCheckouts(
+  baseLocator: string,
+  runtime: Pick<Runtime, 'vcs'>,
+  access: FileAccessContext,
+): Promise<string[]> {
+  const base = parseLocator(baseLocator)
+  if (!base.path) return []
+  const worktrees = await runtime.vcs.worktreeList(base.path, access)
+  return worktrees
+    .filter((worktree) => !worktree.isBare)
+    .map((worktree) => formatLocator({ runtimeId: base.runtimeId, path: worktree.path }))
+}

--- a/src/renderer/dialogs/SkillsDialog.tsx
+++ b/src/renderer/dialogs/SkillsDialog.tsx
@@ -232,6 +232,7 @@ export function SkillsDialog() {
       installed={installedRow}
       saved={savedIds.has(entry.id)}
       rootPath={rootPath}
+      workspaceId={currentWs?.id}
       installedKeys={installedKeys}
       onChanged={onChanged}
       onError={setError}
@@ -345,6 +346,7 @@ function SkillRow({
   installed,
   saved,
   rootPath,
+  workspaceId,
   installedKeys,
   onChanged,
   onError,
@@ -353,6 +355,7 @@ function SkillRow({
   installed: boolean
   saved: boolean
   rootPath: string
+  workspaceId?: string
   installedKeys: Set<string>
   onChanged: () => void
   onError: (m: string | null) => void
@@ -486,6 +489,7 @@ function SkillRow({
           anchor={menuAnchor}
           triggerRef={installRef}
           rootPath={rootPath}
+          workspaceId={workspaceId}
           installedKeys={installedKeys}
           onChanged={onChanged}
           onError={onError}
@@ -506,6 +510,7 @@ function AgentMenu({
   anchor,
   triggerRef,
   rootPath,
+  workspaceId,
   installedKeys,
   onChanged,
   onError,
@@ -515,6 +520,7 @@ function AgentMenu({
   anchor: { top: number; left: number }
   triggerRef: React.RefObject<HTMLButtonElement>
   rootPath: string
+  workspaceId?: string
   installedKeys: Set<string>
   onChanged: () => void
   onError: (m: string | null) => void
@@ -541,10 +547,10 @@ function AgentMenu({
     setBusy(targetId)
     try {
       if (on) {
-        const res = await api().skillsUninstall(entry.id, entry.name, targetId, rootPath)
+        const res = await api().skillsUninstall(entry.id, entry.name, targetId, rootPath, workspaceId)
         if (!res.ok) onError(errorMessage(res.error, 'Could not remove skill.'))
       } else {
-        const res = await api().skillsInstall(entry, targetId, rootPath)
+        const res = await api().skillsInstall(entry, targetId, rootPath, workspaceId)
         if (!res.ok) onError(errorMessage(res.error, 'Could not install skill.'))
         else if (res.warnings?.length) onError(res.warnings.join('\n'))
       }

--- a/src/renderer/hooks/useMissingAgentHookNotice.test.tsx
+++ b/src/renderer/hooks/useMissingAgentHookNotice.test.tsx
@@ -1,0 +1,72 @@
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { useMissingAgentHookNotice } from './useMissingAgentHookNotice'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const state = vi.hoisted(() => ({
+  status: {
+    workspaces: {
+      'workspace-1': {
+        terminals: {
+          'pty-1': {
+            activity: { type: 'running', processName: 'codex' },
+            agentPresent: false,
+          },
+        },
+      },
+    },
+  },
+  settings: { agentHookInjection: {} },
+}))
+
+vi.mock('../stores/statusStore', () => ({
+  useStatusStore: (selector: (value: typeof state.status) => unknown) => selector(state.status),
+}))
+vi.mock('../stores/settingsStore', () => ({
+  useSettingsStore: (selector: (value: typeof state.settings) => unknown) => selector(state.settings),
+}))
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: { ptyIdForPanel: () => 'pty-1' },
+}))
+
+let root: Root
+let host: HTMLDivElement
+let observed: string | null = null
+
+function Harness({ checkout }: { checkout: string }) {
+  observed = useMissingAgentHookNotice('workspace-1', 'panel-1', checkout)
+  return null
+}
+
+beforeEach(() => {
+  observed = null
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  ;(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {
+    agentHooksInspect: vi.fn().mockResolvedValue([
+      { agentId: 'codex', displayName: 'Codex', folderPresent: true, injected: false },
+    ]),
+  }
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.clearAllMocks()
+})
+
+describe('useMissingAgentHookNotice worktree inspection', () => {
+  it('checks hook installation in the terminal worktree rather than the base workspace', async () => {
+    const worktree = '/repo/.cate/worktrees/feature'
+    await act(async () => {
+      root.render(<Harness checkout={worktree} />)
+      await Promise.resolve()
+    })
+
+    expect(window.electronAPI.agentHooksInspect).toHaveBeenCalledWith(worktree)
+    expect(observed).toBe('Codex')
+  })
+})

--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -465,6 +465,23 @@ describe('agentHooks capability', () => {
     expect(existsSync(path.join(cwd, '.pi'))).toBe(false)
   })
 
+  test('auto also uses the base workspace folder signal but writes only in the linked worktree', async () => {
+    const cap = makeCap()
+    const baseCwd = tmpDir('ws-auto-base')
+    const worktreeCwd = tmpDir('ws-auto-worktree')
+    mkdirSync(path.join(baseCwd, '.claude'))
+    mkdirSync(path.join(worktreeCwd, '.git'))
+
+    await cap.prepareWorkspace(worktreeCwd, undefined, baseCwd)
+
+    expect(existsSync(path.join(worktreeCwd, '.claude', 'settings.local.json'))).toBe(true)
+    expect(existsSync(path.join(baseCwd, '.claude', 'settings.local.json'))).toBe(false)
+    // Other agents remain gated when their folder is absent in both checkouts.
+    expect(existsSync(path.join(worktreeCwd, '.codex'))).toBe(false)
+    expect(existsSync(path.join(worktreeCwd, '.cursor'))).toBe(false)
+    expect(existsSync(path.join(worktreeCwd, '.pi'))).toBe(false)
+  })
+
   test("'on' injects with no pre-existing folder; 'off' strips our entries but keeps the user's", async () => {
     const cap = makeCap()
     const cwd = tmpDir('ws-onoff')

--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -266,11 +266,14 @@ describe('agentHooks capability', () => {
     const { dir } = await cap.endpoint()
     const env = await cap.envForPty('rpty-nonode', { PATH: '/usr/bin:/bin' })
 
-    const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((resolve) => {
+    const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((resolve, reject) => {
       let err = ''
       const child = execFile(path.join(dir, 'cate-hook-bridge-claude-code'), [], { env, timeout: 15_000 })
       child.stderr!.on('data', (chunk) => { err += String(chunk) })
       child.on('close', (c) => resolve({ code: c, stderr: err }))
+      child.stdin!.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code !== 'EPIPE') reject(error)
+      })
       child.stdin!.end(JSON.stringify({ hook_event_name: 'SessionStart', cwd: '/w' }))
     })
 

--- a/src/runtime/capabilities/agentHooks.ts
+++ b/src/runtime/capabilities/agentHooks.ts
@@ -76,12 +76,13 @@ export interface AgentHooksCapability {
   /** Write (or, for 'off', remove) workspace-scoped hook files for the PTY's
    *  cwd and keep the ones we wrote out of git status via .git/info/exclude.
    *  `config` carries per-agent tri-state overrides: 'auto' (default) injects
-   *  only when the agent's own config folder already exists in the repo, 'on'
-   *  always injects, 'off' strips any entries Cate previously wrote.
+   *  only when the agent's own config folder exists in the cwd or optional
+   *  base-workspace `baseCwd`, 'on' always injects, and 'off' strips any
+   *  entries Cate previously wrote.
    *  Best-effort and idempotent; never touches the user's home dir (~/.codex,
    *  ~/.claude etc. are the CLIs' USER-GLOBAL config dirs — injection stays
    *  repo-local). */
-  prepareWorkspace(cwd: string, config?: AgentHookConfig): Promise<void>
+  prepareWorkspace(cwd: string, config?: AgentHookConfig, baseCwd?: string): Promise<void>
   /** Inspect a workspace's per-agent hook-file injection state (for the
    *  Settings UI): which agents write repo files, whether each one's config
    *  folder is already in the repo (the 'auto' signal), and whether Cate has
@@ -481,11 +482,14 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
       return out
     },
 
-    async prepareWorkspace(cwd, config) {
+    async prepareWorkspace(cwd, config, baseCwd) {
       if (disposed) return
       // Never plant (or strip) agent files in the user's home dir or against a
       // non-absolute cwd — see isRepoLocalCwd.
       if (!isRepoLocalCwd(cwd, os.homedir())) return
+      const autoBaseCwd = baseCwd && isRepoLocalCwd(baseCwd, os.homedir())
+        ? baseCwd
+        : undefined
       let state: HookState
       try {
         state = await ensureReady()
@@ -513,11 +517,18 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
           }
           continue
         }
-        // 'auto': inject only when the agent's config folder is already in the
-        // repo (a "used here" signal). 'on': always inject.
+        // 'auto': inject when the agent's config folder exists in this checkout
+        // or the base workspace checkout (a "used here" signal shared by linked
+        // worktrees). 'on': always inject.
         if (mode === 'auto') {
           const folder = agentHookFolder(agent.id)
-          if (folder && !(await dirExists(path.join(cwd, folder)))) continue
+          if (folder) {
+            const presentHere = await dirExists(path.join(cwd, folder))
+            const presentAtBase = !presentHere && autoBaseCwd
+              ? await dirExists(path.join(autoBaseCwd, folder))
+              : false
+            if (!presentHere && !presentAtBase) continue
+          }
         }
         const ctx = state.contexts.get(agent.id)!
         for (const pf of spec.projectFiles) {

--- a/src/runtime/capabilities/daemonValidation.test.ts
+++ b/src/runtime/capabilities/daemonValidation.test.ts
@@ -140,6 +140,24 @@ describe('buildDaemonRuntime FileHost path validation', () => {
     ).rejects.toThrow(/Access denied|outside allowed/)
   })
 
+  test('process.create rejects a workspace base cwd outside the calling workspace scope', async () => {
+    const outside = path.join(os.homedir(), 'cate-workspace-base-nope')
+    await expect(
+      runtime.process.create(
+        {
+          cols: 80,
+          rows: 24,
+          cwd: root,
+          shell: '/bin/sh',
+          scopeId: 'test',
+          workspaceBaseCwd: outside,
+        },
+        () => {},
+        () => {},
+      ),
+    ).rejects.toThrow(/Access denied|outside allowed/)
+  })
+
   // A workspace root registered under its OWN scope (what workspaceManager does
   // for every opened workspace) must admit a terminal, even though it sits
   // outside the daemon's own root — otherwise a project on another drive than

--- a/src/runtime/capabilities/index.ts
+++ b/src/runtime/capabilities/index.ts
@@ -216,7 +216,7 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
     idleSuspend: config.idleSuspend,
     hooks: {
       envForPty: (ptyId, env) => agentHooks.envForPty(ptyId, env),
-      prepareWorkspace: (cwd, config) => agentHooks.prepareWorkspace(cwd, config),
+      prepareWorkspace: (cwd, config, baseCwd) => agentHooks.prepareWorkspace(cwd, config, baseCwd),
     },
     agentPresence,
   })
@@ -251,6 +251,10 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
     ...innerProc,
     create: async (opts, onData, onExit) => {
       if (opts.cwd) validatePtyCwd(opts.cwd, opts.scopeId) // throws -> rejects create, matching local
+      if (opts.workspaceBaseCwd) {
+        if (!opts.scopeId) throw new Error('A path scope is required for the workspace base cwd')
+        validateCwd(opts.workspaceBaseCwd, undefined, opts.scopeId)
+      }
       return innerProc.create(opts, onData, onExit)
     },
   }

--- a/src/runtime/capabilities/process.agentHooks.test.ts
+++ b/src/runtime/capabilities/process.agentHooks.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createProcessCapability } from './process'
+
+const ptySpawn = vi.hoisted(() => vi.fn())
+vi.mock('node-pty', () => ({ spawn: ptySpawn }))
+
+describe('process agent hook preparation', () => {
+  beforeEach(() => {
+    ptySpawn.mockReset()
+    ptySpawn.mockReturnValue({
+      pid: 123,
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+    })
+  })
+
+  test('passes the base workspace cwd through to hook preparation', async () => {
+    const prepareWorkspace = vi.fn().mockResolvedValue(undefined)
+    const processCapability = createProcessCapability({
+      resolveShell: () => ({ path: '/bin/sh', args: [] }),
+      getEnv: () => ({ PATH: '/usr/bin:/bin' }),
+      hooks: {
+        envForPty: async (_ptyId, env) => env,
+        prepareWorkspace,
+      },
+    })
+
+    const handle = await processCapability.create(
+      {
+        id: 'pty-hooks-worktree',
+        cols: 80,
+        rows: 24,
+        cwd: '/repo/worktree',
+        shell: '/bin/sh',
+        agentHooks: true,
+        agentHookConfig: { codex: 'on' },
+        workspaceBaseCwd: '/repo/base',
+      },
+      () => {},
+      () => {},
+    )
+
+    expect(prepareWorkspace).toHaveBeenCalledWith(
+      '/repo/worktree',
+      { codex: 'on' },
+      '/repo/base',
+    )
+    processCapability.kill(handle.id)
+  })
+})

--- a/src/runtime/capabilities/process.ts
+++ b/src/runtime/capabilities/process.ts
@@ -184,7 +184,7 @@ export interface ProcessDeps {
    */
   hooks?: {
     envForPty(ptyId: string, env: Record<string, string>): Promise<Record<string, string>>
-    prepareWorkspace(cwd: string, config?: AgentHookConfig): Promise<void>
+    prepareWorkspace(cwd: string, config?: AgentHookConfig, baseCwd?: string): Promise<void>
   }
   /**
    * Hook-anchored agent presence (agentPresence.ts): scanActivity reads each
@@ -286,7 +286,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
       if (deps.hooks && opts.agentHooks) {
         try {
           env = await deps.hooks.envForPty(id, env)
-          await deps.hooks.prepareWorkspace(cwd, opts.agentHookConfig)
+          await deps.hooks.prepareWorkspace(cwd, opts.agentHookConfig, opts.workspaceBaseCwd)
         } catch { /* hook injection unavailable */ }
       }
       const pty = ptySpawn(shell.path, shell.args, {

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -1047,9 +1047,9 @@ export interface ElectronAPI {
   skillsGetPreview(entry: SkillEntry): Promise<string>
   /** Install/update a skill from its source. Existing workspace/library bytes
    *  are used only as an offline fallback (reported in warnings). */
-  skillsInstall(entry: SkillEntry, targetId: SkillTargetId, cwd: string): Promise<{ ok: boolean; error?: string; warnings?: string[]; installed?: InstalledSkill }>
+  skillsInstall(entry: SkillEntry, targetId: SkillTargetId, cwd: string, workspaceId?: string): Promise<{ ok: boolean; error?: string; warnings?: string[]; installed?: InstalledSkill }>
   /** Uninstall a skill from a workspace agent. */
-  skillsUninstall(skillId: string, name: string, targetId: SkillTargetId, cwd: string): Promise<{ ok: boolean; error?: string }>
+  skillsUninstall(skillId: string, name: string, targetId: SkillTargetId, cwd: string, workspaceId?: string): Promise<{ ok: boolean; error?: string }>
   /** Installs recorded in this workspace's .cate/skills.json. */
   skillsListInstalled(cwd: string): Promise<InstalledSkill[]>
   /** Skills saved to the user's Cate library (cached in userData). */

--- a/src/skills/main/ipcSkills.test.ts
+++ b/src/skills/main/ipcSkills.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SKILLS_INSTALL, SKILLS_UNINSTALL } from '../../shared/ipc-channels'
+import type { SkillEntry } from '../../shared/skills'
+
+const state = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  install: vi.fn(),
+  uninstall: vi.fn(),
+  worktreeList: vi.fn(),
+  sync: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      state.handlers.set(channel, handler)
+    }),
+  },
+}))
+vi.mock('../../main/logger', () => ({ default: { warn: vi.fn() } }))
+vi.mock('../../main/windowRegistry', () => ({ windowFromEvent: () => ({ id: 9 }) }))
+vi.mock('../../main/runtime/runtimeManager', () => ({
+  runtimes: {
+    resolve: () => ({ vcs: { worktreeList: state.worktreeList } }),
+  },
+}))
+vi.mock('./skillsInstaller', () => ({
+  install: state.install,
+  uninstall: state.uninstall,
+  listInstalled: vi.fn(),
+  saveSkill: vi.fn(),
+  unsaveSkill: vi.fn(),
+}))
+vi.mock('./skillsMirror', () => ({ syncWorkspaceSkills: state.sync }))
+vi.mock('./skillsRegistry', () => ({
+  getMergedIndex: vi.fn(),
+  refresh: vi.fn(),
+  getPreview: vi.fn(),
+}))
+vi.mock('./savedSkills', () => ({ listSaved: vi.fn() }))
+vi.mock('./skillSources', () => ({
+  listSources: vi.fn(),
+  addSource: vi.fn(),
+  removeSource: vi.fn(),
+  getToken: vi.fn(),
+  setToken: vi.fn(),
+}))
+
+import { registerSkillHandlers } from './ipcSkills'
+
+const entry: SkillEntry = {
+  id: 'owner/repo/demo',
+  name: 'Demo',
+  description: 'demo',
+  tags: [],
+  format: 'skill-md',
+  source: { repo: 'owner/repo', ref: 'main', path: 'skills/demo' },
+  provenance: 'curated',
+  sourceId: 'owner/repo',
+}
+
+describe('skill mutation worktree propagation', () => {
+  beforeEach(() => {
+    state.handlers.clear()
+    state.install.mockReset().mockResolvedValue({
+      installed: {
+        skillId: entry.id,
+        name: entry.name,
+        targetId: 'codex',
+        path: '/repo/.codex/skills/demo/SKILL.md',
+        origin: 'local',
+      },
+      warnings: [],
+    })
+    state.uninstall.mockReset().mockResolvedValue(undefined)
+    state.worktreeList.mockReset().mockResolvedValue([
+      { path: '/repo', branch: 'main', isBare: false },
+      { path: '/repo/.cate/worktrees/feature', branch: 'feature', isBare: false },
+      { path: '/repo.git', branch: '(unknown)', isBare: true },
+    ])
+    state.sync.mockReset().mockImplementation(async (_base: string, target: string) => ({
+      copied: [],
+      updated: [],
+      removed: [],
+      preserved: [],
+      warnings: target.includes('feature') ? ['mirror warning'] : [],
+    }))
+    registerSkillHandlers()
+  })
+
+  it('propagates an install to every non-bare worktree under the workspace scope', async () => {
+    const result = await state.handlers.get(SKILLS_INSTALL)!(
+      {},
+      entry,
+      'codex',
+      '/repo',
+      'workspace-1',
+    )
+
+    expect(state.worktreeList).toHaveBeenCalledWith('/repo', {
+      ownerWindowId: 9,
+      scopeId: 'workspace-1',
+    })
+    expect(state.sync).toHaveBeenCalledWith('/repo', '/repo')
+    expect(state.sync).toHaveBeenCalledWith('/repo', '/repo/.cate/worktrees/feature')
+    expect(state.sync).not.toHaveBeenCalledWith('/repo', '/repo.git')
+    expect(result).toMatchObject({ ok: true, warnings: ['mirror warning'] })
+  })
+
+  it('propagates an uninstall so unchanged mirrors are retired immediately', async () => {
+    await state.handlers.get(SKILLS_UNINSTALL)!(
+      {},
+      entry.id,
+      entry.name,
+      'codex',
+      '/repo',
+      'workspace-1',
+    )
+
+    expect(state.uninstall).toHaveBeenCalledWith(entry.id, entry.name, 'codex', '/repo')
+    expect(state.sync).toHaveBeenCalledWith('/repo', '/repo/.cate/worktrees/feature')
+  })
+})

--- a/src/skills/main/ipcSkills.ts
+++ b/src/skills/main/ipcSkills.ts
@@ -26,6 +26,35 @@ import * as installer from './skillsInstaller'
 import * as savedSkills from './savedSkills'
 import * as sources from './skillSources'
 import type { SkillEntry, SkillTargetId } from '../../shared/skills'
+import { parseLocator } from '../../main/runtime/locator'
+import { runtimes } from '../../main/runtime/runtimeManager'
+import { windowFromEvent } from '../../main/windowRegistry'
+import { syncWorkspaceSkills } from './skillsMirror'
+import { listWorktreeCheckouts } from '../../main/worktreeContext'
+
+async function syncOpenWorktrees(
+  baseCwd: string,
+  workspaceId: string | undefined,
+  ownerWindowId: number | undefined,
+): Promise<string[]> {
+  if (!workspaceId) return []
+  const { runtimeId, path } = parseLocator(baseCwd)
+  if (!path) return []
+  try {
+    const runtime = runtimes.resolve(runtimeId)
+    const worktrees = await listWorktreeCheckouts(baseCwd, runtime, {
+      ownerWindowId,
+      scopeId: workspaceId,
+    })
+    const results = await Promise.all(
+      worktrees.map((worktree) => syncWorkspaceSkills(baseCwd, worktree)),
+    )
+    return results.flatMap((result) => result.warnings)
+  } catch (err) {
+    log.warn('[ipc.skills] worktree sync failed: %O', err)
+    return []
+  }
+}
 
 export function registerSkillHandlers(): void {
   ipcMain.handle(SKILLS_GET_INDEX, async () => {
@@ -51,18 +80,28 @@ export function registerSkillHandlers(): void {
     }
   })
 
-  ipcMain.handle(SKILLS_INSTALL, async (_e, entry: SkillEntry, targetId: SkillTargetId, cwd: string) => {
+  ipcMain.handle(SKILLS_INSTALL, async (event, entry: SkillEntry, targetId: SkillTargetId, cwd: string, workspaceId?: string) => {
     try {
       const res = await installer.install(entry, targetId, cwd)
-      return { ok: true as const, warnings: res.warnings, installed: res.installed }
+      const mirrorWarnings = await syncOpenWorktrees(
+        cwd,
+        workspaceId,
+        windowFromEvent(event)?.id,
+      )
+      return {
+        ok: true as const,
+        warnings: [...res.warnings, ...mirrorWarnings],
+        installed: res.installed,
+      }
     } catch (err) {
       return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
     }
   })
 
-  ipcMain.handle(SKILLS_UNINSTALL, async (_e, skillId: string, name: string, targetId: SkillTargetId, cwd: string) => {
+  ipcMain.handle(SKILLS_UNINSTALL, async (event, skillId: string, name: string, targetId: SkillTargetId, cwd: string, workspaceId?: string) => {
     try {
       await installer.uninstall(skillId, name, targetId, cwd)
+      await syncOpenWorktrees(cwd, workspaceId, windowFromEvent(event)?.id)
       return { ok: true as const }
     } catch (err) {
       return { ok: false as const, error: err instanceof Error ? err.message : String(err) }

--- a/src/skills/main/skillsMirror.test.ts
+++ b/src/skills/main/skillsMirror.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const resolve = vi.hoisted(() => vi.fn())
+const logWarn = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+vi.mock('../../main/logger', () => ({ default: { warn: logWarn } }))
+vi.mock('../../main/runtime/runtimeManager', () => ({ runtimes: { resolve } }))
+
+import { syncWorkspaceSkills } from './skillsMirror'
+
+function normalize(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/+$/, '') || '/'
+}
+
+function parent(value: string): string {
+  const normalized = normalize(value)
+  return normalized.slice(0, normalized.lastIndexOf('/')) || '/'
+}
+
+let renameFailure: ((oldPath: string, newPath: string) => boolean) | null
+
+function makeMemoryFs() {
+  const dirs = new Set<string>(['/'])
+  const files = new Map<string, Buffer>()
+  const runtime = {
+    file: {
+      readFile: async (path: string) => {
+        const contents = files.get(normalize(path))
+        if (!contents) throw new Error(`ENOENT: ${path}`)
+        return contents.toString('utf8')
+      },
+      readBinary: async (path: string) => {
+        const contents = files.get(normalize(path))
+        if (!contents) throw new Error(`ENOENT: ${path}`)
+        return Buffer.from(contents)
+      },
+      writeFile: async (path: string, contents: string) => {
+        files.set(normalize(path), Buffer.from(contents))
+        return path
+      },
+      writeBinary: async (path: string, contents: Buffer) => {
+        files.set(normalize(path), Buffer.from(contents))
+        return path
+      },
+      readDir: async (path: string) => {
+        const dir = normalize(path)
+        if (!dirs.has(dir)) throw new Error(`ENOENT: ${path}`)
+        const names = new Map<string, boolean>()
+        for (const candidate of dirs) {
+          if (candidate !== dir && parent(candidate) === dir) {
+            names.set(candidate.slice(dir === '/' ? 1 : dir.length + 1), true)
+          }
+        }
+        for (const candidate of files.keys()) {
+          if (parent(candidate) === dir) {
+            names.set(candidate.slice(dir === '/' ? 1 : dir.length + 1), false)
+          }
+        }
+        return [...names].map(([name, isDirectory]) => ({
+          name,
+          path: `${dir}/${name}`,
+          isDirectory,
+          isExpanded: false,
+          children: [],
+          fileExtension: '',
+        }))
+      },
+      stat: async (path: string) => {
+        const normalized = normalize(path)
+        if (dirs.has(normalized)) return { isDirectory: true, isFile: false }
+        if (files.has(normalized)) return { isDirectory: false, isFile: true }
+        throw new Error(`ENOENT: ${path}`)
+      },
+      remove: async (path: string) => {
+        const normalized = normalize(path)
+        const prefix = `${normalized}/`
+        const existed = files.delete(normalized) || dirs.has(normalized)
+        for (const candidate of [...files.keys()]) {
+          if (candidate.startsWith(prefix)) files.delete(candidate)
+        }
+        for (const candidate of [...dirs]) {
+          if (candidate === normalized || candidate.startsWith(prefix)) dirs.delete(candidate)
+        }
+        if (!existed) throw new Error(`ENOENT: ${path}`)
+      },
+      rename: async (oldPath: string, newPath: string) => {
+        if (renameFailure?.(normalize(oldPath), normalize(newPath))) {
+          throw new Error('injected rename failure')
+        }
+        const oldNormalized = normalize(oldPath)
+        const newNormalized = normalize(newPath)
+        const file = files.get(oldNormalized)
+        if (file) {
+          files.delete(oldNormalized)
+          files.set(newNormalized, file)
+          return newPath
+        }
+        if (!dirs.has(oldNormalized)) throw new Error(`ENOENT: ${oldPath}`)
+        const oldPrefix = `${oldNormalized}/`
+        dirs.delete(oldNormalized)
+        dirs.add(newNormalized)
+        for (const candidate of [...dirs]) {
+          if (candidate.startsWith(oldPrefix)) {
+            dirs.delete(candidate)
+            dirs.add(`${newNormalized}/${candidate.slice(oldPrefix.length)}`)
+          }
+        }
+        for (const [candidate, contents] of [...files]) {
+          if (candidate.startsWith(oldPrefix)) {
+            files.delete(candidate)
+            files.set(`${newNormalized}/${candidate.slice(oldPrefix.length)}`, contents)
+          }
+        }
+        return newPath
+      },
+      mkdir: async (path: string) => { dirs.add(normalize(path)) },
+    },
+  }
+  return { dirs, files, runtime }
+}
+
+const BASE = '/repo'
+const TARGET = '/repo/.cate/worktrees/feature'
+const KEY = 'owner/repo/demo:codex'
+const SOURCE_SKILL = `${BASE}/.codex/skills/demo-skill`
+const TARGET_SKILL = `${TARGET}/.codex/skills/demo-skill`
+
+let fs: ReturnType<typeof makeMemoryFs>
+
+function setText(path: string, contents: string): void {
+  fs.dirs.add(parent(path))
+  fs.files.set(normalize(path), Buffer.from(contents))
+}
+
+function text(path: string): string | undefined {
+  return fs.files.get(normalize(path))?.toString('utf8')
+}
+
+function setCanonicalSkill(contents: string): void {
+  fs.dirs.add(BASE)
+  fs.dirs.add(`${BASE}/.cate`)
+  fs.dirs.add(`${BASE}/.codex`)
+  fs.dirs.add(`${BASE}/.codex/skills`)
+  fs.dirs.add(SOURCE_SKILL)
+  setText(`${SOURCE_SKILL}/SKILL.md`, contents)
+  setText(`${SOURCE_SKILL}/references/guide.md`, 'guide')
+  setText(`${BASE}/.cate/skills.json`, JSON.stringify({
+    skills: [{
+      skillId: 'owner/repo/demo',
+      name: 'Demo Skill',
+      targetId: 'codex',
+      path: `${SOURCE_SKILL}/SKILL.md`,
+      origin: 'local',
+    }],
+  }))
+}
+
+function clearCanonicalManifest(): void {
+  setText(`${BASE}/.cate/skills.json`, JSON.stringify({ skills: [] }))
+}
+
+beforeEach(() => {
+  renameFailure = null
+  fs = makeMemoryFs()
+  fs.dirs.add(BASE)
+  fs.dirs.add(TARGET)
+  resolve.mockReset().mockReturnValue(fs.runtime)
+  logWarn.mockReset()
+})
+
+describe('syncWorkspaceSkills', () => {
+  it('initially mirrors managed files and writes only ownership metadata', async () => {
+    setCanonicalSkill('v1')
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.copied).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('v1')
+    expect(text(`${TARGET_SKILL}/references/guide.md`)).toBe('guide')
+    expect(text(`${TARGET}/.cate/skills.json`)).toBeUndefined()
+    expect(text(`${TARGET}/.cate/skills-mirror.json`)).toContain('"contentHash"')
+    expect(text(`${TARGET}/.cate/.gitignore`)).toContain('!workspace.json')
+  })
+
+  it('does not overwrite an existing target .cate/.gitignore', async () => {
+    setCanonicalSkill('v1')
+    setText(`${TARGET}/.cate/.gitignore`, 'custom\n')
+
+    await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(text(`${TARGET}/.cate/.gitignore`)).toBe('custom\n')
+  })
+
+  it('updates a mirror that still matches the owned hash', async () => {
+    setCanonicalSkill('v1')
+    await syncWorkspaceSkills(BASE, TARGET)
+    setText(`${SOURCE_SKILL}/SKILL.md`, 'v2')
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.updated).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('v2')
+  })
+
+  it('restores the previous mirror when the staged update cannot be installed', async () => {
+    setCanonicalSkill('v1')
+    await syncWorkspaceSkills(BASE, TARGET)
+    setText(`${SOURCE_SKILL}/SKILL.md`, 'v2')
+    renameFailure = (oldPath, newPath) =>
+      oldPath.includes('.skills-mirror-stage-') && newPath === TARGET_SKILL
+
+    const failed = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(failed.warnings).toEqual([expect.stringContaining('injected rename failure')])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('v1')
+
+    renameFailure = null
+    const retried = await syncWorkspaceSkills(BASE, TARGET)
+    expect(retried.updated).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('v2')
+  })
+
+  it('preserves a locally edited mirror and relinquishes ownership', async () => {
+    setCanonicalSkill('v1')
+    await syncWorkspaceSkills(BASE, TARGET)
+    setText(`${TARGET_SKILL}/SKILL.md`, 'local edit')
+    setText(`${SOURCE_SKILL}/SKILL.md`, 'v2')
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.preserved).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('local edit')
+    expect(text(`${TARGET}/.cate/skills-mirror.json`)).not.toContain('owner/repo/demo')
+  })
+
+  it('removes a stale mirror only while its owned hash is unchanged', async () => {
+    setCanonicalSkill('v1')
+    await syncWorkspaceSkills(BASE, TARGET)
+    clearCanonicalManifest()
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.removed).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBeUndefined()
+  })
+
+  it('preserves an edited mirror when its canonical entry becomes stale', async () => {
+    setCanonicalSkill('v1')
+    await syncWorkspaceSkills(BASE, TARGET)
+    setText(`${TARGET_SKILL}/SKILL.md`, 'local edit')
+    clearCanonicalManifest()
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.preserved).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('local edit')
+    expect(text(`${TARGET}/.cate/skills-mirror.json`)).not.toContain('owner/repo/demo')
+  })
+
+  it('never overwrites a pre-existing unowned target skill', async () => {
+    setCanonicalSkill('v1')
+    fs.dirs.add(`${TARGET}/.codex`)
+    fs.dirs.add(`${TARGET}/.codex/skills`)
+    fs.dirs.add(TARGET_SKILL)
+    setText(`${TARGET_SKILL}/SKILL.md`, 'pre-existing')
+
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.preserved).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('pre-existing')
+    expect(text(`${TARGET}/.cate/skills-mirror.json`)).not.toContain('owner/repo/demo')
+  })
+
+  it('is a no-op when base and target are the same locator', async () => {
+    setCanonicalSkill('v1')
+
+    const result = await syncWorkspaceSkills(`${BASE}/`, BASE)
+
+    expect(result).toEqual({ copied: [], updated: [], removed: [], preserved: [], warnings: [] })
+    expect(text(`${BASE}/.cate/skills-mirror.json`)).toBeUndefined()
+  })
+
+  it('treats Windows path casing and separators as the same locator', async () => {
+    const result = await syncWorkspaceSkills('C:\\Repo\\', 'c:/repo')
+
+    expect(result).toEqual({ copied: [], updated: [], removed: [], preserved: [], warnings: [] })
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('silently skips a workspace with no canonical skills manifest', async () => {
+    const result = await syncWorkspaceSkills(BASE, TARGET)
+
+    expect(result.warnings).toEqual([])
+    expect(logWarn).not.toHaveBeenCalled()
+    expect(text(`${TARGET}/.cate/skills-mirror.json`)).toBeUndefined()
+  })
+
+  it('routes remote locator reads and writes through the remote runtime', async () => {
+    setCanonicalSkill('remote')
+    const remoteBase = 'cate-runtime://server//repo'
+    const remoteTarget = 'cate-runtime://server//repo/.cate/worktrees/feature'
+
+    const result = await syncWorkspaceSkills(remoteBase, remoteTarget)
+
+    expect(resolve).toHaveBeenCalledWith('server')
+    expect(result.copied).toEqual([KEY])
+    expect(text(`${TARGET_SKILL}/SKILL.md`)).toBe('remote')
+  })
+})

--- a/src/skills/main/skillsMirror.ts
+++ b/src/skills/main/skillsMirror.ts
@@ -1,0 +1,461 @@
+import { createHash, randomUUID } from 'crypto'
+import log from '../../main/logger'
+import { CATE_GITIGNORE_CONTENT } from '../../main/cateGitignore'
+import { parseLocator } from '../../main/runtime/locator'
+import { runtimes } from '../../main/runtime/runtimeManager'
+import type { Runtime } from '../../main/runtime/types'
+import { hostJoin } from '../../agent/main/agentDir'
+import {
+  isKnownSkillTarget,
+  slugifySkillName,
+  type InstalledSkill,
+  type SkillTargetId,
+} from '../../shared/skills'
+import { pathKey } from '../../shared/pathUtils'
+import { skillPathSegments } from './skillPath'
+import { skillsRootDir, targetInfo } from './targets'
+
+const MIRROR_VERSION = 1
+
+interface MirrorEntry {
+  skillId: string
+  name: string
+  targetId: SkillTargetId
+  contentHash: string
+}
+
+interface MirrorManifest {
+  version: typeof MIRROR_VERSION
+  skills: MirrorEntry[]
+}
+
+interface BundleFile {
+  relPath: string
+  bytes: Buffer
+}
+
+interface InstalledBundle {
+  files: BundleFile[]
+  path: string
+  contentHash: string
+}
+
+export interface SkillMirrorSyncResult {
+  copied: string[]
+  updated: string[]
+  removed: string[]
+  preserved: string[]
+  warnings: string[]
+}
+
+function emptyResult(): SkillMirrorSyncResult {
+  return { copied: [], updated: [], removed: [], preserved: [], warnings: [] }
+}
+
+function entryKey(entry: Pick<MirrorEntry, 'skillId' | 'targetId'>): string {
+  return `${entry.skillId}:${entry.targetId}`
+}
+
+function sameLocator(a: string, b: string): boolean {
+  const left = parseLocator(a)
+  const right = parseLocator(b)
+  return left.runtimeId === right.runtimeId && pathKey(left.path) === pathKey(right.path)
+}
+
+function mirrorManifestPath(runtimeId: string, hostCwd: string): string {
+  return hostJoin(runtimeId, hostCwd, '.cate', 'skills-mirror.json')
+}
+
+function isMissingError(error: unknown): boolean {
+  return (
+    (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') ||
+    (error instanceof Error && /ENOENT|no such file/i.test(error.message))
+  )
+}
+
+function canonicalManifestPath(runtimeId: string, hostCwd: string): string {
+  return hostJoin(runtimeId, hostCwd, '.cate', 'skills.json')
+}
+
+async function readCanonicalManifest(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+): Promise<InstalledSkill[]> {
+  const raw = await runtime.file.readFile(canonicalManifestPath(runtimeId, hostCwd))
+  const parsed = JSON.parse(raw) as { skills?: InstalledSkill[] }
+  if (!Array.isArray(parsed.skills)) throw new Error('Canonical skills manifest has no skills array')
+  return parsed.skills.filter((entry) =>
+    typeof entry?.skillId === 'string' &&
+    typeof entry?.name === 'string' &&
+    isKnownSkillTarget(entry?.targetId),
+  )
+}
+
+async function readMirrorManifest(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+): Promise<MirrorManifest> {
+  try {
+    const raw = await runtime.file.readFile(mirrorManifestPath(runtimeId, hostCwd))
+    const parsed = JSON.parse(raw) as Partial<MirrorManifest>
+    const skills = Array.isArray(parsed.skills)
+      ? parsed.skills.filter((entry): entry is MirrorEntry =>
+          typeof entry?.skillId === 'string' &&
+          typeof entry?.name === 'string' &&
+          typeof entry?.contentHash === 'string' &&
+          isKnownSkillTarget(entry?.targetId),
+        )
+      : []
+    return { version: MIRROR_VERSION, skills }
+  } catch {
+    // Missing or corrupt ownership metadata grants Cate no ownership.
+    return { version: MIRROR_VERSION, skills: [] }
+  }
+}
+
+async function mkdirp(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+  targetDir: string,
+): Promise<void> {
+  const rel = targetDir.slice(hostCwd.length).replace(/^[/\\]+/, '')
+  let current = hostCwd
+  for (const part of rel.split(/[/\\]+/).filter(Boolean)) {
+    current = hostJoin(runtimeId, current, part)
+    await runtime.file.mkdir(current)
+  }
+}
+
+async function writeMirrorManifest(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+  entries: Iterable<MirrorEntry>,
+): Promise<void> {
+  await mkdirp(runtime, runtimeId, hostCwd, hostJoin(runtimeId, hostCwd, '.cate'))
+  const gitignore = hostJoin(runtimeId, hostCwd, '.cate', '.gitignore')
+  try {
+    await runtime.file.stat(gitignore)
+  } catch (error) {
+    if (isMissingError(error)) {
+      try { await runtime.file.writeFile(gitignore, CATE_GITIGNORE_CONTENT) } catch { /* best effort */ }
+    }
+  }
+  const manifest: MirrorManifest = {
+    version: MIRROR_VERSION,
+    skills: [...entries].sort((a, b) => entryKey(a).localeCompare(entryKey(b))),
+  }
+  await runtime.file.writeFile(
+    mirrorManifestPath(runtimeId, hostCwd),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  )
+}
+
+async function readDirectory(
+  runtime: Runtime,
+  runtimeId: string,
+  dir: string,
+  base = '',
+): Promise<BundleFile[]> {
+  const nodes = await runtime.file.readDir(dir)
+  const files: BundleFile[] = []
+  for (const node of [...nodes].sort((a, b) => a.name.localeCompare(b.name))) {
+    const child = hostJoin(runtimeId, dir, node.name)
+    const relPath = base ? `${base}/${node.name}` : node.name
+    if (node.isDirectory) {
+      files.push(...await readDirectory(runtime, runtimeId, child, relPath))
+    } else {
+      skillPathSegments(relPath)
+      files.push({ relPath, bytes: await runtime.file.readBinary(child) })
+    }
+  }
+  return files
+}
+
+function hashBundle(files: BundleFile[]): string {
+  const hash = createHash('sha256')
+  for (const file of [...files].sort((a, b) => a.relPath.localeCompare(b.relPath))) {
+    hash.update(file.relPath)
+    hash.update('\0')
+    hash.update(String(file.bytes.length))
+    hash.update('\0')
+    hash.update(file.bytes)
+    hash.update('\0')
+  }
+  return hash.digest('hex')
+}
+
+function installedPath(
+  runtimeId: string,
+  hostCwd: string,
+  entry: Pick<MirrorEntry, 'name' | 'targetId'>,
+): string {
+  const slug = slugifySkillName(entry.name)
+  const root = skillsRootDir(entry.targetId, runtimeId, hostCwd)
+  return targetInfo(entry.targetId).layout === 'folder'
+    ? hostJoin(runtimeId, root, slug)
+    : hostJoin(runtimeId, root, `${slug}.md`)
+}
+
+async function readInstalledBundle(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+  entry: Pick<MirrorEntry, 'name' | 'targetId'>,
+): Promise<InstalledBundle | null> {
+  const path = installedPath(runtimeId, hostCwd, entry)
+  let stat
+  try {
+    stat = await runtime.file.stat(path)
+  } catch (error) {
+    if (isMissingError(error)) return null
+    throw error
+  }
+  const layout = targetInfo(entry.targetId).layout
+  if ((layout === 'folder' && !stat.isDirectory) || (layout === 'flat' && !stat.isFile)) {
+    throw new Error(`Unexpected skill path type: ${path}`)
+  }
+  const files = layout === 'folder'
+    ? await readDirectory(runtime, runtimeId, path)
+    : [{ relPath: 'SKILL.md', bytes: await runtime.file.readBinary(path) }]
+  return { files, path, contentHash: hashBundle(files) }
+}
+
+async function materializeBundle(
+  runtime: Runtime,
+  runtimeId: string,
+  hostCwd: string,
+  entry: Pick<MirrorEntry, 'name' | 'targetId'>,
+  files: BundleFile[],
+  replace: boolean,
+): Promise<boolean> {
+  const root = skillsRootDir(entry.targetId, runtimeId, hostCwd)
+  const destination = installedPath(runtimeId, hostCwd, entry)
+  const slug = slugifySkillName(entry.name)
+  const layout = targetInfo(entry.targetId).layout
+  const transactionId = randomUUID()
+  const staging = layout === 'folder'
+    ? hostJoin(runtimeId, hostCwd, '.cate', `.skills-mirror-stage-${slug}-${transactionId}`)
+    : hostJoin(runtimeId, hostCwd, '.cate', `.skills-mirror-stage-${slug}-${transactionId}.md`)
+  const backup = hostJoin(runtimeId, hostCwd, '.cate', `.skills-mirror-backup-${slug}-${transactionId}`)
+  let preserveBackup = false
+
+  await mkdirp(runtime, runtimeId, hostCwd, root)
+  await mkdirp(runtime, runtimeId, hostCwd, hostJoin(runtimeId, hostCwd, '.cate'))
+  try {
+    if (layout === 'folder') {
+      await mkdirp(runtime, runtimeId, hostCwd, staging)
+      for (const file of files) {
+        const segments = skillPathSegments(file.relPath)
+        const target = hostJoin(runtimeId, staging, ...segments)
+        if (segments.length > 1) {
+          await mkdirp(
+            runtime,
+            runtimeId,
+            hostCwd,
+            hostJoin(runtimeId, staging, ...segments.slice(0, -1)),
+          )
+        }
+        await runtime.file.writeBinary(target, file.bytes)
+      }
+    } else {
+      const skillMd = files.find((file) => file.relPath === 'SKILL.md')
+      if (!skillMd) throw new Error('Skill is missing SKILL.md')
+      await runtime.file.writeBinary(staging, skillMd.bytes)
+    }
+
+    if (!replace) {
+      try {
+        await runtime.file.stat(destination)
+        return false
+      } catch (error) {
+        if (!isMissingError(error)) throw error
+      }
+    } else {
+      await runtime.file.rename(destination, backup)
+      try {
+        await runtime.file.rename(staging, destination)
+      } catch (error) {
+        try {
+          await runtime.file.rename(backup, destination)
+        } catch (rollbackError) {
+          preserveBackup = true
+          const message = rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+          throw new Error(`Skill update failed and rollback failed; backup retained at ${backup}: ${message}`, {
+            cause: error,
+          })
+        }
+        throw error
+      }
+      return true
+    }
+    await runtime.file.rename(staging, destination)
+    return true
+  } finally {
+    try { await runtime.file.remove(staging) } catch { /* already renamed or best-effort cleanup */ }
+    if (replace && !preserveBackup) {
+      try { await runtime.file.remove(backup) } catch { /* already restored or best-effort cleanup */ }
+    }
+  }
+}
+
+function warn(result: SkillMirrorSyncResult, message: string, error?: unknown): void {
+  const detail = error instanceof Error ? `${message}: ${error.message}` : message
+  result.warnings.push(detail)
+  log.warn('[skills-mirror] %s', detail)
+}
+
+/**
+ * Materialize Cate-managed skills from a base workspace into another checkout.
+ *
+ * The base `.cate/skills.json` is the only desired-state manifest. The target
+ * receives ownership metadata, never another normal skills manifest. This is
+ * best effort: entry failures are returned as warnings and retried by later
+ * launch/worktree sync calls.
+ */
+export async function syncWorkspaceSkills(
+  baseCwd: string,
+  targetCwd: string,
+): Promise<SkillMirrorSyncResult> {
+  const result = emptyResult()
+  if (sameLocator(baseCwd, targetCwd)) return result
+
+  const base = parseLocator(baseCwd)
+  const target = parseLocator(targetCwd)
+  if (!base.path || !target.path) {
+    warn(result, 'Workspace has no folder open')
+    return result
+  }
+
+  let baseRuntime: Runtime
+  let targetRuntime: Runtime
+  try {
+    baseRuntime = runtimes.resolve(base.runtimeId)
+    targetRuntime = runtimes.resolve(target.runtimeId)
+  } catch (error) {
+    warn(result, 'Workspace runtime is unavailable', error)
+    return result
+  }
+
+  const mirror = await readMirrorManifest(targetRuntime, target.runtimeId, target.path)
+  const owned = new Map<string, MirrorEntry>()
+  for (const entry of mirror.skills) owned.set(entryKey(entry), entry)
+
+  let installed: InstalledSkill[]
+  try {
+    installed = await readCanonicalManifest(baseRuntime, base.runtimeId, base.path)
+  } catch (error) {
+    // A workspace with no installed skills normally has no manifest. Stay quiet
+    // unless ownership exists that must not be mistaken for stale desired state.
+    if (!isMissingError(error) || owned.size > 0) {
+      warn(result, 'Could not read canonical skills manifest', error)
+    }
+    return result
+  }
+
+  const sourceByKey = new Map<string, InstalledSkill>()
+  for (const entry of installed) sourceByKey.set(entryKey(entry), entry)
+
+  // First retire ownership whose source disappeared or moved to another slug.
+  for (const [key, prior] of [...owned]) {
+    const source = sourceByKey.get(key)
+    if (source?.name === prior.name) continue
+    try {
+      const current = await readInstalledBundle(targetRuntime, target.runtimeId, target.path, prior)
+      if (!current) {
+        owned.delete(key)
+      } else if (current.contentHash === prior.contentHash) {
+        await targetRuntime.file.remove(current.path)
+        owned.delete(key)
+        result.removed.push(key)
+      } else {
+        owned.delete(key)
+        result.preserved.push(key)
+      }
+    } catch (error) {
+      warn(result, `Could not retire mirrored skill ${key}`, error)
+    }
+  }
+
+  for (const [key, source] of sourceByKey) {
+    try {
+      const sourceBundle = await readInstalledBundle(baseRuntime, base.runtimeId, base.path, source)
+      if (!sourceBundle) {
+        warn(result, `Canonical skill files are missing for ${key}`)
+        continue
+      }
+
+      const prior = owned.get(key)
+      const current = await readInstalledBundle(targetRuntime, target.runtimeId, target.path, source)
+      if (!prior) {
+        if (current) {
+          result.preserved.push(key)
+          continue
+        }
+        if (!await materializeBundle(
+          targetRuntime,
+          target.runtimeId,
+          target.path,
+          source,
+          sourceBundle.files,
+          false,
+        )) {
+          result.preserved.push(key)
+          continue
+        }
+        owned.set(key, {
+          skillId: source.skillId,
+          name: source.name,
+          targetId: source.targetId,
+          contentHash: sourceBundle.contentHash,
+        })
+        result.copied.push(key)
+        continue
+      }
+
+      if (!current) {
+        const copied = await materializeBundle(
+          targetRuntime,
+          target.runtimeId,
+          target.path,
+          source,
+          sourceBundle.files,
+          false,
+        )
+        if (!copied) {
+          owned.delete(key)
+          result.preserved.push(key)
+          continue
+        }
+        owned.set(key, { ...prior, name: source.name, contentHash: sourceBundle.contentHash })
+        result.copied.push(key)
+      } else if (current.contentHash !== prior.contentHash) {
+        owned.delete(key)
+        result.preserved.push(key)
+      } else if (current.contentHash !== sourceBundle.contentHash) {
+        await materializeBundle(
+          targetRuntime,
+          target.runtimeId,
+          target.path,
+          source,
+          sourceBundle.files,
+          true,
+        )
+        owned.set(key, { ...prior, name: source.name, contentHash: sourceBundle.contentHash })
+        result.updated.push(key)
+      }
+    } catch (error) {
+      warn(result, `Could not synchronize skill ${key}`, error)
+    }
+  }
+
+  try {
+    await writeMirrorManifest(targetRuntime, target.runtimeId, target.path, owned.values())
+  } catch (error) {
+    warn(result, 'Could not write skill mirror ownership metadata', error)
+  }
+  return result
+}


### PR DESCRIPTION
Agent hooks now use the base checkout to decide whether auto-installation applies, while writing and checking hooks in the active worktree.

Skills installed in the base workspace are mirrored safely into linked worktrees. Worktree resolution and validation are shared across both paths, with coverage for worktree creation, terminal and agent launch, skill changes, and the missing-hook process check.

Checks: 118 focused tests, typecheck, ESLint, and production build.
