### PR TITLE
Harden worktree actions

### DIFF
--- a/src/renderer/canvas/WorktreeToolbarMenu.tsx
+++ b/src/renderer/canvas/WorktreeToolbarMenu.tsx
@@ -30,6 +30,7 @@ import {
 } from '@phosphor-icons/react'
 import { Tooltip } from '../ui/Tooltip'
 import { CreateWorktreeForm } from '../sidebar/CreateWorktreeForm'
+import { errorMessage } from '../lib/errorMessage'
 import { useWorktrees, type JoinedWorktree } from '../stores/useWorktrees'
 import { useGitStatusSnapshot, gitStatusStore } from '../stores/gitStatusStore'
 import { useUIStore } from '../stores/uiStore'
@@ -222,8 +223,8 @@ const WorktreeMenuPopover: React.FC<PopoverProps> = ({
     try {
       await window.electronAPI.gitInit(rootPath, workspaceId)
       gitStatusStore.refresh(rootPath)
-    } catch (err: any) {
-      setError(`Could not initialize git: ${err?.message || err}`)
+    } catch (err: unknown) {
+      setError(`Couldn’t initialize git: ${errorMessage(err, 'The operation failed.')}`)
     }
   }, [rootPath, workspaceId])
 
@@ -438,14 +439,14 @@ const WorktreeRow: React.FC<{
     () =>
       runWorktreeContextMenu({
         isPrimary,
-        hasPr: !!pr,
+        hasPr: !!pr || !!wt.prNumber,
         prUrl: pr?.url,
         primaryLabel,
         cb,
         beginRename: () => { setRenameValue(label); setRenaming(true) },
         beginRecolor: () => setRecoloring((v) => !v),
       }),
-    [isPrimary, pr, primaryLabel, cb, label],
+    [isPrimary, pr, primaryLabel, cb, label, wt.prNumber],
   )
 
   return (

--- a/src/renderer/lib/errorMessage.test.ts
+++ b/src/renderer/lib/errorMessage.test.ts
@@ -28,6 +28,27 @@ describe('errorMessage', () => {
     )
   })
 
