### PR TITLE
Add detailed post-update changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ npm test           # run vitest suite
 
 Tests use **Vitest** and live alongside the code they cover (`*.test.ts` / `*.test.tsx`). A few git-touching tests assume a clean working repo and may fail when the dev tree has a branch named `main` or local modifications — those failures are environmental, not regressions.
 
+## Release Process
+
+Before creating any beta or stable release, update `CHANGELOG.md` with the
+matching version, release date, summary, and categorized user-facing changes.
+The changelog entry must be complete before bumping or tagging the release.
+
 ## Dependencies
 
 Managed via npm (`package.json`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,244 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.6.0-beta.3] - 2026-07-26
+
+This beta sharpens browser automation, workspace navigation, remote safety, and agent status reporting.
+
+### Added
+
+- **Browser automation controls**: agents and the Cate CLI can inspect pages, manage tabs, enter trusted input, evaluate scripts, read console output, handle dialogs, and capture screenshots through a smaller, clearer command surface.
+- **Workspace navigation commands**: the command palette can switch directly between workspaces, backed by repaired workspace keyboard shortcuts.
+
+### Changed
+
+- **Clearer Cate CLI workflows**: the command set and skill guidance now focus on the supported browser, terminal, file, and panel workflows.
+- **More reliable agent status**: running and waiting states now follow the coding-agent lifecycle more consistently.
+
+### Fixed
+
+- **Remote workspace path validation**: relative remote paths are rejected before they can resolve against an unintended directory.
+
+## [1.6.0-beta.2] - 2026-07-25
+
+Browser panels gain agent-ready controls and secure credential profiles.
+
+### Added
+
+- **Browser control API**: automation can navigate, inspect, click, type, and capture browser panels without relying on page-specific integrations.
+- **Credential profiles**: saved browser credentials can be imported, selected, filled, and cleared through the host UI without exposing secrets to page scripts.
+
+### Fixed
+
+- **Portable browser storage**: SQLite-backed browser history and credential features load only on supported targets, preventing startup failures elsewhere.
+
+## [1.6.0-beta.1] - 2026-07-24
+
+Major agent, workspace, terminal, and security improvements for the 1.6 beta cycle.
+
+### Added
+
+- **Unified Cate Agent chats**: chats are workspace-owned, can be shared between sidebar and panel hosts, and survive moving between views.
+- **Multiple custom AI providers**: configure and choose more than one OpenAI-compatible provider.
+- **Worktree-aware agent setup**: agent configuration and hooks work consistently from the main checkout and linked worktrees.
+
+### Changed
+
+- **Safer workspace trust**: untrusted repositories cannot restore or autosave repo-controlled layouts until the user explicitly trusts them.
+- **Themeable wallpaper scrim**: themes can control the contrast layer above canvas backgrounds.
+
+### Fixed
+
+- **Terminal rendering and focus**: split terminals keep focus, and GPU rendering artifacts recover without manual resizing.
+- **Worktree actions**: failures are surfaced cleanly and closing a canvas preserves panels that were moved elsewhere.
+- **Canvas gestures**: input no longer remains stuck when a gesture target unmounts.
+
+## [1.5.3] - 2026-07-21
+
+### Added
+
+- **Browsable extension catalog**: extensions can be explored by category, searched, and paged instead of appearing as one flat list.
+
+### Changed
+
+- **Shared Cate Agent pickers**: the composer now reuses the standard model and worktree pickers for consistent selection behavior.
+
+## [1.5.2] - 2026-07-21
+
+Agent automation release centered on durable hook-driven status, explicit CLI permissions, extension URL mode, and cross-platform release reliability.
+
+### Added
+
+- **Unified agent hooks**: supported coding agents report lifecycle, permission, and needs-input events through one hook system, with state surviving app restarts.
+- **Cate CLI permission matrix**: read and control capabilities can be granted independently, with a dedicated terminal command group and per-feature settings.
+- **URL-mode extensions**: extension panels can load a declared URL and still participate in off-screen culling.
+- **Grok support and centralized agent registry**: Grok joins the supported agents, with shared metadata and detection policy.
+
+### Changed
+
+- **Non-disruptive Cate automation**: CLI-driven actions avoid stealing focus or disturbing the active workspace.
+- **Detached window chrome**: detached-window controls share the dock tab-bar row for a more compact layout.
+
+### Fixed
+
+- **Cross-platform release builds**: deterministic installs and a Windows runtime fix unblock builds with newer Visual Studio toolchains.
+
+## [1.5.1] - 2026-07-15
+
+### Fixed
+
+- **Workspace and input hardening**: workspace transitions, gesture cleanup, and related input edge cases are more defensive.
+
+## [1.5.0] - 2026-07-15
+
+Stable release of the 1.4 beta cycle, introducing the redesigned Cate Agent, extension platform, agent-facing Cate CLI, and major shell/navigation updates.
+
+### Fixed
+
+- **macOS fullscreen sidebar**: the traffic-light inset collapses correctly when the left sidebar enters fullscreen.
+
+## [1.4.0-beta.6] - 2026-07-15
+
+### Fixed
+
+- **Focus retention**: panels and dialogs keep keyboard focus through common click, drag, and overlay transitions.
+- **Canvas and docking polish**: corrected split rendering, tab-drop previews, sidebar chrome, and window-close quit guards.
+- **Agent model compatibility**: provider catalog changes no longer break the available-model list.
+
+### Changed
+
+- **Editor and terminal overlays**: the Markdown toggle floats over the editor, while terminal search no longer collides with the worktree chip.
+
+## [1.4.0-beta.5] - 2026-07-14
+
+### Added
+
+- **Three-state sidebar rail**: the left rail returns with collapsed, compact, and expanded states plus drag-and-drop between rails.
+- **Responsive canvas toolbar**: the toolbar collapses into a corner control when space is tight.
+- **Workspace navigation shortcuts**: next/previous workspace bindings are customizable.
+
+### Fixed
+
+- **Persistent browser tabs**: webview-backed tabs stay mounted when switching, avoiding unwanted page reloads.
+- **Detached macOS windows**: detached windows regain their header bar and controls.
+
+## [1.4.0-beta.4] - 2026-07-14
+
+### Changed
+
+- **Application chrome redesign**: window chrome, browser tabs, sidebars, and theme integration were reworked as one cohesive shell update.
+
+## [1.4.0-beta.3] - 2026-07-13
+
+### Added
+
+- **Cate Agent sidebar home**: dedicated composer, chat tabs, navigation rail, and merge-target controls.
+- **Agent-oriented Cate CLI**: the host API and CLI surface were reshaped around safe panel, terminal, browser, and workspace automation and enabled by default.
+- **Structured verifier results**: Cate Agent checks report individual verdicts instead of a single opaque outcome.
+
+### Changed
+
+- **Consolidated application state**: legacy migrations and duplicated application systems were removed.
+
+### Fixed
+
+- **Canvas undo**: undo restores deleted panels rather than leaving ghost nodes.
+- **Terminal GPU rendering**: glyph-atlas desynchronization and process-wide WebGL context overflow are contained.
+- **macOS notarization**: native pi-agent addons are signed before packaging.
+
+## [1.4.0-beta.2] - 2026-07-08
+
+### Changed
+
+- **Cate Agent chat motion**: the chat window now morphs cleanly into and out of the toolbar button with consolidated loading states.
+- **Observer chat front door**: observer sessions can be selected and opened through the same chat surface.
+
+## [1.4.0-beta.1] - 2026-07-07
+
+First public beta of the toolbar-driven Cate Agent and extension platform.
+
+### Added
+
+- **Always-on Cate Agent**: workspace chat can observe work, launch parallel attempts, control terminals, manage worktrees, and resume jobs through a toolbar-anchored interface.
+- **Extension system**: isolated, server-backed extension panels with permissions, storage, file-drop support, catalog provisioning, and agent conversation APIs.
+- **Agent-facing browser and CLI control**: terminal agents and extensions can drive browser panels and scoped `cate` command groups.
+- **Multi-repository Source Control**: repositories nested below a workspace root are discovered independently.
+- **Worktree-aware navigation**: sidebars and the minimap group or color panels by worktree.
+
+### Fixed
+
+- **Terminal renderer exhaustion**: WebGL contexts are budgeted process-wide and fall back to the DOM renderer instead of producing blank terminals.
+- **Canvas recovery**: corrupt saved geometry is ignored, selection/focus is unified, and group dragging remains stable.
+- **Windows path handling**: allowed roots use native real paths so extension and workspace operations work across platforms.
+
+## [1.3.2] - 2026-06-24
+
+### Added
+
+- **Grow-to-fill placement**: recommended panel placement can expand into available canvas space.
+
+### Fixed
+
+- **Worktree restore authority**: the saved worktree tag determines a panel's working directory after reload.
+
+## [1.3.2-beta.2] - 2026-06-21
+
+### Added
+
+- **GPU text rasterization toggle**: users can disable GPU text rasterization when a driver or display setup renders text poorly.
+
+### Fixed
+
+- **Runtime startup**: the packaged runtime includes the complete file-watcher dependency closure and retries failed local starts.
+- **Staged updates**: the updater stops rechecking once an update is downloaded, preserving the ready-to-install state.
+
+## [1.3.2-beta.1] - 2026-06-21
+
+### Added
+
+- **Unified browser experience**: browser panels gain history, bookmarks, tabs, settings, and a start page.
+- **OSC 52 clipboard support**: terminal applications can write to the system clipboard through OSC 52.
+- **Worktree panel cleanup**: worktree removal and symlink creation clean up associated panels and metadata.
+
+### Changed
+
+- **Native recursive file watching**: workspace watching moved to a pooled native watcher to avoid descriptor exhaustion on large projects.
+- **Canonical canvas selection**: focus, single selection, and group selection share one state model.
+
+### Fixed
+
+- **Terminal worktree restore**: restored terminals return to their worktree working directory.
+- **Updater prompts**: downloaded-update prompts appear once per version rather than every polling interval.
+- **Agent worktree switching**: a running agent moves with its selected worktree.
+
+## [1.3.1] - 2026-06-15
+
+Stability and editor release with hardened persistence, external-file conflict handling, refined shortcuts, and runtime packaging improvements.
+
+### Added
+
+- **External file-change handling**: editor panels detect disk changes and offer explicit reload/keep resolutions.
+- **Editor customization**: configurable editor font family and copy buttons on Markdown code blocks.
+- **Sidebar workspace controls**: expand or collapse all workspaces from the sidebar header.
+
+### Changed
+
+- **Runtime naming**: the remote companion was renamed and packaged consistently as the Cate runtime.
+- **Telemetry notice**: packaged builds use informational always-on telemetry with a one-time census for existing installs.
+
+### Fixed
+
+- **JSON state reliability**: atomic writes retry transient Windows rename failures, and session restore tolerates damaged state.
+- **Terminal redraw stability**: phantom resizes no longer duplicate full-screen TUI frames.
+- **Hidden-file synchronization**: hidden files remain watched and resync when reopened.
+- **Intel macOS runtime**: macOS packages include the x64 runtime built on the supported Intel runner.
+
+## [1.3.0] - 2026-06-09
+
+### Added
+
+- **Multi-node canvas selection**: marquee-select multiple panels, drag them as a group, and close the selection in one action.
+
 ## [1.2.7] - 2026-06-09
 
 ### Fixed
