### PR TITLE
fix: keep terminal grid and glyph size stable across canvas zoom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ dev-app-update.yml
 .claude/
 .agents/
 
+# oh-my-claudecode agent state — per-machine scratch, never project state
+.omc/
+
 # Cate workspace + local session state
 .cate/
 

--- a/src/renderer/lib/terminal/renderScale.test.ts
+++ b/src/renderer/lib/terminal/renderScale.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { snapRenderScale, RENDER_SCALE_STEPS } from './renderScale'
+
+// The residual CSS rescale applied to xterm's pre-rasterized glyph atlas is
+// zoom / renderScale. It is 1:1 (crisp) only when zoom lands on a step, so what
+// matters is the worst case between steps.
+const residual = (zoom: number): number => zoom / snapRenderScale(zoom)
+
+describe('snapRenderScale', () => {
+  it('is exact on every step', () => {
+    for (const zoom of RENDER_SCALE_STEPS) {
+      expect(residual(zoom)).toBeCloseTo(1, 10)
+    }
+  })
+
+  it('does not jump a full step at 125% (the reported blur/resize boundary)', () => {
+    // Regression: with steps [1.0, 1.5, …], 1.25 was a tie that resolved to 1.0
+    // (a 25% upscale — the blurriest point in the range) and 1.2501 jumped
+    // straight to 1.5, swapping fontSize by 1.5× in one frame and visibly
+    // resizing the terminal. 1.25 must now be its own step.
+    expect(snapRenderScale(1.25)).toBe(1.25)
+    expect(snapRenderScale(1.2501)).toBe(1.25)
+    expect(snapRenderScale(1.24)).toBe(1.25)
+  })
+
+  it('never lets two adjacent steps differ by more than 1.25×', () => {
+    // Bounds how far fontSize swings in a single step crossing — that swing is
+    // what the measured cellCorrection in TerminalPanel has to absorb.
+    for (let i = 1; i < RENDER_SCALE_STEPS.length; i++) {
+      expect(RENDER_SCALE_STEPS[i] / RENDER_SCALE_STEPS[i - 1]).toBeLessThanOrEqual(1.25)
+    }
+  })
+
+  it('keeps the residual rescale under 12.5% across the zoomed-in range', () => {
+    for (let zoom = 1.0; zoom <= 2.0; zoom += 0.01) {
+      expect(Math.abs(residual(zoom) - 1)).toBeLessThan(0.125)
+    }
+  })
+
+  it('clamps below 1 and above the top step', () => {
+    expect(snapRenderScale(0.5)).toBe(1.0)
+    expect(snapRenderScale(1.0)).toBe(1.0)
+    expect(snapRenderScale(3.0)).toBe(2.5)
+  })
+})

--- a/src/renderer/lib/terminal/renderScale.ts
+++ b/src/renderer/lib/terminal/renderScale.ts
@@ -1,0 +1,41 @@
+// =============================================================================
+// renderScale — pick the resolution xterm rasterizes its glyph atlas at for a
+// given canvas zoom. Pure so the snap boundaries can be unit-tested without
+// dragging in xterm (whose WebGL addon needs a browser global at import time).
+// =============================================================================
+
+// Discrete render-scale steps. We snap canvas zoom to one of these so a
+// continuous pinch only triggers a small number of expensive atlas rebuilds.
+// Capped at 2.5× — beyond that, atlas memory grows without perceptible gain.
+//
+// 0.25 spacing, not 0.5: the residual CSS rescale is zoom/renderScale, so the
+// worst case sits halfway between two steps. With [1.0, 1.5, …] that put the
+// blurriest point at exactly 125% (a 25% upscale) — and 125% was also a tie
+// (|1.25-1.0| === |1.25-1.5|), so a hair past it the scale jumped a full 1.5×
+// at once, visibly resizing the terminal. Halving the spacing halves both the
+// worst-case blur and the size step, and lands 125%/175% exactly on a step
+// where the rescale is 1:1.
+export const RENDER_SCALE_STEPS: number[] = [1.0, 1.25, 1.5, 1.75, 2.0, 2.5]
+
+/**
+ * Snap a canvas zoom level to the nearest render-scale step.
+ *
+ * Zoom-out returns 1.0: the atlas is already being downsampled, so rasterizing
+ * it smaller buys nothing back.
+ */
+export function snapRenderScale(zoom: number): number {
+  if (zoom <= 1.0) return 1.0
+  const top = RENDER_SCALE_STEPS[RENDER_SCALE_STEPS.length - 1]
+  if (zoom > top) return top
+
+  let best = RENDER_SCALE_STEPS[0]
+  let bestDist = Math.abs(zoom - best)
+  for (const step of RENDER_SCALE_STEPS) {
+    const d = Math.abs(zoom - step)
+    if (d < bestDist) {
+      best = step
+      bestDist = d
+    }
+  }
+  return best
+}

