### PR TITLE
chore(release): bump version to 1.6.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.0-beta.1",
+      "version": "1.6.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.0-beta.1'
+export const RUNTIME_VERSION = '1.6.0-beta.2'


### PR DESCRIPTION
## What changed

- bump the Cate application version from `1.6.0-beta.1` to `1.6.0-beta.2`
- keep the package lock and bundled runtime version aligned with the application version

## Why

Prepare the next 1.6.0 beta release and its matching runtime artifacts.

## Impact

Release builds and runtime artifact lookup will use the `1.6.0-beta.2` version and tag.

## Validation

- `npm run build:runtime` — passed
- `npm run typecheck` — passed
- `npx vitest run src/main/semver.test.ts src/shared/runtimeConnection.test.ts` — 11 tests passed
- `git diff --check` — passed

Local `.codex/` and `plan.md` files are intentionally excluded.
