### PR TITLE
Fix Windows agent hook command execution

### DIFF
--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -13,7 +13,13 @@ import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import { afterAll, describe, expect, test, vi } from 'vitest'
-import { createAgentHooksCapability, ensureGitExcluded, isRepoLocalCwd, type AgentHooksCapability } from './agentHooks'
+import {
+  bridgeHookCommand,
+  createAgentHooksCapability,
+  ensureGitExcluded,
+  isRepoLocalCwd,
+  type AgentHooksCapability,
+} from './agentHooks'
 import { CATE_HOOK_MARKER, agentHookFolder, type AgentHookEvent } from '../../shared/agentHooks'
 
 const posix = process.platform !== 'win32'
@@ -72,6 +78,15 @@ const post = (url: string, token: string | null, body: unknown): Promise<Respons
   })
 
 describe('agentHooks capability', () => {
+  test('Windows hook commands run .cmd wrappers through cmd.exe', () => {
+    const wrapper = 'C:\\Users\\N3231\\.cate\\agent-hooks\\cate-hook-bridge-claude-code.cmd'
+
+    expect(bridgeHookCommand(wrapper, 'win32')).toBe(`cmd.exe /d /c "${wrapper}"`)
+    expect(bridgeHookCommand('/home/u/.cate/agent-hooks/cate-hook-bridge-claude-code', 'linux')).toBe(
+      '/home/u/.cate/agent-hooks/cate-hook-bridge-claude-code',
+    )
+  })
+
   test('envForPty plants the hook env, agent-agnostic and non-clobbering', async () => {
     const cap = makeCap()
     const env = await cap.envForPty('rpty-1-local', { PATH: '/usr/bin:/bin', HOME: '/home/u' })
@@ -348,7 +363,10 @@ describe('agentHooks capability', () => {
     expect(Object.keys(codexHooks.hooks)).toContain('PermissionRequest')
     const { dir } = await cap.endpoint()
     expect(codexHooks.hooks.SessionStart[0].hooks[0]).toMatchObject({
-      command: path.join(dir, posix ? 'cate-hook-bridge-codex' : 'cate-hook-bridge-codex.cmd'),
+      command: bridgeHookCommand(
+        path.join(dir, posix ? 'cate-hook-bridge-codex' : 'cate-hook-bridge-codex.cmd'),
+        process.platform,
+      ),
       timeout: 60,
     })
 
@@ -360,7 +378,10 @@ describe('agentHooks capability', () => {
     }
     expect(cursorHooks.version).toBe(1)
     expect(cursorHooks.hooks.sessionStart[0].command).toBe(
-      path.join(dir, posix ? 'cate-hook-bridge-cursor' : 'cate-hook-bridge-cursor.cmd'),
+      bridgeHookCommand(
+        path.join(dir, posix ? 'cate-hook-bridge-cursor' : 'cate-hook-bridge-cursor.cmd'),
+        process.platform,
+      ),
     )
 
     // grok merges every *.json in <project>/.grok/hooks; Cate owns cate-hook.json
@@ -371,7 +392,10 @@ describe('agentHooks capability', () => {
     expect(Object.keys(grokHooks.hooks)).toContain('Notification')
     expect(grokHooks.hooks.PreToolUse).toBeUndefined()
     expect(grokHooks.hooks.SessionStart[0].hooks[0]).toMatchObject({
-      command: path.join(dir, posix ? 'cate-hook-bridge-grok' : 'cate-hook-bridge-grok.cmd'),
+      command: bridgeHookCommand(
+        path.join(dir, posix ? 'cate-hook-bridge-grok' : 'cate-hook-bridge-grok.cmd'),
+        process.platform,
+      ),
       timeout: 60,
     })
 

--- a/src/runtime/capabilities/agentHooks.ts
+++ b/src/runtime/capabilities/agentHooks.ts
@@ -157,6 +157,12 @@ async function dirExists(dir: string): Promise<boolean> {
 
 const shQuote = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`
 
+/** Hook runners may pass command strings through Bash even on Windows. Route
+ *  .cmd wrappers through cmd.exe so Bash does not consume path backslashes. */
+export function bridgeHookCommand(wrapper: string, platform: NodeJS.Platform): string {
+  return platform === 'win32' ? `cmd.exe /d /c "${wrapper}"` : wrapper
+}
+
 /** The generic stdin→HTTP bridge all stdin-JSON CLIs share (claude, codex).
  *  No stdout on purpose: every CLI accepts silent exit-0. Always exits 0 — a
  *  hook failure must never surface into the user's agent turn. */
@@ -454,7 +460,7 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
         await chmod(wrapper, 0o755)
       }
 
-      contexts.set(agent.id, { bridgeCommand: wrapper })
+      contexts.set(agent.id, { bridgeCommand: bridgeHookCommand(wrapper, process.platform) })
     }
 
     const server = http.createServer((req, res) => handleRequest(req, res, secret))


### PR DESCRIPTION
## Summary

- invoke generated Windows agent-hook `.cmd` wrappers through `cmd.exe /d /c`
- keep POSIX hook commands unchanged
- add regression coverage for Windows backslash preservation and update cross-platform config assertions

## Root cause

Cate stored a raw Windows `.cmd` path in command-based agent hook configs. When a hook runner passed that command through Bash, Bash treated the path backslashes as escapes and collapsed a path such as `C:\Users\...` into an invalid command.

The command is formatted centrally when the bridge context is created, covering the command-based Claude, Codex, Cursor, and Grok integrations. Pi and OpenCode use in-process hooks and do not execute the wrapper.

## Validation

- `npx vitest run src/runtime/capabilities/agentHooks.test.ts` — 28 passed
- `npm run typecheck` — passed
- `npx eslint src/runtime/capabilities/agentHooks.ts src/runtime/capabilities/agentHooks.test.ts` — passed
- full `npx vitest run` — 3,060 passed; the sole failure is the known unrelated `local-daemon-tarball.test.ts` workspace-allowlist environmental failure

Fixes #554
