### PR TITLE
Support multiple custom AI providers

### DIFF
--- a/src/agent/main/authManager.concurrent.test.ts
+++ b/src/agent/main/authManager.concurrent.test.ts
@@ -9,7 +9,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock('electron', () => ({ shell: { openExternal: vi.fn(async () => {}) } }))
 vi.mock('./agentDir', () => ({ sharedAuthPath: () => '/virtual/auth.json' }))
-vi.mock('./customModels', () => ({ readCustomOpenAI: vi.fn(async () => null) }))
+vi.mock('./customModels', () => ({ readCustomOpenAIProviders: vi.fn(async () => []) }))
 vi.mock('@earendil-works/pi-ai/compat', () => ({
   findEnvKeys: vi.fn(),
   getEnvApiKey: vi.fn(),

--- a/src/agent/main/authManager.ts
+++ b/src/agent/main/authManager.ts
@@ -27,7 +27,7 @@ import { getBuiltinModels, getBuiltinProviders } from '@earendil-works/pi-ai/pro
 import { getOAuthApiKey, getOAuthProvider, getOAuthProviders } from '@earendil-works/pi-ai/oauth'
 import { sharedAuthPath } from './agentDir'
 import { readAgentConfigFile, updateAgentConfigFile } from './agentConfigLock'
-import { readCustomOpenAI } from './customModels'
+import { readCustomOpenAIProviders } from './customModels'
 import log from '../../main/logger'
 import type {
   AgentModelDescriptor,
@@ -188,17 +188,17 @@ export class AuthManager {
       })
     }
 
-    // Custom OpenAI-compatible endpoint (lives in models.json, not auth.json).
-    // Connected once a baseUrl and at least one model are configured — the key
-    // is optional since local servers (Ollama, LM Studio, vLLM) ignore it.
-    const custom = await readCustomOpenAI()
-    const customConnected = !!custom && !!custom.baseUrl && custom.models.length > 0
-    result.push({
-      id: 'custom-openai',
-      connected: customConnected,
-      source: customConnected ? 'config' : undefined,
-      connectedAt: customConnected ? this.connectedAt.get('custom-openai') : undefined,
-    })
+    // Custom OpenAI-compatible endpoints live in models.json, not auth.json.
+    // Keys are optional since local servers (Ollama, LM Studio, vLLM) ignore them.
+    for (const custom of await readCustomOpenAIProviders()) {
+      const connected = !!custom.baseUrl && custom.models.length > 0
+      result.push({
+        id: custom.id,
+        connected,
+        source: connected ? 'config' : undefined,
+        connectedAt: connected ? this.connectedAt.get(custom.id) : undefined,
+      })
+    }
 
     return result
   }
@@ -211,12 +211,14 @@ export class AuthManager {
   async listAvailableModels(): Promise<AgentModelDescriptor[]> {
     const statuses = await this.status()
     const connected = new Set(statuses.filter((s) => s.connected).map((s) => s.id))
+    const customProviders = await readCustomOpenAIProviders()
+    const customIds = new Set(customProviders.map((provider) => provider.id))
 
     const out: AgentModelDescriptor[] = []
     const seen = new Set<string>() // `${provider}:${id}` — OAuth + API-key share ids
 
     for (const providerId of connected) {
-      if (providerId === 'custom-openai') continue
+      if (customIds.has(providerId)) continue
       // getBuiltinModels indexes a static catalog and returns [] for unknown
       // ids, so calling it with any provider string is safe. pi's KnownProvider
       // union can drift ahead of that catalog (0.80.7 widened the union past the
@@ -236,13 +238,13 @@ export class AuthManager {
       }
     }
 
-    if (connected.has('custom-openai')) {
-      const custom = await readCustomOpenAI()
-      for (const id of custom?.models ?? []) {
-        const key = `custom-openai:${id}`
+    for (const custom of customProviders) {
+      if (!connected.has(custom.id)) continue
+      for (const id of custom.models) {
+        const key = `${custom.id}:${id}`
         if (seen.has(key)) continue
         seen.add(key)
-        out.push({ provider: 'custom-openai', id, label: id, contextWindow: 0, reasoning: false })
+        out.push({ provider: custom.id, id, label: id, contextWindow: 0, reasoning: false })
       }
     }
 
@@ -292,9 +294,10 @@ export class AuthManager {
       }
     }
 
-    // custom-openai lives in models.json, not auth.json — presence only.
-    if (providerId === 'custom-openai') {
-      const custom = await readCustomOpenAI()
+    // Cate-managed custom providers live in models.json, not auth.json —
+    // verification is presence-only.
+    if (providerId === 'custom-openai' || providerId.startsWith('custom-openai-')) {
+      const custom = (await readCustomOpenAIProviders()).find((provider) => provider.id === providerId)
       const connected = !!custom && !!custom.baseUrl && custom.models.length > 0
       return { id: providerId, health: connected ? 'ok' : 'error' }
     }

--- a/src/agent/main/authManager.verify.test.ts
+++ b/src/agent/main/authManager.verify.test.ts
@@ -21,12 +21,14 @@ const h = vi.hoisted(() => ({
   getModels: vi.fn(),
   getProviders: vi.fn(),
   findEnvKeys: vi.fn(),
-  readCustomOpenAI: vi.fn(),
+  readCustomOpenAIProviders: vi.fn(),
 }))
 
 vi.mock('electron', () => ({ app: { getPath: () => h.userData }, shell: {} }))
 vi.mock('./agentDir', () => ({ sharedAuthPath: () => h.authJsonPath }))
-vi.mock('./customModels', () => ({ readCustomOpenAI: () => h.readCustomOpenAI() }))
+vi.mock('./customModels', () => ({
+  readCustomOpenAIProviders: () => h.readCustomOpenAIProviders(),
+}))
 vi.mock('@earendil-works/pi-ai/compat', () => ({
   findEnvKeys: (...args: unknown[]) => h.findEnvKeys(...args),
   getEnvApiKey: () => undefined,
@@ -68,7 +70,7 @@ beforeEach(() => {
     'xiaomi-token-plan-ams', 'xiaomi-token-plan-cn', 'xiaomi-token-plan-sgp', 'zai',
   ])
   h.findEnvKeys.mockReset().mockReturnValue(undefined)
-  h.readCustomOpenAI.mockReset().mockResolvedValue(null)
+  h.readCustomOpenAIProviders.mockReset().mockResolvedValue([])
 })
 
 afterEach(() => {
@@ -161,16 +163,69 @@ describe('AuthManager.listProviders — curated API-key catalog', () => {
   })
 })
 
-describe('AuthManager.verify — custom-openai', () => {
-  it('is ok when a baseUrl and models are configured', async () => {
-    h.readCustomOpenAI.mockResolvedValue({ baseUrl: 'http://localhost:11434/v1', apiKey: '', models: ['llama3'] })
-    const res = await authManager.verify('custom-openai')
-    expect(res).toEqual({ id: 'custom-openai', health: 'ok' })
+describe('AuthManager — custom OpenAI providers', () => {
+  it('reports status and selectable models for every configured provider', async () => {
+    h.readCustomOpenAIProviders.mockResolvedValue([
+      {
+        id: 'custom-openai',
+        name: 'Legacy',
+        baseUrl: 'http://legacy/v1',
+        apiKey: '',
+        models: ['legacy-model'],
+      },
+      {
+        id: 'custom-openai-team',
+        name: 'Team Proxy',
+        baseUrl: 'https://team.example/v1',
+        apiKey: 'secret',
+        models: ['team-a', 'team-b'],
+      },
+    ])
+
+    expect(await authManager.status()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'custom-openai', connected: true }),
+      expect.objectContaining({ id: 'custom-openai-team', connected: true }),
+    ]))
+    expect(await authManager.listAvailableModels()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ provider: 'custom-openai', id: 'legacy-model' }),
+      expect.objectContaining({ provider: 'custom-openai-team', id: 'team-a' }),
+      expect.objectContaining({ provider: 'custom-openai-team', id: 'team-b' }),
+    ]))
   })
 
-  it('is error when not configured', async () => {
-    h.readCustomOpenAI.mockResolvedValue(null)
-    const res = await authManager.verify('custom-openai')
-    expect(res).toEqual({ id: 'custom-openai', health: 'error' })
+  it('verifies each managed provider independently', async () => {
+    h.readCustomOpenAIProviders.mockResolvedValue([
+      {
+        id: 'custom-openai-team',
+        name: 'Team Proxy',
+        baseUrl: 'https://team.example/v1',
+        apiKey: 'secret',
+        models: ['team-model'],
+      },
+    ])
+
+    expect(await authManager.verify('custom-openai-team')).toEqual({
+      id: 'custom-openai-team',
+      health: 'ok',
+    })
+    expect(await authManager.verify('custom-openai-missing')).toEqual({
+      id: 'custom-openai-missing',
+      health: 'error',
+    })
+  })
+
+  it('reports an incomplete provider as disconnected', async () => {
+    h.readCustomOpenAIProviders.mockResolvedValue([{
+      id: 'custom-openai',
+      name: 'Legacy',
+      baseUrl: '',
+      apiKey: '',
+      models: [],
+    }])
+
+    expect(await authManager.verify('custom-openai')).toEqual({
+      id: 'custom-openai',
+      health: 'error',
+    })
   })
 })

--- a/src/agent/main/customModels.test.ts
+++ b/src/agent/main/customModels.test.ts
@@ -9,8 +9,9 @@ import path from 'path'
 import fs from 'fs'
 import fsp from 'fs/promises'
 import {
-  readCustomOpenAI,
-  saveCustomOpenAI,
+  deleteCustomOpenAIProvider,
+  readCustomOpenAIProviders,
+  saveCustomOpenAIProvider,
   sharedModelsPath,
   mirrorModelsToWorkspace,
 } from './customModels'
@@ -38,28 +39,55 @@ afterEach(() => {
 })
 
 describe('customModels', () => {
-  it('returns null when no models.json exists', async () => {
-    expect(await readCustomOpenAI()).toBeNull()
+  it('returns an empty list when no models.json exists', async () => {
+    expect(await readCustomOpenAIProviders()).toEqual([])
   })
 
-  it('saves and reads back a custom provider', async () => {
-    await saveCustomOpenAI({
+  it('saves and reads back multiple managed providers', async () => {
+    await saveCustomOpenAIProvider({
+      id: 'custom-openai-ollama',
+      name: 'Local Ollama',
       baseUrl: 'http://localhost:11434/v1',
       apiKey: 'secret',
-      models: ['llama3.1:8b', 'qwen2.5-coder:7b'],
+      models: ['llama3.1:8b'],
     })
-    const cfg = await readCustomOpenAI()
-    expect(cfg).toEqual({
-      baseUrl: 'http://localhost:11434/v1',
-      apiKey: 'secret',
-      models: ['llama3.1:8b', 'qwen2.5-coder:7b'],
+    await saveCustomOpenAIProvider({
+      id: 'custom-openai-proxy',
+      name: 'Team Proxy',
+      baseUrl: 'https://proxy.example/v1',
+      apiKey: 'proxy-secret',
+      models: ['qwen2.5-coder:7b'],
     })
+
+    expect(await readCustomOpenAIProviders()).toEqual([
+      {
+        id: 'custom-openai-ollama',
+        name: 'Local Ollama',
+        baseUrl: 'http://localhost:11434/v1',
+        apiKey: 'secret',
+        models: ['llama3.1:8b'],
+      },
+      {
+        id: 'custom-openai-proxy',
+        name: 'Team Proxy',
+        baseUrl: 'https://proxy.example/v1',
+        apiKey: 'proxy-secret',
+        models: ['qwen2.5-coder:7b'],
+      },
+    ])
   })
 
   it('writes pi-shaped models.json (openai-completions, models as {id})', async () => {
-    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+    await saveCustomOpenAIProvider({
+      id: 'custom-openai-local',
+      name: 'Local',
+      baseUrl: 'http://x/v1',
+      apiKey: '',
+      models: ['m1'],
+    })
     const raw = JSON.parse(await fsp.readFile(sharedModelsPath(), 'utf-8'))
-    expect(raw.providers['custom-openai']).toEqual({
+    expect(raw.providers['custom-openai-local']).toEqual({
+      name: 'Local',
       baseUrl: 'http://x/v1',
       api: 'openai-completions',
       apiKey: 'none', // placeholder when blank, since pi requires a non-empty key
@@ -67,39 +95,113 @@ describe('customModels', () => {
     })
   })
 
-  it('clears the provider when given null', async () => {
-    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
-    await saveCustomOpenAI(null)
-    expect(await readCustomOpenAI()).toBeNull()
-  })
-
-  it('clears the provider when no models are given', async () => {
-    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
-    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: [] })
-    expect(await readCustomOpenAI()).toBeNull()
-  })
-
-  it('preserves other providers a user hand-authored in models.json', async () => {
+  it('updates and deletes one provider without changing managed siblings or unmanaged data', async () => {
     await fsp.mkdir(path.dirname(sharedModelsPath()), { recursive: true })
     await fsp.writeFile(
       sharedModelsPath(),
-      JSON.stringify({ providers: { mine: { baseUrl: 'http://mine/v1', api: 'openai-completions', apiKey: 'k', models: [{ id: 'foo' }] } } }),
+      JSON.stringify({
+        providers: {
+          mine: {
+            baseUrl: 'http://mine/v1',
+            api: 'openai-completions',
+            apiKey: 'k',
+            headers: { 'X-Unmanaged': 'keep' },
+            models: [{ id: 'foo', contextWindow: 1234 }],
+          },
+          'custom-openai-one': {
+            name: 'One',
+            baseUrl: 'http://old/v1',
+            api: 'openai-completions',
+            apiKey: 'old',
+            headers: { 'X-Managed-Advanced': 'keep' },
+            models: [{ id: 'm1', contextWindow: 8192 }],
+          },
+          'custom-openai-two': {
+            name: 'Two',
+            baseUrl: 'http://two/v1',
+            api: 'openai-completions',
+            apiKey: 'two',
+            models: [{ id: 'm2' }],
+          },
+        },
+      }),
       'utf-8',
     )
-    await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+
+    await saveCustomOpenAIProvider({
+      id: 'custom-openai-one',
+      name: 'One updated',
+      baseUrl: 'http://new/v1',
+      apiKey: 'new',
+      models: ['m1', 'm3'],
+    })
+    await deleteCustomOpenAIProvider('custom-openai-two')
+
     const raw = JSON.parse(await fsp.readFile(sharedModelsPath(), 'utf-8'))
-    expect(raw.providers.mine).toBeDefined()
-    expect(raw.providers['custom-openai']).toBeDefined()
+    expect(raw.providers.mine).toEqual({
+      baseUrl: 'http://mine/v1',
+      api: 'openai-completions',
+      apiKey: 'k',
+      headers: { 'X-Unmanaged': 'keep' },
+      models: [{ id: 'foo', contextWindow: 1234 }],
+    })
+    expect(raw.providers['custom-openai-one']).toMatchObject({
+      name: 'One updated',
+      baseUrl: 'http://new/v1',
+      apiKey: 'new',
+      headers: { 'X-Managed-Advanced': 'keep' },
+      models: [{ id: 'm1', contextWindow: 8192 }, { id: 'm3' }],
+    })
+    expect(raw.providers['custom-openai-two']).toBeUndefined()
+  })
+
+  it('loads the legacy custom-openai provider without changing its id', async () => {
+    await fsp.mkdir(path.dirname(sharedModelsPath()), { recursive: true })
+    await fsp.writeFile(
+      sharedModelsPath(),
+      JSON.stringify({
+        providers: {
+          'custom-openai': {
+            baseUrl: 'http://legacy/v1',
+            api: 'openai-completions',
+            apiKey: 'legacy-key',
+            models: [{ id: 'legacy-model' }],
+          },
+          mine: {
+            name: 'Hand-authored',
+            baseUrl: 'http://mine/v1',
+            api: 'openai-completions',
+            apiKey: 'mine',
+            models: [{ id: 'mine-model' }],
+          },
+        },
+      }),
+      'utf-8',
+    )
+
+    expect(await readCustomOpenAIProviders()).toEqual([{
+      id: 'custom-openai',
+      name: 'Custom OpenAI endpoint',
+      baseUrl: 'http://legacy/v1',
+      apiKey: 'legacy-key',
+      models: ['legacy-model'],
+    }])
   })
 
   it('mirrors the shared file into a workspace dir', async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cate-ws-'))
     try {
-      await saveCustomOpenAI({ baseUrl: 'http://x/v1', apiKey: '', models: ['m1'] })
+      await saveCustomOpenAIProvider({
+        id: 'custom-openai-local',
+        name: 'Local',
+        baseUrl: 'http://x/v1',
+        apiKey: '',
+        models: ['m1'],
+      })
       await mirrorModelsToWorkspace(fakeRuntime, cwd)
       const dest = path.join(agentDirFor(cwd), 'models.json')
       const raw = JSON.parse(await fsp.readFile(dest, 'utf-8'))
-      expect(raw.providers['custom-openai'].baseUrl).toBe('http://x/v1')
+      expect(raw.providers['custom-openai-local'].baseUrl).toBe('http://x/v1')
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true })
     }

--- a/src/agent/main/customModels.ts
+++ b/src/agent/main/customModels.ts
@@ -1,6 +1,6 @@
 // =============================================================================
-// customModels — a single user-defined OpenAI-compatible provider, persisted to
-// pi's models.json.
+// customModels — Cate-managed OpenAI-compatible providers, persisted to pi's
+// models.json.
 //
 // Like auth.json, the source of truth is one shared file in cate's userData
 // that we mirror into each workspace's .cate/pi-agent dir, because the embedded
@@ -8,8 +8,9 @@
 // user's global ~/.pi/agent. pi reloads models.json whenever its model list is
 // fetched, so a saved endpoint shows up without restarting a session.
 //
-// We own the `custom-openai` provider key only; any other providers a user
-// hand-authored in models.json are preserved on write.
+// We own the legacy `custom-openai` provider key and the `custom-openai-*`
+// namespace. Any other providers a user hand-authored in models.json are
+// preserved on write.
 // =============================================================================
 
 import path from 'path'
@@ -20,46 +21,106 @@ import type { Runtime } from '../../main/runtime/types'
 import type { CustomOpenAIProvider } from '../../shared/types'
 import { readAgentConfigFile, updateAgentConfigFile } from './agentConfigLock'
 
-const PROVIDER_ID = 'custom-openai'
+const LEGACY_PROVIDER_ID = 'custom-openai'
+const PROVIDER_ID_PATTERN = /^custom-openai(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$/
+
+type ModelEntry = { id?: unknown } & Record<string, unknown>
+type ProviderEntry = Record<string, unknown> & { models?: unknown }
+
+function isManagedProviderId(id: string): boolean {
+  return PROVIDER_ID_PATTERN.test(id)
+}
+
+function requireManagedProviderId(id: string): void {
+  if (!isManagedProviderId(id)) {
+    throw new Error('Custom provider id must be "custom-openai" or start with "custom-openai-"')
+  }
+}
 
 /** The shared models.json — source of truth, mirrored into each workspace. */
 export function sharedModelsPath(): string {
   return path.join(app.getPath('userData'), PI_AGENT_DIR, 'models.json')
 }
 
-/** Read the configured custom OpenAI provider, or null when none is set. */
-export async function readCustomOpenAI(): Promise<CustomOpenAIProvider | null> {
+/** Read all Cate-managed providers. The original `custom-openai` entry remains
+ * addressable under the same id so persisted model references keep working. */
+export async function readCustomOpenAIProviders(): Promise<CustomOpenAIProvider[]> {
   const data = await readAgentConfigFile(sharedModelsPath())
-  const entry = data?.providers?.[PROVIDER_ID]
-  if (!entry) return null
-  return {
-    baseUrl: typeof entry.baseUrl === 'string' ? entry.baseUrl : '',
-    apiKey: typeof entry.apiKey === 'string' ? entry.apiKey : '',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    models: Array.isArray(entry.models)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ? entry.models.map((m: any) => (typeof m?.id === 'string' ? m.id : '')).filter(Boolean)
-      : [],
+  const providers = data?.providers
+  if (!providers || typeof providers !== 'object') return []
+
+  const result: CustomOpenAIProvider[] = []
+  for (const [id, value] of Object.entries(providers)) {
+    if (!isManagedProviderId(id) || !value || typeof value !== 'object') continue
+    const entry = value as ProviderEntry
+    result.push({
+      id,
+      name: typeof entry.name === 'string'
+        ? entry.name
+        : id === LEGACY_PROVIDER_ID ? 'Custom OpenAI endpoint' : id,
+      baseUrl: typeof entry.baseUrl === 'string' ? entry.baseUrl : '',
+      apiKey: typeof entry.apiKey === 'string' ? entry.apiKey : '',
+      models: Array.isArray(entry.models)
+        ? entry.models
+          .map((model) => (
+            model && typeof model === 'object' && typeof (model as ModelEntry).id === 'string'
+              ? (model as ModelEntry).id as string
+              : ''
+          ))
+          .filter(Boolean)
+        : [],
+    })
   }
+  return result
 }
 
-/** Write (or clear, when cfg is null/empty) the custom provider, preserving any
- *  other providers in models.json. */
-export async function saveCustomOpenAI(cfg: CustomOpenAIProvider | null): Promise<void> {
+/** Add or update one managed provider. Unknown provider fields and advanced
+ * model fields are retained when the corresponding model id remains present. */
+export async function saveCustomOpenAIProvider(cfg: CustomOpenAIProvider): Promise<void> {
+  requireManagedProviderId(cfg.id)
+  const name = cfg.name.trim()
+  const baseUrl = cfg.baseUrl.trim()
+  const models = cfg.models.map((id) => id.trim()).filter(Boolean)
+  if (!name) throw new Error('Custom provider name is required')
+  if (!baseUrl) throw new Error('Custom provider base URL is required')
+  if (models.length === 0) throw new Error('Custom provider needs at least one model')
+
   await updateAgentConfigFile(sharedModelsPath(), (data) => {
     if (!data.providers || typeof data.providers !== 'object') data.providers = {}
-
-    if (!cfg || !cfg.baseUrl.trim() || cfg.models.length === 0) {
-      delete data.providers[PROVIDER_ID]
-    } else {
-      data.providers[PROVIDER_ID] = {
-        baseUrl: cfg.baseUrl.trim(),
-        api: 'openai-completions',
-        // pi requires a non-empty apiKey when models are defined; local servers
-        // (Ollama, LM Studio, vLLM) ignore the value, so default to a placeholder.
-        apiKey: cfg.apiKey.trim() || 'none',
-        models: cfg.models.map((id) => ({ id })),
+    const existing = data.providers[cfg.id]
+    const existingEntry = existing && typeof existing === 'object'
+      ? existing as ProviderEntry
+      : {}
+    const existingModels = new Map<string, ModelEntry>()
+    if (Array.isArray(existingEntry.models)) {
+      for (const model of existingEntry.models) {
+        if (model && typeof model === 'object' && typeof (model as ModelEntry).id === 'string') {
+          existingModels.set((model as ModelEntry).id as string, model as ModelEntry)
+        }
       }
+    }
+
+    data.providers[cfg.id] = {
+      ...existingEntry,
+      name,
+      baseUrl,
+      api: 'openai-completions',
+      // pi requires a non-empty apiKey when models are defined; local servers
+      // (Ollama, LM Studio, vLLM) ignore the value, so default to a placeholder.
+      apiKey: cfg.apiKey.trim() || 'none',
+      models: models.map((id) => existingModels.get(id) ?? { id }),
+    }
+    return data
+  })
+}
+
+/** Delete one Cate-managed provider without touching siblings or hand-authored
+ * providers outside Cate's reserved id namespace. */
+export async function deleteCustomOpenAIProvider(providerId: string): Promise<void> {
+  requireManagedProviderId(providerId)
+  await updateAgentConfigFile(sharedModelsPath(), (data) => {
+    if (data.providers && typeof data.providers === 'object') {
+      delete data.providers[providerId]
     }
     return data
   })

--- a/src/agent/main/ipcAgent.test.ts
+++ b/src/agent/main/ipcAgent.test.ts
@@ -15,6 +15,9 @@ const h = vi.hoisted(() => ({
   listSessions: vi.fn(),
   loadSessionTranscript: vi.fn(),
   deleteSession: vi.fn(),
+  readCustomOpenAIProviders: vi.fn(),
+  saveCustomOpenAIProvider: vi.fn(),
+  deleteCustomOpenAIProvider: vi.fn(),
 }))
 
 vi.mock('electron', () => ({
@@ -35,13 +38,17 @@ vi.mock('../../main/runtime/runtimeManager', () => ({
   runtimes: { resolve: vi.fn() },
 }))
 vi.mock('./customModels', () => ({
-  readCustomOpenAI: vi.fn(),
-  saveCustomOpenAI: vi.fn(),
+  readCustomOpenAIProviders: h.readCustomOpenAIProviders,
+  saveCustomOpenAIProvider: h.saveCustomOpenAIProvider,
+  deleteCustomOpenAIProvider: h.deleteCustomOpenAIProvider,
 }))
 
 import { registerAgentHandlers } from './ipcAgent'
 import {
   AGENT_CREATE,
+  AGENT_CUSTOM_MODELS_DELETE,
+  AGENT_CUSTOM_MODELS_GET,
+  AGENT_CUSTOM_MODELS_SAVE,
   AGENT_DELETE_SESSION,
   AGENT_LIST_SESSIONS,
   AGENT_LOAD_SESSION_MESSAGES,
@@ -82,6 +89,9 @@ beforeEach(() => {
   h.listSessions.mockReset()
   h.loadSessionTranscript.mockReset()
   h.deleteSession.mockReset()
+  h.readCustomOpenAIProviders.mockReset()
+  h.saveCustomOpenAIProvider.mockReset()
+  h.deleteCustomOpenAIProvider.mockReset()
 })
 
 describe('agent IPC ownership and session routing', () => {
@@ -169,5 +179,28 @@ describe('agent IPC ownership and session routing', () => {
     })
     expect(JSON.stringify(h.sendEvent.mock.calls)).not.toContain('do not log this prompt')
     expect(JSON.stringify(h.sendEvent.mock.calls)).not.toContain('secret-image-data')
+  })
+
+  it('lists, saves, and deletes custom providers through IPC', async () => {
+    const manager = makeManager()
+    manager.syncCustomModelsToOpenSessions = vi.fn(async () => {})
+    registerAgentHandlers({} as AuthManager, manager)
+    const owner = makeSender(1).sender
+    const provider = {
+      id: 'custom-openai-team',
+      name: 'Team Proxy',
+      baseUrl: 'https://team.example/v1',
+      apiKey: 'secret',
+      models: ['team-model'],
+    }
+    h.readCustomOpenAIProviders.mockResolvedValue([provider])
+
+    await expect(invoke(AGENT_CUSTOM_MODELS_GET, owner)).resolves.toEqual([provider])
+    await invoke(AGENT_CUSTOM_MODELS_SAVE, owner, provider)
+    await invoke(AGENT_CUSTOM_MODELS_DELETE, owner, provider.id)
+
+    expect(h.saveCustomOpenAIProvider).toHaveBeenCalledWith(provider)
+    expect(h.deleteCustomOpenAIProvider).toHaveBeenCalledWith(provider.id)
+    expect(manager.syncCustomModelsToOpenSessions).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/agent/main/ipcAgent.ts
+++ b/src/agent/main/ipcAgent.ts
@@ -33,12 +33,17 @@ import {
   AGENT_DELETE_SESSION,
   AGENT_CUSTOM_MODELS_GET,
   AGENT_CUSTOM_MODELS_SAVE,
+  AGENT_CUSTOM_MODELS_DELETE,
 } from '../../shared/ipc-channels'
 import { deleteSession, listSessions, loadSessionTranscript } from './sessionFiles'
 import { hostAgentDir, hostJoin } from './agentDir'
 import { parseLocator, formatLocator, LOCAL_RUNTIME_ID } from '../../main/runtime/locator'
 import { runtimes } from '../../main/runtime/runtimeManager'
-import { readCustomOpenAI, saveCustomOpenAI } from './customModels'
+import {
+  deleteCustomOpenAIProvider,
+  readCustomOpenAIProviders,
+  saveCustomOpenAIProvider,
+} from './customModels'
 import log from '../../main/logger'
 import { sendEvent } from '../../main/analytics'
 import type {
@@ -335,15 +340,20 @@ export function registerAgentHandlers(authManager: AuthManager, agentManager: Ag
 
   ipcMain.handle(AGENT_CUSTOM_MODELS_GET, async () => {
     try {
-      return await readCustomOpenAI()
+      return await readCustomOpenAIProviders()
     } catch (err) {
       log.warn('[ipc.agent] customModelsGet failed: %O', err)
-      return null
+      return []
     }
   })
 
-  ipcMain.handle(AGENT_CUSTOM_MODELS_SAVE, async (_event, cfg: CustomOpenAIProvider | null) => {
-    await saveCustomOpenAI(cfg)
+  ipcMain.handle(AGENT_CUSTOM_MODELS_SAVE, async (_event, cfg: CustomOpenAIProvider) => {
+    await saveCustomOpenAIProvider(cfg)
+    await agentManager.syncCustomModelsToOpenSessions()
+  })
+
+  ipcMain.handle(AGENT_CUSTOM_MODELS_DELETE, async (_event, providerId: string) => {
+    await deleteCustomOpenAIProvider(providerId)
     await agentManager.syncCustomModelsToOpenSessions()
   })
 }

--- a/src/agent/renderer/ProvidersView.tsx
+++ b/src/agent/renderer/ProvidersView.tsx
@@ -5,10 +5,9 @@
 // its sign-in / API-key form inline beneath it (at most one open at a time).
 // When embedded in Settings the parent owns the surrounding chrome.
 //
-// Built-in providers sign in / store an API key. A final "Custom OpenAI
-// endpoint" section lets the user point the agent at any OpenAI-compatible
-// server (Ollama, LM Studio, vLLM, a proxy); it is persisted to pi's
-// models.json via agentCustomModels* IPC.
+// Built-in providers sign in / store an API key. A final custom section manages
+// OpenAI-compatible servers (Ollama, LM Studio, vLLM, proxies), persisted to
+// pi's models.json via agentCustomModels* IPC.
 // =============================================================================
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -25,6 +24,7 @@ import {
   CaretRight,
   CaretDown,
   Sparkle,
+  Plus,
 } from '@phosphor-icons/react'
 import { ModelPickerDropdown } from './ModelPicker'
 import log from '../../renderer/lib/logger'
@@ -55,6 +55,7 @@ interface ProvidersViewProps {
 export function ProvidersView({ onBack, scopedProviderId, embedded = false }: ProvidersViewProps) {
   const [providers, setProviders] = useState<AuthProviderDescriptor[]>([])
   const [statuses, setStatuses] = useState<AuthProviderStatus[]>([])
+  const [customProviders, setCustomProviders] = useState<CustomOpenAIProvider[]>([])
   // Selectable models for the default-model picker — derived from the connected
   // providers in auth.json, so it works here without an agent session running.
   const [models, setModels] = useState<Array<{ provider: string; model: string; label?: string }>>([])
@@ -64,14 +65,16 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false }: Pr
 
   const refresh = useCallback(async () => {
     try {
-      const [pList, sList, mList] = await Promise.all([
+      const [pList, sList, mList, customList] = await Promise.all([
         window.electronAPI.authListProviders(),
         window.electronAPI.authStatus(),
         window.electronAPI.agentListModels(),
+        window.electronAPI.agentCustomModelsGet(),
       ])
       setProviders(pList)
       setStatuses(sList)
       setModels(mList.map((m) => ({ provider: m.provider, model: m.id, label: m.label })))
+      setCustomProviders(customList)
     } catch (err) {
       log.warn('[ProvidersView] refresh failed', err)
     }
@@ -95,8 +98,12 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false }: Pr
     const match =
       providers.find((p) => p.kind === 'oauth' && p.id === scopedProviderId) ??
       providers.find((p) => p.id === scopedProviderId)
-    if (match) setExpandedKey(`${match.kind}-${match.id}`)
-  }, [scopedProviderId, providers])
+    if (match) {
+      setExpandedKey(`${match.kind}-${match.id}`)
+    } else if (customProviders.some((provider) => provider.id === scopedProviderId)) {
+      setExpandedKey(`custom-${scopedProviderId}`)
+    }
+  }, [scopedProviderId, providers, customProviders])
 
   const statusFor = useCallback(
     (id: string): AuthProviderStatus | undefined => statuses.find((s) => s.id === id),
@@ -151,9 +158,32 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false }: Pr
         })}
       </Section>
       <Section label="Custom">
+        {customProviders.map((provider) => {
+          const key = `custom-${provider.id}`
+          return (
+            <CustomOpenAIRow
+              key={provider.id}
+              cfg={provider}
+              expanded={expandedKey === key}
+              onToggle={() => toggle(key)}
+              onSaved={refresh}
+              onDeleted={async () => {
+                setExpandedKey(null)
+                await refresh()
+              }}
+            />
+          )
+        })}
         <CustomOpenAIRow
-          expanded={expandedKey === 'custom-openai'}
-          onToggle={() => toggle('custom-openai')}
+          cfg={null}
+          existingIds={customProviders.map((provider) => provider.id)}
+          expanded={expandedKey === 'custom-new'}
+          onToggle={() => toggle('custom-new')}
+          onSaved={async (provider) => {
+            await refresh()
+            setExpandedKey(`custom-${provider.id}`)
+          }}
+          onDeleted={refresh}
         />
       </Section>
     </>
@@ -189,25 +219,25 @@ export function ProvidersView({ onBack, scopedProviderId, embedded = false }: Pr
 }
 
 // -----------------------------------------------------------------------------
-// Custom OpenAI-compatible endpoint — one user-defined provider written to pi's
-// models.json. Connects the agent to Ollama, LM Studio, vLLM, a proxy, etc.
+// Custom OpenAI-compatible endpoints written to pi's models.json. Connects the
+// agent to Ollama, LM Studio, vLLM, proxies, etc.
 // -----------------------------------------------------------------------------
 
 function CustomOpenAIRow({
+  cfg,
+  existingIds = [],
   expanded,
   onToggle,
+  onSaved,
+  onDeleted,
 }: {
+  cfg: CustomOpenAIProvider | null
+  existingIds?: string[]
   expanded: boolean
   onToggle: () => void
+  onSaved: (cfg: CustomOpenAIProvider) => Promise<void>
+  onDeleted: () => Promise<void>
 }) {
-  const [cfg, setCfg] = useState<CustomOpenAIProvider | null>(null)
-
-  useEffect(() => {
-    window.electronAPI.agentCustomModelsGet()
-      .then((c) => setCfg(c))
-      .catch((err) => log.warn('[CustomOpenAIRow] load failed', err))
-  }, [])
-
   const configured = !!cfg && !!cfg.baseUrl && cfg.models.length > 0
   return (
     <div className="border-b border-subtle last:border-0">
@@ -216,21 +246,29 @@ function CustomOpenAIRow({
         aria-expanded={expanded}
         className="w-full flex items-center gap-2 px-2.5 py-2 text-left hover:bg-hover"
       >
-        <span className="flex-1 truncate text-[12.5px] text-primary">Custom OpenAI endpoint</span>
+        {!cfg && <Plus size={11} className="text-muted/70" />}
+        <span className="flex-1 truncate text-[12.5px] text-primary">
+          {cfg?.name ?? 'Add custom provider'}
+        </span>
         {configured ? (
           <span className="inline-flex items-center gap-1 text-[10px] text-agent-light/90">
             <CheckCircle size={10} weight="fill" /> Configured
           </span>
-        ) : (
+        ) : cfg ? (
           <CircleDashed size={11} className="text-muted/60" />
-        )}
+        ) : null}
         {expanded
           ? <CaretDown size={10} className="text-muted/60" />
           : <CaretRight size={10} className="text-muted/60" />}
       </button>
       {expanded && (
         <div className="p-2.5 border-t border-subtle bg-surface-0">
-          <CustomOpenAIForm cfg={cfg} onSaved={setCfg} />
+          <CustomOpenAIForm
+            cfg={cfg}
+            existingIds={existingIds}
+            onSaved={onSaved}
+            onDeleted={onDeleted}
+          />
         </div>
       )}
     </div>
@@ -239,53 +277,106 @@ function CustomOpenAIRow({
 
 function CustomOpenAIForm({
   cfg,
+  existingIds,
   onSaved,
+  onDeleted,
 }: {
   cfg: CustomOpenAIProvider | null
-  onSaved: (cfg: CustomOpenAIProvider | null) => void
+  existingIds: string[]
+  onSaved: (cfg: CustomOpenAIProvider) => Promise<void>
+  onDeleted: () => Promise<void>
 }) {
+  const [id, setId] = useState(cfg?.id ?? 'custom-openai-')
+  const [name, setName] = useState(cfg?.name ?? '')
   const [baseUrl, setBaseUrl] = useState(cfg?.baseUrl ?? '')
   const [apiKey, setApiKey] = useState(cfg?.apiKey ?? '')
   const [models, setModels] = useState((cfg?.models ?? []).join(', '))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [savedAt, setSavedAt] = useState<number | null>(null)
+  const [verification, setVerification] = useState<string | null>(null)
 
   const handleSave = useCallback(async () => {
+    const providerId = id.trim()
+    const friendlyName = name.trim()
     const url = baseUrl.trim()
     const modelIds = models.split(',').map((m) => m.trim()).filter(Boolean)
+    if (!/^custom-openai(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$/.test(providerId)) {
+      setError('Id must be custom-openai or custom-openai-name')
+      return
+    }
+    if (!cfg && existingIds.includes(providerId)) { setError('Provider id already exists'); return }
+    if (!friendlyName) { setError('Name is required'); return }
     if (!url) { setError('Base URL is required'); return }
     if (modelIds.length === 0) { setError('Add at least one model id'); return }
     setSaving(true); setError(null)
-    const next: CustomOpenAIProvider = { baseUrl: url, apiKey: apiKey.trim(), models: modelIds }
+    const next: CustomOpenAIProvider = {
+      id: providerId,
+      name: friendlyName,
+      baseUrl: url,
+      apiKey: apiKey.trim(),
+      models: modelIds,
+    }
     try {
       await window.electronAPI.agentCustomModelsSave(next)
-      onSaved(next)
+      await onSaved(next)
       setSavedAt(Date.now())
+      setVerification(null)
     } catch (err) {
       setError(toErrorMessage(err))
     } finally {
       setSaving(false)
     }
-  }, [baseUrl, apiKey, models, onSaved])
+  }, [id, name, baseUrl, apiKey, models, cfg, existingIds, onSaved])
 
   const handleRemove = useCallback(async () => {
+    if (!cfg) return
     setSaving(true); setError(null)
     try {
-      await window.electronAPI.agentCustomModelsSave(null)
-      clearModelPrefsForProvider('custom-openai')
-      onSaved(null)
-      setBaseUrl(''); setApiKey(''); setModels(''); setSavedAt(null)
+      await window.electronAPI.agentCustomModelsDelete(cfg.id)
+      clearModelPrefsForProvider(cfg.id)
+      await onDeleted()
     } catch (err) {
       setError(toErrorMessage(err))
     } finally {
       setSaving(false)
     }
-  }, [onSaved])
+  }, [cfg, onDeleted])
 
-  const configured = !!cfg && !!cfg.baseUrl && cfg.models.length > 0
+  const handleVerify = useCallback(async () => {
+    if (!cfg) return
+    setSaving(true); setError(null); setVerification(null)
+    try {
+      const result = await window.electronAPI.authVerify(cfg.id)
+      if (result.health === 'ok') setVerification('Configuration is ready.')
+      else setError(result.error ?? 'Configuration is incomplete')
+    } catch (err) {
+      setError(toErrorMessage(err))
+    } finally {
+      setSaving(false)
+    }
+  }, [cfg])
+
   return (
     <div className="space-y-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        autoComplete="off"
+        placeholder="Name (e.g. Local Ollama)"
+        className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60"
+      />
+      <input
+        type="text"
+        value={id}
+        disabled={!!cfg}
+        onChange={(e) => setId(e.target.value.toLowerCase())}
+        autoComplete="off"
+        spellCheck={false}
+        placeholder="Provider id (e.g. custom-openai-ollama)"
+        className="w-full bg-surface-3 border border-strong rounded-md px-2 py-1.5 text-[13px] text-primary outline-none focus:border-agent/60 font-mono disabled:opacity-60"
+      />
       <input
         type="text"
         value={baseUrl}
@@ -321,7 +412,16 @@ function CustomOpenAIForm({
         >
           {saving ? 'Saving…' : 'Save'}
         </button>
-        {configured && (
+        {cfg && (
+          <button
+            disabled={saving}
+            onClick={handleVerify}
+            className="text-[11px] text-muted hover:text-primary"
+          >
+            Verify
+          </button>
+        )}
+        {cfg && (
           <button
             disabled={saving}
             onClick={handleRemove}
@@ -333,6 +433,11 @@ function CustomOpenAIForm({
       </div>
 
       <SaveFeedback error={error} savedAt={savedAt} />
+      {verification && !error && (
+        <div className="flex items-center gap-1 text-[11px] text-agent-light">
+          <CheckCircle size={12} weight="fill" /> {verification}
+        </div>
+      )}
     </div>
   )
 }
@@ -909,4 +1014,3 @@ export function ModelPrefRow({
     </div>
   )
 }
-

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -230,6 +230,7 @@ import {
   AGENT_DELETE_SESSION,
   AGENT_CUSTOM_MODELS_GET,
   AGENT_CUSTOM_MODELS_SAVE,
+  AGENT_CUSTOM_MODELS_DELETE,
   SKILLS_GET_INDEX,
   SKILLS_REFRESH,
   SKILLS_GET_PREVIEW,
@@ -571,6 +572,7 @@ const invokeForwarders = {
   agentListSkillFiles: makeInvoker<'agentListSkillFiles'>(AGENT_LIST_SKILL_FILES),
   agentCustomModelsGet: makeInvoker<'agentCustomModelsGet'>(AGENT_CUSTOM_MODELS_GET),
   agentCustomModelsSave: makeInvoker<'agentCustomModelsSave'>(AGENT_CUSTOM_MODELS_SAVE),
+  agentCustomModelsDelete: makeInvoker<'agentCustomModelsDelete'>(AGENT_CUSTOM_MODELS_DELETE),
 
   // Cross-agent skills
   skillsGetIndex: makeInvoker<'skillsGetIndex'>(SKILLS_GET_INDEX),

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -977,11 +977,14 @@ export interface ElectronAPI {
   /** Get token + cost + context-usage stats for the current session. */
   agentGetSessionStats(panelId: string): Promise<AgentSessionStats>
 
-  /** Read the user-defined custom OpenAI-compatible provider config. */
-  agentCustomModelsGet(): Promise<CustomOpenAIProvider | null>
+  /** Read Cate-managed custom OpenAI-compatible provider configs. */
+  agentCustomModelsGet(): Promise<CustomOpenAIProvider[]>
 
-  /** Save (or clear, with null) the custom OpenAI-compatible provider config. */
-  agentCustomModelsSave(cfg: CustomOpenAIProvider | null): Promise<void>
+  /** Add or update a Cate-managed custom OpenAI-compatible provider. */
+  agentCustomModelsSave(cfg: CustomOpenAIProvider): Promise<void>
+
+  /** Delete one Cate-managed custom OpenAI-compatible provider. */
+  agentCustomModelsDelete(providerId: string): Promise<void>
 
   /** Get pi's RPC session state snapshot. */
   agentGetState(panelId: string): Promise<AgentRpcState>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -368,6 +368,7 @@ export const AGENT_DELETE_SESSION = 'agent:deleteSession'       // renderer -> m
 // Custom OpenAI-compatible provider (pi models.json)
 export const AGENT_CUSTOM_MODELS_GET = 'agent:customModelsGet'   // renderer -> main
 export const AGENT_CUSTOM_MODELS_SAVE = 'agent:customModelsSave' // renderer -> main
+export const AGENT_CUSTOM_MODELS_DELETE = 'agent:customModelsDelete' // renderer -> main
 
 // Skills (cross-agent skill manager)
 export const SKILLS_GET_INDEX = 'skills:getIndex'             // renderer -> main (merged catalog)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1786,10 +1786,13 @@ export interface ProviderVerification {
   error?: string
 }
 
-/** A user-defined OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, a
- *  proxy, ...). Surfaced as one extra provider in the agent provider list and
- *  written to pi's models.json. */
+/** A Cate-managed OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, a
+ *  proxy, ...), written to pi's models.json. */
 export interface CustomOpenAIProvider {
+  /** Stable pi provider id. `custom-openai` is retained for legacy configs. */
+  id: string
+  /** Friendly name shown in provider settings. */
+  name: string
   baseUrl: string
   /** Empty for local servers that ignore auth; pi gets a placeholder. */
   apiKey: string


### PR DESCRIPTION
Adds named OpenAI-compatible providers while keeping existing `custom-openai` configs and hand-written `models.json` entries intact.

Tests: `npm test`, `npm run typecheck`, `npm run build`

Closes #529
