### PR TITLE
fix: give a new PTY the terminal's real size, not the 80x24 spawn default

### DIFF
--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -337,6 +337,22 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
     //    brand-new PTY, so the instant-exit diagnostic applies.
     wireTerminalListeners({ panelId, ptyId, opts, terminal, cleanupListeners, freshSpawn: true })
 
+    // 6b. Push the terminal's ACTUAL size to the freshly spawned PTY.
+    //
+    // The entry is registered before the awaits above so concurrent callers
+    // share one object — which also means attach() can, and normally does, fit
+    // the xterm to its real container while we are still waiting for the spawn.
+    // Those fits call terminal.resize(), which fires onResize with no listener
+    // attached yet, so the new size never reaches the PTY: the grid is correct
+    // on screen while the PTY stays at the 80x24 it was created with. Nothing
+    // corrects it afterwards either, because fit() only resizes when the size
+    // CHANGES — so a terminal the user never happens to resize by hand keeps a
+    // shell wrapping at 80 columns for the rest of its life, and any TUI
+    // started in it draws its frame to 80.
+    if (terminal.cols !== cols || terminal.rows !== rows) {
+      electronAPI.terminalResize(ptyId, terminal.cols, terminal.rows)
+    }
+
     // 11. Write initialInput immediately — the PTY buffers writes until the
     //     shell is ready to consume them, so a fixed setTimeout was both
     //     fragile (slow systems) and unnecessary.