+  it('turns a diverged git checkout into an actionable message', () => {
+    const raw =
+      `Error invoking remote method 'git:worktreeAddFromPr': Error: Command failed: gh pr checkout 525\n` +
+      `hint: Diverging branches can't be fast-forwarded\nfatal: Not possible to fast-forward, aborting.`
+    expect(errorMessage(new Error(raw))).toBe(
+      'That branch already exists locally and has diverged. Preserve or rename it, then try again.',
+    )
+  })
+
+  it('maps common worktree action failures', () => {
+    expect(errorMessage('fatal: a branch named feature already exists')).toBe(
+      'A branch with that name already exists.',
+    )
+    expect(errorMessage('fatal: feat@{x is not a valid branch name')).toBe(
+      'That isn’t a valid Git branch name.',
+    )
+    expect(errorMessage('! [rejected] feature -> feature (non-fast-forward)\nerror: failed to push some refs')).toBe(
+      'The remote branch has newer commits. Update this worktree, then try publishing again.',
+    )
+  })
+
   it('accepts strings, plain objects, and Error instances', () => {
     expect(errorMessage('plain string')).toBe('plain string')
     expect(errorMessage({ message: 'object message' })).toBe('object message')

--- a/src/renderer/lib/errorMessage.ts
+++ b/src/renderer/lib/errorMessage.ts
@@ -18,6 +18,34 @@ const ERROR_NAME_PREFIX = /^(?:[A-Z][a-zA-Z]*Error|Error):\s*/
 // the cleaned message; first hit wins.
 const FRIENDLY: ReadonlyArray<{ match: RegExp; message: string }> = [
   {
+    match: /rejected[\s\S]*non-fast-forward|non-fast-forward[\s\S]*failed to push some refs/i,
+    message: 'The remote branch has newer commits. Update this worktree, then try publishing again.',
+  },
+  {
+    match: /diverging branches[\s\S]*fast-forward|not possible to fast-forward/i,
+    message: 'That branch already exists locally and has diverged. Preserve or rename it, then try again.',
+  },
+  {
+    match: /a branch named .* already exists/i,
+    message: 'A branch with that name already exists.',
+  },
+  {
+    match: /not a valid branch name|invalid branch name/i,
+    message: 'That isn’t a valid Git branch name.',
+  },
+  {
+    match: /not a valid object name|unknown revision|invalid reference|not a commit/i,
+    message: 'The selected base branch no longer exists.',
+  },
+  {
+    match: /authentication failed|not authenticated|could not read Username|permission denied.*publickey|HTTP 401|HTTP 403/i,
+    message: 'GitHub rejected the operation. Check your authentication and repository access.',
+  },
+  {
+    match: /does not appear to be a git repository|no configured push destination|no such remote/i,
+    message: 'This repository doesn’t have a usable remote.',
+  },
+  {
     match: /No runtime registered for id/i,
     message: 'The runtime isn’t connected on this host yet. Install it and try again.',
   },

--- a/src/renderer/lib/workspace/worktreePersistence.test.ts
+++ b/src/renderer/lib/workspace/worktreePersistence.test.ts
@@ -53,10 +53,10 @@ function reset() {
 }
 
 const ROOT = '/tmp/wt'
-// worktrees persist only UI metadata (id/path/color/label); branch/isPrimary are
+// worktrees persist only managed metadata (id/path/color/label/PR identity); branch/isPrimary are
 // live git facts joined in at read time (see useWorktrees), never persisted.
 const WT_X: WorktreeMeta = {
-  id: 'wt-x', path: `${ROOT}/.cate/worktrees/x`, color: '#11aa55', label: 'X work',
+  id: 'wt-x', path: `${ROOT}/.cate/worktrees/x`, color: '#11aa55', label: 'X work', prNumber: 42,
 }
 const WT_PRIMARY: WorktreeMeta = {
   id: 'wt-primary-ws', path: ROOT, color: '#3366ff',
@@ -97,6 +97,7 @@ describe('worktree session persistence', () => {
     const x = worktrees.find((w) => w.path === WT_X.path)
     expect(x?.color).toBe('#11aa55')
     expect(x?.label).toBe('X work')
+    expect(x?.prNumber).toBe(42)
     // The primary worktree is the one keyed by the workspace root path.
     expect(worktrees.find((w) => w.path === ROOT)?.color).toBe('#3366ff')
   })

--- a/src/renderer/sidebar/CreateWorktreeForm.tsx
+++ b/src/renderer/sidebar/CreateWorktreeForm.tsx
@@ -11,6 +11,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip } from '../ui/Tooltip'
 import { workspaceIdForRoot } from '../stores/gitStatusStore'
+import { errorMessage } from '../lib/errorMessage'
 import {
   GitBranch,
   Check,
@@ -67,6 +68,7 @@ export const CreateWorktreeForm: React.FC<{
   const [remoteExpanded, setRemoteExpanded] = useState(false)
   const [prsExpanded, setPrsExpanded] = useState(true)
   const [filter, setFilter] = useState('')
+  const busyRef = useRef(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const filterRef = useRef<HTMLInputElement>(null)
   const pickerRef = useRef<HTMLDivElement>(null)
@@ -123,7 +125,8 @@ export const CreateWorktreeForm: React.FC<{
   const canSubmit = selectedPr ? true : !!name.trim()
 
   const submit = useCallback(async () => {
-    if (busy || !canSubmit) return
+    if (busyRef.current || !canSubmit) return
+    busyRef.current = true
     setBusy(true)
     setError(null)
     try {
@@ -132,12 +135,13 @@ export const CreateWorktreeForm: React.FC<{
       } else {
         await onSubmit(name.trim(), baseRef || undefined)
       }
-    } catch (err: any) {
-      setError(err?.message || 'Failed to create')
+    } catch (err: unknown) {
+      setError(errorMessage(err, selectedPr ? 'Couldn’t check out that pull request.' : 'Couldn’t create that worktree.'))
     } finally {
+      busyRef.current = false
       setBusy(false)
     }
-  }, [busy, canSubmit, selectedPr, name, baseRef, onSubmit, onCheckoutPr])
+  }, [canSubmit, selectedPr, name, baseRef, onSubmit, onCheckoutPr])
 
   return (
     <div className="px-1 pt-1">

--- a/src/renderer/stores/useParallelWork.test.tsx
+++ b/src/renderer/stores/useParallelWork.test.tsx
@@ -28,7 +28,12 @@ vi.mock('./useWorktreeActions', () => ({
 
 import { useAppStore } from './appStore'
 import { useSettingsStore } from './settingsStore'
-import { useParallelWork, type UseParallelWork, type WorktreeStatus } from './useParallelWork'
+import {
+  runWorktreeContextMenu,
+  useParallelWork,
+  type UseParallelWork,
+  type WorktreeStatus,
+} from './useParallelWork'
 import type { JoinedWorktree } from './useWorktrees'
 
 const ROOT = '/repo'
@@ -98,9 +103,17 @@ beforeEach(() => {
     selectedWorkspaceId: WS,
   }, true)
   ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    gitPush: vi.fn().mockResolvedValue(undefined),
+    gitCreatePR: vi.fn(),
     gitWorktreeStatus: vi.fn().mockResolvedValue(status()),
     gitWorktreeRemove: vi.fn().mockResolvedValue(undefined),
     gitBranchDelete: vi.fn().mockResolvedValue(undefined),
+    gitWorktreePrune: vi.fn().mockResolvedValue({ output: '' }),
+    gitWorktreeList: vi.fn().mockResolvedValue([
+      { path: ROOT, branch: 'main', isBare: false, isCurrent: true },
+    ]),
+    shellShowInFolder: vi.fn().mockResolvedValue(undefined),
+    showContextMenu: vi.fn().mockResolvedValue(null),
   }
   vi.spyOn(window, 'confirm').mockReturnValue(true)
   host = document.createElement('div')
@@ -148,7 +161,7 @@ describe('useParallelWork handleDelete', () => {
     expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(true)
     expect(window.electronAPI.gitBranchDelete).not.toHaveBeenCalled()
     expect(h.refresh).not.toHaveBeenCalled()
-    expect(setError).toHaveBeenCalledWith('worktree locked')
+    expect(setError).toHaveBeenCalledWith('Discard failed: worktree locked')
     expect(setBusy.mock.calls).toEqual([[worktree.id], [null]])
   })
 
@@ -174,5 +187,99 @@ describe('useParallelWork handleDelete', () => {
     expect(window.electronAPI.gitWorktreeRemove).not.toHaveBeenCalled()
     expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(true)
     expect(setBusy).not.toHaveBeenCalled()
+  })
+
+  it('does not offer a destructive confirmation when status cannot be verified', async () => {
+    vi.mocked(window.electronAPI.gitWorktreeStatus).mockRejectedValueOnce(
+      new Error(`Error invoking remote method 'git:worktreeStatus': Error: runtime disconnected`),
+    )
+
+    await act(async () => {
+      await actions.handleDelete(worktree)
+    })
+
+    expect(window.confirm).not.toHaveBeenCalled()
+    expect(window.electronAPI.gitWorktreeRemove).not.toHaveBeenCalled()
+    expect(setError).toHaveBeenCalledWith(
+      'Couldn’t verify this worktree before discarding it: runtime disconnected',
+    )
+  })
+})
+
+describe('useParallelWork failure handling', () => {
+  it('strips IPC and raw push noise from publish errors', async () => {
+    vi.mocked(window.electronAPI.gitPush).mockRejectedValueOnce(
+      new Error(
+        `Error invoking remote method 'git:push': Error: ` +
+        `To github.com:owner/repo.git\n ! [rejected] feature -> feature (non-fast-forward)\n` +
+        `error: failed to push some refs`,
+      ),
+    )
+
+    await act(async () => {
+      await actions.handlePublish(worktree)
+    })
+
+    expect(setError).toHaveBeenCalledWith(
+      'Publish failed: The remote branch has newer commits. Update this worktree, then try publishing again.',
+    )
+  })
+
+  it('does not remove saved entries when cleanup cannot verify the primary worktree', async () => {
+    vi.mocked(window.electronAPI.gitWorktreeList).mockResolvedValueOnce([])
+
+    await act(async () => {
+      await actions.handlePrune()
+    })
+
+    expect(workspace().worktrees?.some((wt) => wt.id === worktree.id)).toBe(true)
+    expect(setError).toHaveBeenCalledWith(
+      'Couldn’t verify the live worktrees after cleanup. No saved entries were removed.',
+    )
+  })
+
+  it('does not create a duplicate PR when an existing PR temporarily cannot be loaded', () => {
+    actions.makeCallbacks({ ...worktree, prNumber: 525 }).onOpenPr(undefined)
+
+    expect(setError).toHaveBeenCalledWith(
+      'Couldn’t load PR #525. Check your GitHub connection and try again.',
+    )
+  })
+
+  it('refuses direct PR creation for a worktree that already belongs to a PR', async () => {
+    await act(async () => {
+      await actions.handleCreatePR({ ...worktree, prNumber: 525 })
+    })
+
+    expect(window.electronAPI.gitCreatePR).not.toHaveBeenCalled()
+    expect(setError).toHaveBeenCalledWith(
+      'This worktree already belongs to PR #525. Open that pull request instead.',
+    )
+  })
+
+  it('reports native menu and reveal failures through the popup error channel', async () => {
+    const callbacks = actions.makeCallbacks(worktree)
+    vi.mocked(window.electronAPI.showContextMenu).mockRejectedValueOnce(
+      new Error(`Error invoking remote method 'menu:showContext': Error: menu unavailable`),
+    )
+
+    await runWorktreeContextMenu({
+      isPrimary: false,
+      hasPr: false,
+      primaryLabel: 'main',
+      cb: callbacks,
+      beginRename: vi.fn(),
+      beginRecolor: vi.fn(),
+    })
+
+    expect(setError).toHaveBeenCalledWith('Couldn’t open worktree actions: menu unavailable')
+
+    vi.mocked(window.electronAPI.shellShowInFolder).mockRejectedValueOnce(
+      new Error(`Error invoking remote method 'shell:showInFolder': Error: folder missing`),
+    )
+    callbacks.onReveal()
+    await vi.waitFor(() => {
+      expect(setError).toHaveBeenCalledWith('Couldn’t reveal this worktree: folder missing')
+    })
   })
 })

--- a/src/renderer/stores/useParallelWork.ts
+++ b/src/renderer/stores/useParallelWork.ts
@@ -20,6 +20,8 @@ import type { WorktreeMeta } from '../../shared/types'
 import type { PrListItem } from '../sidebar/CreateWorktreeForm'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
 import { isLocalLocator } from '../../main/runtime/locator'
+import { errorMessage } from '../lib/errorMessage'
+import { pathKey } from '../../shared/pathUtils'
 
 /** Apply a color/label change to a worktree's UI metadata, creating the metadata
  *  record when none exists yet (a worktree discovered only from git has its path
@@ -39,6 +41,7 @@ function upsertWorktreeMeta(
     path: wt.path,
     color: patch.color ?? existing?.color ?? wt.color ?? '#888888',
     label: 'label' in patch ? patch.label : existing?.label ?? wt.label,
+    prNumber: existing?.prNumber ?? wt.prNumber,
   })
 }
 
@@ -66,7 +69,8 @@ export interface CardCallbacks {
   onReveal: () => void
   onRename: (label: string | undefined) => void
   onRecolor: (color: string) => void
-  onOpenPr: (url: string) => void
+  onOpenPr: (url?: string) => void
+  onError: (message: string) => void
 }
 
 /** Build + run the native "more actions" menu shared by the sidebar card and the
@@ -97,10 +101,16 @@ export async function runWorktreeContextMenu(opts: {
     items.push({ type: 'separator' })
     items.push({ id: 'delete', label: 'Discard this work…' })
   }
-  const choice = await window.electronAPI.showContextMenu(items)
+  let choice: string | null
+  try {
+    choice = await window.electronAPI.showContextMenu(items)
+  } catch (err: unknown) {
+    opts.cb.onError(`Couldn’t open worktree actions: ${errorMessage(err, 'The menu is unavailable.')}`)
+    return
+  }
   switch (choice) {
     case 'publish': opts.cb.onPublish(); break
-    case 'pr': if (opts.hasPr && opts.prUrl) opts.cb.onOpenPr(opts.prUrl); else opts.cb.onCreatePR(); break
+    case 'pr': if (opts.hasPr) opts.cb.onOpenPr(opts.prUrl); else opts.cb.onCreatePR(); break
     case 'update': opts.cb.onUpdateFromMain(); break
     case 'merge': opts.cb.onMerge(); break
     case 'reveal': opts.cb.onReveal(); break
@@ -168,8 +178,8 @@ export function useParallelWork(
       try {
         await window.electronAPI.gitPush(wt.path, 'origin', wt.branch, workspaceId ?? '')
         reconcile()
-      } catch (err: any) {
-        setError(`Publish failed: ${err?.message || err}`)
+      } catch (err: unknown) {
+        setError(`Publish failed: ${errorMessage(err, 'Couldn’t publish this branch.')}`)
       } finally {
         setBusy?.(null)
       }
@@ -180,6 +190,10 @@ export function useParallelWork(
   const handleCreatePR = useCallback(
     async (wt: JoinedWorktree) => {
       if (!wt.branch) return
+      if (wt.prNumber) {
+        setError(`This worktree already belongs to PR #${wt.prNumber}. Open that pull request instead.`)
+        return
+      }
       setError(null)
       setBusy?.(wt.id)
       try {
@@ -188,10 +202,10 @@ export function useParallelWork(
           window.electronAPI.openExternalUrl(res.url)
           onPrCreated?.()
         } else {
-          setError(res.message)
+          setError(errorMessage(res.message, 'Couldn’t create the pull request.'))
         }
-      } catch (err: any) {
-        setError(`Could not create pull request: ${err?.message || err}`)
+      } catch (err: unknown) {
+        setError(`Couldn’t create pull request: ${errorMessage(err, 'The operation failed.')}`)
       } finally {
         setBusy?.(null)
       }
@@ -210,14 +224,14 @@ export function useParallelWork(
           setError(
             result.conflict
               ? `Conflicts updating from ${target} — open a terminal here to resolve them.`
-              : `Update from ${target}: ${result.message}`,
+              : `Update from ${target}: ${errorMessage(result.message, 'The update failed.')}`,
           )
         } else {
           setError(null)
           reconcile()
         }
-      } catch (err: any) {
-        setError(err?.message || 'Update failed')
+      } catch (err: unknown) {
+        setError(`Update failed: ${errorMessage(err, 'The operation failed.')}`)
       } finally {
         setBusy?.(null)
       }
@@ -239,13 +253,13 @@ export function useParallelWork(
       try {
         const result = await window.electronAPI.gitWorktreeMergeTo(rootPath, wt.branch, target, workspaceId ?? '')
         if (!result.ok) {
-          setError(`Merge ${wt.branch} → ${target}: ${result.message}`)
+          setError(`Merge ${wt.branch} → ${target}: ${errorMessage(result.message, 'The merge failed.')}`)
         } else {
           setError(null)
           reconcile()
         }
-      } catch (err: any) {
-        setError(err?.message || 'Merge failed')
+      } catch (err: unknown) {
+        setError(`Merge failed: ${errorMessage(err, 'The operation failed.')}`)
       } finally {
         setBusy?.(null)
       }
@@ -262,8 +276,13 @@ export function useParallelWork(
       let status: WorktreeStatus | null = null
       try {
         status = await window.electronAPI.gitWorktreeStatus(wt.path, workspaceId)
-      } catch {
-        status = null
+      } catch (err: unknown) {
+        setError(`Couldn’t verify this worktree before discarding it: ${errorMessage(err, 'Status is unavailable.')}`)
+        return
+      }
+      if (!status) {
+        setError('Couldn’t verify this worktree before discarding it. No files were removed.')
+        return
       }
       const dirty = !!status?.dirty
       const branchAhead = (status?.ahead ?? 0) > 0
@@ -293,14 +312,14 @@ export function useParallelWork(
         if (wt.branch) {
           try {
             await window.electronAPI.gitBranchDelete(rootPath, wt.branch, true, workspaceId)
-          } catch (err: any) {
-            setError(`Removed, but branch ${wt.branch} could not be deleted: ${err?.message || err}`)
+          } catch (err: unknown) {
+            setError(`Removed, but branch ${wt.branch} could not be deleted: ${errorMessage(err, 'Branch deletion failed.')}`)
           }
         }
         removeWorktree(workspaceId, wt.id)
         reconcile()
-      } catch (err: any) {
-        setError(err?.message || 'Discard failed')
+      } catch (err: unknown) {
+        setError(`Discard failed: ${errorMessage(err, 'The worktree was not removed.')}`)
       } finally {
         setBusy?.(null)
       }
@@ -317,16 +336,22 @@ export function useParallelWork(
       // prune is a no-op for them — drop those stale entries from the store
       // explicitly, otherwise "Clean up" appears to do nothing.
       const list = await window.electronAPI.gitWorktreeList(rootPath, workspaceId)
-      const livePaths = new Set(list.map((g) => g.path))
+      if (!list.some((worktree) => pathKey(worktree.path) === pathKey(rootPath))) {
+        setError('Couldn’t verify the live worktrees after cleanup. No saved entries were removed.')
+        return
+      }
+      const livePaths = new Set(list.map((g) => pathKey(g.path)))
+      const rootKey = pathKey(rootPath)
       const ws = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
       for (const w of ws?.worktrees ?? []) {
-        if (w.path !== rootPath && !livePaths.has(w.path)) removeWorktree(workspaceId, w.id)
+        const worktreeKey = pathKey(w.path)
+        if (worktreeKey !== rootKey && !livePaths.has(worktreeKey)) removeWorktree(workspaceId, w.id)
       }
       reconcile()
-    } catch (err: any) {
-      setError(err?.message || 'Cleanup failed')
+    } catch (err: unknown) {
+      setError(`Cleanup failed: ${errorMessage(err, 'No saved entries were removed.')}`)
     }
-  }, [rootPath, workspaceId, removeWorktree, reconcile])
+  }, [rootPath, workspaceId, removeWorktree, reconcile, setError])
 
   const makeCallbacks = useCallback(
     (wt: JoinedWorktree): CardCallbacks => ({
@@ -337,12 +362,23 @@ export function useParallelWork(
       onMerge: () => handleMerge(wt),
       onDelete: () => handleDelete(wt),
       canReveal: isLocalLocator(wt.path),
-      onReveal: () => window.electronAPI.shellShowInFolder(wt.path, workspaceId ?? undefined),
+      onReveal: () => {
+        void window.electronAPI.shellShowInFolder(wt.path, workspaceId ?? undefined).catch((err: unknown) => {
+          setError(`Couldn’t reveal this worktree: ${errorMessage(err, 'The folder is unavailable.')}`)
+        })
+      },
       onRename: (label) => workspaceId && upsertWorktreeMeta(workspaceId, wt, { label: label?.trim() || undefined }),
       onRecolor: (color) => workspaceId && upsertWorktreeMeta(workspaceId, wt, { color }),
-      onOpenPr: (url) => window.electronAPI.openExternalUrl(url),
+      onOpenPr: (url) => {
+        if (url) window.electronAPI.openExternalUrl(url)
+        else {
+          const prLabel = wt.prNumber ? `PR #${wt.prNumber}` : 'the pull request'
+          setError(`Couldn’t load ${prLabel}. Check your GitHub connection and try again.`)
+        }
+      },
+      onError: setError,
     }),
-    [launchInWorktree, handlePublish, handleCreatePR, handleUpdateFromMain, handleMerge, handleDelete, workspaceId],
+    [launchInWorktree, handlePublish, handleCreatePR, handleUpdateFromMain, handleMerge, handleDelete, workspaceId, setError],
   )
 
   return {

--- a/src/renderer/stores/useWorktreeActions.test.tsx
+++ b/src/renderer/stores/useWorktreeActions.test.tsx
@@ -159,6 +159,7 @@ describe('useWorktreeActions', () => {
         id: 'wt-test',
         path: '/runtime/repo/.cate/worktrees/pr-42-fork-feature',
         label: '#42 fork/feature',
+        prNumber: 42,
       }),
     ]))
     expect(workspace().additionalRoots).toContain('/runtime/repo/.cate/worktrees/pr-42-fork-feature')

--- a/src/renderer/stores/useWorktreeActions.ts
+++ b/src/renderer/stores/useWorktreeActions.ts
@@ -97,6 +97,7 @@ export function useWorktreeActions(rootPath: string, workspaceId: string | null)
         id: newWorktreeId(),
         path: res.path,
         label: `#${pr.number} ${pr.headRefName}`,
+        prNumber: pr.number,
         color: pickWorktreeColor(ws?.worktrees ?? []),
       }
       upsertWorktree(workspaceId, meta)

--- a/src/renderer/stores/useWorktreeStatuses.test.tsx
+++ b/src/renderer/stores/useWorktreeStatuses.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { JoinedWorktree } from './useWorktrees'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('./gitStatusStore', () => ({
+  workspaceIdForRoot: () => 'ws-1',
+}))
+
+import { useWorktreeStatuses } from './useWorktreeStatuses'
+
+const worktree: JoinedWorktree = {
+  id: 'wt-pr',
+  path: '/repo/.cate/worktrees/pr-525',
+  branch: 'cate-pr-525',
+  prNumber: 525,
+  isPrimary: false,
+  isCurrent: false,
+  isOrphan: false,
+}
+
+let host: HTMLDivElement
+let root: Root
+
+function Probe(): React.ReactElement {
+  useWorktreeStatuses('/repo', [worktree])
+  return <div />
+}
+
+beforeEach(() => {
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    gitWorktreeStatus: vi.fn().mockResolvedValue(null),
+    gitPrStatus: vi.fn().mockResolvedValue(null),
+  }
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+})
+
+describe('useWorktreeStatuses', () => {
+  it('looks up an isolated checkout by its persisted PR number', async () => {
+    act(() => root.render(<Probe />))
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(window.electronAPI.gitPrStatus).toHaveBeenCalled()
+      })
+    })
+
+    expect(window.electronAPI.gitPrStatus).toHaveBeenCalledWith(
+      worktree.path,
+      '525',
+      'ws-1',
+    )
+  })
+})

--- a/src/renderer/stores/useWorktreeStatuses.ts
+++ b/src/renderer/stores/useWorktreeStatuses.ts
@@ -84,7 +84,10 @@ export function useWorktreeStatuses(rootPath: string, live: JoinedWorktree[]): U
   // PR status — only for non-primary branches, refetched when the branch set
   // changes or after a PR action (each lookup shells out to `gh`).
   const prKey = useMemo(
-    () => live.filter((w) => !w.isPrimary && w.branch).map((w) => `${w.path}:${w.branch}`).join('|'),
+    () => live
+      .filter((w) => !w.isPrimary && w.branch)
+      .map((w) => `${w.path}:${w.prNumber ?? w.branch}`)
+      .join('|'),
     [live],
   )
   useEffect(() => {
@@ -95,7 +98,8 @@ export function useWorktreeStatuses(rootPath: string, live: JoinedWorktree[]): U
       const entries = await Promise.all(
         targets.map(async (w) => {
           try {
-            const pr = await window.electronAPI.gitPrStatus(w.path, w.branch, workspaceIdForRoot(rootPath))
+            const prRef = w.prNumber ? String(w.prNumber) : w.branch
+            const pr = await window.electronAPI.gitPrStatus(w.path, prRef, workspaceIdForRoot(rootPath))
             return pr ? ([w.path, pr] as const) : null
           } catch {
             return null

--- a/src/renderer/stores/useWorktrees.test.tsx
+++ b/src/renderer/stores/useWorktrees.test.tsx
@@ -39,7 +39,7 @@ import { useAppStore } from './appStore'
 const WS = 'ws-1'
 const ROOT = '/repo'
 
-function setWorkspace(worktrees: Array<{ id: string; path: string; color?: string; label?: string }>) {
+function setWorkspace(worktrees: Array<{ id: string; path: string; color?: string; label?: string; prNumber?: number }>) {
   useAppStore.setState({
     workspaces: [{ id: WS, rootPath: ROOT, worktrees } as any],
   } as any)
@@ -98,7 +98,7 @@ afterEach(() => {
 describe('useWorktrees', () => {
   it('joins live git facts with persisted UI metadata and mounts without a loop', () => {
     setWorkspace([
-      { id: 'meta-feat', path: '/repo/.cate/worktrees/feat', color: '#f00', label: 'Feature' },
+      { id: 'meta-feat', path: '/repo/.cate/worktrees/feat', color: '#f00', label: 'Feature', prNumber: 42 },
     ])
     mount()
     expect(renderCount).toBeLessThanOrEqual(2)
@@ -112,6 +112,7 @@ describe('useWorktrees', () => {
     expect(feat.id).toBe('meta-feat')
     expect(feat.color).toBe('#f00')
     expect(feat.label).toBe('Feature')
+    expect(feat.prNumber).toBe(42)
     expect(feat.isOrphan).toBe(false)
   })
 

--- a/src/renderer/stores/useWorktrees.ts
+++ b/src/renderer/stores/useWorktrees.ts
@@ -11,7 +11,7 @@
 // UI metadata (id/color/label) keyed by path. This hook joins the two so every
 // consumer derives the same view from one source.
 //
-// appStore.worktrees persists ONLY UI metadata (id/color/label) keyed by path;
+// appStore.worktrees persists ONLY managed metadata (id/color/label/PR identity) keyed by path;
 // the live git facts (branch/isPrimary/isCurrent) come from gitStatusStore and
 // are joined on here at read time, so they can never drift from the repo.
 // =============================================================================
@@ -38,6 +38,8 @@ export interface JoinedWorktree {
   color?: string
   /** Friendly label from persisted metadata, if any. */
   label?: string
+  /** Pull request this worktree was created from, if any. */
+  prNumber?: number
   /** True when there is persisted metadata but no live git worktree (orphan). */
   isOrphan: boolean
 }
@@ -68,6 +70,7 @@ export function useWorktrees(rootPath: string, workspaceId: string): JoinedWorkt
         isCurrent: g.isCurrent,
         color: m?.color,
         label: m?.label,
+        prNumber: m?.prNumber,
         isOrphan: false,
       }
     })
@@ -85,6 +88,7 @@ export function useWorktrees(rootPath: string, workspaceId: string): JoinedWorkt
         isCurrent: false,
         color: m.color,
         label: m.label,
+        prNumber: m.prNumber,
         isOrphan: true,
       })
     }