@@ -21,6 +259,202 @@ Bug-fix release for terminals detached into their own window.
 
 - **Detached terminals no longer render blank or grey**: the GPU renderer now rebuilds and repaints once the new window is actually shown, instead of staying empty until the next output.
 - **Detached terminal scrollback keeps its formatting**: replayed history is written with proper line breaks, so multi-column output (like `ls`) lines up again instead of cascading down the screen.
+
+## [1.2.5] - 2026-06-09
+
+### Changed
+
+- **Modular main process and renderer state**: sessions, terminals, panel windows, the app store, and IPC bridge were split into focused modules.
+- **Cross-window panels**: detached panel rows show live agent state, provider branding, ports, and worktree accents while keeping scrollback synchronized.
+
+### Added
+
+- **In-app update-ready modal**: downloaded updates offer restart-now or install-on-quit actions inside Cate.
+
+## [1.2.5-beta.4] - 2026-06-08
+
+Release-candidate rebuild of beta.3 with no additional user-facing changes.
+
+## [1.2.5-beta.3] - 2026-06-08
+
+### Fixed
+
+- **Reliable update archives**: differential downloads are disabled to avoid partially assembled macOS bundles.
+- **Lean native unpacking**: packaged native dependencies are limited to the required runtime floor.
+
+## [1.2.5-beta.2] - 2026-06-08
+
+### Fixed
+
+- **Install-loop recovery**: repeated failed update installs now reach the manual-download fallback instead of resetting their retry counter forever.
+- **Release availability**: macOS releases no longer wait on the end-to-end suite.
+
+## [1.2.5-beta.1] - 2026-06-08
+
+### Added
+
+- **Self-healing updater diagnostics**: failed installs are persisted, retried, and eventually routed to a clear manual fallback, with a development update harness for verification.
+- **Worktree identity on panels**: panel overlays expose the active worktree and apply its accent color.
+
+### Fixed
+
+- **Remote SSH parsing**: invalid key parser results no longer crash the connection flow.
+- **Windows/Linux menu access**: frameless windows regain an accessible title-bar menu.
+- **Canvas typing stability**: typing to the end of a line no longer shifts the canvas and exposes a background gap.
+- **Agent setup errors**: missing pi-agent directories are not mislabeled as permission failures.
+
+## [1.2.4] - 2026-06-08
+
+### Added
+
+- **Remote SSH key workflow**: choose a private key with a native picker, validate its format, and get clearer disconnect logging.
+
+### Changed
+
+- **Curated skills catalog**: catalog sources require descriptions, duplicate rows are removed, and GitHub source links stay visible.
+- **Command palette navigation**: keyboard navigation and action routing are unified across commands and overview panels.
+
+## [1.2.3] - 2026-06-07
+
+### Added
+
+- **Cross-agent skills manager**: discover and manage reusable skills for supported agents.
+- **Multi-canvas sessions**: project sessions can persist and restore more than one canvas.
+
+## [1.2.2] - 2026-06-07
+
+### Added
+
+- **Custom Windows/Linux chrome**: frameless windows receive native-feeling window controls and a consistent themed title bar.
+- **Themed placement picker**: placement previews and worktree colors follow the active theme.
+
+### Changed
+
+- **Stock updater path**: the custom updater UI was replaced with electron-updater's reliable install-on-quit flow and macOS recovery handling.
+
+### Fixed
+
+- **Saved layouts**: layouts apply to the active canvas rather than a stale/default canvas.
+- **Window and terminal titles**: display names derive from folder names instead of full filesystem paths.
+- **Dock tab sizing**: tab titles remain readable when no worktree pill is present.
+
+## [1.2.1] - 2026-06-06
+
+### Changed
+
+- **Theme-aware agent surfaces**: agent UI colors track the active theme.
+- **Snap-preview dragging**: drag previews show the eventual grid-snapped placement.
+
+### Fixed
+
+- **Update restart flow**: installing an update relaunches Cate, and the update affordance remains visible with an empty right sidebar.
+
+## [1.2.0] - 2026-06-06
+
+### Added
+
+- **Parallel-worktree toolbar**: create and manage worktrees directly from a canvas toolbar menu.
+- **Friendly application errors**: common failures are translated into actionable messages.
+
+### Changed
+
+- **Simpler canvas model**: canvas regions were removed in favor of shared modal and placement primitives.
+- **Spatial territories**: worktree territory outlines were slimmed down for a quieter canvas.
+
+### Fixed
+
+- **Cross-zoom dragging**: dock-to-canvas drag previews scale correctly for the destination canvas.
+
+## [1.2.0-beta.1] - 2026-06-06
+
+First beta of spatial worktrees and the hand-editable JSON persistence model.
+
+### Added
+
+- **Spatial worktree territories**: worktrees appear as live, colored canvas territories with tab pills and session persistence.
+- **Hand-editable application state**: Cate settings and UI state moved to readable JSON files with consolidated provider preferences.
+- **Hillside wallpaper**: a built-in canvas background joins custom background images.
+- **Worktree-aware minimap**: terminals running agents display the agent icon.
+
+### Changed
+
+- **Single-source panel state**: panel, dock, canvas, and window records were consolidated to reduce conflicting state.
+- **Cate Agent naming**: the former Pi Agent UI was renamed and its tooltips and shortcuts were cleaned up.
+- **Sidebar layout**: the sidebar pushes dock content instead of overlaying it.
+- **Update location**: update status moved to the right sidebar.
+
+### Fixed
+
+- **Panel creation shortcuts**: creation shortcuts work even when focus is outside the canvas.
+- **Spatial selection and panning**: territory shapes, panning locks, and active-row behavior were refined.
+
+## [1.1.1-beta.8] - 2026-06-05
+
+### Fixed
+
+- **macOS signing identity lookup**: the release keychain is added to the search list before codesigning.
+
+## [1.1.1-beta.7] - 2026-06-05
+
+### Fixed
+
+- **macOS runtime notarization**: native companion binaries are signed before the app is notarized.
+
+## [1.1.1-beta.6] - 2026-06-05
+
+### Fixed
+
+- **Release version consistency**: companion and pi-agent versions are synchronized before the application build begins.
+
+## [1.1.1-beta.5] - 2026-06-05
+
+### Fixed
+
+- **Portable Windows packaging**: archive paths work across drive letters, duplicate native builds are avoided, and unsupported Intel macOS packaging was temporarily removed.
+
+## [1.1.1-beta.4] - 2026-06-04
+
+### Fixed
+
+- **Windows archive naming**: release tarballs are created from a basename in their source directory rather than an absolute Windows path.
+
+## [1.1.1-beta.3] - 2026-06-04
+
+### Fixed
+
+- **Windows tar invocation**: release archives use local-path mode so drive-letter paths are not parsed as remote hosts.
+
+## [1.1.1-beta.2] - 2026-06-04
+
+### Fixed
+
+- **Windows binary staging**: packaged Node and ripgrep binaries are copied across filesystems instead of relying on a rename that can fail with `EXDEV`.
+
+## [1.1.1-beta.1] - 2026-06-04
+
+Large production-readiness beta introducing remote workspaces, saved layouts, content search, beta updates, and broad navigation polish.
+
+### Added
+
+- **Remote SSH and WSL workspaces**: connect to projects outside the local machine through the packaged runtime.
+- **Saved layouts**: save and apply layouts from a dedicated dialog, empty-canvas picker, sidebar action, or native menu.
+- **Content search view**: VS Code-style workspace search with keyboard navigation.
+- **Keyboard canvas navigation**: move between panels and pan the canvas without reaching for the mouse.
+- **Per-browser proxy**: each browser panel can use its own HTTP proxy.
+- **Editable settings file**: open `settings.json`, edit it by hand, and see supported changes reload live.
+- **Beta update channel and canvas backgrounds**: opt into prereleases and choose a theme-aware canvas image.
+
+### Changed
+
+- **Themed macOS title bar**: macOS consistently uses Cate's title bar instead of a separate native-tabs mode.
+- **Searchable settings**: settings use sidebar navigation, search, fixed sizing, and scroll-spy highlighting.
+
+### Fixed
+
+- **Notification focus**: clicking an OS notification reliably brings its Cate window forward.
+- **Command palette results**: file-name matches no longer starve content-search results.
+- **Shortcut routing**: commands target the active canvas store, including new-file and VS Code/browser parity bindings.
+- **Foreground terminal close protection**: closing a terminal with a running foreground process asks for confirmation.
 
 ## [1.1.1] - 2026-06-01
 
