### PR TITLE
chore(release): bump version to 1.6.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.5.3",
+  "version": "1.6.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.5.3",
+      "version": "1.6.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.5.3",
+  "version": "1.6.0-beta.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.5.3'
+export const RUNTIME_VERSION = '1.6.0-beta.1'


### PR DESCRIPTION
## Summary

Bump Cate's application, lockfile, and runtime artifact version to `1.6.0-beta.1` for the first 1.6.0 beta release.

`RUNTIME_VERSION` remains aligned with the application version so the client resolves the matching runtime tarballs from the `v1.6.0-beta.1` prerelease.

## Impact

Pushing `v1.6.0-beta.1` from the merged commit will trigger the release workflow and publish the build as a GitHub prerelease for users who opt into beta updates.

## Validation

- `npm run build:runtime`
- `npm run build`
- `npm run typecheck`
- `git diff --check`