--- a/src/runtime/capabilities/vcs.ts
+++ b/src/runtime/capabilities/vcs.ts
@@ -172,6 +172,33 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
     }
   }
 
+  async function availablePrBranch(git: ReturnType<typeof simpleGit>, prNumber: number): Promise<string> {
+    const base = `cate-pr-${prNumber}`
+    const existing = new Set((await git.branchLocal()).all)
+    const conflicts = (candidate: string) =>
+      existing.has(candidate) || [...existing].some((branch) => branch.startsWith(`${candidate}/`))
+    let branch = base
+    for (let suffix = 2; conflicts(branch); suffix += 1) branch = `${base}-${suffix}`
+    return branch
+  }
+
+  function prCheckoutError(prNumber: number, error: unknown): Error {
+    const detail = [
+      error instanceof Error ? error.message : String(error),
+      typeof error === 'object' && error && 'stderr' in error ? String(error.stderr) : '',
+    ].join('\n')
+    if (/authentication|not authenticated|auth login|not logged|HTTP 401|HTTP 403/i.test(detail)) {
+      return new Error(`GitHub CLI isn’t authenticated. Run “gh auth login”, then try PR #${prNumber} again.`)
+    }
+    if (/could not resolve to a pull request|no pull requests found|pull request.*not found/i.test(detail)) {
+      return new Error(`Pull request #${prNumber} could not be found. It may have been closed or removed.`)
+    }
+    if (/ETIMEDOUT|timed out|network|ENOTFOUND|ECONNRESET|could not resolve host/i.test(detail)) {
+      return new Error(`Couldn’t reach GitHub while checking out PR #${prNumber}. Check your connection and try again.`)
+    }
+    return new Error(`Couldn’t check out PR #${prNumber}. Check that GitHub CLI can access this repository, then try again.`)
+  }
+
   async function ensureContainingDir(targetPath: string): Promise<void> {
     const containingDir = path.dirname(targetPath)
     await fsp.mkdir(containingDir, { recursive: true })
@@ -358,17 +385,32 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
       const git = simpleGit(validRepo)
       if (!(await ghAvailable(validRepo))) throw new Error('GitHub CLI (gh) is required to check out pull requests.')
       await ensureContainingDir(targetPath)
-      await git.raw(['worktree', 'add', '--detach', targetPath])
+      const branch = await availablePrBranch(git, prNumber)
+      try {
+        await git.raw(['worktree', 'add', '--detach', targetPath])
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        if (/already exists|already checked out|already registered/i.test(detail)) {
+          throw new Error(`A worktree for PR #${prNumber} already exists. Remove it or run Clean up, then try again.`)
+        }
+        throw new Error(`Couldn’t create a worktree for PR #${prNumber}. Check that the repository is writable and try again.`)
+      }
       addWorktreeRoot(targetPath, repoCwd)
       try {
-        await execFileP('gh', ['pr', 'checkout', String(prNumber)], { cwd: targetPath, timeout: 120000, env: env() })
+        // Never let gh reuse the contributor's local branch: it may have
+        // diverged, be checked out elsewhere, or contain unpublished work.
+        await execFileP('gh', ['pr', 'checkout', String(prNumber), '--branch', branch], {
+          cwd: targetPath,
+          timeout: 120000,
+          env: env(),
+        })
       } catch (error) {
         await git.raw(['worktree', 'remove', '--force', targetPath]).catch(() => {})
+        await git.branch(['-D', branch]).catch(() => {})
         await fsp.rm(targetPath, { recursive: true, force: true }).catch(() => {})
         removeAllowedRootFromAllScopes(targetPath)
-        throw new Error(`Could not check out PR #${prNumber}: ${error instanceof Error ? error.message : String(error)}`)
+        throw prCheckoutError(prNumber, error)
       }
-      const branch = (await simpleGit(targetPath).raw(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
       await linkWorktreePaths(validRepo, targetPath, options?.symlinkPaths)
       return { path: targetPath, branch }
     },
@@ -415,26 +457,67 @@ export function createVcsCapability(deps: VcsCapabilityDeps): VcsHost {
       }
     },
     async worktreeMergeTo(repoCwd, fromBranch, toBranch, access) {
+      const git = simpleGit(validateCwd(repoCwd, access))
       try {
-        const git = simpleGit(validateCwd(repoCwd, access))
-        await git.fetch()
+        if ((await git.status()).files.length > 0) {
+          return {
+            ok: false,
+            conflict: false,
+            message: `Commit or stash changes in ${toBranch} before merging into it.`,
+          }
+        }
         await git.checkout(toBranch)
         const result = await git.merge([fromBranch, '--no-edit'])
         return { ok: true, result }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error)
-        return { ok: false, conflict: /CONFLICT|conflict/.test(msg), message: msg }
+        const mergeInProgress = await git.raw(['rev-parse', '-q', '--verify', 'MERGE_HEAD']).then(
+          () => true,
+          () => false,
+        )
+        if (/CONFLICT|conflict/.test(msg) || mergeInProgress) {
+          const aborted = await git.raw(['merge', '--abort']).then(
+            () => true,
+            () => false,
+          )
+          return {
+            ok: false,
+            conflict: true,
+            message: aborted
+              ? 'The branches have conflicting changes. The merge was aborted.'
+              : `The branches have conflicting changes. Open a terminal in ${toBranch} to resolve or abort the merge.`,
+          }
+        }
+        return {
+          ok: false,
+          conflict: false,
+          message: `Couldn’t merge ${fromBranch} into ${toBranch}. Make sure both branches still exist.`,
+        }
       }
     },
     async worktreeUpdateFrom(worktreePath, fromBranch, access) {
       try {
         const git = simpleGit(validateCwd(worktreePath, access))
+        if ((await git.status()).files.length > 0) {
+          return {
+            ok: false,
+            conflict: false,
+            message: `Commit or stash changes before updating from ${fromBranch}.`,
+          }
+        }
         await git.fetch().catch(() => {})
         const result = await git.merge([fromBranch, '--no-edit'])
         return { ok: true, result }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error)
-        return { ok: false, conflict: /CONFLICT|conflict/.test(msg), message: msg }
+        const conflict = /CONFLICT|conflict/.test(msg)
+        return {
+          ok: false,
+          conflict,
+          message: conflict
+            ? 'The branches have conflicting changes.'
+            : `Couldn’t update from ${fromBranch}. Make sure the branch still exists.`,
+        }
       }
     },
     async createPr(worktreePath, branch, access) {

--- a/src/runtime/capabilities/vcs.worktreeMerge.test.ts
+++ b/src/runtime/capabilities/vcs.worktreeMerge.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { simpleGit } from 'simple-git'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { createVcsCapability } from './vcs'
+
+const access = { scopeId: 'vcs-merge-test' }
+
+describe('vcs.worktreeMergeTo', () => {
+  let root: string
+  let primaryBranch: string
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-vcs-merge-'))
+    const git = simpleGit(root)
+    await git.init()
+    await git.addConfig('user.name', 'Cate Test')
+    await git.addConfig('user.email', 'cate@example.test')
+    await fs.writeFile(path.join(root, 'shared.txt'), 'base\n')
+    await git.add('shared.txt')
+    await git.commit('initial')
+    primaryBranch = (await git.branchLocal()).current
+    await git.checkoutLocalBranch('feature')
+    await fs.writeFile(path.join(root, 'shared.txt'), 'feature\n')
+    await git.add('shared.txt')
+    await git.commit('feature change')
+    await git.checkout(primaryBranch)
+  })
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  function vcs() {
+    return createVcsCapability({ env: () => process.env, scopeId: 'vcs-merge-test' })
+  }
+
+  test('refuses to merge over uncommitted primary-worktree changes', async () => {
+    await fs.writeFile(path.join(root, 'local.txt'), 'uncommitted\n')
+
+    const result = await vcs().worktreeMergeTo(root, 'feature', primaryBranch, access)
+
+    expect(result).toEqual({
+      ok: false,
+      conflict: false,
+      message: `Commit or stash changes in ${primaryBranch} before merging into it.`,
+    })
+    expect((await simpleGit(root).status()).files).toHaveLength(1)
+  })
+
+  test('aborts a conflicting merge and restores a clean primary worktree', async () => {
+    const git = simpleGit(root)
+    await fs.writeFile(path.join(root, 'shared.txt'), 'primary\n')
+    await git.add('shared.txt')
+    await git.commit('primary change')
+
+    const result = await vcs().worktreeMergeTo(root, 'feature', primaryBranch, access)
+
+    expect(result).toEqual({
+      ok: false,
+      conflict: true,
+      message: 'The branches have conflicting changes. The merge was aborted.',
+    })
+    expect((await git.status()).files).toHaveLength(0)
+    await expect(fs.stat(path.join(root, '.git', 'MERGE_HEAD'))).rejects.toMatchObject({ code: 'ENOENT' })
+    expect((await git.branchLocal()).current).toBe(primaryBranch)
+  })
+})

