### PR TITLE
fix: handle mapped network drives in path validation (#239)

### DIFF
--- a/src/main/ipc/pathValidation.test.ts
+++ b/src/main/ipc/pathValidation.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import fsSync from 'node:fs'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
@@ -37,6 +38,7 @@ describe('pathValidation', () => {
     await fs.rm(rootDir, { recursive: true, force: true })
     await fs.rm(outsideDir, { recursive: true, force: true })
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   test('allows creation inside trusted roots', async () => {
@@ -132,6 +134,32 @@ describe('pathValidation', () => {
       await fs.symlink(outsideDir, link)
       await expect(validatePathStrict(path.join(link, 'new-file.txt'), undefined, SCOPE)).rejects.toThrow(
         /outside allowed directories/,
+      )
+    })
+  })
+
+  describe('realpath fallback', () => {
+    test('uses the JS resolver when the native resolver fails on an existing mount path', async () => {
+      const target = path.join(rootDir, 'file.txt')
+      await fs.writeFile(target, 'data')
+      vi.spyOn(fs, 'realpath').mockRejectedValueOnce(
+        Object.assign(new Error('unknown realpath error'), { code: 'UNKNOWN' }),
+      )
+
+      await expect(validatePathStrict(target, undefined, SCOPE)).resolves.toBe(
+        fsSync.realpathSync(target),
+      )
+    })
+
+    test('fails closed when both realpath implementations reject a non-ENOENT error', async () => {
+      const target = path.join(rootDir, 'file.txt')
+      await fs.writeFile(target, 'data')
+      const error = Object.assign(new Error('I/O failure'), { code: 'EIO' })
+      vi.spyOn(fs, 'realpath').mockRejectedValue(error)
+      vi.spyOn(fsSync, 'realpathSync').mockImplementation(() => { throw error })
+
+      await expect(validatePathStrict(target, undefined, SCOPE)).rejects.toThrow(
+        /cannot resolve real path/,
       )
     })
   })

--- a/src/main/ipc/pathValidation.ts
+++ b/src/main/ipc/pathValidation.ts
@@ -1,5 +1,5 @@
 // =============================================================================
-// Path validation — prevent path traversal and restrict filesystem access
+// Path validation  prevent path traversal and restrict filesystem access
 // to registered workspace roots and the system temp directory.
 // =============================================================================
 
@@ -22,6 +22,33 @@ export function pathCompareKey(p: string, platform: NodeJS.Platform = process.pl
   return platform === 'win32' ? p.toLowerCase() : p
 }
 
+// -----------------------------------------------------------------------------
+// Windows network-drive helpers
+// -----------------------------------------------------------------------------
+
+/**
+ * Strip the Windows long-path prefix (\\?\) so that paths returned by
+ * `realpathSync.native` / `fs.realpath` (which may add this prefix) can be
+ * compared with paths from `path.resolve` (which never adds it).
+ *
+ *   \\?\UNC\server\share\foo  ->  \\server\share\foo
+ *   \\?\C:\foo                ->  C:\foo
+ *
+ * On non-Windows platforms this is a no-op.
+ */
+function normalizeForComparison(p: string): string {
+  if (process.platform !== 'win32') return p
+  if (p.startsWith('\\\\?\\UNC\\')) {
+    // \\?\UNC\server\share -> \\server\share  (keep leading double-backslash)
+    return '\\' + p.slice(7)
+  }
+  if (p.startsWith('\\\\?\\')) {
+    // \\?\C:\foo -> C:\foo
+    return p.slice(4)
+  }
+  return p
+}
+
 // Persistent per-window grants for files the user explicitly chose outside
 // the workspace roots (e.g. via the native Save-As dialog). Unlike scoped
 // write allowances, these:
@@ -41,13 +68,21 @@ const persistentFileGrants = new Map<number, Set<string>>()
 // form would make the strict check reject paths that are genuinely inside the
 // root, so each root is stored with every canonical form we can compute.
 function canonicalForms(resolved: string): string[] {
+  const forms = new Set<string>()
+  forms.add(resolved)
+  forms.add(normalizeForComparison(resolved))
+
   try {
     const real = realpathSync.native(resolved)
-    if (pathCompareKey(real) !== pathCompareKey(resolved)) return [resolved, real]
+    forms.add(real)
+    forms.add(normalizeForComparison(real))
   } catch {
-    // Root doesn't exist (yet) — lexical form only.
+    // Root doesn't exist yet, or realpath failed (common on FUSE/WinFsp/
+    // network drives).  Lexical + normalized forms are still stored above
+    // so that drive-letter / UNC equivalence works when both sides were
+    // registered via addAllowedRoot.
   }
-  return [resolved]
+  return [...forms]
 }
 
 export function addAllowedRoot(root: string, scopeId: string): void {
@@ -97,7 +132,12 @@ export function removeAllowedRootFromAllScopes(root: string): void {
 function keyUnderRoots(key: string, roots: Iterable<string>): boolean {
   for (const root of roots) {
     const rootKey = pathCompareKey(root)
-    if (key.startsWith(rootKey + path.sep) || key === rootKey) {
+    // Filesystem roots (e.g. Z:\, \\server\share\) already end with a path
+    // separator.  Appending another separator would create a double-separator
+    // (e.g. "z:\\") that never matches a child path like "z:\foo".  Use the
+    // root key directly when it already ends with a separator.
+    const prefix = rootKey.endsWith(path.sep) ? rootKey : rootKey + path.sep
+    if (key.startsWith(prefix) || key === rootKey) {
       return true
     }
   }
@@ -105,7 +145,7 @@ function keyUnderRoots(key: string, roots: Iterable<string>): boolean {
 }
 
 // os.tmpdir() in both lexical and realpath form (see canonicalForms), computed
-// once — it's checked on every validation and never changes within a process.
+// once  it's checked on every validation and never changes within a process.
 let tmpDirForms: string[] | undefined
 
 function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
@@ -121,6 +161,20 @@ function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
   for (const forms of roots.values()) {
     if (keyUnderRoots(key, forms)) return true
   }
+
+  // On Windows, also try the comparison with the \\?\ prefix stripped so that
+  // a realpath result like "\\?\UNC\server\share\file" can match a root stored
+  // as "\\server\share" (or its drive-letter equivalent "Z:\").
+  if (process.platform === 'win32') {
+    const normalizedKey = pathCompareKey(normalizeForComparison(normalized))
+    if (normalizedKey !== key) {
+      if (keyUnderRoots(normalizedKey, tmpDirForms)) return true
+      for (const forms of roots.values()) {
+        if (keyUnderRoots(normalizedKey, forms)) return true
+      }
+    }
+  }
+
   return false
 }
 
@@ -135,25 +189,42 @@ function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
  * This keeps the symlink-escape protection intact: every segment that actually
  * exists is resolved (a symlink can only exist if its segment exists), so a
  * symlink pointing outside an allowed root still resolves and gets rejected.
- * Only not-yet-created segments — which cannot be symlinks — stay literal.
- * Non-ENOENT errors (e.g. EACCES) are rethrown so genuine access failures keep
- * surfacing as access errors rather than being mistaken for "doesn't exist".
+ * Only not-yet-created segments  which cannot be symlinks  stay literal.
+ *
+ * Error handling for network / FUSE drives:
+ *   - ENOENT: walk up to the parent and retry (existing behaviour).
+ *   - Any other error (EIO, EACCES, etc.): common on WinFsp, rclone, sshfs-win
+ *     and read-only SMB mounts.  Fall back to the lexically resolved path
+ *     instead of throwing, so that validation can still succeed.
+ *   - A hard cap on parent-directory traversals prevents retry storms on
+ *     degenerate or deeply nested paths.
  */
+const MAX_PARENT_TRAVERSALS = 256
+
 async function realpathAllowingMissing(targetPath: string): Promise<string> {
   const resolved = path.resolve(targetPath)
   const missing: string[] = []
   let cur = resolved
+  let attempts = 0
   for (;;) {
     try {
       const real = await fs.realpath(cur)
       return missing.length ? path.join(real, ...missing) : real
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+      const code = (err as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT') {
+        // Non-ENOENT error common on network/FUSE drives (EIO, EACCES,
+        // ERRNO_UNKNOWN, etc.).  Fall back to the lexically resolved path
+        // rather than throwing, so that path validation can still succeed
+        // for workspaces on mapped network drives.
+        return resolved
+      }
     }
     const parent = path.dirname(cur)
     if (parent === cur) return resolved // reached the fs root with nothing existing
     missing.unshift(path.basename(cur))
     cur = parent
+    if (++attempts >= MAX_PARENT_TRAVERSALS) return resolved
   }
 }
 
@@ -309,7 +380,7 @@ export async function validatePathForCreation(filePath: string, ownerWindowId?: 
   // a write follow the link out of the allowed root. Mirrors statEntry /
   // removeEntry, which likewise refuse to operate through a symlink.
   const targetStat = await fs.lstat(safeTarget).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === 'ENOENT') return null // target doesn't exist yet — fine
+    if (err.code === 'ENOENT') return null // target doesn't exist yet  fine
     throw err
   })
   if (targetStat?.isSymbolicLink()) {

--- a/src/main/ipc/pathValidation.ts
+++ b/src/main/ipc/pathValidation.ts
@@ -1,10 +1,10 @@
 // =============================================================================
-// Path validation  prevent path traversal and restrict filesystem access
+// Path validation — prevent path traversal and restrict filesystem access
 // to registered workspace roots and the system temp directory.
 // =============================================================================
 
 import fs from 'fs/promises'
-import { realpathSync } from 'fs'
+import fsSync from 'fs'
 import path from 'path'
 import os from 'os'
 
@@ -73,14 +73,18 @@ function canonicalForms(resolved: string): string[] {
   forms.add(normalizeForComparison(resolved))
 
   try {
-    const real = realpathSync.native(resolved)
+    let real: string
+    try {
+      real = fsSync.realpathSync.native(resolved)
+    } catch {
+      // The native resolver fails on some WinFsp disk-mode mounts. Node's JS
+      // implementation still resolves every existing segment on those mounts.
+      real = fsSync.realpathSync(resolved)
+    }
     forms.add(real)
     forms.add(normalizeForComparison(real))
   } catch {
-    // Root doesn't exist yet, or realpath failed (common on FUSE/WinFsp/
-    // network drives).  Lexical + normalized forms are still stored above
-    // so that drive-letter / UNC equivalence works when both sides were
-    // registered via addAllowedRoot.
+    // Root doesn't exist yet, or neither resolver can read it — lexical form only.
   }
   return [...forms]
 }
@@ -145,7 +149,7 @@ function keyUnderRoots(key: string, roots: Iterable<string>): boolean {
 }
 
 // os.tmpdir() in both lexical and realpath form (see canonicalForms), computed
-// once  it's checked on every validation and never changes within a process.
+// once — it's checked on every validation and never changes within a process.
 let tmpDirForms: string[] | undefined
 
 function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
@@ -189,17 +193,22 @@ function isWithinAllowedRoots(normalized: string, scopeId?: string): boolean {
  * This keeps the symlink-escape protection intact: every segment that actually
  * exists is resolved (a symlink can only exist if its segment exists), so a
  * symlink pointing outside an allowed root still resolves and gets rejected.
- * Only not-yet-created segments  which cannot be symlinks  stay literal.
+ * Only not-yet-created segments — which cannot be symlinks — stay literal.
  *
- * Error handling for network / FUSE drives:
- *   - ENOENT: walk up to the parent and retry (existing behaviour).
- *   - Any other error (EIO, EACCES, etc.): common on WinFsp, rclone, sshfs-win
- *     and read-only SMB mounts.  Fall back to the lexically resolved path
- *     instead of throwing, so that validation can still succeed.
- *   - A hard cap on parent-directory traversals prevents retry storms on
- *     degenerate or deeply nested paths.
+ * If the native resolver fails on a WinFsp mount, Node's JS resolver is tried
+ * before validation fails. A bounded parent walk rejects paths with an
+ * unreasonable number of missing segments instead of accepting them lexically.
  */
 const MAX_PARENT_TRAVERSALS = 256
+
+async function realpathWithFallback(targetPath: string): Promise<string> {
+  try {
+    return await fs.realpath(targetPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') throw err
+    return fsSync.realpathSync(targetPath)
+  }
+}
 
 async function realpathAllowingMissing(targetPath: string): Promise<string> {
   const resolved = path.resolve(targetPath)
@@ -208,23 +217,18 @@ async function realpathAllowingMissing(targetPath: string): Promise<string> {
   let attempts = 0
   for (;;) {
     try {
-      const real = await fs.realpath(cur)
+      const real = await realpathWithFallback(cur)
       return missing.length ? path.join(real, ...missing) : real
     } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code
-      if (code !== 'ENOENT') {
-        // Non-ENOENT error common on network/FUSE drives (EIO, EACCES,
-        // ERRNO_UNKNOWN, etc.).  Fall back to the lexically resolved path
-        // rather than throwing, so that path validation can still succeed
-        // for workspaces on mapped network drives.
-        return resolved
-      }
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
     }
     const parent = path.dirname(cur)
     if (parent === cur) return resolved // reached the fs root with nothing existing
     missing.unshift(path.basename(cur))
     cur = parent
-    if (++attempts >= MAX_PARENT_TRAVERSALS) return resolved
+    if (++attempts >= MAX_PARENT_TRAVERSALS) {
+      throw new Error(`Too many missing path segments while resolving "${targetPath}"`)
+    }
   }
 }
 
@@ -380,7 +384,7 @@ export async function validatePathForCreation(filePath: string, ownerWindowId?: 
   // a write follow the link out of the allowed root. Mirrors statEntry /
   // removeEntry, which likewise refuse to operate through a symlink.
   const targetStat = await fs.lstat(safeTarget).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === 'ENOENT') return null // target doesn't exist yet  fine
+    if (err.code === 'ENOENT') return null // target doesn't exist yet — fine
     throw err
   })
   if (targetStat?.isSymbolicLink()) {

--- a/src/main/ipc/pathValidation.win32.test.ts
+++ b/src/main/ipc/pathValidation.win32.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const realpathMocks = vi.hoisted(() => {
+  const native = vi.fn<(path: string) => string>()
+  const fallback = Object.assign(vi.fn<(path: string) => string>(), { native })
+  return { native, fallback }
+})
+
+vi.mock('fs', () => ({ default: { realpathSync: realpathMocks.fallback } }))
+vi.mock('path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path')
+  return { default: actual.win32 }
+})
+vi.mock('os', () => ({ default: { tmpdir: () => 'C:\\Temp' } }))
+
+const { addAllowedRoot, removeAllowedRoot, validatePath } = await import('./pathValidation')
+
+describe('pathValidation on win32 network paths', () => {
+  const SCOPE = 'mapped-drive'
+
+  beforeEach(() => {
+    realpathMocks.native.mockImplementation((value) => value)
+    realpathMocks.fallback.mockImplementation((value) => value)
+  })
+
+  afterEach(() => {
+    removeAllowedRoot('X:\\project', SCOPE)
+    removeAllowedRoot('X:\\', SCOPE)
+    removeAllowedRoot('\\\\server\\share\\', SCOPE)
+    vi.clearAllMocks()
+  })
+
+  test('accepts both drive-letter and UNC forms of a canonicalized root', () => {
+    realpathMocks.native.mockImplementation((value) =>
+      value === 'X:\\project' ? '\\\\server\\share\\project' : value,
+    )
+    addAllowedRoot('X:\\project', SCOPE)
+
+    expect(validatePath('X:\\project\\src\\index.ts', undefined, SCOPE)).toBe(
+      'X:\\project\\src\\index.ts',
+    )
+    expect(validatePath('\\\\server\\share\\project\\src\\index.ts', undefined, SCOPE)).toBe(
+      '\\\\server\\share\\project\\src\\index.ts',
+    )
+  })
+
+  test.each(['X:\\', '\\\\server\\share\\'])('accepts children when the root already ends in a separator: %s', (root) => {
+    addAllowedRoot(root, SCOPE)
+    const child = root + 'folder\\file.txt'
+    expect(validatePath(child, undefined, SCOPE)).toBe(child)
+  })
+})

--- a/src/main/workspaceRoots.test.ts
+++ b/src/main/workspaceRoots.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('./logger', () => ({ default: { warn: vi.fn() } }))
+
+import { resolveTrustedWorkspaceRoot } from './workspaceRoots'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe('resolveTrustedWorkspaceRoot', () => {
+  test('falls back to the JS realpath implementation for WinFsp-style native failures', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cate-workspace-root-'))
+    tempDirs.push(root)
+    vi.spyOn(fs, 'realpath').mockRejectedValueOnce(
+      Object.assign(new Error('unknown realpath error'), { code: 'UNKNOWN' }),
+    )
+
+    await expect(resolveTrustedWorkspaceRoot(root)).resolves.toBe(path.resolve(root))
+  })
+
+  test('preserves the selected path form after validating its canonical alias', async () => {
+    const selected = path.resolve('/mapped-drive/project')
+    vi.spyOn(fs, 'realpath').mockResolvedValue('/server/share/project')
+    vi.spyOn(fs, 'stat').mockResolvedValue({ isDirectory: () => true } as Awaited<ReturnType<typeof fs.stat>>)
+
+    await expect(resolveTrustedWorkspaceRoot(selected)).resolves.toBe(selected)
+  })
+})

--- a/src/main/workspaceRoots.ts
+++ b/src/main/workspaceRoots.ts
@@ -1,17 +1,27 @@
 import fs from 'fs/promises'
+import fsSync from 'fs'
 import path from 'path'
 import log from './logger'
 
 export async function resolveTrustedWorkspaceRoot(rootPath: string): Promise<string | null> {
   try {
     const resolved = path.resolve(rootPath)
-    const realPath = await fs.realpath(resolved)
+    let realPath: string
+    try {
+      realPath = await fs.realpath(resolved)
+    } catch {
+      // WinFsp disk-mode mounts can reject the native resolver while Node's
+      // JS implementation can still canonicalize the same directory safely.
+      realPath = fsSync.realpathSync(resolved)
+    }
     const stat = await fs.stat(realPath)
     if (!stat.isDirectory()) {
       log.warn('workspaceRoots: rootPath is not a directory, rejecting: %s', rootPath)
       return null
     }
-    return realPath
+    // Preserve the user-selected form (for example X:\project). The path
+    // validator registers both this lexical form and realPath's UNC alias.
+    return resolved
   } catch {
     log.warn('workspaceRoots: rootPath does not exist or is unreadable, rejecting: %s', rootPath)
     return null

--- a/src/renderer/lib/workspace/sessionSave.perRootOwner.test.ts
+++ b/src/renderer/lib/workspace/sessionSave.perRootOwner.test.ts
@@ -95,4 +95,16 @@ describe('per-root write ownership', () => {
     await saveSession()
     expect(savesForRoot()).toHaveLength(firstCount)
   })
+
+  it('stops retrying .cate saves after three consecutive failures', async () => {
+    projectStateSave.mockRejectedValue(new Error('EPERM: read-only mount'))
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      await saveSession()
+      await Promise.resolve()
+      await Promise.resolve()
+    }
+
+    expect(savesForRoot()).toHaveLength(3)
+  })
 })

--- a/src/renderer/lib/workspace/sessionSave.ts
+++ b/src/renderer/lib/workspace/sessionSave.ts
@@ -31,6 +31,12 @@ import type {
 // actually changed, so the periodic auto-save doesn't rewrite an identical file
 // every ~1s.
 const lastSerializedByRoot = new Map<string, string>()
+// A read-only or broken mount must not trigger one failed `.cate` write every
+// autosave tick forever. Stop scheduling writes for the root after a small
+// consecutive-failure budget; relaunching Cate starts a fresh budget.
+const MAX_PROJECT_STATE_SAVE_FAILURES = 3
+const projectStateSaveFailuresByRoot = new Map<string, number>()
+const projectStateSavesInFlight = new Set<string>()
 // Same idea for the global sidebar arrangement: skip the IPC + electron-store
 // write when order/active-workspace haven't changed since the last save.
 let lastSidebarSessionSerialized: string | null = null
@@ -224,12 +230,24 @@ export async function saveSession(): Promise<void> {
     // Dedup: skip IPC when the payload hasn't changed
     const serialized = JSON.stringify({ ws: wsFile, sess: sessFile })
     if (lastSerializedByRoot.get(snapshot.rootPath) === serialized) continue
+    if ((projectStateSaveFailuresByRoot.get(snapshot.rootPath) ?? 0) >= MAX_PROJECT_STATE_SAVE_FAILURES) continue
+    if (projectStateSavesInFlight.has(snapshot.rootPath)) continue
 
+    projectStateSavesInFlight.add(snapshot.rootPath)
     window.electronAPI.projectStateSave(snapshot.rootPath, wsFile, sessFile)
-      .then(() => { lastSerializedByRoot.set(snapshot.rootPath!, serialized) })
-      .catch((err) => {
-        log.warn('[session] Project state save failed for %s: %s', snapshot.rootPath, err)
+      .then(() => {
+        lastSerializedByRoot.set(snapshot.rootPath!, serialized)
+        projectStateSaveFailuresByRoot.delete(snapshot.rootPath!)
       })
+      .catch((err) => {
+        const failures = (projectStateSaveFailuresByRoot.get(snapshot.rootPath!) ?? 0) + 1
+        projectStateSaveFailuresByRoot.set(snapshot.rootPath!, failures)
+        log.warn('[session] Project state save failed for %s: %s', snapshot.rootPath, err)
+        if (failures === MAX_PROJECT_STATE_SAVE_FAILURES) {
+          log.warn('[session] Disabling project state saves for %s after %d consecutive failures', snapshot.rootPath, failures)
+        }
+      })
+      .finally(() => { projectStateSavesInFlight.delete(snapshot.rootPath!) })
   }
 
   // Persist the sidebar arrangement (order + active workspace, keyed by root


### PR DESCRIPTION
## Problem
Workspaces on mapped network drives (SMB, rclone, WinFsp, sshfs-win) never load because path validation fails due to 4 distinct bugs:
1. `realpath` throws on FUSE/WinFsp paths
2. UNC paths don't match their mapped drive letter equivalents
3. Trailing backslash on filesystem roots causes validation failure
4. Read-only mounts trigger retry storms

## Solution
1. Wrap `realpath` in try/catch with fallback to original path
2. Normalize paths to a canonical form before comparison (resolve both UNC and drive-letter paths)
3. Handle filesystem root paths (trailing separator) correctly
4. Add retry limits for read-only mount detection

Fixes #239