### PR TITLE
Reject relative remote workspace paths

### DIFF
--- a/src/main/ipc/runtime-transport.test.ts
+++ b/src/main/ipc/runtime-transport.test.ts
@@ -90,6 +90,15 @@ describe('listWslDistros', () => {
 })
 
 describe('buildTransport', () => {
+  test.each([
+    { kind: 'wsl' as const, distro: 'Ubuntu', distroPath: '~/project' },
+    { kind: 'server' as const, host: 'host', user: 'user', remotePath: 'project' },
+  ])('rejects a relative $kind workspace path', async (spec) => {
+    await expect(buildTransport('runtime_relative', spec)).rejects.toThrow(
+      'Remote workspace path must be an absolute POSIX path',
+    )
+  })
+
   test('rejects a WSL spec on a non-Windows host with a clear message', async () => {
     setPlatform('darwin')
     await expect(

--- a/src/main/ipc/runtime.ts
+++ b/src/main/ipc/runtime.ts
@@ -37,7 +37,7 @@ import type {
   SshHostEntry,
 } from '../../shared/types'
 import { broadcastToAll } from '../windowRegistry'
-import { formatLocator } from '../../shared/runtimeLocator'
+import { assertAbsoluteRuntimePath, formatLocator } from '../../shared/runtimeLocator'
 import {
   isRemoteRuntimeConnection,
   remoteConnectSpecFromConnection,
@@ -157,6 +157,7 @@ export function mintRuntimeId(spec: RemoteConnectSpec): string {
  *  from the GitHub release, with a client-side SFTP/copy fallback — see
  *  runtimeArtifacts.ts), so nothing runtime-related ships with the app. */
 export async function buildTransport(runtimeId: string, spec: RemoteConnectSpec): Promise<RuntimeTransport> {
+  assertAbsoluteRuntimePath(spec.kind === 'server' ? spec.remotePath : spec.distroPath)
   if (spec.kind === 'wsl') {
     // Guard before we hand off to the transport so the failure is a clear
     // message rather than a raw wsl.exe ENOENT / "no distribution" error.
@@ -227,8 +228,10 @@ export function registerRuntimeHandlers(): void {
   // determined there and streamed back as phases. Keeps state purely
   // probe-driven instead of inferred from this call.
   ipcMain.handle(RUNTIME_CONNECT, async (_event, spec: RemoteConnectSpec): Promise<RuntimeConnectResult> => {
-    const runtimeId = mintRuntimeId(spec)
     try {
+      const remotePath = spec.kind === 'server' ? spec.remotePath : spec.distroPath
+      assertAbsoluteRuntimePath(remotePath)
+      const runtimeId = mintRuntimeId(spec)
       if (spec.kind === 'server' && spec.auth && (spec.auth.passphrase || spec.auth.keyPath || spec.auth.useAgent)) {
         await saveSshSecret(runtimeId, {
           passphrase: spec.auth.passphrase,
@@ -237,12 +240,11 @@ export function registerRuntimeHandlers(): void {
         })
       }
       const connection = runtimeConnectionFromSpec(runtimeId, spec)
-      const remotePath = runtimeConnectionPath(connection)
       const rootPath = formatLocator({ runtimeId, path: remotePath })
       return { ok: true, runtimeId, rootPath, connection }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      log.warn('[runtime:connect] %s failed: %s', runtimeId, message)
+      log.warn('[runtime:connect] failed: %s', message)
       return { ok: false, error: message }
     }
   })
@@ -254,7 +256,15 @@ export function registerRuntimeHandlers(): void {
     if (!isRemoteRuntimeConnection(connection)) return { ok: false, error: 'local connection needs no runtime' }
     const { runtimeId } = connection
     const remotePath = runtimeConnectionPath(connection)
-    const rootPath = formatLocator({ runtimeId, path: remotePath })
+    let rootPath: string
+    try {
+      rootPath = formatLocator({ runtimeId, path: remotePath })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      runtimes.report(runtimeId, 'unreachable', message)
+      log.warn('[runtime:ensure] %s rejected: %s', runtimeId, message)
+      return { ok: false, error: message }
+    }
     // isConnected (not has): connect() now registers a DeferredRuntime
     // synchronously while connecting, so has() would be true mid-connect too. Only
     // short-circuit when FULLY connected; an in-flight connect falls through to
@@ -299,7 +309,15 @@ export function registerRuntimeHandlers(): void {
     if (!isRemoteRuntimeConnection(connection)) return { ok: false, error: 'the local runtime has nothing to install' }
     const { runtimeId } = connection
     const remotePath = runtimeConnectionPath(connection)
-    const rootPath = formatLocator({ runtimeId, path: remotePath })
+    let rootPath: string
+    try {
+      rootPath = formatLocator({ runtimeId, path: remotePath })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      runtimes.report(runtimeId, 'unreachable', message)
+      log.warn('[runtime:install] %s rejected: %s', runtimeId, message)
+      return { ok: false, error: message }
+    }
     await runtimes.disposeConnection(runtimeId)
     let transport: RuntimeTransport
     try {

--- a/src/renderer/ui/RemoteConnect.test.ts
+++ b/src/renderer/ui/RemoteConnect.test.ts
@@ -42,6 +42,19 @@ describe('buildConnectSpec', () => {
     const spec = buildConnectSpec('wsl', { ...base, host: 'ignored', distro: ' Ubuntu-22.04 ', distroPath: ' /home/me/proj ' })
     expect(spec).toEqual({ kind: 'wsl', distro: 'Ubuntu-22.04', distroPath: '/home/me/proj' })
   })
+
+  test.each(['~/project', 'home/user/project', 'cwd'])(
+    'rejects a relative WSL path (%s)',
+    (distroPath) => {
+      expect(() => buildConnectSpec('wsl', { ...base, distro: 'Ubuntu', distroPath }))
+        .toThrow('Remote workspace path must be an absolute POSIX path')
+    },
+  )
+
+  test('rejects a relative SSH path', () => {
+    expect(() => buildConnectSpec('server', { ...base, host: 'h', user: 'u', remotePath: 'project' }))
+      .toThrow('Remote workspace path must be an absolute POSIX path')
+  })
 })
 
 describe('parseSshTarget', () => {

--- a/src/renderer/ui/RemoteConnect.tsx
+++ b/src/renderer/ui/RemoteConnect.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react'
 import { CaretRight } from '@phosphor-icons/react'
 import type { RemoteConnectSpec, SshHostEntry } from '../../shared/types'
+import {
+  ABSOLUTE_RUNTIME_PATH_ERROR,
+  assertAbsoluteRuntimePath,
+  isAbsoluteRuntimePath,
+} from '../../shared/runtimeLocator'
 import { btn, inputCls, SEGMENT } from './Modal'
 
 // In-panel connect form (no modal) for a remote SSH server or a WSL distro.
@@ -29,15 +34,19 @@ export interface RemoteConnectFields {
 /** Pure: assemble a validated RemoteConnectSpec from raw form fields. */
 export function buildConnectSpec(kind: Kind, f: RemoteConnectFields): RemoteConnectSpec {
   if (kind === 'wsl') {
-    return { kind: 'wsl', distro: f.distro.trim(), distroPath: f.distroPath.trim() }
+    const distroPath = f.distroPath.trim()
+    assertAbsoluteRuntimePath(distroPath)
+    return { kind: 'wsl', distro: f.distro.trim(), distroPath }
   }
+  const remotePath = f.remotePath.trim()
+  assertAbsoluteRuntimePath(remotePath)
   const portNum = f.port.trim() ? Number(f.port.trim()) : undefined
   return {
     kind: 'server',
     host: f.host.trim(),
     user: f.user.trim(),
     port: portNum !== undefined && Number.isFinite(portNum) ? portNum : undefined,
-    remotePath: f.remotePath.trim(),
+    remotePath,
     auth: {
       keyPath: f.keyPath.trim() || undefined,
       passphrase: f.passphrase || undefined,
@@ -163,8 +172,13 @@ export function RemoteConnect({
   }
 
   const parsed = parseSshTarget(target)
+  const activePath = (kind === 'server' ? remotePath : distroPath).trim()
+  const pathError = activePath && !isAbsoluteRuntimePath(activePath)
+    ? ABSOLUTE_RUNTIME_PATH_ERROR
+    : null
   const canSubmit =
     !pending &&
+    !pathError &&
     (kind === 'server'
       ? !!parsed.host && !!parsed.user && !!remotePath.trim()
       : (distros?.length ?? 0) > 0 && distro.trim() && distroPath.trim())
@@ -231,7 +245,9 @@ export function RemoteConnect({
             value={remotePath}
             onChange={(e) => setRemotePath(e.target.value)}
             placeholder="Remote path"
+            aria-invalid={!!pathError}
           />
+          {pathError && <div className="text-[12px] text-red-400 px-0.5">{pathError}</div>}
 
           <button
             type="button"
@@ -297,7 +313,9 @@ export function RemoteConnect({
             value={distroPath}
             onChange={(e) => setDistroPath(e.target.value)}
             placeholder="Path in distro"
+            aria-invalid={!!pathError}
           />
+          {pathError && <div className="text-[12px] text-red-400 px-0.5">{pathError}</div>}
         </>
       )}
 

--- a/src/shared/runtimeLocator.test.ts
+++ b/src/shared/runtimeLocator.test.ts
@@ -58,6 +58,19 @@ describe('locator', () => {
         'cate-runtime://srv_x/home/my%20proj/a%23b.ts',
       )
     })
+
+    test('preserves an authority-only locator', () => {
+      expect(formatLocator({ runtimeId: 'srv_x', path: '' })).toBe('cate-runtime://srv_x')
+    })
+
+    test.each(['~/project', 'home/user/project', 'cwd'])(
+      'rejects a relative remote path (%s)',
+      (path) => {
+        expect(() => formatLocator({ runtimeId: 'wsl_ubuntu', path })).toThrow(
+          'Remote workspace path must be an absolute POSIX path',
+        )
+      },
+    )
   })
 
   describe('round-trips', () => {

--- a/src/shared/runtimeLocator.ts
+++ b/src/shared/runtimeLocator.ts
@@ -25,6 +25,9 @@ export type RuntimeId = string
 /** The id of the always-present in-process runtime (the local machine). */
 export const LOCAL_RUNTIME_ID = 'local'
 
+export const ABSOLUTE_RUNTIME_PATH_ERROR =
+  'Remote workspace path must be an absolute POSIX path starting with "/"'
+
 export interface ResourceLocator {
   /** Routing key. `LOCAL_RUNTIME_ID` for bare paths. */
   runtimeId: string
@@ -41,6 +44,15 @@ function encodePath(p: string): string {
 
 function decodePath(p: string): string {
   return p.split('/').map(decodeURIComponent).join('/')
+}
+
+/** Runtime hosts are POSIX; their workspace roots must be absolute. */
+export function isAbsoluteRuntimePath(path: string): boolean {
+  return path.startsWith('/')
+}
+
+export function assertAbsoluteRuntimePath(path: string): void {
+  if (!isAbsoluteRuntimePath(path)) throw new Error(ABSOLUTE_RUNTIME_PATH_ERROR)
 }
 
 /**
@@ -74,6 +86,9 @@ export function formatLocator(loc: ResourceLocator): string {
   if (loc.runtimeId === LOCAL_RUNTIME_ID) {
     return loc.path
   }
+  // An empty path is the existing authority-only representation. Real remote
+  // workspace locators carry a path and must keep the absolute-path invariant.
+  if (loc.path) assertAbsoluteRuntimePath(loc.path)
   return SCHEME + loc.runtimeId + encodePath(loc.path)
 }
 


### PR DESCRIPTION
## Summary

- require absolute POSIX workspace roots in both WSL and SSH connection forms
- enforce the invariant in locator formatting and runtime transport setup
- reject malformed persisted connections with a clear unreachable-state error instead of constructing an unresolvable locator
- add regression coverage for `~/project`, `home/user/project`, and `cwd`

## Root cause

The connection form only required a non-empty path, while `formatLocator` assumed every non-local path already started with `/`. Relative values were concatenated directly onto the runtime authority and parsed back as part of the runtime ID.

## User impact

New relative remote paths are blocked with an actionable message. Existing malformed connection records fail clearly and can be corrected through Edit connection. Valid absolute paths keep their existing behavior.

## Validation

- `npm run typecheck`
- scoped ESLint on all changed files
- `npm test -- --reporter=dot` — 2,978 passed, 50 skipped
- `npm run build`

Fixes #542
