### PR TITLE
Enable OpenCode worker follow-ups

### DIFF
--- a/src/renderer/lib/agent/codingAgentDriver.test.ts
+++ b/src/renderer/lib/agent/codingAgentDriver.test.ts
@@ -511,7 +511,7 @@ describe('codingAgentDriver mission integration', () => {
     expect(reviewCodingAgentWorktree).toHaveBeenCalledWith('ws', 'worker')
   })
 
-  it('enforces follow-up capability and terminal readiness', async () => {
+  it('supports OpenCode follow-ups and enforces terminal readiness', async () => {
     resolveDriverAgentCli.mockResolvedValue(AGENTS.find((agent) => agent.id === 'opencode'))
     await handleCodingAgentMethod('ws', 'supervisor-1', 'cate.codingAgent.create', {
       agentId: 'opencode', prompt: 'Implement it',
@@ -519,12 +519,12 @@ describe('codingAgentDriver mission integration', () => {
     const run = state.app.workspaces[0].panels.worker.codingAgentRun
     await expect(handleCodingAgentMethod(
       'ws', 'supervisor-1', 'cate.codingAgent.send', { runId: run.id, prompt: 'Again' },
-    )).resolves.toEqual({ ok: false, error: 'coding-agent-follow-up-unsupported' })
+    )).resolves.toMatchObject({ ok: true, result: { id: run.id, followUpSupported: true } })
+    expect(submitTerminalText).toHaveBeenCalledWith('worker', 'Again')
 
-    run.agentId = 'codex'
     submitTerminalText.mockResolvedValueOnce(false)
     await expect(handleCodingAgentMethod(
-      'ws', 'supervisor-1', 'cate.codingAgent.send', { runId: run.id, prompt: 'Again' },
+      'ws', 'supervisor-1', 'cate.codingAgent.send', { runId: run.id, prompt: 'One more time' },
     )).resolves.toEqual({ ok: false, error: 'coding-agent-not-ready' })
   })
 

--- a/src/shared/agents.ts
+++ b/src/shared/agents.ts
@@ -182,8 +182,10 @@ export const AGENTS: readonly AgentDef[] = [
     id: 'opencode',
     displayName: 'OpenCode',
     command: 'opencode',
-    codingAgentArgs: (prompt) => ['run', prompt],
-    codingAgentFollowUp: false,
+    // Seed the persistent TUI instead of using the one-shot `run` command so
+    // the mission supervisor can submit follow-up prompts on the same PTY.
+    codingAgentArgs: (prompt) => ['--prompt', prompt],
+    codingAgentFollowUp: true,
     matchProcess: (n) => n === 'opencode',
     resumeArgs: (sid) => ['--session', sid],
     skills: folderSkills('opencode', ['.opencode', 'skills']),

--- a/src/shared/codingAgentRuns.test.ts
+++ b/src/shared/codingAgentRuns.test.ts
@@ -19,7 +19,7 @@ describe('codingAgentCommand', () => {
       { id: 'codex', command: { executable: 'codex', args: [prefixed] }, followUp: true },
       { id: 'cursor', command: { executable: 'cursor-agent', args: [prefixed] }, followUp: true },
       { id: 'grok', command: { executable: 'grok', args: [prefixed] }, followUp: true },
-      { id: 'opencode', command: { executable: 'opencode', args: ['run', prefixed] }, followUp: false },
+      { id: 'opencode', command: { executable: 'opencode', args: ['--prompt', prefixed] }, followUp: true },
       { id: 'pi', command: { executable: 'pi', args: [prefixed] }, followUp: true },
     ])
   })


### PR DESCRIPTION
## Summary

- launch managed OpenCode workers in its persistent TUI with an initial `--prompt`
- advertise OpenCode follow-up support to the orchestration supervisor
- update the focused worker command and follow-up integration tests

## Root cause

Cate launched OpenCode through the one-shot `opencode run` command, so the process exited after its initial task and the registry correctly rejected follow-up prompts.

## Impact

Cate Agent can now reuse `send_to_coding_agent` to reprompt a managed OpenCode worker on the same live PTY, matching the existing Codex and Claude workflow.

## Validation

- `npm test -- --run src/shared/codingAgentRuns.test.ts src/shared/agents.test.ts src/renderer/lib/agent/codingAgentDriver.test.ts`
- `npm run typecheck`
- `git diff --check`