--- a/src/renderer/lib/terminal/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.test.ts
@@ -119,6 +119,9 @@ vi.mock('../logger', () => ({ default: { warn: () => {}, info: () => {}, error: 
 // a pre-existing ptyId. The bug manifests when a leaked pending-transfer
 // causes a fresh getOrCreate to silently go down the reconnect path.
 const terminalCreate = vi.fn(async () => 'pty-fresh')
+// Every winsize pushed to the PTY. Used to pin that a terminal fitted while the
+// spawn was still in flight still gets its real size through.
+const terminalResize = vi.fn()
 const panelTransferAck = vi.fn(async (_id: string) => undefined as undefined)
 // Process-wide WebGL grant broker (main-side); default to granting so the
 // attach() upgrade path runs. Individual tests can override the resolved value.
@@ -136,6 +139,7 @@ beforeEach(() => {
   settingsState.terminalContrast = 4.5
   settingsState.terminalOptionIsMeta = true
   terminalCreate.mockClear()
+  terminalResize.mockClear()
   panelTransferAck.mockClear()
   webglRequestGrant.mockClear()
   webglRequestGrant.mockImplementation(async () => true)
@@ -149,7 +153,7 @@ beforeEach(() => {
     value: {
       terminalCreate,
       terminalWrite: vi.fn(),
-      terminalResize: vi.fn(),
+      terminalResize,
       terminalKill: vi.fn(async () => undefined),
       onTerminalData: vi.fn(() => () => {}),
       onTerminalExit: vi.fn(() => () => {}),
@@ -819,5 +823,61 @@ describe('process-wide WebGL context grant lifecycle', () => {
 
     document.body.removeChild(container)
     terminalRegistry.dispose('panel-reset')
+  })
+})
+
+// Regression: a terminal the user never resizes by hand keeps its PTY at the
+// 80x24 spawn default forever, so the shell wraps at 80 columns and any TUI
+// started in it draws its frame to 80 — while the on-screen grid looks correct.
+//
+// Root cause: getOrCreate registers the entry BEFORE awaiting the spawn (so
+// concurrent callers share one object), which lets attach() fit the xterm to its
+// real container while the spawn is still in flight. Those fits call
+// terminal.resize(), firing onResize before the listener that forwards it to the
+// PTY exists — the size is applied to xterm and dropped on the floor for the
+// PTY. Nothing corrects it later because fit() only resizes on a CHANGE.
+//
+// Contract: once the spawn resolves, the PTY must be told the terminal's actual
+// size.
+describe('PTY adopts a size the terminal reached during spawn', () => {
+  it('pushes the real size once the spawn resolves', async () => {
+    const { terminalRegistry } = await import('./terminalRegistry')
+
+    // Hold the spawn open so we can fit the terminal mid-flight, exactly as
+    // attach() does while getOrCreate is still awaiting.
+    let releaseSpawn!: (id: string) => void
+    terminalCreate.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { releaseSpawn = resolve }),
+    )
+
+    const pending = terminalRegistry.getOrCreate('panel-race', { workspaceId: 'ws-1' })
+
+    // getOrCreate awaits settingsGet before terminalCreate; drain the queue so
+    // the spawn is genuinely in flight when we fit.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The entry is already registered even though the spawn hasn't resolved.
+    const entry = terminalRegistry.getEntry('panel-race')!
+    expect(entry.terminal.cols).toBe(80)
+    entry.terminal.resize(120, 40) // what safeFit() does — no PTY listener yet
+
+    releaseSpawn('pty-fresh')
+    await pending
+
+    expect(terminalResize).toHaveBeenCalledWith('pty-fresh', 120, 40)
+
+    terminalRegistry.dispose('panel-race')
+  })
+
+  it('stays quiet when the terminal is still at the spawn size', async () => {
+    const { terminalRegistry } = await import('./terminalRegistry')
+
+    // Never fitted (panel not laid out yet): the PTY was created at 80x24 and
+    // is already correct, so re-sending it would be a pointless SIGWINCH.
+    await terminalRegistry.getOrCreate('panel-norace', { workspaceId: 'ws-1' })
+
+    expect(terminalResize).not.toHaveBeenCalled()
+
+    terminalRegistry.dispose('panel-norace')
   })
 })


### PR DESCRIPTION
## Symptom

The on-screen grid fits the panel, but **the PTY stays at 80 columns**. The shell wraps at 80, and any TUI started in that terminal draws its frame to 80.

Found via a restored Claude Code session rendering its welcome banner into the left ~75% of the panel with dead space beside it.

```
freshly opened terminal              tput cols → 80
  ↳ nudge the panel border by 1px    tput cols → 89   (fixed permanently)
```

That "nudge fixes it forever" behaviour is what made it look cosmetic.

## Cause

`getOrCreate` registers the entry **before** awaiting the spawn, so that concurrent callers share one object:

```ts
registry.set(panelId, entry)                        // concurrent callers share this
...
const ptyId = await electronAPI.terminalCreate(...) // ← hundreds of ms
wireTerminalListeners(...)                          // onResize is registered here
```

During that wait `attach()` fits the xterm to its real container. The `terminal.resize()` those fits perform fires `onResize` **before the listener that forwards it to the PTY exists**, so the size lands on xterm and is dropped for the PTY.

Nothing corrects it afterwards, because **`fit()` only resizes on a change**. The grid already matches the container, so every later fit is a no-op and the PTY is never told. Nudging the panel is the one thing that makes the size *change* again.

Instrumenting both ends made the ordering unambiguous:

```
safeFit calling resize {"probeId":"UNWIRED", "80x24" → "96x27"}   ← no listener yet (×6)
wiring listeners       {"...rpty-1-local", cols:107, rows:27}      ← registers already-resized
main resizeTerminal    → 0 calls                                    ← nothing reached the PTY
```

Three layers swallow the failure silently — `runtimeForTerminal(id)?.`, `RemoteRuntime`'s `.catch(() => {})`, and the daemon's `ptys.get(id)?.` — so nothing was logged anywhere. That made it look like a main-process or runtime problem when in fact the renderer never made the IPC call at all.

## Fix

Push the terminal's current size once, right after the listeners are wired:

```ts
if (terminal.cols !== cols || terminal.rows !== rows) {
  electronAPI.terminalResize(ptyId, terminal.cols, terminal.rows)
}
```

The guard keeps it silent when the terminal genuinely is still at the spawn size (panel not laid out yet), so no pointless SIGWINCH reaches an already-correct PTY.

## Tests

Two regression tests, and I checked they actually fail without the fix:

```
fix removed  → 1 failed | 39 passed
restored     → 40 passed
```

- a terminal fitted while the spawn was in flight gets its real size through once the spawn resolves
- a terminal still at the spawn size sends nothing

Typecheck passes; 232 terminal/panel tests pass.

## Verification

Instrumented a dev build on the **session-restore path**: `main resizeTerminal` went from 0 calls to carrying the real sizes (107x27, 89x24) through to the PTY, and `tput cols` changed from 80 to the panel's actual width.

**Other entry paths — new window, detach, dock switch — were not exercised.** The fix sits on the common path every fresh spawn takes, so they should be covered by construction, but the empirical check is one path only.

## Relationship to #551

**Independent, and they do not conflict.** Both touch `terminalRegistry.test.ts` but in different regions; `git merge-tree` confirms a clean automatic merge. Either can land first.

The causes are unrelated too — #551 is about render scaling under canvas zoom, this one is about PTY size at spawn time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsMgXwPNJJ4SgXgRff5wJk
