### PR TITLE
Fix stuck canvas input after gesture unmount

### DIFF
--- a/src/renderer/hooks/gestureBlurCancel.test.tsx
+++ b/src/renderer/hooks/gestureBlurCancel.test.tsx
@@ -191,6 +191,21 @@ describe('pan — window-level cleanup', () => {
     expect(bodyClassRefCount('canvas-interacting')).toBe(0)
     expect(document.body.classList.contains('canvas-interacting')).toBe(false)
   })
+
+  it('releases the interaction lock when the canvas unmounts mid-pan', () => {
+    const store = freshStore()
+    const el = renderPanProbe(store)
+
+    mouseDownOn(el, 2, 100, 100)
+    expect(bodyClassRefCount('canvas-interacting')).toBe(1)
+
+    // App.tsx keys the canvas subtree by workspace/reload epoch, so switching
+    // workspace or reloading its layout can unmount it before mouseup/blur.
+    act(() => root.render(<></>))
+
+    expect(bodyClassRefCount('canvas-interacting')).toBe(0)
+    expect(document.body.classList.contains('canvas-interacting')).toBe(false)
+  })
 })
 
 // =============================================================================
@@ -242,6 +257,24 @@ describe('resize — blur cancellation', () => {
     act(() => window.dispatchEvent(new MouseEvent('mousemove', { clientX: 900, clientY: 300, bubbles: true })))
     flushRaf()
     expect(store.getState().nodes['A'].size.width).toBe(widthAfterMove)
+  })
+
+  it('releases the interaction lock when the resize owner unmounts mid-gesture', () => {
+    const store = freshStore()
+    addNode(store, 'A', { x: 100, y: 100 }, { width: 500, height: 400 })
+    act(() => root.render(<ResizeProbe nodeId="A" edge="right" panelType="editor" store={store} />))
+    const handle = container.querySelector<HTMLElement>('[data-testid="resize-handle"]')!
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 600, clientY: 300, bubbles: true }))
+    })
+    expect(bodyClassRefCount('canvas-interacting')).toBe(1)
+
+    act(() => root.render(<></>))
+
+    expect(bodyClassRefCount('canvas-interacting')).toBe(0)
+    expect(document.body.classList.contains('canvas-interacting')).toBe(false)
+    expect(document.body.style.cursor).toBe('')
   })
 })
 

--- a/src/renderer/hooks/useCanvasInteraction.gesture.test.tsx
+++ b/src/renderer/hooks/useCanvasInteraction.gesture.test.tsx
@@ -535,6 +535,19 @@ describe('marquee selection', () => {
     act(() => window.dispatchEvent(new Event('blur')))
     expect(document.body.classList.contains('canvas-interacting')).toBe(false)
   })
+
+  it('releases canvas-interacting if the canvas unmounts mid-marquee', () => {
+    const { el } = setupScene()
+
+    leftDown(el, 100, 100)
+    winMove(140, 140)
+    expect(document.body.classList.contains('canvas-interacting')).toBe(true)
+
+    act(() => root.render(<></>))
+
+    expect(document.body.classList.contains('canvas-interacting')).toBe(false)
+    expect(useUIStore.getState().marquee).toBeNull()
+  })
 })
 
 // =============================================================================

--- a/src/renderer/hooks/useCanvasInteraction.ts
+++ b/src/renderer/hooks/useCanvasInteraction.ts
@@ -77,6 +77,11 @@ export function useCanvasInteraction(
   // We add the class when a wheel pan starts and remove it after the wheel goes quiet.
   const wheelPanActive = useRef(false)
   const wheelPanEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelMarqueeRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    return () => cancelMarqueeRef.current?.()
+  }, [])
 
   const [canvasContextMenu, setCanvasContextMenu] =
     useState<CanvasContextMenuState | null>(null)
