### PR TITLE
Fix workspace shortcuts and add command palette navigation

### DIFF
--- a/src/renderer/settings/ShortcutRecorder.tsx
+++ b/src/renderer/settings/ShortcutRecorder.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import type { StoredShortcut } from '../../shared/types'
-import { displayString } from '../../shared/types'
+import { displayString, normaliseShortcutKey, type StoredShortcut } from '../../shared/types'
 
 interface ShortcutRecorderProps {
   currentShortcut: StoredShortcut
@@ -30,7 +29,7 @@ export function ShortcutRecorder({ currentShortcut, onRecord }: ShortcutRecorder
       if (!e.metaKey && !e.ctrlKey && !e.altKey) return
 
       const shortcut: StoredShortcut = {
-        key: e.key.length === 1 ? e.key.toLowerCase() : e.key,
+        key: normaliseShortcutKey(e.key),
         command: e.metaKey,
         shift: e.shiftKey,
         option: e.altKey,

--- a/src/renderer/stores/shortcutStore.test.ts
+++ b/src/renderer/stores/shortcutStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { DEFAULT_SHORTCUTS, storedShortcut } from '../../shared/types'
+import { DEFAULT_SHORTCUTS, normaliseShortcutKey, storedShortcut } from '../../shared/types'
 
 async function loadStores() {
   vi.resetModules()
@@ -35,6 +35,21 @@ describe('shortcutStore', () => {
     expect(matchShortcutEvent(keyEvent('ArrowLeft', { meta: true, alt: true }))).toBe('previousWorkspace')
     // Plain Cmd+Arrow stays panel navigation, not workspace switching.
     expect(matchShortcutEvent(keyEvent('ArrowRight', { meta: true }))).not.toBe('nextWorkspace')
+  })
+
+  it('normalizes recorded arrow keys before matching custom workspace shortcuts', async () => {
+    const { useSettingsStore, getResolvedShortcuts, matchShortcutEvent } = await loadStores()
+    useSettingsStore.setState({
+      customShortcuts: {
+        nextWorkspace: storedShortcut(normaliseShortcutKey('ArrowRight'), { command: true, shift: true }),
+        previousWorkspace: storedShortcut(normaliseShortcutKey('ArrowLeft'), { command: true, shift: true }),
+      },
+    })
+
+    expect(getResolvedShortcuts().nextWorkspace.key).toBe('→')
+    expect(getResolvedShortcuts().previousWorkspace.key).toBe('←')
+    expect(matchShortcutEvent(keyEvent('ArrowRight', { meta: true, shift: true }))).toBe('nextWorkspace')
+    expect(matchShortcutEvent(keyEvent('ArrowLeft', { meta: true, shift: true }))).toBe('previousWorkspace')
   })
 
   it('clearShortcut disables a binding so it never matches (#372)', async () => {

--- a/src/renderer/stores/shortcutStore.ts
+++ b/src/renderer/stores/shortcutStore.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
 import type { ShortcutAction, StoredShortcut } from '../../shared/types'
-import { DEFAULT_SHORTCUTS, SHORTCUT_ACTIONS, resolveShortcuts, storedShortcut } from '../../shared/types'
+import {
+  DEFAULT_SHORTCUTS,
+  SHORTCUT_ACTIONS,
+  normaliseShortcutKey,
+  resolveShortcuts,
+  storedShortcut,
+} from '../../shared/types'
 import { useSettingsStore } from './settingsStore'
 
 interface ModifierState {
@@ -11,18 +17,7 @@ interface ModifierState {
 }
 
 function normaliseKey(event: KeyboardEvent): string {
-  switch (event.key) {
-    case 'Tab': return '\t'
-    case 'Enter': return '\r'
-    case ' ': return ' '
-    case 'Backspace': return 'Backspace'
-    case 'Escape': return 'Escape'
-    case 'ArrowLeft': return '\u2190'
-    case 'ArrowRight': return '\u2192'
-    case 'ArrowDown': return '\u2193'
-    case 'ArrowUp': return '\u2191'
-    default: return event.key.toLowerCase()
-  }
+  return normaliseShortcutKey(event.key)
 }
 
 function sameShortcut(a: StoredShortcut, b: StoredShortcut): boolean {

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -1,10 +1,9 @@
 // =============================================================================
 // CommandPalette — Unified searchable command launcher + workspace navigator.
-// A single Cmd+K overlay listing all commands, all open panels, and workspace
-// files. Files and panels are matched by NAME ONLY (no content search — that's
-// the separate ripgrep-backed Search view). With no query typed, it lists all
-// commands, all open panels, and recently-opened files — so it's obvious the
-// palette reaches panels and files too, not just commands.
+// A single Cmd+K overlay listing all commands, workspaces, open panels, and
+// workspace files. Files and panels are matched by NAME ONLY (no content search
+// — that's the separate ripgrep-backed Search view). With no query typed, it
+// lists all commands, workspaces, open panels, and recently-opened files.
 // =============================================================================
 
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
@@ -105,9 +104,18 @@ interface PanelResult {
   inOtherWindow?: boolean
 }
 
+interface WorkspaceResult {
+  id: string
+  name: string
+  rootPath?: string
+  color: string
+  isCurrent: boolean
+}
+
 // A single navigable entry in the flat list, used for keyboard selection.
 type FlatItem =
   | { kind: 'command'; command: CommandItem }
+  | { kind: 'workspace'; workspace: WorkspaceResult }
   | { kind: 'panel'; panel: PanelResult }
   | { kind: 'file'; file: FileResult }
 
@@ -119,6 +127,7 @@ export const CommandPalette: React.FC = () => {
   const showCommandPalette = useUIStore((s) => s.showCommandPalette)
   const setShowCommandPalette = useUIStore((s) => s.setShowCommandPalette)
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
+  const workspaces = useAppStore((s) => s.workspaces)
   const canvasApi = useOptionalCanvasStoreApi()
   // Detached windows have no sidebar, so sidebar toggles are hidden there.
   const isMainWindow = useContext(WindowTypeContext) === 'main'
@@ -235,6 +244,22 @@ export const CommandPalette: React.FC = () => {
     return allCommands.filter((cmd) => cmd.title.toLowerCase().includes(query))
   }, [allCommands, query])
 
+  const filteredWorkspaces = useMemo<WorkspaceResult[]>(() => (
+    workspaces
+      .filter((workspace) => (
+        !query ||
+        workspace.name.toLowerCase().includes(query) ||
+        workspace.rootPath?.toLowerCase().includes(query)
+      ))
+      .map((workspace) => ({
+        id: workspace.id,
+        name: workspace.name,
+        rootPath: workspace.rootPath,
+        color: workspace.color,
+        isCurrent: workspace.id === selectedWorkspaceId,
+      }))
+  ), [workspaces, selectedWorkspaceId, query])
+
   // Navigable panels in overview order, matched by title. Local panels first,
   // then panels living in other windows (labelled "Other window").
   const filteredPanels = useMemo<PanelResult[]>(() => {
@@ -310,9 +335,10 @@ export const CommandPalette: React.FC = () => {
   // Flat list of every navigable item, in render order. Drives keyboard nav.
   const flatItems = useMemo<FlatItem[]>(() => [
     ...filteredCommands.map((command) => ({ kind: 'command', command }) as FlatItem),
+    ...filteredWorkspaces.map((workspace) => ({ kind: 'workspace', workspace }) as FlatItem),
     ...filteredPanels.map((panel) => ({ kind: 'panel', panel }) as FlatItem),
     ...displayedFiles.map((file) => ({ kind: 'file', file }) as FlatItem),
-  ], [filteredCommands, filteredPanels, displayedFiles])
+  ], [filteredCommands, filteredWorkspaces, filteredPanels, displayedFiles])
 
   const totalItems = flatItems.length
 
@@ -371,6 +397,8 @@ export const CommandPalette: React.FC = () => {
       close()
       if (item.kind === 'command') {
         item.command.action()
+      } else if (item.kind === 'workspace') {
+        void useAppStore.getState().selectWorkspace(item.workspace.id)
       } else if (item.kind === 'panel') {
         // A panel in another window: ask main to focus that window and reveal it.
         if (item.panel.inOtherWindow) void window.electronAPI.focusWindowPanel(item.panel.panelId)
@@ -391,7 +419,8 @@ export const CommandPalette: React.FC = () => {
   if (!showCommandPalette) return null
 
   // Section boundaries within the flat list.
-  const panelStart = filteredCommands.length
+  const workspaceStart = filteredCommands.length
+  const panelStart = workspaceStart + filteredWorkspaces.length
   const fileStart = panelStart + filteredPanels.length
   const filesLabel = query ? 'Files' : 'Recent Files'
 
@@ -433,7 +462,7 @@ export const CommandPalette: React.FC = () => {
                     break
                 }
               }}
-              placeholder="Search commands, panels and files by name"
+              placeholder="Search commands, workspaces, panels and files"
               className="flex-1 bg-transparent text-primary text-[13px] outline-none placeholder:text-muted"
             />
           </div>
@@ -469,10 +498,43 @@ export const CommandPalette: React.FC = () => {
                 </>
               )}
 
+              {/* Workspaces */}
+              {filteredWorkspaces.length > 0 && (
+                <>
+                  {filteredCommands.length > 0 && <Separator />}
+                  <SectionHeader>Workspaces</SectionHeader>
+                  {filteredWorkspaces.map((workspace, i) => {
+                    const itemIndex = workspaceStart + i
+                    const isSelected = itemIndex === selectedIndex
+                    return (
+                      <Row
+                        key={workspace.id}
+                        ref={isSelected ? selectedRowRef : undefined}
+                        selected={isSelected}
+                        onClick={() => activate({ kind: 'workspace', workspace })}
+                        onMouseEnter={() => setSelectedIndex(itemIndex)}
+                      >
+                        <span
+                          className="w-2.5 h-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: workspace.color || 'var(--text-muted)' }}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-primary text-[13px] truncate">{workspace.name}</div>
+                          {workspace.rootPath && (
+                            <div className="text-muted text-[11px] truncate">{workspace.rootPath}</div>
+                          )}
+                        </div>
+                        {workspace.isCurrent && <span className="text-[11px] text-muted">Current</span>}
+                      </Row>
+                    )
+                  })}
+                </>
+              )}
+
               {/* Panels */}
               {filteredPanels.length > 0 && (
                 <>
-                  {filteredCommands.length > 0 && <Separator />}
+                  {(filteredCommands.length > 0 || filteredWorkspaces.length > 0) && <Separator />}
                   <SectionHeader>Panels</SectionHeader>
                   {filteredPanels.map((panel, i) => {
                     const itemIndex = panelStart + i
@@ -497,7 +559,7 @@ export const CommandPalette: React.FC = () => {
               {/* Files */}
               {displayedFiles.length > 0 && (
                 <>
-                  {(filteredCommands.length > 0 || filteredPanels.length > 0) && <Separator />}
+                  {(filteredCommands.length > 0 || filteredWorkspaces.length > 0 || filteredPanels.length > 0) && <Separator />}
                   <SectionHeader>{filesLabel}</SectionHeader>
                   {displayedFiles.map((file, i) => {
                     const itemIndex = fileStart + i

--- a/src/renderer/ui/CommandPalette.windowPanels.test.tsx
+++ b/src/renderer/ui/CommandPalette.windowPanels.test.tsx
@@ -85,6 +85,32 @@ function rowWithText(text: string): HTMLElement | undefined {
 }
 
 describe('CommandPalette in the main window', () => {
+  it('lists workspaces and switches to the selected one', () => {
+    useAppStore.setState({
+      workspaces: [
+        { id: 'ws-A', name: 'Proj', color: '#4a8ad0', rootPath: '/tmp/p', panels: {} } as never,
+        { id: 'ws-B', name: 'Other Project', color: '#d05c5c', rootPath: '/tmp/other', panels: {} } as never,
+      ],
+      selectedWorkspaceId: 'ws-A',
+    })
+    const selectWorkspace = vi.spyOn(useAppStore.getState(), 'selectWorkspace').mockResolvedValue(undefined)
+
+    renderPalette('main')
+
+    expect(host.textContent).toContain('Workspaces')
+    expect(host.textContent).toContain('Proj')
+    expect(host.textContent).toContain('Other Project')
+    expect(host.textContent).toContain('Current')
+
+    const row = rowWithText('Other Project')
+    expect(row).toBeTruthy()
+    act(() => { row!.click() })
+
+    expect(selectWorkspace).toHaveBeenCalledWith('ws-B')
+    expect(useUIStore.getState().showCommandPalette).toBe(false)
+    selectWorkspace.mockRestore()
+  })
+
   it('lists panels living in other windows and reveals them via main', () => {
     renderPalette('main')
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -592,6 +592,22 @@ export function storedShortcut(
   }
 }
 
+/** Convert DOM KeyboardEvent key names to Cate's persisted shortcut keys. */
+export function normaliseShortcutKey(key: string): string {
+  switch (key) {
+    case 'Tab': return '\t'
+    case 'Enter': return '\r'
+    case ' ': return ' '
+    case 'Backspace': return 'Backspace'
+    case 'Escape': return 'Escape'
+    case 'ArrowLeft': return '\u2190'
+    case 'ArrowRight': return '\u2192'
+    case 'ArrowDown': return '\u2193'
+    case 'ArrowUp': return '\u2191'
+    default: return key.toLowerCase()
+  }
+}
+
 /** Mirrors StoredShortcut.displayString from Swift. */
 export function displayString(s: StoredShortcut): string {
   // An empty key means the binding is disabled (see clearShortcut).


### PR DESCRIPTION
## Summary

- normalize recorded special keys so custom arrow-key workspace shortcuts dispatch correctly
- add a searchable Workspaces section to the Command Palette
- show workspace names, paths, colors, and the current-workspace state
- switch workspaces by clicking a result or selecting it with the keyboard

## Root cause

The shortcut recorder persisted DOM `KeyboardEvent.key` names such as `ArrowRight`, while shortcut matching expected Cate's canonical `→` representation. The saved binding therefore displayed correctly but could never match. The recorder now converts the key before saving it.

## User impact

Custom workspace shortcuts such as Command+Shift+Left/Right now work when recorded. Users can also open Command+K, search for a workspace by name or path, and activate it without using the workspace tabs.

## Validation

- `npm test -- --run src/renderer/stores/shortcutStore.test.ts src/renderer/ui/CommandPalette.windowPanels.test.tsx`
- `npm run typecheck`
- targeted ESLint on the six changed files
- `git diff --check`
- `npm run build`
