### PR TITLE
Stabilize coding agent status tracking

### DIFF
--- a/src/renderer/lib/agent/agentScreenDetector.test.ts
+++ b/src/renderer/lib/agent/agentScreenDetector.test.ts
@@ -6,6 +6,7 @@ import {
   stopAgentScreenDetector,
   noteAgentPresence,
   noteAgentHookEvent,
+  noteAgentInputSubmitted,
   forgetAgentTracker,
 } from './agentScreenDetector'
 import { sendOsNotification } from '../notifications/osNotificationSend'
@@ -117,12 +118,19 @@ describe('agent activity coordinator (hook FSM + presence edges)', () => {
     expect(sendOsNotification).not.toHaveBeenCalled()
   })
 
-  it('session-start resets to idle silently', () => {
+  it('a new session-start resets to idle silently', () => {
     noteAgentPresence(PTY, true)
     noteAgentHookEvent(hookEvent('turn-start'))
-    noteAgentHookEvent(hookEvent('session-start'))
+    noteAgentHookEvent({ ...hookEvent('session-start'), sessionId: 'session-2' })
     expect(state()).toBe('waitingForInput')
     expect(sendOsNotification).not.toHaveBeenCalled()
+  })
+
+  it('a deferred session-start for the active session cannot overwrite its running turn', () => {
+    noteAgentPresence(PTY, true)
+    noteAgentHookEvent(hookEvent('turn-start', 'codex'))
+    noteAgentHookEvent(hookEvent('session-start', 'codex'))
+    expect(state()).toBe('running')
   })
 
   it('permission-wait mid-turn → waitingForInput + "needs permission" notification', () => {
@@ -175,6 +183,16 @@ describe('agent activity coordinator (hook FSM + presence edges)', () => {
     noteAgentHookEvent(hookEvent('permission-wait'))
     expect(state()).toBe('waitingForInput')
     expect(sendOsNotification).toHaveBeenCalledTimes(2) // a NEW approval is due
+  })
+
+  it('submitting a permission answer resumes immediately, before PostToolUse', () => {
+    noteAgentPresence(PTY, true)
+    noteAgentHookEvent(hookEvent('turn-start', 'codex'))
+    noteAgentHookEvent(hookEvent('permission-wait', 'codex'))
+    expect(state()).toBe('waitingForInput')
+
+    noteAgentInputSubmitted(PTY)
+    expect(state()).toBe('running')
   })
 
   it('repeated permission-wait without a resume does not re-notify', () => {

--- a/src/renderer/lib/agent/agentScreenDetector.ts
+++ b/src/renderer/lib/agent/agentScreenDetector.ts
@@ -9,9 +9,10 @@
 // running after /clear). permission-wait (the CLI is blocked on tool approval)
 // flips to 'waitingForInput' immediately with a "needs permission"
 // notification whose body carries the blocked command; turn-resume (the
-// approval ran the tool — also re-fired on every ordinary tool call) flips
-// back to 'running' silently. The events are authoritative, so no settle
-// timer is involved.
+// CLI reported a permission reply or a tool completed) flips back to 'running'
+// silently. For CLIs with no approval-reply hook, terminal Enter supplies the
+// earlier resume edge. The signals are authoritative, so no settle timer is
+// involved.
 //
 // Presence (noteAgentPresence, fed 1 Hz from main's activity scan) stays
 // authoritative for EXISTENCE — but it is itself hook-anchored now: the
@@ -59,6 +60,10 @@ export function resolveAgentState(s: DetectorSignals): AgentState {
 interface Tracker {
   present: boolean
   wasPresent: boolean
+  /** Current CLI session identity. Used to make a deferred/replayed
+   *  session-start idempotent instead of letting it overwrite a turn event
+   *  from the same session that already arrived. */
+  sessionId: string | null
   /** turn-start seen more recently than turn-end/session-end. */
   hookTurnActive: boolean
   /** The in-flight turn is parked on a permission prompt (permission-wait seen
@@ -78,6 +83,7 @@ function trackerFor(terminalId: string): Tracker {
     t = {
       present: false,
       wasPresent: false,
+      sessionId: null,
       hookTurnActive: false,
       hookPermissionWait: false,
       state: 'notRunning',
@@ -163,13 +169,14 @@ export function noteAgentHookEvent(event: AgentHookEvent): void {
   const t = trackerFor(event.terminalId)
   switch (event.kind) {
     case 'turn-start':
+      t.sessionId = event.sessionId
       t.hookTurnActive = true
       t.hookPermissionWait = false
       recompute(event.terminalId)
       break
     case 'turn-resume':
-      // The blocked tool call resolved (or an ordinary tool call completed) —
-      // the turn is in flight again. Idempotent and silent.
+      // A permission reply arrived or a tool completed — either way the turn
+      // is in flight. Idempotent and silent.
       t.hookTurnActive = true
       t.hookPermissionWait = false
       recompute(event.terminalId)
@@ -189,7 +196,14 @@ export function noteAgentHookEvent(event: AgentHookEvent): void {
       recompute(event.terminalId)
       break
     case 'session-start':
-      // A fresh session starts idle; no turn is in flight yet.
+      // Codex defers SessionStart until the first prompt and delivers it on a
+      // separate hook post from UserPromptSubmit. If the prompt event won that
+      // race, a SessionStart for the SAME session is only identity
+      // confirmation; resetting it would flicker a running turn back to
+      // waitingForInput. A genuinely new session (e.g. /clear) still starts
+      // idle.
+      if (t.sessionId === event.sessionId && t.hookTurnActive) break
+      t.sessionId = event.sessionId
       t.hookTurnActive = false
       t.hookPermissionWait = false
       recompute(event.terminalId)
@@ -204,6 +218,19 @@ export function noteAgentHookEvent(event: AgentHookEvent): void {
       recompute(event.terminalId, true, permissionBodyFor(event))
       break
   }
+}
+
+/** The user submitted a response while the CLI was parked on a permission
+ *  prompt. Claude, Codex, and Grok do not expose an "approval answered" hook:
+ *  their next hook is PostToolUse, after the approved tool has FINISHED. The
+ *  terminal Enter is therefore the earliest truthful resume edge. A denial
+ *  also resumes the agent while it processes that answer, before its Stop. */
+export function noteAgentInputSubmitted(terminalId: string): void {
+  const t = trackers.get(terminalId)
+  if (!t?.hookPermissionWait) return
+  t.hookTurnActive = true
+  t.hookPermissionWait = false
+  recompute(terminalId)
 }
 
 /** Main's scan reported whether the hook-registered agent pid is alive. The

--- a/src/renderer/lib/agent/agentStatus.integration.test.ts
+++ b/src/renderer/lib/agent/agentStatus.integration.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizeAgentHookPayload } from '../../../shared/agentHooks'
+import { AGENTS, type AgentId } from '../../../shared/agents'
+import {
+  noteAgentHookEvent,
+  noteAgentInputSubmitted,
+  noteAgentPresence,
+  startAgentScreenDetector,
+  stopAgentScreenDetector,
+} from './agentScreenDetector'
+import { setTerminalWorkspaceResolver, useStatusStore } from '../../stores/statusStore'
+
+vi.mock('../notifications/osNotificationSend', () => ({ sendOsNotification: vi.fn() }))
+
+const WS = 'ws-agent-status'
+const PTY = 'pty-agent-status'
+const SESSION = 'session-agent-status'
+
+interface AgentLifecycleFixture {
+  agentId: AgentId
+  sessionStart: Record<string, unknown>
+  turnStart: Record<string, unknown>
+  turnEnd: Record<string, unknown>
+}
+
+interface PermissionFixture {
+  agentId: AgentId
+  turnStart: Record<string, unknown>
+  permissionWait: Record<string, unknown>
+}
+
+const fixtures: AgentLifecycleFixture[] = [
+  {
+    agentId: 'claude-code',
+    sessionStart: { hook_event_name: 'SessionStart', session_id: SESSION },
+    turnStart: { hook_event_name: 'UserPromptSubmit', session_id: SESSION },
+    turnEnd: { hook_event_name: 'Stop', session_id: SESSION },
+  },
+  {
+    agentId: 'codex',
+    sessionStart: { hook_event_name: 'SessionStart', session_id: SESSION },
+    turnStart: { hook_event_name: 'UserPromptSubmit', session_id: SESSION },
+    turnEnd: { hook_event_name: 'Stop', session_id: SESSION },
+  },
+  {
+    agentId: 'cursor',
+    sessionStart: { hook_event_name: 'sessionStart', session_id: SESSION, workspace_roots: ['/workspace'] },
+    turnStart: { hook_event_name: 'beforeSubmitPrompt', session_id: SESSION, workspace_roots: ['/workspace'] },
+    turnEnd: { hook_event_name: 'stop', session_id: SESSION, workspace_roots: ['/workspace'] },
+  },
+  {
+    agentId: 'grok',
+    sessionStart: { hookEventName: 'session_start', sessionId: SESSION },
+    turnStart: { hookEventName: 'user_prompt_submit', sessionId: SESSION },
+    turnEnd: { hookEventName: 'stop', sessionId: SESSION },
+  },
+  {
+    agentId: 'pi',
+    sessionStart: { event: 'session_start', sessionId: SESSION },
+    turnStart: { event: 'agent_start', sessionId: SESSION },
+    turnEnd: { event: 'agent_end', sessionId: SESSION },
+  },
+  {
+    agentId: 'opencode',
+    sessionStart: { type: 'session.created', sessionID: SESSION },
+    turnStart: { type: 'session.status', sessionID: SESSION, status: { type: 'busy' } },
+    turnEnd: { type: 'session.idle', sessionID: SESSION },
+  },
+]
+
+const permissionFixtures: PermissionFixture[] = [
+  {
+    agentId: 'claude-code',
+    turnStart: { hook_event_name: 'UserPromptSubmit', session_id: SESSION },
+    permissionWait: {
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      session_id: SESSION,
+    },
+  },
+  {
+    agentId: 'codex',
+    turnStart: { hook_event_name: 'UserPromptSubmit', session_id: SESSION },
+    permissionWait: {
+      hook_event_name: 'PermissionRequest',
+      session_id: SESSION,
+      turn_id: 'turn-1',
+      tool_name: 'Bash',
+    },
+  },
+  {
+    agentId: 'grok',
+    turnStart: { hookEventName: 'user_prompt_submit', sessionId: SESSION },
+    permissionWait: {
+      hookEventName: 'notification',
+      notificationType: 'permission_prompt',
+      sessionId: SESSION,
+    },
+  },
+  {
+    agentId: 'opencode',
+    turnStart: { type: 'session.status', sessionID: SESSION, status: { type: 'busy' } },
+    permissionWait: { type: 'permission.asked', sessionID: SESSION },
+  },
+]
+
+function state(): string | undefined {
+  return useStatusStore.getState().workspaces[WS]?.terminals[PTY]?.agentState
+}
+
+function emit(agentId: AgentId, raw: Record<string, unknown>): void {
+  const event = normalizeAgentHookPayload(agentId, PTY, raw)
+  expect(event, `${agentId} payload normalizes`).not.toBeNull()
+  noteAgentHookEvent(event!)
+}
+
+describe('coding-agent hook status integration', () => {
+  beforeEach(() => {
+    useStatusStore.setState({ workspaces: {} })
+    setTerminalWorkspaceResolver((ptyId) => (ptyId === PTY ? WS : undefined))
+    useStatusStore.getState().registerTerminal(PTY, WS)
+    useStatusStore.getState().setAgentName(WS, PTY, 'Agent')
+    ;(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {
+      shellReportAgentScreenState: vi.fn(),
+    }
+    startAgentScreenDetector()
+    noteAgentPresence(PTY, true)
+  })
+
+  afterEach(() => {
+    stopAgentScreenDetector()
+  })
+
+  it('covers every registered coding-agent CLI', () => {
+    expect(fixtures.map((fixture) => fixture.agentId).sort()).toEqual(AGENTS.map((agent) => agent.id).sort())
+  })
+
+  it.each(fixtures)('$agentId remains stable across consecutive turns', ({
+    agentId,
+    sessionStart,
+    turnStart,
+    turnEnd,
+  }) => {
+    emit(agentId, sessionStart)
+    expect(state()).toBe('waitingForInput')
+
+    emit(agentId, turnStart)
+    expect(state()).toBe('running')
+    emit(agentId, turnEnd)
+    expect(state()).toBe('waitingForInput')
+
+    emit(agentId, turnStart)
+    expect(state()).toBe('running')
+    emit(agentId, turnEnd)
+    expect(state()).toBe('waitingForInput')
+  })
+
+  it('codex does not let its deferred SessionStart overwrite the first running turn', () => {
+    const codex = fixtures.find((fixture) => fixture.agentId === 'codex')!
+
+    // Codex TUI defers SessionStart until the first submit. These two hook
+    // posts are independent, so the coordinator must tolerate either arrival
+    // order for the same session.
+    emit(codex.agentId, codex.turnStart)
+    expect(state()).toBe('running')
+    emit(codex.agentId, codex.sessionStart)
+    expect(state()).toBe('running')
+  })
+
+  it.each(permissionFixtures)(
+    '$agentId resumes as soon as the user submits a permission answer',
+    ({ agentId, turnStart, permissionWait }) => {
+      emit(agentId, turnStart)
+      emit(agentId, permissionWait)
+      expect(state()).toBe('waitingForInput')
+
+      noteAgentInputSubmitted(PTY)
+      expect(state()).toBe('running')
+    },
+  )
+})

--- a/src/renderer/lib/terminal/terminalLifecycle.test.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.test.ts
@@ -20,6 +20,7 @@ interface FakeTerminalShape {
   options: Record<string, unknown>
   cols: number
   rows: number
+  emitData(data: string): void
 }
 const terminalInstances: FakeTerminalShape[] = []
 
@@ -32,6 +33,7 @@ vi.mock('@xterm/xterm', () => {
     public element: HTMLElement | undefined
     public cols = 80
     public rows = 24
+    private dataCallback?: (data: string) => void
     constructor(options: Record<string, unknown> = {}) {
       this.options = options
       terminalInstances.push(this as unknown as FakeTerminalShape)
@@ -42,7 +44,11 @@ vi.mock('@xterm/xterm', () => {
       container.appendChild(this.element)
     }
     write(s: string): void { this.writes.push(s) }
-    onData(): { dispose: () => void } { return { dispose: () => {} } }
+    onData(cb: (data: string) => void): { dispose: () => void } {
+      this.dataCallback = cb
+      return { dispose: () => { this.dataCallback = undefined } }
+    }
+    emitData(data: string): void { this.dataCallback?.(data) }
     onResize(): { dispose: () => void } { return { dispose: () => {} } }
     onTitleChange(): { dispose: () => void } { return { dispose: () => {} } }
     hasSelection(): boolean { return false }
@@ -114,9 +120,11 @@ vi.mock('./terminalFileLinkProvider', () => ({
   createFileLinkProvider: () => ({ provideLinks: (_y: number, cb: (l?: unknown[]) => void) => cb(undefined) }),
   resolveLinkRoot: () => undefined,
 }))
+const noteAgentInputSubmitted = vi.fn()
 vi.mock('../agent/agentScreenDetector', () => ({
   noteAgentPresence: vi.fn(),
   forgetAgentTracker: vi.fn(),
+  noteAgentInputSubmitted,
 }))
 vi.mock('../themeManager', () => ({
   getActiveTheme: () => ({ terminal: {} }),
@@ -213,6 +221,7 @@ beforeEach(() => {
   statusUnregisterTerminal.mockClear()
   replayTerminalLog.mockClear()
   replayTerminalLog.mockImplementation(async () => {})
+  noteAgentInputSubmitted.mockClear()
 })
 
 // ===========================================================================
@@ -257,6 +266,16 @@ describe('spawn → wire → dispose happy path', () => {
     expect(RS.panelIdForPty('pty-happy')).toBeNull()
     expect(fake.disposeCount).toBe(1)
     expect(dataDisposers[0]).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a submitted terminal line to the agent status coordinator', async () => {
+    terminalCreate.mockResolvedValueOnce('pty-input')
+    await LC.getOrCreate('panel-input', { workspaceId: 'ws-1' })
+
+    terminalInstances[0].emitData('\r')
+
+    expect(noteAgentInputSubmitted).toHaveBeenCalledWith('pty-input')
+    expect(terminalWrite).toHaveBeenCalledWith('pty-input', '\r')
   })
 
   it('returns the same in-flight entry for concurrent getOrCreate calls and spawns once', async () => {

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -39,6 +39,7 @@ import { getActiveTheme } from '../themeManager'
 import { useStatusStore } from '../../stores/statusStore'
 import { awaitWorkspaceSync, useAppStore } from '../../stores/appStore'
 import { replayTerminalLog } from '../workspace/session'
+import { noteAgentInputSubmitted } from '../agent/agentScreenDetector'
 
 interface CreateOpts {
   workspaceId: string
@@ -205,6 +206,11 @@ export function wireTerminalListeners(args: {
 
   // xterm -> PTY: keystrokes (standard path for all other input)
   const dataDisposable = terminal.onData((data) => {
+    // Permission hooks report the wait, but several CLIs expose no matching
+    // "user answered" event until after the approved tool finishes. Enter is
+    // the real resume edge; the detector ignores it unless this terminal is
+    // currently parked on a permission prompt.
+    if (data.includes('\r')) noteAgentInputSubmitted(ptyId)
     electronAPI.terminalWrite(ptyId, data)
   })
   cleanupListeners.push(() => dataDisposable.dispose())

--- a/src/runtime/capabilities/agentHookContracts.itest.ts
+++ b/src/runtime/capabilities/agentHookContracts.itest.ts
@@ -22,8 +22,9 @@
 //             -p and TUI.
 //             Permission-wait: Notification hook, notification_type
 //             "permission_prompt" (and "idle_prompt" once idle nags kick in).
-//             Approval resolution: PostToolUse fires once the approved tool
-//             ran (denial produces no PostToolUse — the turn just Stops).
+//             PostToolUse fires once the approved tool FINISHES (denial
+//             produces none). Cate therefore resumes earlier from the user's
+//             terminal submission.
 //   codex   · JSON-on-stdin hooks configured in <project root>/.codex/
 //             hooks.json (repo scope, discovered by codex itself —
 //             launch-method independent, unlike the six per-invocation -c
@@ -46,8 +47,8 @@
 //             Permission-wait: PermissionRequest hook (session_id, turn_id,
 //             tool_name, tool_input) — fires in exec mode too, where the
 //             unanswerable approval is then auto-rejected and the turn Stops.
-//             Approval resolution: PostToolUse (label post_tool_use) fires
-//             after an executed command, same payload family.
+//             PostToolUse (label post_tool_use) fires only after an executed
+//             command finishes; Cate resumes earlier from terminal input.
 //   cursor  · JSON-on-stdin hooks configured in <workspace>/.cursor/hooks.json
 //             (project scope, discovered by the CLI itself; hooks landed in
 //             the CLI ~2026.07 — pinned live 2026-07-19 against
@@ -114,6 +115,15 @@ import { createAgentPresenceTracker } from './agentPresence'
 import { snapshotProcessTree } from './process'
 import { AGENT_HOOK_SPECS, normalizeAgentHookPayload, type AgentHookEventKind } from '../../shared/agentHooks'
 import type { AgentId } from '../../shared/agents'
+import type { AgentState } from '../../shared/types'
+import {
+  noteAgentHookEvent,
+  noteAgentInputSubmitted,
+  noteAgentPresence,
+  startAgentScreenDetector,
+  stopAgentScreenDetector,
+} from '../../renderer/lib/agent/agentScreenDetector'
+import { setTerminalWorkspaceResolver, useStatusStore } from '../../renderer/stores/statusStore'
 
 // --- the interrupt contract, shared by every CLI ----------------------------
 // A USER INTERRUPT (Esc / Ctrl+C on a running turn) leaves the CLI back at its
@@ -273,6 +283,44 @@ function readJsonl<T>(file: string): T[] {
 function expectEcho(events: { terminalId?: unknown; cateTerminalId?: unknown }[], tid: string): void {
   expect(events.length).toBeGreaterThan(0)
   for (const e of events) expect(e.terminalId ?? e.cateTerminalId, 'CATE_TERMINAL_ID echo').toBe(tid)
+}
+
+/** Replay REAL captured CLI hook posts through the same normalizer,
+ *  coordinator, and status store the workspace overview uses. This closes the
+ *  old contract-test gap where an event could be present and correctly shaped
+ *  while still producing the wrong visible state. */
+function replayAgentState(
+  agentId: AgentId,
+  terminalId: string,
+  events: BridgeEvent[],
+  opts: { permissionAnswered?: boolean } = {},
+): AgentState | undefined {
+  const workspaceId = `live-status-${terminalId}`
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { electronAPI: { shellReportAgentScreenState: () => {}, notifyOS: () => {} } },
+  })
+  stopAgentScreenDetector()
+  useStatusStore.setState({ workspaces: {} })
+  setTerminalWorkspaceResolver((id) => (id === terminalId ? workspaceId : undefined))
+  useStatusStore.getState().registerTerminal(terminalId, workspaceId)
+  useStatusStore.getState().setAgentName(workspaceId, terminalId, agentId)
+  startAgentScreenDetector()
+  noteAgentPresence(terminalId, true)
+  for (const captured of events) {
+    const event = normalizeAgentHookPayload(agentId, terminalId, captured.payload)
+    if (event) noteAgentHookEvent(event)
+  }
+  if (opts.permissionAnswered) noteAgentInputSubmitted(terminalId)
+  const state = useStatusStore.getState().workspaces[workspaceId]?.terminals[terminalId]?.agentState
+  stopAgentScreenDetector()
+  return state
+}
+
+function throughFirst(events: BridgeEvent[], predicate: (event: BridgeEvent) => boolean): BridgeEvent[] {
+  const index = events.findIndex(predicate)
+  expect(index, 'status checkpoint event exists').toBeGreaterThanOrEqual(0)
+  return events.slice(0, index + 1)
 }
 
 // --- tiny TUI driver (for the CLIs whose hooks need a live TUI) --------------
@@ -439,8 +487,18 @@ describe.skipIf(!LIVE || !hasBin('claude'))('claude hook contract', () => {
     await tui.send(PROMPT)
     await tui.waitFor(() => byName(events(), 'UserPromptSubmit').length > 0, 120_000, 'UserPromptSubmit')
     expect(byName(events(), 'UserPromptSubmit')[0].payload.session_id).toBe(id1)
+    expect(
+      replayAgentState(
+        'claude-code',
+        tid,
+        throughFirst(events(), (event) => event.payload.hook_event_name === 'UserPromptSubmit'),
+      ),
+      'the workspace overview is running after Claude accepts the prompt',
+    ).toBe('running')
     await tui.waitFor(() => byName(events(), 'Stop').length > 0, 120_000, 'Stop')
     expect(byName(events(), 'Stop')[0].payload.session_id).toBe(id1)
+    expect(replayAgentState('claude-code', tid, events()), 'the workspace overview awaits after Claude stops')
+      .toBe('waitingForInput')
 
     // transcript_path points at a real transcript once the first prompt ran —
     // the moment the RESUMABLE_FROM_SESSION_START gating counts on.
@@ -566,10 +624,16 @@ describe.skipIf(!LIVE || !hasBin('claude'))('claude hook contract', () => {
     expect(perm?.message, 'human-readable permission message').toContain('permission')
     // The turn is still in flight — the wait signal precedes any Stop.
     expect(byName(events(), 'Stop').length, 'no Stop while blocked on approval').toBe(0)
+    expect(replayAgentState('claude-code', tid, events()), 'the workspace overview shows Claude awaiting approval')
+      .toBe('waitingForInput')
 
     // Approve (Enter accepts the highlighted "Yes"): the tool runs, PostToolUse
     // pushes the back-in-flight signal, then the turn completes with Stop.
     await tui.send('')
+    expect(
+      replayAgentState('claude-code', tid, events(), { permissionAnswered: true }),
+      'submitting the approval resumes the overview before PostToolUse',
+    ).toBe('running')
     await tui.waitFor(() => byName(events(), 'PostToolUse').length > 0, 120_000, 'PostToolUse after approval')
     expect(byName(events(), 'PostToolUse')[0].payload.session_id).toBe(id)
     expect(byName(events(), 'PostToolUse')[0].payload.tool_name).toBe('Bash')
@@ -917,6 +981,20 @@ describe.skipIf(!LIVE || !hasBin('codex'))('codex hook contract', () => {
     cleanups.push(() => rmSync(start?.transcript_path as string, { force: true }))
     const perm = events().find((e) => e.payload.hook_event_name === 'PermissionRequest')?.payload
     expect(perm?.session_id).toBe(start?.session_id)
+    expect(
+      replayAgentState(
+        'codex',
+        tid,
+        throughFirst(events(), (event) => event.payload.hook_event_name === 'UserPromptSubmit'),
+      ),
+      'deferred SessionStart/UserPromptSubmit order resolves to running',
+    ).toBe('running')
+    expect(replayAgentState('codex', tid, events()), 'the workspace overview shows Codex awaiting approval')
+      .toBe('waitingForInput')
+    expect(
+      replayAgentState('codex', tid, events(), { permissionAnswered: true }),
+      'submitting the approval resumes Codex before PostToolUse',
+    ).toBe('running')
     expectEcho(events(), tid)
     tui.kill()
   })
@@ -1006,6 +1084,8 @@ describe.skipIf(!LIVE || !hasBin('codex'))('codex hook contract', () => {
     const stop = events().find((e) => e.payload.hook_event_name === 'Stop')!.payload
     expect(stop.turn_id, 'Stop carries the turn it ends').toEqual(expect.any(String))
     expect(normalizedKinds('codex', [{ terminalId: tid, payload: stop }])).toEqual(['turn-end'])
+    expect(replayAgentState('codex', tid, events()), 'the workspace overview awaits after Codex stops')
+      .toBe('waitingForInput')
     cleanups.push(() => rmSync(events()[0].payload.transcript_path as string, { force: true }))
     tui.kill()
   })
@@ -1110,10 +1190,20 @@ describe.skipIf(!LIVE || !hasBin('cursor-agent'))('cursor hook contract', () => 
     await tui.send(PROMPT)
     await tui.waitFor(() => byName(events(), 'beforeSubmitPrompt').length > 0, 120_000, 'beforeSubmitPrompt')
     expect(byName(events(), 'beforeSubmitPrompt')[0].payload.session_id).toBe(id)
+    expect(
+      replayAgentState(
+        'cursor',
+        tid,
+        throughFirst(events(), (event) => event.payload.hook_event_name === 'beforeSubmitPrompt'),
+      ),
+      'the workspace overview is running after Cursor accepts the prompt',
+    ).toBe('running')
     await tui.waitFor(() => byName(events(), 'stop').length > 0, 180_000, 'stop')
     const stop = byName(events(), 'stop')[0].payload
     expect(stop.session_id).toBe(id)
     expect(stop.status).toBe('completed')
+    expect(replayAgentState('cursor', tid, events()), 'the workspace overview awaits after Cursor stops')
+      .toBe('waitingForInput')
 
     // transcript_path materializes with the turn and points at a real file.
     const transcript = byName(events(), 'stop')[0].payload.transcript_path as string
@@ -1397,6 +1487,16 @@ export default function (pi: ExtensionAPI) {
       expect(hit, `${name} fired`).toBeTruthy()
       expect(hit?.sessionId, `${name} carries the session id`).toBe(id)
     }
+    const statusEvents: BridgeEvent[] = events.map((event) => ({
+      terminalId: event.cateTerminalId,
+      payload: event as unknown as Record<string, unknown>,
+    }))
+    expect(
+      replayAgentState('pi', tid, throughFirst(statusEvents, (event) => event.payload.event === 'agent_start')),
+      'the workspace overview is running after Pi starts the turn',
+    ).toBe('running')
+    expect(replayAgentState('pi', tid, statusEvents), 'the workspace overview awaits after Pi ends the turn')
+      .toBe('waitingForInput')
     const sessionFile = events[0].sessionFile as string
     expect(sessionFile).toContain(id)
     cleanups.push(() => rmSync(dirname(sessionFile), { recursive: true, force: true }))
@@ -1615,6 +1715,24 @@ export const CateEventLogger = async ({ directory }) => {
       'session.status busy',
     ).toBe(true)
     expect(events.some((e) => e.type === 'session.idle' && e.sessionID === id), 'session.idle').toBe(true)
+    const statusEvents: BridgeEvent[] = events.map((event) => ({
+      terminalId: event.cate_terminal_id,
+      payload: event as unknown as Record<string, unknown>,
+    }))
+    expect(
+      replayAgentState(
+        'opencode',
+        tid,
+        throughFirst(
+          statusEvents,
+          (event) => event.payload.type === 'session.status' &&
+            (event.payload.status as { type?: string } | null)?.type === 'busy',
+        ),
+      ),
+      'the workspace overview is running while OpenCode is busy',
+    ).toBe('running')
+    expect(replayAgentState('opencode', tid, statusEvents), 'the workspace overview awaits after OpenCode idles')
+      .toBe('waitingForInput')
     expectEcho(events.map((e) => ({ cateTerminalId: e.cate_terminal_id })), tid)
 
     // Resume identifies by the first sessionID-bearing event — session.created
@@ -1742,6 +1860,17 @@ export const CatePermLogger = async () => ({
     expect(asked?.metadata?.command).toContain('touch')
     // The turn is still busy while parked on approval — idle has not fired.
     expect(events().some((e) => e.type === 'session.idle' && e.sessionID === id)).toBe(false)
+    const asStatusEvents = (): BridgeEvent[] => events().map((event) => ({
+      terminalId: event.cate_terminal_id,
+      payload: {
+        type: event.type,
+        sessionID: event.sessionID,
+        permission: event.properties?.permission,
+        metadata: event.properties?.metadata,
+      },
+    }))
+    expect(replayAgentState('opencode', tid, asStatusEvents()), 'the workspace overview awaits OpenCode approval')
+      .toBe('waitingForInput')
 
     // Approve (Enter accepts the highlighted "allow once"): permission.replied
     // resolves the SAME request, then the turn runs on to completion.
@@ -1751,6 +1880,14 @@ export const CatePermLogger = async () => ({
     expect(replied?.sessionID).toBe(id)
     expect(replied?.requestID, 'resolution references the asked request').toBe(asked?.id)
     expect(replied?.reply).toBeTruthy()
+    expect(
+      replayAgentState(
+        'opencode',
+        tid,
+        throughFirst(asStatusEvents(), (event) => event.payload.type === 'permission.replied'),
+      ),
+      'the workspace overview resumes when OpenCode reports the reply',
+    ).toBe('running')
     await tui.waitFor(
       () => events().some((e) => e.type === 'session.idle' && e.sessionID === id),
       120_000,
@@ -2019,6 +2156,16 @@ describe.skipIf(!LIVE || !hasBin('grok'))('grok hook contract', () => {
     const order = events.map((e) => e.payload.hookEventName)
     expect(order.indexOf('stop')).toBeGreaterThan(order.indexOf('user_prompt_submit'))
     expect(order.indexOf('user_prompt_submit')).toBeGreaterThan(order.indexOf('session_start'))
+    expect(
+      replayAgentState(
+        'grok',
+        tid,
+        throughFirst(events, (event) => event.payload.hookEventName === 'user_prompt_submit'),
+      ),
+      'the workspace overview is running after Grok accepts the prompt',
+    ).toBe('running')
+    expect(replayAgentState('grok', tid, events), 'the workspace overview awaits after Grok stops')
+      .toBe('waitingForInput')
 
     // The reserved runner env — the deterministic "grok spawned me" marker.
     const first = events[0]
@@ -2199,6 +2346,14 @@ describe.skipIf(!LIVE || !hasBin('grok'))('grok hook contract', () => {
     // opened for.
     await tui.waitFor(() => byName(events(), 'user_prompt_submit').length > 0, 60_000, 'UserPromptSubmit')
     expect(byName(events(), 'user_prompt_submit')[0].payload.sessionId).toBe(start.sessionId)
+    expect(
+      replayAgentState(
+        'grok',
+        tid,
+        throughFirst(events(), (event) => event.payload.hookEventName === 'user_prompt_submit'),
+      ),
+      'the workspace overview is running through Grok deferred session startup',
+    ).toBe('running')
 
     const lineage = events().find((e) => typeof e.ppid === 'number')
     expect(lineage, 'bridge recorded its parent pid').toBeTruthy()
@@ -2211,6 +2366,8 @@ describe.skipIf(!LIVE || !hasBin('grok'))('grok hook contract', () => {
 
     await tui.waitFor(() => byName(events(), 'stop').length > 0, 180_000, 'Stop')
     expect(byName(events(), 'stop')[0].payload.sessionId).toBe(start.sessionId)
+    expect(replayAgentState('grok', tid, events()), 'the workspace overview awaits after Grok stops')
+      .toBe('waitingForInput')
     expectEcho(events(), tid)
     tui.kill()
   })

--- a/src/shared/agentHooks.ts
+++ b/src/shared/agentHooks.ts
@@ -47,10 +47,10 @@ export type AgentHookEventKind =
   | 'turn-start'
   | 'turn-end'
   | 'permission-wait'
-  /** A blocked permission-wait resolved and the turn is in flight again
-   *  (claude/codex PostToolUse, opencode permission.replied). Also fires on
-   *  every ordinary tool call for claude/codex — consumers treat it as an
-   *  idempotent "the turn is running" re-assertion. */
+  /** An idempotent "the turn is running" re-assertion. OpenCode emits it when
+   *  a permission reply arrives; other CLIs emit it after a tool completes.
+   *  Claude/Codex/Grok do not hook the actual approval reply, so renderer
+   *  terminal input supplies that earlier resume edge. */
   | 'turn-resume'
 
 export interface AgentHookEvent {
@@ -372,9 +372,9 @@ const claudeSpec: AgentHookSpec = {
     switch (p.hook_event_name) {
       case 'SessionStart': return { kind: 'session-start', ...base }
       case 'UserPromptSubmit': return { kind: 'turn-start', ...base }
-      // Fires after EVERY executed tool call; the one after a permission-wait
-      // is the approval resolution (denial produces no PostToolUse — the turn
-      // just Stops).
+      // Fires after EVERY executed tool call. This confirms the turn is still
+      // active, but is too late to represent approval resolution: an approved
+      // long-running tool fires it only after finishing.
       case 'PostToolUse': return { kind: 'turn-resume', ...base }
       case 'Stop': return { kind: 'turn-end', ...base }
       case 'SessionEnd': return { kind: 'session-end', ...base }
@@ -456,8 +456,9 @@ const codexSpec: AgentHookSpec = {
       case 'UserPromptSubmit': return { kind: 'turn-start', ...base }
       case 'Stop': return { kind: 'turn-end', ...base }
       case 'PermissionRequest': return { kind: 'permission-wait', ...base }
-      // Fires after EVERY executed tool call; the one after a PermissionRequest
-      // is the approval resolution (denial produces no PostToolUse).
+      // Fires after EVERY executed tool call. This confirms the turn is still
+      // active, but is too late to represent approval resolution: an approved
+      // long-running tool fires it only after finishing.
       case 'PostToolUse': return { kind: 'turn-resume', ...base }
       // SessionEnd never fires (pinned live) — no mapping on purpose.
       default: return null
@@ -721,8 +722,8 @@ const grokSpec: AgentHookSpec = {
     switch (p.hookEventName) {
       case 'session_start': return { kind: 'session-start', ...base }
       case 'user_prompt_submit': return { kind: 'turn-start', ...base }
-      // Fires after every executed tool call; the one following a
-      // permission_prompt is the approval resolution.
+      // Fires after every executed tool call. Terminal input supplies the
+      // earlier approval-answer edge for long-running approved tools.
       case 'post_tool_use': return { kind: 'turn-resume', ...base }
       case 'stop': return { kind: 'turn-end', ...base }
       case 'session_end': return { kind: 'session-end', ...base }


### PR DESCRIPTION
## What changed

- make a deferred `SessionStart` idempotent when a turn for the same CLI session is already active
- resume a permission-blocked agent as soon as terminal input is submitted, instead of waiting for `PostToolUse` after the approved command finishes
- add renderer integration coverage that feeds realistic raw hook payloads through normalization, the status coordinator, and the Zustand workspace status store for Claude Code, Codex, Cursor, Grok, Pi, and OpenCode
- extend the live CLI contract suite to replay captured events through the same visible-status path

## Why

Codex can defer `SessionStart` until its first prompt. Because its hook posts are independent, `UserPromptSubmit` can be processed first and then be overwritten by the late session-start reset, making the workspace overview flicker from running back to awaiting input.

Claude, Codex, and Grok also do not expose an approval-answer hook. Their next `PostToolUse` event arrives only after the approved tool finishes, so the overview could continue showing awaiting input while the agent was already running the command.

## Impact

Workspace agent indicators now remain running across Codex's deferred startup ordering and return to running immediately after a permission response. New coverage pins consecutive-turn and permission lifecycles for every registered coding-agent CLI.

## Validation

- regression test reproduced the Codex failure before the fix: expected `running`, received `waitingForInput`
- focused status/hook/UI suite: 110/110 passed
- `npm run typecheck`: passed
- full `npm test`: 3,052/3,053 passed; the remaining unrelated tarball test rejects its generated workspace through its allowed-directory policy
- live CLI contracts: 27/33 passed, including all Codex, Cursor, OpenCode, and Grok checks and the new status assertions reached by those runs; remaining failures are external CLI/harness drift (Claude `haiku` unavailable, changed Codex negative trust behavior, and Pi print mode producing no hooks)
