### PR TITLE
chore(release): bump version to 1.6.0-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.0-beta.2",
+  "version": "1.6.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.0-beta.2",
+      "version": "1.6.0-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.0-beta.2",
+  "version": "1.6.0-beta.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.0-beta.2'
+export const RUNTIME_VERSION = '1.6.0-beta.3'


### PR DESCRIPTION
## Summary

- bump the Cate package version to `1.6.0-beta.3`
- keep the npm lockfile root version in sync
- update the bundled runtime version used to resolve matching release artifacts

## Impact

This prepares the next beta build and its matching runtime artifacts. The prerelease tag will cause the release workflow to publish a GitHub prerelease for beta-channel users.

## Validation

- `npm run typecheck`
- `npm test -- --run` (3,050 passed, 5 skipped)
- direct package/lockfile/runtime version consistency check
- `git diff --check`
