### PR TITLE
Make agent CLI session restore retryable

### DIFF
--- a/src/renderer/lib/terminal/terminalLifecycle.test.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.test.ts
@@ -81,6 +81,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 
 const statusRegisterTerminal = vi.fn()
 const statusUnregisterTerminal = vi.fn()
+const setPanelAgentSession = vi.fn()
 vi.mock('../../stores/statusStore', () => ({
   useStatusStore: {
     getState: () => ({
@@ -108,7 +109,7 @@ vi.mock('../../stores/settingsStore', () => ({
 vi.mock('../../stores/appStore', () => ({
   awaitWorkspaceSync: async () => {},
   useAppStore: {
-    getState: () => ({ workspaces: [], updatePanelTitleFromAgent: vi.fn() }),
+    getState: () => ({ workspaces: [], updatePanelTitleFromAgent: vi.fn(), setPanelAgentSession }),
   },
 }))
 const replayTerminalLog = vi.fn(async () => {})
@@ -219,6 +220,7 @@ beforeEach(() => {
   onTerminalExit.mockImplementation(captureExitListener)
   statusRegisterTerminal.mockClear()
   statusUnregisterTerminal.mockClear()
+  setPanelAgentSession.mockClear()
   replayTerminalLog.mockClear()
   replayTerminalLog.mockImplementation(async () => {})
   noteAgentInputSubmitted.mockClear()
@@ -292,6 +294,25 @@ describe('spawn → wire → dispose happy path', () => {
     await LC.getOrCreate('panel-input', { workspaceId: 'ws-1', initialInput: 'npm test\r' })
     expect(terminalInstances[0].writes).toContain('npm test\r')
     LC.dispose('panel-input')
+  })
+
+  it('writes a restored agent resume command once and retains its stamp until the agent reports', async () => {
+    terminalCreate.mockResolvedValueOnce('pty-agent-restore')
+
+    const first = await LC.getOrCreate('panel-agent-restore', {
+      workspaceId: 'ws-1',
+      resumeCommand: 'codex resume session-1',
+    })
+    const reused = await LC.getOrCreate('panel-agent-restore', {
+      workspaceId: 'ws-1',
+      resumeCommand: 'codex resume session-1',
+    })
+
+    expect(reused).toBe(first)
+    expect(terminalWrite).toHaveBeenCalledTimes(1)
+    expect(terminalWrite).toHaveBeenCalledWith('pty-agent-restore', 'codex resume session-1\r')
+    expect(setPanelAgentSession).not.toHaveBeenCalled()
+    LC.dispose('panel-agent-restore')
   })
 
   it('uses the session-restore cwd and replays the scrollback log for restored terminals', async () => {

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -37,7 +37,7 @@ import { createFileLinkProvider, resolveLinkRoot } from './terminalFileLinkProvi
 import { clearWebglDisabled, releaseWebglGrant } from './terminalDom'
 import { getActiveTheme } from '../themeManager'
 import { useStatusStore } from '../../stores/statusStore'
-import { awaitWorkspaceSync, useAppStore } from '../../stores/appStore'
+import { awaitWorkspaceSync } from '../../stores/appStore'
 import { replayTerminalLog } from '../workspace/session'
 import { noteAgentInputSubmitted } from '../agent/agentScreenDetector'
 
@@ -48,8 +48,8 @@ interface CreateOpts {
   placementGroupId?: string
   /** Terminal session-restore: a full agent resume command (e.g.
    *  `claude --resume <id>`) typed into the fresh shell right after spawn, via
-   *  the real PTY input path. One-shot — the persisted stamp it came from is
-   *  cleared as soon as it is written. */
+   *  the real PTY input path. One-shot per fresh PTY; the persisted stamp is
+   *  retained until agent evidence replaces or clears it. */
   resumeCommand?: string
 }
 
@@ -346,14 +346,16 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
 
     // 11b. Resume a persisted agent session: type the resume command into the
     //      PTY (kernel type-ahead — the shell reads it at its first prompt and
-    //      echoes it like user input). Clear the stamp immediately: if the
-    //      resume succeeds the process monitor re-probes and re-stamps; if the
-    //      id is stale the CLI errors visibly and the next restore is a plain
-    //      shell. Only fresh spawns reach this line, so a remount that reuses
-    //      a live registry entry never re-injects.
+    //      echoes it like user input). Keep the stamp until observed agent
+    //      evidence replaces or clears it: writing input only proves IPC
+    //      accepted the bytes, not that the shell consumed them or the CLI
+    //      resumed. Clearing here made a second restart restore a plain shell
+    //      whenever the first resumed CLI had not emitted a hook yet
+    //      (codex/cursor are silent until the next prompt). Only fresh spawns
+    //      reach this line, so a remount that reuses a live registry entry never
+    //      re-injects.
     if (opts.resumeCommand) {
       void electronAPI.terminalWrite(ptyId, opts.resumeCommand + '\r')
-      useAppStore.getState().setPanelAgentSession(opts.workspaceId, panelId, null)
     }
 
     // 12. Replay scrollback log if this terminal was restored from a session

--- a/src/renderer/lib/workspace/sessionSerialize.ts
+++ b/src/renderer/lib/workspace/sessionSerialize.ts
@@ -141,7 +141,8 @@ export function projectFilesToSnapshot(
         worktreeId: sp?.worktreeId,
         unsavedContent: sp?.unsavedContent,
         // The agent session to resume in this terminal — TerminalPanel types
-        // the resume command into the fresh shell and clears the field.
+        // the resume command into the fresh shell and retains the stamp until
+        // observed agent evidence replaces or clears it.
         agentSession: sp?.agentSession,
         // Restore the per-panel cwd (worktree path / dropped folder) so the
         // terminal respawns there. TerminalPanel reads panel.cwd directly. The

--- a/src/runtime/capabilities/agentHookContracts.itest.ts
+++ b/src/runtime/capabilities/agentHookContracts.itest.ts
@@ -878,6 +878,17 @@ describe.skipIf(!LIVE || !hasBin('codex'))('codex hook contract', () => {
     expect(resumeStart?.transcript_path).toBe(rollout)
     expect(resumeEvents.some((e) => e.payload.hook_event_name === 'Stop')).toBe(true)
     expectEcho(resumeEvents, tid)
+
+    // Exact interactive command Cate types into a restored terminal. Replaying
+    // the prior prompt proves `codex resume <id>` loaded this rollout rather
+    // than opening a fresh TUI. No harness-only argv are added here.
+    const tui = await driveTui(codexBin(), ['resume', id], cwd, cleanEnv(), { dismissUpdateBanner: false })
+    await tui.waitFor(
+      () => stripAnsi(tui.peek()).includes(PROMPT),
+      60_000,
+      'restored Codex conversation history',
+    )
+    tui.kill()
   })
 
   // Permission-wait is PUSHED: PermissionRequest fires the moment a tool call
@@ -1747,6 +1758,24 @@ export const CateEventLogger = async ({ directory }) => {
       'resume must not create a new session',
     ).toBe(false)
     expect(resumeEvents.some((e) => e.type === 'session.idle' && e.sessionID === id)).toBe(true)
+
+    // Exact interactive command Cate types into a restored terminal. Unlike
+    // `opencode run --session`, this covers the default TUI argument path.
+    const tuiEventsFile = join(cwd, 'events-resume-tui.jsonl')
+    const tui = await driveTui('opencode', ['--session', id], cwd, env(tuiEventsFile))
+    const tuiEvents = (): OcEvent[] => readJsonl<OcEvent>(tuiEventsFile)
+    await tui.settle(8_000)
+    await tui.send(PROMPT2)
+    await tui.waitFor(
+      () => tuiEvents().some((e) => e.type === 'session.idle' && e.sessionID === id),
+      180_000,
+      'session.idle on exact interactive resume command',
+    )
+    expect(
+      tuiEvents().some((e) => e.type === 'session.created' && e.sessionID !== id),
+      'interactive resume must not create a new session',
+    ).toBe(false)
+    tui.kill()
   })
 
   // Permission-wait is PUSHED: permission.asked fires on the bus when a gated

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,10 +128,11 @@ export interface PanelState {
    *  the new `cwd`. */
   ptyEpoch?: number
   /** Terminal panels only: the coding-agent session running in this terminal
-   *  at save time (pushed by the agent's own hook events, with a session-store
-   *  probe as fallback for hook-less agents; cleared when the agent exits).
+   *  at save time (pushed by the agent's own hook events and cleared after an
+   *  observed exit).
    *  On restore, TerminalPanel types the agent's resume command into the
-   *  fresh shell and clears this. */
+   *  fresh shell and retains this until newer agent evidence replaces or
+   *  clears it. */
   agentSession?: TerminalAgentSession
   /** Extension panels only: which installed extension + which of its declared
    *  panels this instance renders. */


### PR DESCRIPTION
## Summary

- retain the persisted agent-session stamp after injecting a resume command
- keep resume-command injection one-shot per fresh PTY
- add a regression test for interrupted or rapid consecutive restores
- cover the exact interactive Codex and OpenCode resume commands in live contracts

## Root cause

Cate cleared PanelState.agentSession immediately after initiating the PTY write. That write only proved IPC accepted the bytes; it did not prove the shell consumed them or that the agent CLI resumed. Codex and Cursor may remain silent until the next prompt, so autosave could persist a cleared stamp before any hook re-stamped it. A subsequent restart then opened a plain shell.

## Impact

Valid agent sessions remain retryable across interrupted or rapid consecutive app restarts. The same resume command is still injected only once for each fresh PTY.

## Validation

- 61 targeted restore and stamping tests passed
- npm run typecheck passed
- ESLint passed on all changed files
- live agent contract suite compiles; provider-backed cases remain opt-in and were not run in this environment