--- a/src/renderer/lib/terminal/terminalDom.ts
+++ b/src/renderer/lib/terminal/terminalDom.ts
@@ -209,7 +209,6 @@ function safeFit(
   terminal: Terminal,
   fitAddon: FitAddon,
   container: HTMLElement,
-  opts?: { preserveGrid?: boolean },
 ): void {
   // Coalesce into a single terminal.resize() call so the PTY only receives one
   // SIGWINCH per fit. Two rapid resizes confuse TUI agents (claude code, vim,
@@ -230,7 +229,7 @@ function safeFit(
   // Fractional rect heights, not offsetHeight: the integer rounding of
   // offsetHeight made this guard intermittently shave a row near exact
   // cell-multiple heights — a silent rows-change that leaks a duplicate TUI
-  // frame into scrollback (see preserveGrid below).
+  // frame into scrollback (anthropics/claude-code#46981).
   const xtermEl = (terminal as unknown as { element?: HTMLElement }).element
   if (xtermEl) {
     const xtermHeight = xtermEl.getBoundingClientRect().height
@@ -238,19 +237,6 @@ function safeFit(
     if (cellHeight > 0 && rows * cellHeight > container.getBoundingClientRect().height + 0.5) {
       rows = Math.max(1, rows - 1)
     }
-  }
-
-  // A renderScale/fontSize swap keeps the visual size constant by construction,
-  // so any ±1 delta here is ceil/parseInt quantization noise (the WebGL
-  // renderer ceils cell px, FitAddon truncates the box px — cell(k·fs) is not
-  // k·cell(fs)). Resizing would SIGWINCH the PTY, and Ink-style TUIs (Claude
-  // Code) leak a duplicate frame into scrollback on every rows change while
-  // their frame is taller than the viewport (anthropics/claude-code#46981).
-  // Pin the grid instead; a sub-cell box/grid mismatch is hidden by the
-  // container's overflow:hidden.
-  if (opts?.preserveGrid) {
-    if (Math.abs(rows - terminal.rows) === 1) rows = terminal.rows
-    if (Math.abs(cols - terminal.cols) === 1) cols = terminal.cols
   }
 
   if (cols !== terminal.cols || rows !== terminal.rows) {
@@ -432,14 +418,50 @@ export function attach(panelId: string, container: HTMLDivElement): void {
 }
 
 /**
+ * Re-measure the viewport's scrollbar track and write it back into xterm's
+ * cached `scrollBarWidth`.
+ *
+ * xterm measures that track exactly once, in the Viewport constructor, and
+ * never again. That is fine for a fixed-width scrollbar, but TerminalPanel
+ * scales the track with the terminal's render scale (see the `--cell-scale`
+ * rule in globals.css) so a 8px track becomes 10, 12, 17px… With the cached
+ * value stale, FitAddon — the ONLY reader of this field, xterm's own core never
+ * touches it — keeps subtracting 8 and hands back a column count whose grid is
+ * wider than the viewport that must hold it, clipping the right-hand columns.
+ *
+ * Writing the fresh measurement back is therefore data maintenance rather than
+ * a behaviour override, but it does reach into `_core`, so every hop is guarded:
+ * a future xterm that renames or removes the field simply leaves the scaling
+ * off instead of throwing.
+ */
+export function syncScrollBarWidth(panelId: string): void {
+  const entry = registry.get(panelId)
+  if (!entry) return
+
+  const el = (entry.terminal as unknown as { element?: HTMLElement }).element
+  const viewport = el?.querySelector('.xterm-viewport') as HTMLElement | null
+  if (!viewport) return
+
+  void viewport.offsetWidth // flush the pending CSS width change before reading
+  const measured = viewport.offsetWidth - viewport.clientWidth
+  // 0 means no track is being reserved right now (nothing to scroll). That is a
+  // real state, but caching it would tell FitAddon to claim the full width and
+  // then clip once a scrollbar reappears. Keep the last good value instead.
+  if (measured <= 0 || measured > 200) return
+
+  const core = (entry.terminal as unknown as {
+    _core?: { viewport?: { scrollBarWidth?: number } }
+  })._core
+  if (core?.viewport && typeof core.viewport.scrollBarWidth === 'number') {
+    core.viewport.scrollBarWidth = measured
+  }
+}
+
+/**
  * Safely fit the terminal to its current container, correcting for
  * sub-pixel overflow. No-op if the terminal is not attached to a container.
- *
- * `preserveGrid` is for fits where the on-screen size is unchanged by
- * construction (render-scale/fontSize swaps): ±1 col/row deltas are treated as
- * quantization noise and discarded so the PTY never sees a phantom SIGWINCH.
  */
-export function fit(panelId: string, opts?: { preserveGrid?: boolean }): void {
+export function fit(panelId: string): void {
   const entry = registry.get(panelId)
   if (!entry) return
 
@@ -448,7 +470,7 @@ export function fit(panelId: string, opts?: { preserveGrid?: boolean }): void {
   const container = el?.parentElement
   if (!el || !container) return
 
-  safeFit(terminal, fitAddon, container, opts)
+  safeFit(terminal, fitAddon, container)
 }
 
 /**

--- a/src/renderer/lib/terminal/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.test.ts
@@ -40,6 +40,9 @@ vi.mock('@xterm/xterm', () => {
     public element: HTMLElement | undefined
     public cols = 80
     public rows = 24
+    // Mirrors the one internal xterm touches: Viewport measures the scrollbar
+    // once at construction and never again, and FitAddon is its only reader.
+    public _core = { viewport: { scrollBarWidth: 8 } }
     constructor(options: Record<string, unknown> = {}) {
       this.options = options
     }
@@ -187,34 +190,58 @@ describe('terminal font settings', () => {
   })
 })
 
-describe('fit() preserveGrid', () => {
-  // Render-scale steps swap fontSize and counter-scale the box, so the visual
-  // size is unchanged — but cell-px rounding makes FitAddon propose ±1 row.
-  // That phantom SIGWINCH makes Ink TUIs (Claude Code) stack a duplicate frame
-  // into scrollback. preserveGrid must discard ±1 deltas and keep real ones.
-  it('discards ±1 quantization deltas but applies real grid changes', async () => {
+describe('syncScrollBarWidth', () => {
+  // TerminalPanel scales the scrollbar track with the terminal's render scale so
+  // it doesn't thin out as the canvas zooms in. xterm measures that track once in
+  // its Viewport constructor and never again, and FitAddon — its only reader —
+  // would go on subtracting the stale width, returning a column count whose grid
+  // is wider than the viewport and clipping the right-hand columns.
+  const openAt = async (panelId: string, offsetWidth: number, clientWidth: number) => {
     const { terminalRegistry } = await import('./terminalRegistry')
-    const entry = await terminalRegistry.getOrCreate('panel-grid', { workspaceId: 'ws-1' })
+    const entry = await terminalRegistry.getOrCreate(panelId, { workspaceId: 'ws-1' })
     const container = document.createElement('div')
     document.body.appendChild(container)
     ;(entry.terminal as unknown as { open: (c: HTMLElement) => void }).open(container)
-    expect(entry.terminal.rows).toBe(24)
+    const vp = entry.terminal.element!.querySelector('.xterm-viewport') as HTMLElement
+    // jsdom does no layout, so the track has to be described explicitly.
+    Object.defineProperty(vp, 'offsetWidth', { value: offsetWidth, configurable: true })
+    Object.defineProperty(vp, 'clientWidth', { value: clientWidth, configurable: true })
+    return { terminalRegistry, entry, container }
+  }
+  const cached = (entry: { terminal: unknown }) =>
+    (entry.terminal as { _core: { viewport: { scrollBarWidth: number } } })._core.viewport.scrollBarWidth
 
-    // ±1 proposal with preserveGrid: pinned, no resize.
-    fitProposal.rows = 23
-    terminalRegistry.fit('panel-grid', { preserveGrid: true })
-    expect(entry.terminal.rows).toBe(24)
+  it('writes the freshly measured track width into the cache', async () => {
+    const { terminalRegistry, entry, container } = await openAt('panel-sb', 117, 100)
+    expect(cached(entry)).toBe(8) // xterm's construction-time reading
 
-    // Same proposal via a plain fit (a real container resize): applied.
-    terminalRegistry.fit('panel-grid')
-    expect(entry.terminal.rows).toBe(23)
+    terminalRegistry.syncScrollBarWidth('panel-sb')
+    expect(cached(entry)).toBe(17)
 
-    // A multi-row change passes through even with preserveGrid.
-    fitProposal.rows = 30
-    terminalRegistry.fit('panel-grid', { preserveGrid: true })
-    expect(entry.terminal.rows).toBe(30)
+    terminalRegistry.dispose('panel-sb')
+    container.remove()
+  })
 
-    terminalRegistry.dispose('panel-grid')
+  it('keeps the last good value when no track is reserved', async () => {
+    // A terminal with nothing to scroll reports 0. Caching that would tell
+    // FitAddon it may claim the full width, then clip once a scrollbar returns.
+    const { terminalRegistry, entry, container } = await openAt('panel-sb-none', 100, 100)
+    terminalRegistry.syncScrollBarWidth('panel-sb-none')
+    expect(cached(entry)).toBe(8)
+
+    terminalRegistry.dispose('panel-sb-none')
+    container.remove()
+  })
+
+  it('does nothing when xterm no longer exposes the field', async () => {
+    // Guards the internal access: a future xterm that renames or drops
+    // _core.viewport must degrade to unscaled scrollbars, never throw.
+    const { terminalRegistry, entry, container } = await openAt('panel-sb-gone', 120, 100)
+    delete (entry.terminal as unknown as { _core?: unknown })._core
+
+    expect(() => terminalRegistry.syncScrollBarWidth('panel-sb-gone')).not.toThrow()
+
+    terminalRegistry.dispose('panel-sb-gone')
     container.remove()
   })
 })

--- a/src/renderer/lib/terminal/terminalRegistry.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.ts
@@ -23,7 +23,7 @@ import {
   setPendingTransfer,
   setPendingRestore,
 } from './terminalLifecycle'
-import { attach, detach, fit, resetRendering, restoreScroll } from './terminalDom'
+import { attach, detach, fit, resetRendering, restoreScroll, syncScrollBarWidth } from './terminalDom'
 import { findNext, findPrevious, clearSearch } from './terminalSearch'
 import { serializeTerminalState } from './scrollbackCapture'
 import {
@@ -57,6 +57,7 @@ export const terminalRegistry = {
   fit,
   resetRendering,
   restoreScroll,
+  syncScrollBarWidth,
   setPendingTransfer,
   setPendingRestore,
   getEntry,

--- a/src/renderer/panels/TerminalPanel.renderScale.test.tsx
+++ b/src/renderer/panels/TerminalPanel.renderScale.test.tsx
@@ -1,0 +1,234 @@
+// Regression: a terminal panel mounted while the canvas is ALREADY zoomed in.
+//
+// getOrCreate is async, so the render-scale effect can run before attach() has
+// opened xterm into the render box. At that point terminal.element is undefined
+// and there is nothing to measure — but the effect still wanted to raise
+// fontSize to base × renderScale. That grows the cell while cellScale stays at
+// 1, which is exactly the box/cell mismatch the effect exists to prevent, and
+// nothing recomputes it: renderScale has already settled at its target, so the
+// effect never runs again on its own and the grid stays shrunk.
+//
+// Contract: the font is only ever bumped together with a matching measurement,
+// and attach() re-triggers that measurement.
+
+// @vitest-environment jsdom
+
+import React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// jsdom performs no layout, so the effect's "is this panel actually visible"
+// guards (offsetParent, getBoundingClientRect) would bail before measuring
+// anything. Give them plausible non-zero answers.
+vi.hoisted(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() { return document.body },
+  })
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: () => null,
+  })
+})
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 800, height: 600, top: 0, left: 0, right: 800, bottom: 600, x: 0, y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+  // ResizeObserver drives the plain-fit path; the panel only needs it to exist.
+  ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {} unobserve() {} disconnect() {}
+  }
+})
+
+// Hoisted because vi.mock factories are lifted above this file's const
+// declarations and reference these.
+const h = vi.hoisted(() => {
+  const BASE_FONT = 13
+  const BASE_CELL_W = 7
+  const BASE_CELL_H = 15
+  return {
+    BASE_FONT,
+    BASE_CELL_W,
+    BASE_CELL_H,
+    // xterm ceils cell pixels — the whole reason cellScale is measured rather
+    // than assumed. Model that so the effect sees realistic numbers.
+    cellW: (fontSize: number) => Math.ceil((fontSize * BASE_CELL_W) / BASE_FONT),
+    cellH: (fontSize: number) => Math.ceil((fontSize * BASE_CELL_H) / BASE_FONT),
+    fake: {
+      cols: 80,
+      rows: 24,
+      options: { fontSize: BASE_FONT },
+      element: null as HTMLElement | null,
+    },
+    // Resolved by the test to simulate a slow getOrCreate.
+    releaseCreate: null as null | (() => void),
+    attachCalls: 0,
+  }
+})
+const { BASE_FONT, BASE_CELL_W, cellW } = h
+
+vi.mock('../lib/terminal/terminalRegistry', () => {
+  const entry = { terminal: h.fake, ptyId: 'pty-1', workspaceId: 'ws-1' }
+  return {
+    terminalRegistry: {
+      getOrCreate: vi.fn(
+        () => new Promise((resolve) => { h.releaseCreate = () => resolve(entry) }),
+      ),
+      // attach() is what gives xterm a DOM element in the real code.
+      attach: vi.fn(() => {
+        h.attachCalls++
+        const el = document.createElement('div')
+        const screen = document.createElement('div')
+        screen.className = 'xterm-screen'
+        // jsdom does no layout: derive the box from the current font, the way a
+        // real xterm would after re-rasterizing its atlas.
+        Object.defineProperty(screen, 'offsetWidth', {
+          get: () => h.fake.cols * h.cellW(h.fake.options.fontSize),
+        })
+        Object.defineProperty(screen, 'offsetHeight', {
+          get: () => h.fake.rows * h.cellH(h.fake.options.fontSize),
+        })
+        const viewport = document.createElement('div')
+        viewport.className = 'xterm-viewport'
+        el.append(screen, viewport)
+        h.fake.element = el
+      }),
+      detach: vi.fn(),
+      getEntry: vi.fn(() => (h.fake.element || h.releaseCreate ? { terminal: h.fake } : null)),
+      getFailure: vi.fn(() => null),
+      subscribeFailure: vi.fn(() => () => {}),
+      fit: vi.fn(),
+      syncScrollBarWidth: vi.fn(),
+      findNext: vi.fn(),
+      findPrevious: vi.fn(),
+      clearSearch: vi.fn(),
+      focus: vi.fn(),
+      write: vi.fn(),
+      isAlive: vi.fn(() => true),
+    },
+  }
+})
+
+// --- collaborators the panel pulls in but that are irrelevant here ----------
+
+const canvasState = { zoomLevel: 2.0 }
+vi.mock('../stores/CanvasStoreContext', () => ({
+  useOptionalCanvasStoreApi: () => null,
+  // Selectors that read state this fake doesn't model fall back, as they do
+  // when the panel lives outside a canvas.
+  useOptionalCanvasStoreContext: (sel: (s: unknown) => unknown, fallback: unknown) => {
+    try {
+      const v = sel(canvasState)
+      return v === undefined ? fallback : v
+    } catch {
+      return fallback
+    }
+  },
+}))
+vi.mock('../stores/appStore', () => ({
+  useAppStore: Object.assign(
+    (sel: (s: unknown) => unknown) => sel({ workspaces: [], retryRuntime: () => {} }),
+    { getState: () => ({ workspaces: [], retryRuntime: () => {} }) },
+  ),
+}))
+vi.mock('../stores/settingsStore', () => {
+  const state = { terminalFontSize: h.BASE_FONT, terminalFontFamily: '' }
+  return {
+    useSettingsStore: Object.assign(
+      (sel: (s: unknown) => unknown) => sel(state),
+      { getState: () => state, subscribe: () => () => {} },
+    ),
+  }
+})
+vi.mock('../stores/uiStore', () => ({
+  useUIStore: Object.assign((sel: (s: unknown) => unknown) => sel({}), { getState: () => ({}) }),
+}))
+vi.mock('../lib/activePanel', () => ({
+  useActivePanelStore: Object.assign(
+    (sel: (s: unknown) => unknown) => sel({ activePanelId: null }),
+    { getState: () => ({ activePanelId: null }), subscribe: () => () => {} },
+  ),
+  getActivePanelId: () => null,
+  setActivePanel: () => {},
+}))
+vi.mock('./panelChrome', () => ({ useClaimPanelCorner: () => null }))
+vi.mock('../hooks/useMissingAgentHookNotice', () => ({ useMissingAgentHookNotice: () => null }))
+vi.mock('../lib/logger', () => ({
+  default: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}))
+
+import TerminalPanel from './TerminalPanel'
+
+describe('render scale on a panel mounted while already zoomed', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    h.fake.options.fontSize = BASE_FONT
+    h.fake.element = null
+    h.releaseCreate = null
+    h.attachCalls = 0
+    canvasState.zoomLevel = 2.0
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.clearAllTimers()
+  })
+
+  const renderPanel = async () => {
+    await act(async () => {
+      root.render(
+        <TerminalPanel panelId="p1" workspaceId="ws-1" nodeId="n1" />,
+      )
+    })
+  }
+  // The render box carries the counter-scale as a width percentage.
+  const renderBoxWidth = () =>
+    (container.querySelector('[data-terminal-render-box]') as HTMLElement | null)?.style.width
+
+  // The render-scale effect commits a new scale after 2 idle frames (so a
+  // continuous pinch rebuilds the atlas only once).
+  const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r(undefined)))
+  const flushFrames = async () => {
+    await act(async () => { await nextFrame(); await nextFrame(); await nextFrame() })
+  }
+
+  it('does not raise the font while xterm is still unattached', async () => {
+    await renderPanel()
+    // Let renderScale settle at 2.0 with the spawn STILL in flight. This is the
+    // race: the scale is now at its target and will not change again, so if the
+    // font were raised here nothing would ever measure the matching cellScale.
+    await flushFrames()
+
+    expect(h.fake.element).toBeNull()
+    expect(h.fake.options.fontSize).toBe(BASE_FONT)
+  })
+
+  it('measures and scales once attach provides an element', async () => {
+    await renderPanel()
+    await flushFrames() // renderScale reaches 2.0 before xterm exists
+
+    await act(async () => {
+      h.releaseCreate!()
+      await Promise.resolve()
+    })
+    await flushFrames()
+
+    expect(h.attachCalls).toBeGreaterThan(0)
+    // Font raised to base × renderScale, now that there is something to measure.
+    expect(h.fake.options.fontSize).toBe(BASE_FONT * 2)
+
+    // And the box grew to match the MEASURED cell, not the intended ratio:
+    // ceil(26 * 7/13) = 14 against a 7px base → exactly 200%.
+    expect(renderBoxWidth()).toBe(`${(cellW(BASE_FONT * 2) / BASE_CELL_W) * 100}%`)
+  })
+})

--- a/src/renderer/panels/TerminalPanel.renderScale.test.tsx
+++ b/src/renderer/panels/TerminalPanel.renderScale.test.tsx
@@ -75,6 +75,7 @@ const h = vi.hoisted(() => {
     // Resolved by the test to simulate a slow getOrCreate.
     releaseCreate: null as null | (() => void),
     attachCalls: 0,
+    renderedDpr: null as number | null,
   }
 })
 const { BASE_FONT, cellW } = h
@@ -95,10 +96,16 @@ vi.mock('../lib/terminal/terminalRegistry', () => {
         // jsdom does no layout: derive the box from the current font, the way a
         // real xterm would after re-rasterizing its atlas.
         Object.defineProperty(screen, 'offsetWidth', {
-          get: () => h.fake.cols * h.cellW(h.fake.options.fontSize),
+          get: () => h.fake.cols * h.cellW(
+            h.fake.options.fontSize,
+            h.renderedDpr ?? window.devicePixelRatio,
+          ),
         })
         Object.defineProperty(screen, 'offsetHeight', {
-          get: () => h.fake.rows * h.cellH(h.fake.options.fontSize),
+          get: () => h.fake.rows * h.cellH(
+            h.fake.options.fontSize,
+            h.renderedDpr ?? window.devicePixelRatio,
+          ),
         })
         const viewport = document.createElement('div')
         viewport.className = 'xterm-viewport'
@@ -201,6 +208,7 @@ describe('render scale on a panel mounted while already zoomed', () => {
     h.fake.element = null
     h.releaseCreate = null
     h.attachCalls = 0
+    h.renderedDpr = null
     canvasState.zoomLevel = 2.0
     setDpr(1)
     container = document.createElement('div')
@@ -285,6 +293,36 @@ describe('render scale on a panel mounted while already zoomed', () => {
     // At DPR 2 the cell rounds on a half-pixel grid, so both the baseline and
     // the scaled cell differ from their DPR 1 values. The box must follow the
     // NEW pair — reusing the stale DPR 1 baseline leaves it at the old width.
+    const base2 = cellW(BASE_FONT, 2)
+    const scaled2 = cellW(BASE_FONT * 2, 2)
+    expect(renderBoxWidth()).toBe(`${(scaled2 / base2) * 100}%`)
+  })
+
+  it('does not cache old geometry if DPR changes at render scale 1', async () => {
+    h.renderedDpr = 1
+    canvasState.zoomLevel = 1
+    await renderPanel()
+    await act(async () => {
+      h.releaseCreate!()
+      await Promise.resolve()
+    })
+    await flushFrames()
+
+    // TerminalPanel's media-query callback runs first. At scale 1 it writes the
+    // same font size, so xterm's option setter would not force a fresh measure.
+    await act(async () => { moveToDisplay(2) })
+
+    // xterm's own MediaQueryList listener runs after Cate's callback but before
+    // the next animation frame, updating the terminal's geometry.
+    h.renderedDpr = 2
+    await flushFrames()
+
+    canvasState.zoomLevel = 2
+    await act(async () => {
+      root.render(<TerminalPanel panelId="p1" workspaceId="ws-1" nodeId="n1" />)
+    })
+    await flushFrames()
+
     const base2 = cellW(BASE_FONT, 2)
     const scaled2 = cellW(BASE_FONT * 2, 2)
     expect(renderBoxWidth()).toBe(`${(scaled2 / base2) * 100}%`)

--- a/src/renderer/panels/TerminalPanel.renderScale.test.tsx
+++ b/src/renderer/panels/TerminalPanel.renderScale.test.tsx
@@ -48,16 +48,24 @@ beforeEach(() => {
 // declarations and reference these.
 const h = vi.hoisted(() => {
   const BASE_FONT = 13
-  const BASE_CELL_W = 7
-  const BASE_CELL_H = 15
+  // Deliberately fractional, like a real glyph advance. With whole numbers the
+  // DPR 1 and DPR 2 rounding grids would coincide and the DPR test below could
+  // not distinguish a stale baseline from a fresh one.
+  const BASE_CELL_W = 7.3
+  const BASE_CELL_H = 15.4
   return {
     BASE_FONT,
     BASE_CELL_W,
     BASE_CELL_H,
-    // xterm ceils cell pixels — the whole reason cellScale is measured rather
-    // than assumed. Model that so the effect sees realistic numbers.
-    cellW: (fontSize: number) => Math.ceil((fontSize * BASE_CELL_W) / BASE_FONT),
-    cellH: (fontSize: number) => Math.ceil((fontSize * BASE_CELL_H) / BASE_FONT),
+    // xterm rounds the cell to DEVICE pixels and reports CSS pixels back:
+    // css.cell = round(char × dpr) / dpr. So the rounding grid is 1/dpr — whole
+    // pixels at DPR 1, half pixels at DPR 2 — and the same font measures
+    // differently per display. Model that; it is the whole reason a baseline is
+    // only valid for the DPR it was taken at.
+    cellW: (fontSize: number, dpr = window.devicePixelRatio) =>
+      Math.round(((fontSize * BASE_CELL_W) / BASE_FONT) * dpr) / dpr,
+    cellH: (fontSize: number, dpr = window.devicePixelRatio) =>
+      Math.round(((fontSize * BASE_CELL_H) / BASE_FONT) * dpr) / dpr,
     fake: {
       cols: 80,
       rows: 24,
@@ -69,7 +77,7 @@ const h = vi.hoisted(() => {
     attachCalls: 0,
   }
 })
-const { BASE_FONT, BASE_CELL_W, cellW } = h
+const { BASE_FONT, cellW } = h
 
 vi.mock('../lib/terminal/terminalRegistry', () => {
   const entry = { terminal: h.fake, ptyId: 'pty-1', workspaceId: 'ws-1' }
@@ -163,6 +171,27 @@ vi.mock('../lib/logger', () => ({
 
 import TerminalPanel from './TerminalPanel'
 
+// jsdom has no display model: drive devicePixelRatio directly and fire the
+// resolution media query the panel arms, the way a real display change would.
+const dprListeners = new Set<() => void>()
+const setDpr = (dpr: number) => {
+  Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: dpr })
+}
+const moveToDisplay = (dpr: number) => {
+  setDpr(dpr)
+  for (const fn of [...dprListeners]) fn()
+}
+window.matchMedia = ((q: string) => ({
+  media: q,
+  matches: true,
+  addEventListener: (_: string, fn: () => void) => { dprListeners.add(fn) },
+  removeEventListener: (_: string, fn: () => void) => { dprListeners.delete(fn) },
+  addListener: () => {},
+  removeListener: () => {},
+  onchange: null,
+  dispatchEvent: () => false,
+})) as unknown as typeof window.matchMedia
+
 describe('render scale on a panel mounted while already zoomed', () => {
   let container: HTMLDivElement
   let root: Root
@@ -173,6 +202,7 @@ describe('render scale on a panel mounted while already zoomed', () => {
     h.releaseCreate = null
     h.attachCalls = 0
     canvasState.zoomLevel = 2.0
+    setDpr(1)
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -227,8 +257,36 @@ describe('render scale on a panel mounted while already zoomed', () => {
     // Font raised to base × renderScale, now that there is something to measure.
     expect(h.fake.options.fontSize).toBe(BASE_FONT * 2)
 
-    // And the box grew to match the MEASURED cell, not the intended ratio:
-    // ceil(26 * 7/13) = 14 against a 7px base → exactly 200%.
-    expect(renderBoxWidth()).toBe(`${(cellW(BASE_FONT * 2) / BASE_CELL_W) * 100}%`)
+    // And the box grew to match the MEASURED cell, not the intended ratio.
+    expect(renderBoxWidth()).toBe(`${(cellW(BASE_FONT * 2) / cellW(BASE_FONT)) * 100}%`)
+  })
+
+  // Moving the window to a display with a different pixel density re-rounds
+  // every cell (the grid is 1/dpr). A baseline captured on the old screen is
+  // wrong on the new one, and nothing else would notice: the render box keeps
+  // its CSS size so the ResizeObserver stays quiet, and renderScale is already
+  // at its target so the measuring effect has no reason to re-run. The grid
+  // would stay wrong until the user happened to zoom or resize by hand.
+  it('re-derives the baseline when the window changes display density', async () => {
+    await renderPanel()
+    await flushFrames()
+    await act(async () => {
+      h.releaseCreate!()
+      await Promise.resolve()
+    })
+    await flushFrames()
+
+    const atDpr1 = renderBoxWidth()
+    expect(atDpr1).toBe(`${(cellW(BASE_FONT * 2, 1) / cellW(BASE_FONT, 1)) * 100}%`)
+
+    await act(async () => { moveToDisplay(2) })
+    await flushFrames()
+
+    // At DPR 2 the cell rounds on a half-pixel grid, so both the baseline and
+    // the scaled cell differ from their DPR 1 values. The box must follow the
+    // NEW pair — reusing the stale DPR 1 baseline leaves it at the old width.
+    const base2 = cellW(BASE_FONT, 2)
+    const scaled2 = cellW(BASE_FONT * 2, 2)
+    expect(renderBoxWidth()).toBe(`${(scaled2 / base2) * 100}%`)
   })
 })

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -70,6 +70,11 @@ export default function TerminalPanel({
   // Width and height are tracked separately because the two ceil independently.
   const baseCellRef = useRef<{ w: number; h: number } | null>(null)
   const [cellScale, setCellScale] = useState({ w: 1, h: 1 })
+  // Bumped by attach() so the measuring effect below re-runs once xterm has a
+  // DOM element to measure. Without it, a panel mounted at zoom > 1 would have
+  // run that effect before attach and then never again — renderScale is already
+  // at its target, so nothing else would invalidate it.
+  const [attachEpoch, setAttachEpoch] = useState(0)
   const terminalBaseFontSize = useSettingsStore((state) =>
     resolveTerminalFontSize(state.terminalFontSize),
   )
@@ -232,6 +237,9 @@ export default function TerminalPanel({
 
       // Move the xterm DOM element into the render box and fit it
       terminalRegistry.attach(panelId, renderBox!)
+      // xterm now has a DOM element, so the render-scale effect can measure the
+      // cell. It may have already run and bailed (panel mounted at zoom > 1).
+      setAttachEpoch((n) => n + 1)
 
       // ResizeObserver — keep xterm sized to the render box.
       //
@@ -562,7 +570,17 @@ export default function TerminalPanel({
       const screenEl = entry.terminal.element?.querySelector('.xterm-screen') as HTMLElement | null
       const cols = entry.terminal.cols
       const rows = entry.terminal.rows
-      const measurable = !!screenEl && cols > 0 && rows > 0
+      const measurable = !!screenEl && cols > 0 && rows > 0 && screenEl.offsetWidth > 0
+
+      // Bail before touching fontSize, not after. terminal.element only exists
+      // once attach() has opened xterm into the render box, and getOrCreate is
+      // async — so on a panel mounted while the canvas is ALREADY zoomed, this
+      // effect can run first. Bumping the font here would grow the cell while
+      // cellScale stayed at 1, which is precisely the box/cell mismatch this
+      // effect exists to prevent, and nothing would recompute it: renderScale
+      // has already settled, so the effect would not run again on its own.
+      // attachEpoch below re-triggers it once xterm is measurable.
+      if (!measurable) return
 
       // The baseline is the cell at the UNSCALED font, and it can only be read
       // at that font — a scaled cell cannot be divided back down, because the
@@ -576,7 +594,7 @@ export default function TerminalPanel({
       // reading offsetWidth forces the layout that makes the middle reading
       // real, so the browser never paints the intermediate state. Costs one
       // extra glyph-atlas rebuild, once per panel.
-      if (!baseCellRef.current && renderScale !== 1 && measurable) {
+      if (!baseCellRef.current && renderScale !== 1) {
         entry.terminal.options.fontSize = terminalBaseFontSize
         if (screenEl!.offsetWidth > 0) {
           baseCellRef.current = {
@@ -596,7 +614,7 @@ export default function TerminalPanel({
       // resize the box to match it, and let the ResizeObserver's plain fit run
       // against a box that is already in proportion — at which point it
       // computes the same column count and never resizes the PTY at all.
-      if (measurable && screenEl!.offsetWidth > 0) {
+      {
         const cellW = screenEl!.offsetWidth / cols
         const cellH = screenEl!.offsetHeight / rows
         // At renderScale 1 the target font IS the base font, so this reading is
@@ -615,7 +633,7 @@ export default function TerminalPanel({
     } catch {
       // Ignore — fit can throw on zero-size frames during layout transitions.
     }
-  }, [renderScale, panelId, terminalBaseFontSize])
+  }, [renderScale, panelId, terminalBaseFontSize, attachEpoch])
 
   // The --cell-scale above has just changed the scrollbar's width, and xterm
   // caches that width once at construction — so re-measure and write it back
@@ -871,6 +889,7 @@ export default function TerminalPanel({
         */}
         <div
           ref={renderBoxRef}
+          data-terminal-render-box=""
           style={{
             position: 'absolute',
             top: 0,

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -102,11 +102,19 @@ export default function TerminalPanel({
   // to be re-armed at the new value after each change.
   useEffect(() => {
     let query: MediaQueryList | null = null
+    let measureRaf: number | null = null
     let disposed = false
 
     const onChange = (): void => {
       baseCellRef.current = null
-      setMeasureEpoch((n) => n + 1)
+      // xterm watches DPR through its own MediaQueryList. Defer our read until
+      // the next frame so every resolution-change listener has refreshed its
+      // cell geometry before we capture the new baseline.
+      if (measureRaf !== null) cancelAnimationFrame(measureRaf)
+      measureRaf = requestAnimationFrame(() => {
+        measureRaf = null
+        setMeasureEpoch((n) => n + 1)
+      })
       arm()
     }
     function arm(): void {
@@ -119,6 +127,7 @@ export default function TerminalPanel({
 
     return () => {
       disposed = true
+      if (measureRaf !== null) cancelAnimationFrame(measureRaf)
       query?.removeEventListener('change', onChange)
     }
   }, [])

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -29,6 +29,7 @@ import { useActivePanelStore, getActivePanelId } from '../lib/activePanel'
 import { collectPanelIds } from '../../shared/collectPanelIds'
 import { resolveTerminalFontSize } from '../lib/terminal/terminalSettings'
 import { shouldAdjustTerminalCoords } from '../lib/terminal/terminalCoordAdjust'
+import { snapRenderScale } from '../lib/terminal/renderScale'
 import { resolveWorktree } from '../../shared/worktrees'
 import { resumeCommandForAgent } from '../../shared/agents'
 import { CATE_FILE_MIME, hasChatDrag, readCateFileLocation, readCateFilePaths } from '../drag/fileDragPayload'
@@ -37,29 +38,6 @@ import { parseLocator } from '../../shared/runtimeLocator'
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
-
-// Discrete render-scale steps. We snap canvas zoom to one of these so a
-// continuous pinch only triggers a small number of expensive atlas rebuilds.
-// Capped at 2.5× — beyond that, atlas memory grows without perceptible gain.
-const RENDER_SCALE_STEPS: number[] = [1.0, 1.5, 2.0, 2.5]
-
-function snapRenderScale(zoom: number): number {
-  if (zoom <= 1.0) return 1.0
-  let best = RENDER_SCALE_STEPS[0]
-  let bestDist = Math.abs(zoom - best)
-  for (const step of RENDER_SCALE_STEPS) {
-    const d = Math.abs(zoom - step)
-    if (d < bestDist) {
-      best = step
-      bestDist = d
-    }
-  }
-  // For zoom above the top step, just use the top step.
-  if (zoom > RENDER_SCALE_STEPS[RENDER_SCALE_STEPS.length - 1]) {
-    return RENDER_SCALE_STEPS[RENDER_SCALE_STEPS.length - 1]
-  }
-  return best
-}
 
 export default function TerminalPanel({
   panelId,
@@ -74,9 +52,34 @@ export default function TerminalPanel({
   const fitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastFitSizeRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 })
   const [renderScale, setRenderScale] = useState(1.0)
+  // xterm ceils its cell pixels, so bumping fontSize to base × renderScale does
+  // NOT grow the cell by exactly renderScale (cell(k·fs) ≠ k·cell(fs)) — it
+  // overshoots. Measured at 13px/DPR 1: renderScale 1.25 wants a 8.75px cell
+  // and gets 9 (+2.9%), 1.5 wants 10.5 and gets 11 (+4.8%).
+  //
+  // Sizing the render box by renderScale while the cell grew by more than that
+  // is what silently resized the terminal on every zoom step: the box grew
+  // 1.25× but the cell grew 1.286×, so 90 columns became 87. preserveGrid only
+  // absorbs ±1, so a 3-4 column jump went straight through to the PTY as a
+  // SIGWINCH and reflowed the shell/TUI.
+  //
+  // So drive the layout off the MEASURED cell instead. With
+  //   box = container × (cell / baseCell)
+  // the column count is container/baseCell — renderScale cancels out entirely,
+  // and the counter-scale below pins the on-screen cell to its base size.
+  // Width and height are tracked separately because the two ceil independently.
+  const baseCellRef = useRef<{ w: number; h: number } | null>(null)
+  const [cellScale, setCellScale] = useState({ w: 1, h: 1 })
   const terminalBaseFontSize = useSettingsStore((state) =>
     resolveTerminalFontSize(state.terminalFontSize),
   )
+
+  // A font-size change moves the baseline everything is measured against. Drop
+  // it so the next pass re-derives it instead of scaling toward a cell size
+  // that no longer exists.
+  useEffect(() => {
+    baseCellRef.current = null
+  }, [terminalBaseFontSize])
 
   const [showSearch, setShowSearch] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -556,25 +559,81 @@ export default function TerminalPanel({
         ? Math.abs(viewport.scrollTop - (viewport.scrollHeight - viewport.clientHeight)) < 5
         : true
 
+      const screenEl = entry.terminal.element?.querySelector('.xterm-screen') as HTMLElement | null
+      const cols = entry.terminal.cols
+      const rows = entry.terminal.rows
+      const measurable = !!screenEl && cols > 0 && rows > 0
+
+      // The baseline is the cell at the UNSCALED font, and it can only be read
+      // at that font — a scaled cell cannot be divided back down, because the
+      // ceil already threw the remainder away (at 1.5 the cell is 11, and
+      // 11/1.5 = 7.33 for a cell that is really 7; that 4.8% error then shrank
+      // the box at every scale, including 1).
+      //
+      // So when a panel is first laid out already zoomed in, take the reading
+      // directly: drop to the base font, measure, and go straight back up. Both
+      // writes and the measurement happen in this one synchronous block, and
+      // reading offsetWidth forces the layout that makes the middle reading
+      // real, so the browser never paints the intermediate state. Costs one
+      // extra glyph-atlas rebuild, once per panel.
+      if (!baseCellRef.current && renderScale !== 1 && measurable) {
+        entry.terminal.options.fontSize = terminalBaseFontSize
+        if (screenEl!.offsetWidth > 0) {
+          baseCellRef.current = {
+            w: screenEl!.offsetWidth / cols,
+            h: screenEl!.offsetHeight / rows,
+          }
+        }
+      }
+
       // Mutating options.fontSize triggers xterm's internal renderer refresh,
-      // which rebuilds the WebGL glyph atlas at the new resolution.
+      // which rebuilds the WebGL glyph atlas at the new resolution. xterm
+      // relays out the cell synchronously, so the grid can be measured below.
       entry.terminal.options.fontSize = terminalBaseFontSize * renderScale
-      // preserveGrid: the box and the cell grew by the same factor, so the
-      // grid must not change — but ceil/parseInt quantization flips rows by
-      // ±1 across scale steps, and each phantom SIGWINCH makes a TUI like
-      // Claude Code stack a duplicate frame into scrollback (doubled content
-      // that only a large vertical resize clears).
-      terminalRegistry.fit(panelId, { preserveGrid: true })
-      // The render box's layout size legitimately changed by the scale factor;
-      // sync the ResizeObserver's last-fit size so its debounced plain fit()
-      // doesn't run right after this and un-pin the grid.
-      lastFitSizeRef.current = { w: renderBox.clientWidth, h: renderBox.clientHeight }
+
+      // No fit() here. Fitting against a box still sized for the PREVIOUS cell
+      // is exactly what dropped columns (see cellScale). Measure the new cell,
+      // resize the box to match it, and let the ResizeObserver's plain fit run
+      // against a box that is already in proportion — at which point it
+      // computes the same column count and never resizes the PTY at all.
+      if (measurable && screenEl!.offsetWidth > 0) {
+        const cellW = screenEl!.offsetWidth / cols
+        const cellH = screenEl!.offsetHeight / rows
+        // At renderScale 1 the target font IS the base font, so this reading is
+        // itself the baseline — no second pass needed.
+        if (renderScale === 1) baseCellRef.current = { w: cellW, h: cellH }
+        const base = baseCellRef.current
+        const next = base
+          ? { w: cellW / base.w, h: cellH / base.h }
+          : { w: renderScale, h: renderScale }
+        // Guard a mid-layout read: the scale tracks renderScale to within a few
+        // percent, so anything outside the step range is noise, not signal.
+        if (next.w > 0.5 && next.w < 3 && next.h > 0.5 && next.h < 3) setCellScale(next)
+      }
 
       if (wasAtBottom) entry.terminal.scrollToBottom()
     } catch {
       // Ignore — fit can throw on zero-size frames during layout transitions.
     }
   }, [renderScale, panelId, terminalBaseFontSize])
+
+  // The --cell-scale above has just changed the scrollbar's width, and xterm
+  // caches that width once at construction — so re-measure and write it back
+  // BEFORE anything fits against it, or FitAddon subtracts a stale track and
+  // returns a column count too wide for the viewport (clipped right-hand
+  // columns). This effect runs after the style is committed, and the sync
+  // itself flushes layout before reading, so the measurement is live.
+  //
+  // With both the box and the scrollbar scaling by the cell ratio, a plain
+  // fit() now computes the same column count it had before — the scale cancels
+  // out of (box - scrollbar) / cell. So the ResizeObserver is left alone to do
+  // its job; a genuine panel resize must still re-fit.
+  useEffect(() => {
+    const renderBox = renderBoxRef.current
+    if (!renderBox || renderBox.offsetParent === null) return
+    if (renderBox.clientWidth === 0 || renderBox.clientHeight === 0) return
+    terminalRegistry.syncScrollBarWidth(panelId)
+  }, [cellScale, panelId])
 
   // -------------------------------------------------------------------------
   // Repaint after the zoom settles
@@ -634,9 +693,11 @@ export default function TerminalPanel({
     if (!container) return
 
     // The full transform chain on .xterm-screen is:
-    //   inner render box: scale(1/renderScale)   (counter-scale, see effect above)
+    //   inner render box: scale(1/cellScale.w, 1/cellScale.h)  (see effect above)
     //   outer world div : scale(zoomLevel)
-    // so screen pixels = DOM pixels × (zoomLevel / renderScale).
+    // so screen pixels = DOM pixels × zoomLevel / cellScale, PER AXIS — the two
+    // differ by a couple of percent, which is enough to drift a selection by a
+    // row near the bottom of a tall terminal, so each axis converts by its own.
     // xterm computes hit-testing against its own DOM-space cell metrics, so we
     // must convert the incoming screen-space offset back into DOM space.
     const adjustCoords = (e: MouseEvent) => {
@@ -645,7 +706,8 @@ export default function TerminalPanel({
       // rewrite when a canvas gesture owns the pointer (canvas-interacting), for
       // every event in a non-left-button gesture, and when the canvas isn't
       // zoomed. See terminalCoordAdjust.ts for the full rationale.
-      const effective = zoomLevel / renderScale
+      const effective = zoomLevel / cellScale.w
+      const effectiveY = zoomLevel / cellScale.h
       if (
         !shouldAdjustTerminalCoords(
           e.type,
@@ -665,7 +727,7 @@ export default function TerminalPanel({
       const rect = screenEl.getBoundingClientRect()
       // Convert screen-space offset to local (DOM-space) offset
       const adjustedX = rect.left + (e.clientX - rect.left) / effective
-      const adjustedY = rect.top + (e.clientY - rect.top) / effective
+      const adjustedY = rect.top + (e.clientY - rect.top) / effectiveY
 
       Object.defineProperty(e, 'clientX', { value: adjustedX, configurable: true })
       Object.defineProperty(e, 'clientY', { value: adjustedY, configurable: true })
@@ -681,7 +743,7 @@ export default function TerminalPanel({
       container.removeEventListener('mousemove', adjustCoords, { capture: true })
       container.removeEventListener('mouseup', adjustCoords, { capture: true })
     }
-  }, [zoomLevel, renderScale])
+  }, [zoomLevel, cellScale])
 
   // -------------------------------------------------------------------------
   // Drag-and-drop: accept files from OS or internal file explorer
@@ -813,10 +875,22 @@ export default function TerminalPanel({
             position: 'absolute',
             top: 0,
             left: 0,
-            width: `${100 * renderScale}%`,
-            height: `${100 * renderScale}%`,
-            transform: `scale(${1 / renderScale})`,
+            width: `${100 * cellScale.w}%`,
+            height: `${100 * cellScale.h}%`,
+            // Per-axis, not uniform: width and height ceil independently, so the
+            // cell's aspect ratio shifts slightly per scale step (7:15 → 9:19 →
+            // 11:23). A uniform width-driven counter-scale therefore left the
+            // height 1.5-2.4% short depending on the step, which read as the
+            // terminal's vertical size wobbling on zoom. Undoing each axis by
+            // its own measured ratio lands the on-screen cell back on exactly
+            // baseCell × baseCell at every step. The glyph inside is then off
+            // its true aspect by the same ~2%, which is imperceptible — and far
+            // preferable to a grid that visibly resizes.
+            transform: `scale(${1 / cellScale.w}, ${1 / cellScale.h})`,
             transformOrigin: '0 0',
+            // Drives the scrollbar rule in globals.css so the track scales with
+            // the cell instead of thinning as the terminal zooms in.
+            ['--cell-scale' as string]: String(cellScale.w),
           }}
         />
         {/* Supported agent running without Cate hooks — nudge to Settings. */}

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -68,13 +68,19 @@ export default function TerminalPanel({
   // the column count is container/baseCell — renderScale cancels out entirely,
   // and the counter-scale below pins the on-screen cell to its base size.
   // Width and height are tracked separately because the two ceil independently.
-  const baseCellRef = useRef<{ w: number; h: number } | null>(null)
+  // The DPR the baseline was taken at is part of the baseline: xterm rounds the
+  // cell to DEVICE pixels and reports it back in CSS pixels
+  // (css.cell = round(char × dpr) / dpr), so the same font measures 7px on a
+  // DPR 1 display and can measure 6.5px on a DPR 2 one. A baseline captured on
+  // one screen is simply wrong on the other.
+  const baseCellRef = useRef<{ w: number; h: number; dpr: number } | null>(null)
   const [cellScale, setCellScale] = useState({ w: 1, h: 1 })
-  // Bumped by attach() so the measuring effect below re-runs once xterm has a
-  // DOM element to measure. Without it, a panel mounted at zoom > 1 would have
-  // run that effect before attach and then never again — renderScale is already
-  // at its target, so nothing else would invalidate it.
-  const [attachEpoch, setAttachEpoch] = useState(0)
+  // Bumped whenever something outside this component's own state makes the
+  // terminal measurable again, or makes an existing measurement invalid:
+  // attach() (xterm finally has a DOM element — without this a panel mounted at
+  // zoom > 1 would measure nothing and never retry, since renderScale has
+  // already settled) and a DPR change (see above).
+  const [measureEpoch, setMeasureEpoch] = useState(0)
   const terminalBaseFontSize = useSettingsStore((state) =>
     resolveTerminalFontSize(state.terminalFontSize),
   )
@@ -85,6 +91,37 @@ export default function TerminalPanel({
   useEffect(() => {
     baseCellRef.current = null
   }, [terminalBaseFontSize])
+
+  // Same for a DPR change — dragging the window to a display with a different
+  // pixel density re-rounds every cell. Nothing else would notice: the render
+  // box keeps its CSS size, so the ResizeObserver stays quiet, and renderScale
+  // is already at its target, so the measuring effect has no reason to re-run.
+  // The grid would stay wrong until the user happened to zoom or resize.
+  //
+  // A resolution media query only matches the DPR it was built with, so it has
+  // to be re-armed at the new value after each change.
+  useEffect(() => {
+    let query: MediaQueryList | null = null
+    let disposed = false
+
+    const onChange = (): void => {
+      baseCellRef.current = null
+      setMeasureEpoch((n) => n + 1)
+      arm()
+    }
+    function arm(): void {
+      if (disposed) return
+      query?.removeEventListener('change', onChange)
+      query = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+      query.addEventListener('change', onChange)
+    }
+    arm()
+
+    return () => {
+      disposed = true
+      query?.removeEventListener('change', onChange)
+    }
+  }, [])
 
   const [showSearch, setShowSearch] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -239,7 +276,7 @@ export default function TerminalPanel({
       terminalRegistry.attach(panelId, renderBox!)
       // xterm now has a DOM element, so the render-scale effect can measure the
       // cell. It may have already run and bailed (panel mounted at zoom > 1).
-      setAttachEpoch((n) => n + 1)
+      setMeasureEpoch((n) => n + 1)
 
       // ResizeObserver — keep xterm sized to the render box.
       //
@@ -579,7 +616,7 @@ export default function TerminalPanel({
       // cellScale stayed at 1, which is precisely the box/cell mismatch this
       // effect exists to prevent, and nothing would recompute it: renderScale
       // has already settled, so the effect would not run again on its own.
-      // attachEpoch below re-triggers it once xterm is measurable.
+      // measureEpoch below re-triggers it once xterm is measurable.
       if (!measurable) return
 
       // The baseline is the cell at the UNSCALED font, and it can only be read
@@ -600,6 +637,7 @@ export default function TerminalPanel({
           baseCellRef.current = {
             w: screenEl!.offsetWidth / cols,
             h: screenEl!.offsetHeight / rows,
+            dpr: window.devicePixelRatio,
           }
         }
       }
@@ -619,7 +657,9 @@ export default function TerminalPanel({
         const cellH = screenEl!.offsetHeight / rows
         // At renderScale 1 the target font IS the base font, so this reading is
         // itself the baseline — no second pass needed.
-        if (renderScale === 1) baseCellRef.current = { w: cellW, h: cellH }
+        if (renderScale === 1) {
+          baseCellRef.current = { w: cellW, h: cellH, dpr: window.devicePixelRatio }
+        }
         const base = baseCellRef.current
         const next = base
           ? { w: cellW / base.w, h: cellH / base.h }
@@ -633,7 +673,7 @@ export default function TerminalPanel({
     } catch {
       // Ignore — fit can throw on zero-size frames during layout transitions.
     }
-  }, [renderScale, panelId, terminalBaseFontSize, attachEpoch])
+  }, [renderScale, panelId, terminalBaseFontSize, measureEpoch])
 
   // The --cell-scale above has just changed the scrollbar's width, and xterm
   // caches that width once at construction — so re-measure and write it back

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -219,8 +219,23 @@
    (xterm toggles `.focus` on its root element). The thumb is transparent until
    then — its track space stays reserved, so revealing it doesn't reflow the
    terminal. Unlayered so it overrides the @layer base defaults above. */
+/* The scrollbar lives inside the render box, which is counter-scaled by
+   1/cellScale — so a fixed 8px track shrinks on screen as the terminal zooms in
+   (down to −36% at the top scale step, while every other scrollbar in the app
+   stays put). Scale the track and its insets with the cell so the pill keeps a
+   constant on-screen size and shape. `--cell-scale` is set on the render box;
+   the `1` fallback leaves docked and detached terminals untouched.
+   xterm caches this width at construction and never re-measures it, so
+   TerminalPanel writes the new value back — see syncScrollBarWidth(). */
+.xterm-viewport::-webkit-scrollbar {
+  width: calc(8px * var(--cell-scale, 1));
+}
 .xterm-viewport::-webkit-scrollbar-thumb {
   background-color: transparent;
+  border-top: calc(2px * var(--cell-scale, 1)) solid transparent;
+  border-bottom: calc(2px * var(--cell-scale, 1)) solid transparent;
+  border-left: calc(3px * var(--cell-scale, 1)) solid transparent;
+  border-right: calc(1px * var(--cell-scale, 1)) solid transparent;
   /* Fade the thumb in/out as the pointer enters/leaves or focus changes. */
   transition: background-color 280ms ease;
 }


### PR DESCRIPTION
## Symptoms

Three things went wrong whenever the canvas was zoomed:

- Text was blurriest around 125%, and crossing that point visibly jumped the terminal's size
- Every zoom step resized the terminal, reflowing the shell and any TUI in it
- Vertical size wobbled by a percent or two per step
- Sizes were also wrong below 100%

## Cause

Canvas zoom CSS-scales the world div, which stretches xterm's pre-rasterized glyph atlas and blurs it. `TerminalPanel` compensated by raising `fontSize` to `base × renderScale` and counter-scaling the box by `1/renderScale`.

The problem is that **xterm ceils its cell pixels**, so `cell(k·fs) ≠ k·cell(fs)` and the compensation drifts away from the thing it is compensating for.

Measured at 13px / DPR 1:

| renderScale | expected cell | actual | overshoot | columns |
|---|---|---|---|---|
| 1 | 7 | 7 | — | 90 |
| 1.25 | 8.75 | **9** | +2.9% | 87 |
| 1.5 | 10.5 | **11** | +4.8% | 86 |
| 2.5 | 17.5 | **19** | +8.6% | **−9 cols** |

The box grows by `renderScale` while the cell grows by more, so columns disappear — and each drop reaches the PTY as a SIGWINCH. **Zoom stopped being a zoom and became a resize.**

## Fix

Drive layout off the **measured cell** instead of the intended ratio:

```
box = container × (cell / baseCell)
→ columns = container / baseCell        ← the scale cancels out
```

With the scale gone from the arithmetic, the column count is **fixed by construction at any zoom**.

- **Per-axis counter-scale** — width and height ceil independently (`7:15 → 9:19 → 11:23`), so a uniform width-driven scale left the height 1.5–2.4% short.
- **Measure the baseline directly** — a ceiled cell cannot be divided back down (`11/1.5 = 7.33` for a cell that is really 7). That 4.8% error shrank the box at **every** scale including 1, which is what broke sizes below 100%. A panel first laid out already zoomed now drops to the base font, measures, and returns in the same frame (no visible flicker).
- **Halve the snap spacing to 0.25** — 125% was both the blurriest point (a 25% upscale) and a tie between two steps, so a hair past it the scale jumped a full 1.5× in one frame.
- **Scale the scrollbar with the cell** — it lives inside the counter-scaled box, so a fixed 8px track thinned on screen as the terminal zoomed in, down to −36% at the top step.
- **Sync xterm's cached `scrollBarWidth`** — it is measured once in the `Viewport` constructor and never again. FitAddon is its only reader (xterm's core never touches the field), so a stale value meant subtracting 8 from a 17px track and returning a column count whose grid overflowed its viewport, clipping right-hand columns.

## Removing `preserveGrid`

It was the earlier mitigation: discard ±1 column/row deltas so the PTY never saw a phantom SIGWINCH. **The real deltas turned out to be 3–9 columns**, which went straight through it.

It now has no callers and is removed. Its regression coverage is replaced by three tests for the scrollbar cache sync (writes the measurement, keeps the last good value when the track reports 0, degrades quietly if a future xterm drops the field).

`snapRenderScale` moves to its own module — left in place, testing the snap boundaries pulls in xterm's WebGL addon, which needs a browser global at import time and dies under the node test environment.

## Verification

Instrumented a running app:

```
renderScale 1 → 1.25 → 1.5 → 2 → 2.5     column count held at 101x27
scrollbar                                 measured == cached at every step
```

`plain fit changed grid` logged **zero times** during zoom. 237 tests pass (5 + 3 new).

## Limits of that verification

**All measurements come from a single DPR 1 machine.** The arithmetic is DPR-independent but the confirmation is not — the rounding unit is `1/DPR`, so on a retina display the error halves and may be zero at some steps.

This is the same trap the `preserveGrid` commit fell into: it was tuned to "flipped rows by 1" as observed in one environment, and broke where the deltas were 3–9. **A second pair of eyes on a retina display would be valuable.**

## Left alone

- **Zoom-out (<100%)** stays pinned at `renderScale` 1 — the atlas is being downsampled anyway, so rasterizing it larger buys nothing.
- **Glyphs sit 2–4% smaller inside the cell.** As long as cells are ceiled to integers the `glyph:cell` ratio differs per scale; the cell itself is fixed, so layout does not move.
- **`_core.viewport.scrollBarWidth` is an internal.** The only debt here. Every hop is optional-chained so a future xterm turns scaling off rather than throwing — but it fails *silently*, which is why the tests above stand guard.

---

Also adds `.omc/` (agent tooling state) to `.gitignore` — same category as the `.agents/` and `.cate/` entries beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsMgXwPNJJ4SgXgRff5wJk