@@ -412,6 +417,7 @@ export function useCanvasInteraction(
     return () => {
       window.removeEventListener('mouseup', onWindowMouseUp)
       window.removeEventListener('blur', onWindowBlur)
+      endPanDrag()
     }
   }, [endPanDrag])
 
@@ -525,6 +531,9 @@ export function useCanvasInteraction(
             window.removeEventListener('mousemove', handleMarqueeMove)
             window.removeEventListener('mouseup', handleMarqueeUp)
             window.removeEventListener('blur', handleMarqueeBlur)
+            if (cancelMarqueeRef.current === handleMarqueeBlur) {
+              cancelMarqueeRef.current = null
+            }
             if (acquiredInteracting) {
               releaseBodyClass('canvas-interacting')
               acquiredInteracting = false
@@ -575,6 +584,7 @@ export function useCanvasInteraction(
             canvasStoreApi.getState().selectNodes(hitNodeIds, true)
           }
 
+          cancelMarqueeRef.current = handleMarqueeBlur
           window.addEventListener('mousemove', handleMarqueeMove)
           window.addEventListener('mouseup', handleMarqueeUp)
           window.addEventListener('blur', handleMarqueeBlur)

--- a/src/renderer/hooks/useNodeResize.ts
+++ b/src/renderer/hooks/useNodeResize.ts
@@ -4,7 +4,7 @@
 // resizes both simultaneously.
 // =============================================================================
 
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type { StoreApi } from 'zustand'
 import type { CanvasStore } from '../stores/canvasStore'
 import { useAppStore } from '../stores/appStore'
@@ -72,6 +72,11 @@ export function useNodeResize(
   const currentEdgeRef = useRef<ResizeEdge | null>(null)
   const rafId = useRef<number>(0)
   const pendingResize = useRef<PendingResize | null>(null)
+  const cancelResizeRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    return () => cancelResizeRef.current?.()
+  }, [])
 
   // Shared border state
   const sharedBordersRef = useRef<SharedBorder[]>([])
@@ -408,6 +413,9 @@ export function useNodeResize(
         window.removeEventListener('mousemove', handleMouseMove)
         window.removeEventListener('mouseup', handleMouseUp)
         window.removeEventListener('blur', handleBlur)
+        if (cancelResizeRef.current === handleBlur) {
+          cancelResizeRef.current = null
+        }
         document.body.style.cursor = previousBodyCursor
         unpinCursor()
       }
@@ -471,6 +479,7 @@ export function useNodeResize(
         pendingResize.current = null
       }
 
+      cancelResizeRef.current = handleBlur
       window.addEventListener('mousemove', handleMouseMove)
       window.addEventListener('mouseup', handleMouseUp)
       window.addEventListener('blur', handleBlur)


### PR DESCRIPTION
## What changed
- release the shared `canvas-interacting` lock when canvas pan or marquee owners unmount
- cancel active node resize on unmount, removing window listeners and restoring the document cursor
- add regression coverage for pan, marquee, and resize unmount paths

## Root cause
Canvas gestures intentionally set `body.canvas-interacting` to make embedded terminal, editor, and browser content transparent during gestures. Mouseup and blur paths released it, but React subtree unmounts did not. A workspace/layout remount or node error during an active gesture could therefore strand the class. That disabled xterm pointer events and made `useDragOp` reject new panel drags, while the external resize handles kept working.

## Impact
Terminals remain scrollable and panels remain draggable after workspace/layout remounts or node teardown interrupts a gesture.

## Validation
- `npm test -- --run src/renderer/hooks/gestureBlurCancel.test.tsx src/renderer/hooks/useCanvasInteraction.gesture.test.tsx src/renderer/hooks/useNodeResize.gesture.test.tsx` — 46 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- scoped ESLint — 0 errors; 7 pre-existing hook-dependency warnings
- full `npm test` — 2,963 passed; one unrelated `local-daemon-tarball` fixture failure because its generated workspace path was rejected as outside the allowed directories