@@ -197,6 +631,12 @@ First major release. Stabilises the agent panel, introduces semantic color token
 ### Fixed
 
 - **Auto-update download fallback** — when electron-updater's initial check errors (e.g. provider mismatch), the fallback now broadcasts `available` instead of `manual`, so clicking Update attempts a native download first and only falls back to the release page if that fails.
+
+## [0.4.13] - 2026-05-24
+
+### Fixed
+
+- **Native update retry first**: a failed update check now attempts electron-updater's native download path before offering a manual installer.
 
 ## [0.4.12] - 2026-05-24
 
@@ -406,6 +846,257 @@ First minor release since the open-source drop. Major focus: unified **Spotlight
 
 - 13 PRs across the release (#3–#5, #7–#15). One commit per feature on main via squash-merge. All commits follow conventional-commits formatting with why-not-what bodies.
 - CI builds green across `ubuntu-latest`, `macos-latest`, `windows-latest` for every merged PR.
+
+## [0.2.18] - 2026-04-15
+
+Security and stability hardening release across workspace trust, filesystem boundaries, crash reporting, and continuous integration.
+
+### Added
+
+- **Workspace session trust**: restored sessions are checked before project-controlled state is applied.
+- **Crash-report archive**: renderer and main-process crashes are retained with a bounded history for later diagnosis.
+- **Electron smoke tests and unit coverage**: CI verifies application startup plus git, path-validation, and session-trust behavior.
+
+### Changed
+
+- **Tighter filesystem sandbox**: workspace roots, web security, feature flags, and preload IPC contracts were hardened together.
+
+### Fixed
+
+- **Release icon generation**: restored the Cate logo asset required by the packaging pipeline.
+
+## [0.2.17] - 2026-04-14
+
+### Fixed
+
+- **Clean application exit**: corrected the final quit/exit call and silenced the production console logger.
+- **Release asset publishing**: repaired the workflow that attaches platform builds to a release.
+
+## [0.2.16] - 2026-04-14
+
+### Added
+
+- **File explorer drag-and-drop moves**: move files and folders directly in the explorer and create new entries relative to the clicked folder.
+
+### Fixed
+
+- **Terminal lifecycle leaks**: PTYs and terminal resources are released on crashes and abnormal teardown.
+
+## [0.2.15] - 2026-04-13
+
+### Fixed
+
+- **Safe shutdown**: normal quits no longer trigger `SIGABRT`.
+- **Continuous session persistence**: active session state is saved throughout the run instead of relying only on final shutdown.
+
+## [0.2.14] - 2026-04-13
+
+### Fixed
+
+- **Long-session memory usage**: terminal loggers, usage watchers, and caches now release resources when their owners close.
+
+## [0.2.13] - 2026-04-12
+
+### Added
+
+- **Processes and ports overview**: the sidebar can show running workspace processes and listening ports in one popover.
+
+## [0.2.12] - 2026-04-12
+
+### Fixed
+
+- **Quit-time session restore**: workspace state is flushed reliably before exit.
+- **Zombie child processes**: terminals and other spawned processes are terminated when Cate closes.
+
+## [0.2.11] - 2026-04-08
+
+### Fixed
+
+- **Embedded browser loading**: the renderer content-security policy no longer blocks browser-panel objects required by Electron webviews.
+
+## [0.2.10] - 2026-04-08
+
+### Changed
+
+- **Canvas, docking, and workspace integration**: refined the in-progress multi-window layout and workspace state flow.
+
+## [0.2.9] - 2026-04-08
+
+### Changed
+
+- **Faster startup**: an inline splash paints before the renderer loads, panel-window restoration is deferred, panel chunks preload in parallel, and background scans wait until idle.
+
+### Fixed
+
+- **Usage scan scope**: usage watchers limit directory depth and ignore unrelated files.
+
+## [0.2.8] - 2026-04-08
+
+### Fixed
+
+- **Fullscreen event typing**: corrected Electron fullscreen listener signatures so the release builds typecheck cleanly.
+
+## [0.2.7] - 2026-04-08
+
+### Changed
+
+- **Electron 41.2.0**: updated the desktop runtime to the current 41.x patch release.
+
+## [0.2.6] - 2026-04-08
+
+Broad work-in-progress stabilization release across docking, the sidebar, updater UI, and usage tracking.
+
+### Added
+
+- **Usage view and model pricing**: inspect usage from the sidebar with model-cost metadata.
+- **Dirty-editor close confirmation**: editor buffers register save handlers and warn before being discarded.
+- **Visible-panel autofocus**: the largest visible canvas node can receive focus automatically.
+
+### Fixed
+
+- **Updater progress window**: install progress remains visible, closes reliably, and allows enough time for disk-image installation.
+
+## [0.2.5] - 2026-04-07
+
+### Changed
+
+- **Electron 41**: upgraded the desktop runtime and refreshed native packaging.
+- **Sidebar polish**: workspace naming and navigation received a visual cleanup.
+
+### Fixed
+
+- **Crisp terminal fitting**: resize work is coalesced and terminal rendering remains sharp at high canvas zoom.
+- **Workspace rename**: renamed workspaces persist and display correctly.
+- **macOS signing inputs**: the entitlements file is included, and icon generation handles the current `png-to-ico` export.
+
+## [0.2.4] - 2026-04-05
+
+### Added
+
+- **Fallback installer**: when the native updater fails, Cate can download and launch a platform installer directly.
+
+### Fixed
+
+- **Windows installer launch**: detached installers use `spawn` so they survive Cate exiting.
+- **Panel drag ghost**: the cross-window drag preview follows the cursor accurately.
+
+## [0.2.3] - 2026-04-04
+
+### Added
+
+- **Terminal scrollback restore**: terminal history is replayed when panels or sessions return.
+- **Canvas annotation colors**: annotations can carry distinct visual accents.
+- **Isolated development data**: local development no longer shares the packaged application's user data.
+
+### Fixed
+
+- **Terminal scrolling**: restored and focused terminals keep the intended viewport position.
+
+## [0.2.2] - 2026-04-03
+
+### Added
+
+- **File explorer background menu**: right-click empty explorer space to create a file or folder.
+
+### Fixed
+
+- **Terminal scroll retention**: focus changes no longer jump the terminal viewport.
+- **Deferred workspace notifications**: notification actions retry until a lazily restored workspace is ready.
+
+## [0.2.1] - 2026-04-03
+
+### Added
+
+- **Structured logging**: renderer and main-process events use a shared logging pipeline.
+- **Filesystem path validation**: file operations are constrained to registered workspace roots.
+
+### Changed
+
+- **Session reliability**: closing child windows flushes their state before teardown.
+
+### Fixed
+
+- **Notification error colors**: error notifications use the correct status-dot type.
+- **Terminal, browser, resize, and docking polish**: corrected several early multi-window lifecycle edge cases.
+
+## [0.2.0] - 2026-04-02
+
+Major architecture release introducing detachable windows and a VS Code-style docking model.
+
+### Added
+
+- **Multi-window shells**: main, panel, and dock windows share a registry and route to the correct renderer shell.
+- **Four-zone docking**: left, right, bottom, and center zones support split layouts and tab stacks.
+- **Cross-window panel transfer**: drag panels between windows while preserving terminal scrollback, browser state, and editor position.
+- **Canvas panels**: canvases became first-class panels that can live in a dock zone.
+- **Persisted window layouts**: dock layouts, detached windows, and multi-workspace state restore across launches.
+- **Shell environment resolution**: terminals inherit paths from common version managers and package-manager installations.
+
+### Changed
+
+- **Main-owned workspaces**: workspace records moved to the main process as the shared source of truth.
+
+## [0.1.5] - 2026-04-01
+
+### Added
+
+- **Notification center**: in-app toasts, OS notifications, a bell popover, and notification preferences.
+- **Generic coding-agent detection**: terminal activity recognizes Claude Code, Codex, Gemini CLI, Cursor, and OpenCode.
+- **Terminal file drops**: drop operating-system files or file-explorer entries into a terminal to insert their paths.
+
+### Fixed
+
+- **Browser panel interaction**: focus, saved URLs, and wheel-event passthrough work reliably.
+- **Terminal input and rendering**: Option-as-Meta, WebGL recovery, scroll retention, and shortcut isolation were corrected.
+- **Directory drops**: folders no longer create invalid editor panels on the canvas.
+
+## [0.1.4] - 2026-03-31
+
+### Fixed
+
+- **Updater outcomes**: update-available, up-to-date, and error results all produce clear feedback.
+- **Release publication order**: a release is published only after every platform build finishes.
+
+## [0.1.3] - 2026-03-31
+
+### Added
+
+- **Full Source Control panel**: push, pull, branch, stash, and diff workflows are available inside Cate.
+
+### Changed
+
+- **Canvas performance**: reduced unnecessary work during common canvas interactions.
+
+### Fixed
+
+- **Panel scrolling**: wheel input scrolls the focused editor, terminal, or browser instead of panning the canvas.
+- **Release reuse**: CI skips release creation when the target release already exists.
+
+## [0.1.2] - 2026-03-31
+
+### Changed
+
+- **Focused initial scope**: removed unfinished features and the early AI chat panel from the release build.
+
+### Fixed
+
+- **Panel switcher colors**: all supported panel types map to a valid color.
+- **Release assets**: the pipeline uploads packaged files instead of publishing an empty release.
+
+## [0.1.1] - 2026-03-30
+
+### Added
+
+- **Automatic updates**: packaged builds can discover and install newer Cate releases.
+- **Collapsible sidebar**: reclaim canvas space without closing sidebar tools.
+
+### Changed
+
+- **Browser URL handling**: entering and normalizing addresses is more forgiving.
+
+### Fixed
+
+- **macOS quarantine guidance**: documented the workaround for unsigned/quarantined early builds.
 
 ## [0.1.0] - 2026-03-29
 

--- a/src/main/analytics.test.ts
+++ b/src/main/analytics.test.ts
@@ -130,16 +130,16 @@ describe('decideUpdateAction', () => {
     expect(action.nextState.pendingFeedbackFromVersion).toBe('1.5.0')
   })
 
-  test('patch-only update does NOT trigger the dialog prompt', () => {
+  test('patch-only update also triggers the changelog dialog prompt', () => {
     const action = decideUpdateAction('1.0.1', { lastSeenVersion: '1.0.0' })
     expect(action.kind).toBe('version_changed')
     if (action.kind !== 'version_changed') return
     expect(action.emit).toBe('app_updated')
     expect(action.from).toBe('1.0.0')
     expect(action.to).toBe('1.0.1')
-    expect(action.prompt).toBeUndefined()
-    expect(action.nextState.pendingFeedbackForVersion).toBeUndefined()
-    expect(action.nextState.pendingFeedbackFromVersion).toBeUndefined()
+    expect(action.prompt).toEqual({ from: '1.0.0', to: '1.0.1' })
+    expect(action.nextState.pendingFeedbackForVersion).toBe('1.0.1')
+    expect(action.nextState.pendingFeedbackFromVersion).toBe('1.0.0')
   })
 
   test('normal launch (same version, no pending) does NOT trigger dialog', () => {

--- a/src/main/analytics.ts
+++ b/src/main/analytics.ts
@@ -17,7 +17,7 @@
 //   - update_install_clicked   : user clicked "Restart" to install
 //   - update_manual_open_clicked : user clicked through to GitHub release page
 //   - feedback_submitted       : 1-5 rating + optional free-text comment, post-update
-//   - feedback_dismissed       : user skipped/closed the post-update feedback dialog
+//   - feedback_dismissed       : user skipped/closed the post-update dialog
 //   - agent_message_sent       : user sent a message to an agent — kind (prompt/
 //                                steer/follow_up), char count, has_images. No text.
 //
@@ -53,7 +53,7 @@ const MAX_PENDING_BYTES = 256 * 1024 // cap the offline buffer so it can't grow 
 
 export interface AnalyticsState {
   lastSeenVersion?: string
-  /** When set, the renderer should show the post-update feedback modal once.
+  /** When set, the renderer should show the post-update changelog + feedback modal once.
    *  Cleared after the user submits or dismisses. */
   pendingFeedbackForVersion?: string
   /** Track previous version so the feedback event can include both. */
@@ -80,8 +80,7 @@ function writeState(state: AnalyticsState): void {
 
 /** Dev-only: seed the analytics state so the next launch looks like an update
  *  from a synthetic previous version one `level` below the current app version.
- *  Returns the synthesized "from" version. A major/minor delta triggers the
- *  post-update feedback dialog; a patch delta intentionally does not. */
+ *  Returns the synthesized "from" version. */
 export function devSimulateUpdateFrom(level: 'major' | 'minor' | 'patch'): string {
   const [maj = 0, min = 0, pat = 0] = app.getVersion().replace(/^v/, '').split('.').map(Number)
   const from =
@@ -341,7 +340,7 @@ export function initAnalytics(): void {
 
 export type UpdateAction =
   // First install emits app_install but does NOT queue a feedback prompt — the
-  // onboarding tour is the first-run welcome, so the promo/feedback dialog would
+  // onboarding tour is the first-run welcome, so the changelog/feedback dialog would
   // overlap it. The dialog is for updates only.
   | { kind: 'first_install'; emit: 'app_install'; nextState: AnalyticsState }
   | { kind: 'no_change'; nextState: AnalyticsState; prompt?: { from: string; to: string } }
@@ -382,12 +381,6 @@ export function decideCensusAction(state: AnalyticsState, installIdPreexistedFla
   }
 }
 
-function isMajorOrMinorBump(from: string, to: string): boolean {
-  const pa = from.replace(/^v/, '').split('.').map(Number)
-  const pb = to.replace(/^v/, '').split('.').map(Number)
-  return (pb[0] || 0) !== (pa[0] || 0) || (pb[1] || 0) !== (pa[1] || 0)
-}
-
 export function decideUpdateAction(current: string, state: AnalyticsState): UpdateAction {
   const previous = state.lastSeenVersion
 
@@ -396,7 +389,7 @@ export function decideUpdateAction(current: string, state: AnalyticsState): Upda
       kind: 'first_install',
       emit: 'app_install',
       // No pendingFeedback*: the first-run welcome is the onboarding tour, so we
-      // never surface the feedback/promo dialog on a brand-new install.
+      // never surface the changelog/feedback dialog on a brand-new install.
       nextState: { ...state, lastSeenVersion: current },
     }
   }
@@ -405,15 +398,11 @@ export function decideUpdateAction(current: string, state: AnalyticsState): Upda
     const action: UpdateAction = { kind: 'no_change', nextState: state }
     // Re-prompt if a previous launch queued feedback but the user killed the
     // app before answering. The pending flag is cleared on submit/dismiss.
-    // Only re-prompt for major/minor bumps.
-    if (state.pendingFeedbackForVersion === current &&
-        isMajorOrMinorBump(state.pendingFeedbackFromVersion ?? '0.0.0', current)) {
+    if (state.pendingFeedbackForVersion === current) {
       action.prompt = { from: state.pendingFeedbackFromVersion ?? previous, to: current }
     }
     return action
   }
-
-  const showPrompt = isMajorOrMinorBump(previous, current)
 
   return {
     kind: 'version_changed',
@@ -423,10 +412,10 @@ export function decideUpdateAction(current: string, state: AnalyticsState): Upda
     nextState: {
       ...state,
       lastSeenVersion: current,
-      pendingFeedbackForVersion: showPrompt ? current : undefined,
-      pendingFeedbackFromVersion: showPrompt ? previous : undefined,
+      pendingFeedbackForVersion: current,
+      pendingFeedbackFromVersion: previous,
     },
-    prompt: showPrompt ? { from: previous, to: current } : undefined,
+    prompt: { from: previous, to: current },
   }
 }
 
@@ -437,7 +426,7 @@ export function decideUpdateAction(current: string, state: AnalyticsState): Upda
  */
 export async function checkAndReportUpdate(mainWin: BrowserWindow): Promise<void> {
   // E2E profiles start from a fresh version state every run, which looks like a
-  // first install / version bump and would pop the post-update feedback modal.
+  // first install / version bump and would pop the post-update changelog modal.
   // That modal intercepts pointer events and flakes tests — never show it here.
   if (process.env.CATE_E2E === '1') return
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -168,8 +168,8 @@ if (!app.isPackaged && process.env.CATE_FRESH_USERDATA === '1') {
 // (already-onboarded) user, so the onboarding tour stays hidden — but the
 // telemetry notice still appears, because the simulated profile hasn't
 // acknowledged the current TELEMETRY_NOTICE_VERSION (exactly like a real user
-// updating into this release). On major/minor bumps the post-update feedback
-// dialog appears alongside it; a patch bump shows the notice only. See dev:update:*.
+// updating into this release). The post-update changelog/feedback dialog then
+// appears for every simulated version bump. See dev:update:*.
 if (!app.isPackaged && (process.env.CATE_SIMULATE_UPDATE === 'major' || process.env.CATE_SIMULATE_UPDATE === 'minor' || process.env.CATE_SIMULATE_UPDATE === 'patch')) {
   const level = process.env.CATE_SIMULATE_UPDATE
   const fs = require('fs') as typeof import('fs')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -951,7 +951,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // ---------------------------------------------------------------------------
-  // Analytics — post-update feedback prompt
+  // Post-update changelog + feedback prompt
   // ---------------------------------------------------------------------------
 
   onUpdateStatus(callback: (status: UpdateStatus) => void): () => void {

--- a/src/renderer/assets/assets.d.ts
+++ b/src/renderer/assets/assets.d.ts
@@ -14,3 +14,8 @@ declare module '*.svg?url' {
   const src: string
   export default src
 }
+
+declare module '*.md?raw' {
+  const content: string
+  export default content
+}

--- a/src/renderer/dialogs/PostUpdateFeedbackDialog.test.tsx
+++ b/src/renderer/dialogs/PostUpdateFeedbackDialog.test.tsx
@@ -1,7 +1,7 @@
 // =============================================================================
-// PostUpdateFeedbackDialog — post-update "rate this update" dialog. It must wait
+// PostUpdateFeedbackDialog — post-update changelog + rating dialog. It must wait
 // for the telemetry notice (WelcomeDialog) to be acknowledged before it appears,
-// so on an update the notice goes first and the feedback dialog isn't mounted
+// so on an update the notice goes first and the post-update dialog isn't mounted
 // (and running its GitHub fetch) behind the opaque notice. Mirrors the gating
 // the OnboardingTour already uses.
 // =============================================================================
@@ -17,6 +17,7 @@ import { TELEMETRY_NOTICE_VERSION } from '../../shared/types'
 let host: HTMLDivElement
 let root: Root
 let promptCallback: ((p: { fromVersion: string; toVersion: string }) => void) | null = null
+const openExternalUrl = vi.fn()
 
 function firePrompt(p: { fromVersion: string; toVersion: string }): void {
   if (!promptCallback) throw new Error('onFeedbackPrompt was never subscribed')
@@ -28,6 +29,7 @@ beforeEach(() => {
   document.body.appendChild(host)
   root = createRoot(host)
   promptCallback = null
+  openExternalUrl.mockClear()
   ;(window as unknown as { electronAPI: Record<string, unknown> }).electronAPI = {
     ...(window as unknown as { electronAPI?: Record<string, unknown> }).electronAPI,
     onFeedbackPrompt: (cb: (p: { fromVersion: string; toVersion: string }) => void) => {
@@ -38,7 +40,7 @@ beforeEach(() => {
     submitFeedback: vi.fn(() => Promise.resolve({ ok: true })),
     dismissFeedback: vi.fn(),
     trackLinkClick: vi.fn(),
-    openExternalUrl: vi.fn(),
+    openExternalUrl,
   }
   // The dialog fetches the GitHub star count once visible; stub it so the effect
   // never hits the network in jsdom.
@@ -66,15 +68,31 @@ describe('PostUpdateFeedbackDialog', () => {
     act(() => root.render(<PostUpdateFeedbackDialog />))
     firePrompt({ fromVersion: '1.2.0', toVersion: '1.3.0' })
     expect(host.textContent).toBe('')
-    // The notice's acknowledgement flips the setting — the feedback dialog,
+    // The notice's acknowledgement flips the setting — the post-update dialog,
     // already holding the pending prompt, then reveals itself.
     act(() => { useSettingsStore.setState({ telemetryNoticeAcknowledgedVersion: TELEMETRY_NOTICE_VERSION } as never) })
     expect(host.textContent).toContain('Rate this update')
   })
 
-  it('shows the post-update feedback when the notice is already acknowledged', () => {
+  it('shows the post-update dialog when the notice is already acknowledged', () => {
     act(() => root.render(<PostUpdateFeedbackDialog />))
     firePrompt({ fromVersion: '1.2.0', toVersion: '1.3.0' })
     expect(host.textContent).toContain('Rate this update')
+  })
+
+  it('shows the matching detailed release notes and links to the full changelog', () => {
+    act(() => root.render(<PostUpdateFeedbackDialog />))
+    firePrompt({ fromVersion: '1.6.0-beta.2', toVersion: '1.6.0-beta.3' })
+
+    expect(host.textContent).toContain('Browser automation controls')
+    expect(host.textContent).toContain('Remote workspace path validation')
+
+    const link = [...host.querySelectorAll('button')]
+      .find((button) => button.textContent?.includes('Full changelog'))
+    if (!link) throw new Error('Full changelog button not found')
+    act(() => { link.dispatchEvent(new MouseEvent('click', { bubbles: true })) })
+    expect(openExternalUrl).toHaveBeenCalledWith(
+      'https://github.com/0-AI-UG/cate/blob/main/CHANGELOG.md',
+    )
   })
 })

--- a/src/renderer/dialogs/PostUpdateFeedbackDialog.tsx
+++ b/src/renderer/dialogs/PostUpdateFeedbackDialog.tsx
@@ -4,14 +4,15 @@ import heroImg from '../assets/dialog-hero.jpg'
 import { useEscapeKey } from '../lib/hooks/useEscapeKey'
 import { useSettingsStore } from '../stores/settingsStore'
 import { TELEMETRY_NOTICE_VERSION } from '../../shared/types'
+import { findChangelogRelease, parseChangelog } from '../../shared/changelog'
+import changelogMarkdown from '../../../CHANGELOG.md?raw'
 
 type Payload = { fromVersion: string; toVersion: string }
 
 const GITHUB_REPO = 'https://github.com/0-AI-UG/cate'
-const GITHUB_API = 'https://api.github.com/repos/0-AI-UG/cate'
-const PRODUCT_HUNT_URL = 'https://www.producthunt.com/products/cate?embed=true&utm_source=embed&utm_medium=post_embed'
-const PRODUCT_HUNT_LOGO = 'https://ph-files.imgix.net/fd92bbb7-e106-43a8-93e2-a9e5b663e320.png?auto=format&fit=crop&w=80&h=80'
+const CHANGELOG_URL = `${GITHUB_REPO}/blob/main/CHANGELOG.md`
 const NEWSLETTER_URL = 'https://cate.cero-ai.com'
+const changelogReleases = parseChangelog(changelogMarkdown)
 
 function openLink(url: string, linkName: string) {
   window.electronAPI.trackLinkClick(linkName)
@@ -25,11 +26,10 @@ export function PostUpdateFeedbackDialog() {
   const [comment, setComment] = useState('')
   const [sending, setSending] = useState(false)
   const [resultMessage, setResultMessage] = useState<string | null>(null)
-  const [starCount, setStarCount] = useState<number | null>(null)
 
   // Gate on the telemetry notice (WelcomeDialog) the same way the onboarding
   // tour does: the notice goes first. Until it's acknowledged this dialog stays
-  // fully dormant — not rendered, and no GitHub fetch — so on an update it never
+  // fully dormant — not rendered — so on an update it never
   // mounts behind the opaque notice. The pending prompt is held in main and
   // re-pulled, so it surfaces here the moment the notice is dismissed.
   const loaded = useSettingsStore((s) => s._loaded)
@@ -64,16 +64,6 @@ export function PostUpdateFeedbackDialog() {
     }
   }, [])
 
-  useEffect(() => {
-    if (!payload || !noticeReady) return
-    fetch(GITHUB_API, { headers: { Accept: 'application/vnd.github.v3+json' } })
-      .then((r) => r.json())
-      .then((data) => {
-        if (typeof data.stargazers_count === 'number') setStarCount(data.stargazers_count)
-      })
-      .catch(() => {})
-  }, [payload, noticeReady])
-
   const close = useCallback(() => {
     window.electronAPI.dismissFeedback('close')
     setPayload(null)
@@ -104,13 +94,14 @@ export function PostUpdateFeedbackDialog() {
   if (!payload || !noticeReady) return null
 
   const displayRating = hover || rating
+  const release = findChangelogRelease(changelogReleases, payload.toVersion)
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
     >
       <div
-        className="w-[460px] rounded-2xl flex flex-col bg-[#1a1a1e] border border-subtle shadow-[0_32px_80px_rgba(0,0,0,0.7)] overflow-hidden"
+        className="w-[520px] max-w-[92vw] max-h-[90vh] rounded-2xl flex flex-col bg-[#1a1a1e] border border-subtle shadow-[0_32px_80px_rgba(0,0,0,0.7)] overflow-hidden"
       >
         {resultMessage && !sending ? (
           <div className="px-6 py-12 text-center text-white text-sm">
@@ -132,60 +123,60 @@ export function PostUpdateFeedbackDialog() {
               </div>
             </div>
 
-            <div className="px-5 pb-5 pt-3 flex flex-col gap-3">
-              <p className="text-[#999] text-[12px] leading-relaxed">
-                {isFirstInstall
-                  ? 'An open canvas for development. Join the community!'
-                  : 'Thanks for updating. Support the project and stay connected.'}
-              </p>
-
-              {/* Product Hunt embed card */}
-              <button
-                onClick={() => openLink(PRODUCT_HUNT_URL, 'product_hunt')}
-                className="w-full rounded-xl bg-white/[0.97] p-3.5 flex flex-col gap-3 hover:shadow-[0_4px_20px_rgba(255,97,84,0.15)] transition-all group text-left"
-              >
-                <div className="flex items-center gap-3">
-                  <img
-                    src={PRODUCT_HUNT_LOGO}
-                    alt="CATE"
-                    className="w-12 h-12 rounded-lg object-cover flex-shrink-0"
-                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-[#1a1a1a] text-[15px] font-semibold leading-tight">CATE</div>
-                    <div className="text-[#666] text-[12px] mt-0.5 leading-snug">Figma like open canvas for development</div>
-                  </div>
-                </div>
-                <span className="inline-flex items-center gap-1.5 self-start px-4 py-2 bg-[#ff6154] text-white text-[13px] font-semibold rounded-lg group-hover:brightness-110 transition-all">
-                  Check it out on Product Hunt
-                  <ArrowSquareOut size={13} />
-                </span>
-              </button>
-
-              {/* GitHub + Newsletter row */}
-              <div className="flex gap-1.5">
-                {/* GitHub Stars */}
-                <button
-                  onClick={() => openLink(GITHUB_REPO, 'github_star')}
-                  className="flex-1 flex flex-col items-center gap-1.5 px-3 py-3 rounded-xl bg-white/[0.04] hover:bg-white/[0.08] border border-subtle transition-all group"
-                >
-                  <GithubLogo size={20} weight="fill" className="text-white" />
-                  <span className="text-white text-[12px] font-semibold">Star on GitHub</span>
-                  {starCount !== null && (
-                    <span className="flex items-center gap-1 text-[11px] text-yellow-400 font-medium">
-                      <Star size={10} weight="fill" /> {formatStars(starCount)}
-                    </span>
+            <div className="px-5 pb-5 pt-3 flex flex-col gap-3 overflow-y-auto">
+              {isFirstInstall ? (
+                <p className="text-[#999] text-[12px] leading-relaxed">
+                  An open canvas for development. Join the community!
+                </p>
+              ) : release ? (
+                <>
+                  {release.summary && (
+                    <p className="text-[#aaa] text-[12.5px] leading-relaxed">
+                      {release.summary}
+                    </p>
                   )}
-                </button>
+                  <div className="rounded-xl border border-white/[0.07] bg-black/15 px-4 py-3 max-h-[260px] overflow-y-auto">
+                    <div className="flex flex-col gap-4">
+                      {release.sections.map((section) => (
+                        <section key={section.title}>
+                          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-emerald-400">
+                            {section.title}
+                          </h3>
+                          <ul className="flex flex-col gap-2">
+                            {section.items.map((item) => (
+                              <li key={item} className="flex gap-2 text-[12px] leading-relaxed text-[#aaa]">
+                                <span aria-hidden="true" className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-[#666]" />
+                                <span>{renderChangelogItem(item)}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </section>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p className="text-[#999] text-[12px] leading-relaxed">
+                  Cate has been updated. Detailed notes for this build are available in the full changelog.
+                </p>
+              )}
 
-                {/* Newsletter */}
+              {/* Changelog + community links */}
+              <div className="flex gap-1.5">
+                <button
+                  onClick={() => openLink(CHANGELOG_URL, 'full_changelog')}
+                  className="flex-1 inline-flex items-center justify-center gap-2 px-3 h-10 rounded-xl bg-white/[0.04] hover:bg-white/[0.08] border border-subtle text-white text-[12px] font-semibold transition-all"
+                >
+                  <GithubLogo size={16} weight="fill" />
+                  Full changelog
+                  <ArrowSquareOut size={12} />
+                </button>
                 <button
                   onClick={() => openLink(NEWSLETTER_URL, 'newsletter')}
-                  className="flex-1 flex flex-col items-center gap-1.5 px-3 py-3 rounded-xl bg-white/[0.04] hover:bg-white/[0.08] border border-subtle transition-all group"
+                  className="flex-1 inline-flex items-center justify-center gap-2 px-3 h-10 rounded-xl bg-white/[0.04] hover:bg-white/[0.08] border border-subtle text-white text-[12px] font-semibold transition-all"
                 >
-                  <Envelope size={20} weight="fill" className="text-blue-400" />
-                  <span className="text-white text-[12px] font-semibold">Newsletter</span>
-                  <span className="text-[11px] text-[#777]">Stay updated</span>
+                  <Envelope size={16} weight="fill" className="text-blue-400" />
+                  Newsletter
                 </button>
               </div>
 
@@ -250,7 +241,21 @@ export function PostUpdateFeedbackDialog() {
   )
 }
 
-function formatStars(count: number): string {
-  if (count >= 1000) return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
-  return String(count)
+function renderChangelogItem(item: string) {
+  const feature = item.match(/^\*\*(.+?)\*\*([:—-]?\s*)(.*)$/)
+  if (!feature) return stripInlineMarkdown(item)
+  return (
+    <>
+      <strong className="font-semibold text-[#ddd]">{stripInlineMarkdown(feature[1])}</strong>
+      {feature[2]}
+      {stripInlineMarkdown(feature[3])}
+    </>
+  )
+}
+
+function stripInlineMarkdown(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
 }

--- a/src/shared/changelog.test.ts
+++ b/src/shared/changelog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { findChangelogRelease, parseChangelog } from './changelog'
+
+const markdown = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Not shipped yet.
+
+## [1.2.0-beta.2] - 2026-07-25
+
+A focused beta release.
+
+### Added
+
+- **Browser controls**: Agents can inspect pages.
+- Credential profiles.
+
+### Fixed
+
+- Browser startup.
+
+## [1.1.0] - 2026-07-20
+
+### Changed
+
+- Previous change.
+`
+
+describe('parseChangelog', () => {
+  it('parses release metadata, summaries, sections, and items', () => {
+    expect(parseChangelog(markdown)).toEqual([
+      {
+        version: '1.2.0-beta.2',
+        date: '2026-07-25',
+        summary: 'A focused beta release.',
+        sections: [
+          {
+            title: 'Added',
+            items: [
+              '**Browser controls**: Agents can inspect pages.',
+              'Credential profiles.',
+            ],
+          },
+          { title: 'Fixed', items: ['Browser startup.'] },
+        ],
+      },
+      {
+        version: '1.1.0',
+        date: '2026-07-20',
+        sections: [{ title: 'Changed', items: ['Previous change.'] }],
+      },
+    ])
+  })
+
+  it('finds an exact version and tolerates a leading v', () => {
+    const releases = parseChangelog(markdown)
+    expect(findChangelogRelease(releases, 'v1.2.0-beta.2')?.summary).toBe('A focused beta release.')
+    expect(findChangelogRelease(releases, '1.2.1')).toBeNull()
+  })
+})

--- a/src/shared/changelog.ts
+++ b/src/shared/changelog.ts
@@ -1,0 +1,77 @@
+export interface ChangelogSection {
+  title: string
+  items: string[]
+}
+
+export interface ChangelogRelease {
+  version: string
+  date?: string
+  summary?: string
+  sections: ChangelogSection[]
+}
+
+/** Parse the release sections from a Keep a Changelog-formatted Markdown file. */
+export function parseChangelog(markdown: string): ChangelogRelease[] {
+  const releases: ChangelogRelease[] = []
+  let release: ChangelogRelease | null = null
+  let section: ChangelogSection | null = null
+  const summaryLines: string[] = []
+
+  const finishRelease = (): void => {
+    if (!release) return
+    const summary = summaryLines.join(' ').trim()
+    if (summary) release.summary = summary
+    releases.push(release)
+    release = null
+    section = null
+    summaryLines.length = 0
+  }
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    const releaseMatch = line.match(/^## \[([^\]]+)\](?:\s+-\s+(\d{4}-\d{2}-\d{2}))?$/)
+    if (releaseMatch) {
+      finishRelease()
+      if (releaseMatch[1].toLowerCase() !== 'unreleased') {
+        release = {
+          version: releaseMatch[1],
+          ...(releaseMatch[2] ? { date: releaseMatch[2] } : {}),
+          sections: [],
+        }
+      }
+      continue
+    }
+
+    if (!release) continue
+
+    const sectionMatch = line.match(/^### (.+)$/)
+    if (sectionMatch) {
+      section = { title: sectionMatch[1], items: [] }
+      release.sections.push(section)
+      continue
+    }
+
+    if (line.startsWith('- ')) {
+      if (!section) {
+        section = { title: 'Highlights', items: [] }
+        release.sections.push(section)
+      }
+      section.items.push(line.slice(2).trim())
+      continue
+    }
+
+    if (line && !section) summaryLines.push(line)
+  }
+
+  finishRelease()
+  return releases
+}
+
+/** Find the bundled notes for an exact app version (with or without a leading v). */
+export function findChangelogRelease(
+  releases: ChangelogRelease[],
+  version: string,
+): ChangelogRelease | null {
+  const normalized = version.replace(/^v/, '')
+  return releases.find((release) => release.version.replace(/^v/, '') === normalized) ?? null
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -996,10 +996,10 @@ export interface ElectronAPI {
   quitAndInstallUpdate(): Promise<boolean>
 
   // -------------------------------------------------------------------------
-  // Analytics — post-update feedback prompt
+  // Post-update changelog + feedback prompt
   // -------------------------------------------------------------------------
 
-  /** Subscribe to the main-process request to show the feedback modal. */
+  /** Subscribe to the main-process request to show the changelog + feedback modal. */
   onFeedbackPrompt(
     callback: (payload: { fromVersion: string; toVersion: string }) => void,
   ): () => void

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -157,7 +157,7 @@ export const UPDATE_QUIT_AND_INSTALL = 'update:quitAndInstall'
 // download-finished event already fired). Returns the cached UpdateStatus.
 export const UPDATE_GET_STATUS = 'update:getStatus'
 
-// Analytics — post-update feedback prompt
+// Post-update changelog + feedback prompt
 // Main -> renderer: show the modal. Payload: { fromVersion, toVersion }
 export const ANALYTICS_FEEDBACK_PROMPT = 'analytics:feedbackPrompt'
 // Renderer -> main: user submitted feedback. Payload: { rating: 1-5, comment? }


### PR DESCRIPTION
## Summary

- parse the bundled Keep-a-Changelog Markdown into structured release data
- show version-matched summaries and categorized changes in the existing post-update dialog, including patch releases
- link users to the full GitHub changelog and keep the existing update-rating flow
- retrospectively document all 59 previously missing beta and stable releases, bringing coverage to all 89 semantic-version tags
- require changelog completion before any beta or stable version bump/tag in `AGENTS.md`

## Why

The existing “What’s New” dialog contained promotional content but no actual release details, and patch updates skipped it entirely. `CHANGELOG.md` had also fallen behind, leaving exact-version lookups without notes for many historical releases.

## Impact

After an update, users now see the matching release summary and categorized changes inside Cate. First installs remain unaffected, missing entries fall back to the full changelog link, and future release work has an explicit changelog-first gate.

## Validation

- `npm test -- --run src/shared/changelog.test.ts src/main/analytics.test.ts src/renderer/dialogs/PostUpdateFeedbackDialog.test.tsx` (31 tests)
- `npm run typecheck`
- targeted ESLint on changed TypeScript/TSX files
- `npm run build`
- tag audit: 89 semantic release tags, 89 unique changelog entries, no missing/extra/duplicate versions
- release-date audit: all 89 changelog dates match tag creation dates
- `git diff --check`
