### PR TITLE
Remove stale canvas annotation interactions

### DIFF
--- a/src/renderer/hooks/useCanvasInteraction.ts
+++ b/src/renderer/hooks/useCanvasInteraction.ts
@@ -281,17 +281,6 @@ export function useCanvasInteraction(
         }
       }
 
-      // Sticky-note content scrolls natively when it can scroll in the wheel's
-      // primary direction (annotations aren't canvas nodes).
-      const annotationContent = target.closest?.('[data-annotation-content]') as HTMLElement | null
-      if (annotationContent) {
-        const isHorizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY)
-        const canScroll = isHorizontal
-          ? annotationContent.scrollWidth > annotationContent.clientWidth
-          : annotationContent.scrollHeight > annotationContent.clientHeight
-        if (canScroll) return
-      }
-
       const panelContent = target.closest?.('[data-panel-content]')
       if (panelContent) {
         const nodeEl = panelContent.closest('[data-node-id]')
@@ -647,7 +636,7 @@ export function useCanvasInteraction(
         // — but only if the click landed on empty canvas (not on a node).
         if (!rightClickDidDrag.current && rightClickStart.current) {
           const target = e.target as HTMLElement
-          const isOnInteractive = target.closest('[data-node-id]') !== null || target.closest('[data-annotation-id]') !== null
+          const isOnInteractive = target.closest('[data-node-id]') !== null
           if (!isOnInteractive) {
             const rect = canvasRef.current?.getBoundingClientRect()
             if (rect) {


### PR DESCRIPTION
## What changed

- removed the obsolete sticky-note wheel handling for `[data-annotation-content]`
- removed the obsolete right-click exclusion for `[data-annotation-id]`
- audited the repository for the deleted annotation, drawing, and connection APIs and DOM markers

## Why

The canvas annotation system was removed in `997fe1bc`, but two interaction branches remained. Nothing in the current renderer creates either annotation DOM marker, so these branches were unreachable stale code. This cleanup was identified while reviewing #528 and does not implement the feature request.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- src/renderer/hooks/useCanvasInteraction.gesture.test.tsx` (34 passed)
- `npm test -- --silent` (3,059 passed, 1 environment-sensitive failure in `src/main/runtime/local-daemon-tarball.test.ts`; generated workspace path rejected as outside allowed directories)
- `npx eslint src/renderer/hooks/useCanvasInteraction.ts` (0 errors, 6 pre-existing hook dependency warnings)