--- a/src/runtime/capabilities/vcs.worktreePr.test.ts
+++ b/src/runtime/capabilities/vcs.worktreePr.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { simpleGit } from 'simple-git'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { createVcsCapability } from './vcs'
+
+const posixTest = process.platform === 'win32' ? test.skip : test
+const access = { scopeId: 'vcs-pr-test' }
+
+describe('vcs.worktreeAddFromPr', () => {
+  let root: string
+  let binDir: string
+  let target: string
+  let failCheckout = false
+
+  beforeEach(async () => {
+    failCheckout = false
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-vcs-pr-'))
+    binDir = path.join(root, 'bin')
+    target = path.join(root, '.cate', 'worktrees', 'pr-525-feature')
+    await fs.mkdir(binDir)
+    await fs.writeFile(path.join(binDir, 'gh'), `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version test"
+  exit 0
+fi
+if [ "$CATE_TEST_GH_FAIL" = "1" ]; then
+  echo "hint: Diverging branches can't be fast-forwarded" >&2
+  echo "fatal: Not possible to fast-forward, aborting." >&2
+  exit 1
+fi
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--branch" ]; then branch="$argument"; fi
+  previous="$argument"
+done
+git switch --create "$branch"
+`)
+    await fs.chmod(path.join(binDir, 'gh'), 0o755)
+
+    const git = simpleGit(root)
+    await git.init()
+    await git.addConfig('user.name', 'Cate Test')
+    await git.addConfig('user.email', 'cate@example.test')
+    await fs.writeFile(path.join(root, 'README.md'), 'initial\n')
+    await git.add('README.md')
+    await git.commit('initial')
+    const primaryBranch = (await git.branchLocal()).current
+    await git.branch(['feature'])
+    await git.checkout('feature')
+    await fs.writeFile(path.join(root, 'FEATURE.md'), 'contributor work\n')
+    await git.add('FEATURE.md')
+    await git.commit('feature work')
+    await git.checkout(primaryBranch)
+    await fs.writeFile(path.join(root, 'README.md'), 'main moved on\n')
+    await git.add('README.md')
+    await git.commit('main work')
+  })
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  function vcs() {
+    return createVcsCapability({
+      env: () => ({
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        CATE_TEST_GH_FAIL: failCheckout ? '1' : '0',
+      }),
+      scopeId: 'vcs-pr-test',
+    })
+  }
+
+  posixTest('uses an isolated branch instead of the PR head branch', async () => {
+    const result = await vcs().worktreeAddFromPr(root, 525, target, undefined, access)
+
+    expect(result).toEqual({ path: target, branch: 'cate-pr-525' })
+    expect((await simpleGit(target).branchLocal()).current).toBe('cate-pr-525')
+    expect((await simpleGit(root).branchLocal()).all).toContain('feature')
+  })
+
+  posixTest('chooses a fresh suffix when a previous Cate PR branch exists', async () => {
+    await simpleGit(root).branch(['cate-pr-525'])
+
+    const result = await vcs().worktreeAddFromPr(root, 525, target, undefined, access)
+
+    expect(result.branch).toBe('cate-pr-525-2')
+  })
+
+  posixTest('removes the partial worktree and returns a concise checkout error', async () => {
+    failCheckout = true
+
+    await expect(vcs().worktreeAddFromPr(root, 525, target, undefined, access)).rejects.toThrow(
+      'Couldn’t check out PR #525. Check that GitHub CLI can access this repository, then try again.',
+    )
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect((await simpleGit(root).branchLocal()).all).not.toContain('cate-pr-525')
+  })
+})

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -138,7 +138,7 @@ export interface PanelState {
 // -----------------------------------------------------------------------------
 // Worktree metadata — per-workspace registry of UI-owned facts about the git
 // worktrees Cate manages, keyed by worktree path. This persists ONLY the UI
-// metadata (id/color/label). The live facts (branch / isPrimary / isCurrent)
+// metadata (id/color/label/PR identity). The live facts (branch / isPrimary / isCurrent)
 // are authoritative from `git worktree list` (owned by gitStatusStore) and are
 // joined onto this metadata at read time by useWorktrees — they are never
 // persisted here, so they can't drift out of sync with the repo.
@@ -153,6 +153,8 @@ export interface WorktreeMeta {
   color: string
   /** Optional friendly label shown in the sidebar in place of the branch. */
   label?: string
+  /** Pull request this worktree was created from, if any. */
+  prNumber?: number
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes flaky worktree actions and replaces raw Git errors with clear messages.

Also makes merge, cleanup, discard, and PR checkout safer.

Checked with focused tests, typecheck, lint, and a production build.
