### PR TITLE
Expose recursive agent orchestration through Cate CLI

### DIFF
--- a/.codex/skills/cate-cli/SKILL.md
+++ b/.codex/skills/cate-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cate-cli
-description: Drive Cate browser, terminal, editor, and panel surfaces from a Cate terminal. Browser page automation uses native agent-browser command syntax.
+description: Drive Cate browser, terminal, editor, panel, and coding-agent orchestration surfaces from a Cate terminal. Browser page automation uses native agent-browser command syntax.
 user-invocable: true
 ---
 
@@ -125,3 +125,67 @@ cate terminal press enter
 
 Terminal input goes to whatever currently owns that PTY, including foreground
 TUIs. Never send keys until the panel id and current screen are verified.
+
+## Agent orchestration
+
+Use `cate agent` when a task benefits from visible, persistent delegation:
+independent parallel work, cross-provider review, or isolated implementation in
+a Cate worktree. Keep small, tightly coupled edits in the current agent.
+
+Discover registered runs before acting on an older mission or after context
+compaction:
+
+```bash
+cate agent list
+```
+
+Create a worker with a bounded, self-contained prompt and concrete success
+criteria. Cate chooses the first hook-ready registered agent when `--agent` is
+omitted:
+
+```bash
+cate agent create "Inspect the API boundary and report risks" --title "API scout"
+cate agent create "Implement the parser and run its focused tests" \
+  --agent codex --title "Parser" --new-worktree agent/parser
+cate agent create "Review the current worktree changes" --worktree <worktree-id>
+```
+
+Workers may recursively create and supervise their own workers with the same
+commands. This naturally forms an agent tree: each terminal owns the workers it
+creates, and each parent normally communicates with its direct children. Use
+recursion when another level of decomposition is genuinely useful, not merely
+to relay a simple instruction.
+
+Supervise workers through the agent lifecycle rather than typing into their
+terminals:
+
+```bash
+cate agent wait <run-id> [<run-id>...] --wait-timeout 10000
+cate agent inspect <run-id>
+cate agent send <run-id> "Please add the missing regression test"
+cate agent review <run-id>
+cate agent apply <run-id>
+cate agent keep <run-id>
+cate agent discard <run-id>
+cate agent stop <run-id>
+```
+
+Run ids may be the unique short ids printed by `cate agent list`. `wait` accepts
+5000–60000 milliseconds and may be called with no ids to monitor all live
+direct children. Call it again while workers remain active. `inspect` includes
+recent terminal output; use `cate terminal read --panel <panel-id>` only as a
+lower-level diagnostic fallback.
+
+Prefer `send` for follow-up work on the same responsibility. If
+`followUpSupported` is false, create a fresh worker instead. When a worker fails,
+inspect `failureReason`; a provider-specific authentication, quota, or service
+failure can justify retrying with a different registered `--agent`.
+
+For an isolated worker, ask it to run relevant checks and commit completed work,
+then use `review` before choosing `apply`, `keep`, or `discard`. Apply rechecks
+that the worktree is clean and mergeable. Discard permanently removes a
+worker-owned worktree and its branch, including uncommitted changes, without an
+interactive confirmation. Keep records that the worktree should remain for
+later. Review is read-only: a finished process or successful review does not
+mean its branch has been integrated. The parent remains responsible for
+verification and for reporting any uncommitted or unintegrated work.

--- a/skills/cate-cli/SKILL.md
+++ b/skills/cate-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cate-cli
-description: Drive Cate browser, terminal, editor, and panel surfaces from a Cate terminal. Browser page automation uses native agent-browser command syntax.
+description: Drive Cate browser, terminal, editor, panel, and coding-agent orchestration surfaces from a Cate terminal. Browser page automation uses native agent-browser command syntax.
 user-invocable: true
 ---
 
@@ -125,3 +125,67 @@ cate terminal press enter
 
 Terminal input goes to whatever currently owns that PTY, including foreground
 TUIs. Never send keys until the panel id and current screen are verified.
+
+## Agent orchestration
+
+Use `cate agent` when a task benefits from visible, persistent delegation:
+independent parallel work, cross-provider review, or isolated implementation in
+a Cate worktree. Keep small, tightly coupled edits in the current agent.
+
+Discover registered runs before acting on an older mission or after context
+compaction:
+
+```bash
+cate agent list
+```
+
+Create a worker with a bounded, self-contained prompt and concrete success
+criteria. Cate chooses the first hook-ready registered agent when `--agent` is
+omitted:
+
+```bash
+cate agent create "Inspect the API boundary and report risks" --title "API scout"
+cate agent create "Implement the parser and run its focused tests" \
+  --agent codex --title "Parser" --new-worktree agent/parser
+cate agent create "Review the current worktree changes" --worktree <worktree-id>
+```
+
+Workers may recursively create and supervise their own workers with the same
+commands. This naturally forms an agent tree: each terminal owns the workers it
+creates, and each parent normally communicates with its direct children. Use
+recursion when another level of decomposition is genuinely useful, not merely
+to relay a simple instruction.
+
+Supervise workers through the agent lifecycle rather than typing into their
+terminals:
+
+```bash
+cate agent wait <run-id> [<run-id>...] --wait-timeout 10000
+cate agent inspect <run-id>
+cate agent send <run-id> "Please add the missing regression test"
+cate agent review <run-id>
+cate agent apply <run-id>
+cate agent keep <run-id>
+cate agent discard <run-id>
+cate agent stop <run-id>
+```
+
+Run ids may be the unique short ids printed by `cate agent list`. `wait` accepts
+5000–60000 milliseconds and may be called with no ids to monitor all live
+direct children. Call it again while workers remain active. `inspect` includes
+recent terminal output; use `cate terminal read --panel <panel-id>` only as a
+lower-level diagnostic fallback.
+
+Prefer `send` for follow-up work on the same responsibility. If
+`followUpSupported` is false, create a fresh worker instead. When a worker fails,
+inspect `failureReason`; a provider-specific authentication, quota, or service
+failure can justify retrying with a different registered `--agent`.
+
+For an isolated worker, ask it to run relevant checks and commit completed work,
+then use `review` before choosing `apply`, `keep`, or `discard`. Apply rechecks
+that the worktree is clean and mergeable. Discard permanently removes a
+worker-owned worktree and its branch, including uncommitted changes, without an
+interactive confirmation. Keep records that the worktree should remain for
+later. Review is read-only: a finished process or successful review does not
+mean its branch has been integrated. The parent remains responsible for
+verification and for reporting any uncommitted or unintegrated work.

--- a/src/cateAgent/extensions/cate-orchestrator/index.test.ts
+++ b/src/cateAgent/extensions/cate-orchestrator/index.test.ts
@@ -1,206 +1,41 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import registerOrchestrator from "./index"
 
-const TOOL_NAMES = [
-  "create_coding_agent",
-  "send_to_coding_agent",
-  "wait_for_coding_agents",
-  "inspect_coding_agent",
-  "review_coding_agent",
-  "stop_coding_agent",
-]
-
 function makeApi() {
-  const tools = new Map<string, any>()
   const commands = new Map<string, any>()
   const handlers = new Map<string, (event: any) => Promise<any>>()
-  let activeTools = ["read", "bash"]
-  let setActiveToolsCalls = 0
-  const sendMessage = vi.fn()
+  const registerTool = vi.fn()
   const pi = {
-    registerTool: (tool: any) => {
-      tools.set(tool.name, tool)
-      activeTools = [...activeTools, tool.name]
-    },
     registerCommand: (name: string, command: any) => commands.set(name, command),
-    on: (event: string, handler: (value: any) => Promise<any>) =>
-      handlers.set(event, handler),
-    getActiveTools: () => [...activeTools],
-    setActiveTools: (names: string[]) => {
-      setActiveToolsCalls += 1
-      activeTools = [...names]
-    },
-    sendMessage,
+    registerTool,
+    on: (event: string, handler: (value: any) => Promise<any>) => handlers.set(event, handler),
   }
   registerOrchestrator(pi as any)
-  return {
-    tools,
-    commands,
-    handlers,
-    getActiveTools: () => [...activeTools],
-    getSetActiveToolsCalls: () => setActiveToolsCalls,
-    sendMessage,
-  }
+  return { commands, handlers, registerTool }
 }
-
-function registeredTools() {
-  return makeApi().tools
-}
-
-beforeEach(() => {
-  process.env.CATE_API = "http://127.0.0.1:1234"
-  process.env.CATE_TOKEN = "supervisor-token"
-  process.env.CATE_CODING_AGENT_IDS = JSON.stringify(["codex", "pi"])
-  vi.unstubAllGlobals()
-})
 
 describe("cate-orchestrator", () => {
-  it("registers the complete worker lifecycle surface", () => {
-    const tools = registeredTools()
-    expect([...tools.keys()]).toEqual(TOOL_NAMES)
-    expect(tools.get("wait_for_coding_agents").parameters.properties.timeoutSeconds)
-      .toMatchObject({ minimum: 5, maximum: 60, default: 10 })
-    expect(tools.get("create_coding_agent").parameters.properties.background)
-      .toMatchObject({ type: "boolean", default: true })
-    expect(tools.get("create_coding_agent").parameters.properties.agentId.anyOf)
-      .toEqual([{ const: "codex", type: "string" }, { const: "pi", type: "string" }])
-    expect(tools.get("create_coding_agent").parameters.properties.title)
-      .toMatchObject({ minLength: 1, maxLength: 80 })
-    expect(tools.get("wait_for_coding_agents").parameters.required).toContain("runIds")
-  })
-
-  it("keeps orchestration tools inactive until orchestration mode is enabled", async () => {
+  it("is a prompt mode over the public recursive agent CLI", async () => {
     const api = makeApi()
     const setStatus = vi.fn()
     const ctx = { ui: { setStatus } }
 
-    expect(api.getSetActiveToolsCalls()).toBe(0)
-    expect(api.getActiveTools()).toEqual(["read", "bash", ...TOOL_NAMES])
-    await api.handlers.get("session_start")!({})
-    expect(api.getActiveTools()).toEqual(["read", "bash"])
-    expect(api.getSetActiveToolsCalls()).toBe(1)
+    expect(api.registerTool).not.toHaveBeenCalled()
     expect(await api.handlers.get("before_agent_start")!({ systemPrompt: "base" }))
       .toBeUndefined()
-    expect(await api.handlers.get("tool_call")!({ toolName: "create_coding_agent" }))
-      .toEqual({
-        block: true,
-        reason: "Coding-agent orchestration mode is not active.",
-      })
 
     await api.commands.get("orchestrate").handler("", ctx)
 
     expect(setStatus).toHaveBeenCalledWith("orchestrator-mode", "Orchestration mode")
-    // The command only flips mode state. Tool changes happen at the next real
-    // prompt so selecting the mode cannot itself start the agent loop.
-    expect(api.getActiveTools()).toEqual(["read", "bash"])
     const prompt = await api.handlers.get("before_agent_start")!({ systemPrompt: "base" })
-    expect(api.getActiveTools()).toEqual(["read", "bash", ...TOOL_NAMES])
     expect(prompt.systemPrompt).toContain("Orchestration mode is ACTIVE")
-    expect(prompt.systemPrompt).toContain("Act as the mission lead")
-    expect(await api.handlers.get("tool_call")!({ toolName: "create_coding_agent" }))
-      .toBeUndefined()
+    expect(prompt.systemPrompt).toContain("read the bundled `cate-cli` skill")
+    expect(prompt.systemPrompt).toContain("existing `cate agent` CLI")
+    expect(prompt.systemPrompt).toContain("Workers may recursively create")
 
     await api.commands.get("orchestrate").handler("", ctx)
-
     expect(setStatus).toHaveBeenLastCalledWith("orchestrator-mode", undefined)
-    expect(api.getActiveTools()).toEqual(["read", "bash", ...TOOL_NAMES])
     expect(await api.handlers.get("before_agent_start")!({ systemPrompt: "base" }))
       .toBeUndefined()
-    expect(api.getActiveTools()).toEqual(["read", "bash"])
-  })
-
-  it("creates workers without another confirmation after orchestration mode is selected", async () => {
-    const fetch = vi.fn(async (_url: string, init: RequestInit) => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ result: { id: "run-1", panelId: "panel-1" } }),
-      init,
-    }))
-    vi.stubGlobal("fetch", fetch)
-    const tool = registeredTools().get("create_coding_agent")
-
-    await tool.execute("call-1", { agentId: "codex", prompt: "Implement it" })
-    await tool.execute("call-2", { agentId: "codex", prompt: "Test it" })
-
-    expect(fetch).toHaveBeenCalledTimes(2)
-    const [, init] = fetch.mock.calls[0]
-    expect(init.headers).toMatchObject({ Authorization: "Bearer supervisor-token" })
-    expect(JSON.parse(String(init.body))).toEqual({
-      method: "cate.codingAgent.create",
-      args: { agentId: "codex", prompt: "Implement it" },
-    })
-  })
-
-  it("wakes the supervisor for a background worker but not a foreground worker", async () => {
-    let finishWait: ((value: unknown) => void) | undefined
-    const fetch = vi.fn(async (_url: string, init: RequestInit) => {
-      const request = JSON.parse(String(init.body)) as { method: string; args: Record<string, unknown> }
-      if (request.method === "cate.codingAgent.wait") {
-        return await new Promise((resolve) => { finishWait = resolve })
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ result: { id: request.args.background === false ? "run-fg" : "run-bg" } }),
-      }
-    })
-    vi.stubGlobal("fetch", fetch)
-    const api = makeApi()
-    await api.commands.get("orchestrate").handler("", { ui: { setStatus: vi.fn() } })
-
-    await api.tools.get("create_coding_agent").execute("call-bg", {
-      prompt: "Background task",
-      background: true,
-    })
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"))
-    finishWait!({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        result: {
-          changedRunIds: ["run-bg"],
-          runs: [{ id: "run-bg", title: "Background task", status: "ready" }],
-        },
-      }),
-    })
-
-    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customType: "cate-coding-agent-background-update",
-        content: expect.stringContaining("Background task: ready"),
-      }),
-      { triggerTurn: true, deliverAs: "followUp" },
-    ))
-
-    fetch.mockClear()
-    await api.tools.get("create_coding_agent").execute("call-fg", {
-      prompt: "Foreground task",
-      background: false,
-    })
-    expect(fetch).toHaveBeenCalledTimes(1)
-    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body)).method)
-      .toBe("cate.codingAgent.create")
-  })
-
-  it("teaches the supervisor to switch CLIs for CLI-specific failures", () => {
-    const guidelines = registeredTools().get("create_coding_agent").promptGuidelines
-    expect(guidelines.join("\n")).toContain("failureReason")
-    expect(guidelines.join("\n")).toContain("different registered agentId")
-  })
-
-  it("reviews worker changes through the read-only lifecycle method", async () => {
-    const fetch = vi.fn(async (_url: string, _init: RequestInit) => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ result: { review: { canApply: true } } }),
-    }))
-    vi.stubGlobal("fetch", fetch)
-
-    await registeredTools().get("review_coding_agent").execute("call-1", { runId: "run-1" })
-
-    expect(JSON.parse(String(fetch.mock.calls[0][1]?.body))).toEqual({
-      method: "cate.codingAgent.review",
-      args: { runId: "run-1" },
-    })
   })
 })

--- a/src/cateAgent/extensions/cate-orchestrator/index.ts
+++ b/src/cateAgent/extensions/cate-orchestrator/index.ts
@@ -1,341 +1,39 @@
-// Native coding-agent orchestration tools for Cate Agent. These call a
-// dedicated, panel-bound CATE_API endpoint. Ordinary terminals and the workers
-// created by these tools receive a different token without this capability.
+// Opt-in orchestration instructions for Cate's direct agent. The orchestration
+// capability itself lives in the public `cate agent` CLI so Cate Agent and
+// terminal-based agents use the same recursive workflow.
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { Type } from "typebox"
 
 const STATUS_KEY = "orchestrator-mode"
-const TOOL_NAMES = [
-  "create_coding_agent",
-  "send_to_coding_agent",
-  "wait_for_coding_agents",
-  "inspect_coding_agent",
-  "review_coding_agent",
-  "stop_coding_agent",
-] as const
-const TOOL_NAME_SET: ReadonlySet<string> = new Set(TOOL_NAMES)
-const BACKGROUND_WATCH_TIMEOUT_SECONDS = 60
 
 const ORCHESTRATOR_PROMPT = `
 <orchestration_mode>
 Orchestration mode is ACTIVE. Act as the mission lead for the user's coding
-task. Create coding agents only for bounded work that benefits from delegation,
-give each one a self-contained prompt and isolated worktree when appropriate,
-then supervise, steer, inspect, and verify their results. You retain ownership
-of architecture, integration, and the final answer.
+task and use the existing \`cate agent\` CLI to create, supervise, steer,
+inspect, review, and stop visible coding-agent workers.
+
+Before acting, read the bundled \`cate-cli\` skill and follow its orchestration
+instructions. Delegate bounded work when it materially helps, give workers
+self-contained prompts and isolated worktrees when appropriate, and explicitly
+wait for or inspect their progress. Workers may recursively create and
+supervise their own workers through the same CLI. You retain ownership of
+architecture, integration, verification, and the final answer.
 </orchestration_mode>
 `.trim()
 
-function agentIdSchema() {
-  let ids: string[] = []
-  try {
-    const parsed = JSON.parse(process.env.CATE_CODING_AGENT_IDS || "[]")
-    if (Array.isArray(parsed)) {
-      ids = [...new Set(parsed.filter((id): id is string => typeof id === "string" && id.length > 0))]
-    }
-  } catch {
-    // Renderer validation remains authoritative if a hand-run extension has a
-    // malformed environment; Cate-managed sessions always provide this value.
-  }
-  return ids.length > 0
-    ? Type.Union(ids.map((id) => Type.Literal(id)) as [ReturnType<typeof Type.Literal>, ...ReturnType<typeof Type.Literal>[]])
-    : Type.String({ minLength: 1, description: "A coding agent registered by Cate." })
-}
-
-async function invoke(
-  method: string,
-  args: Record<string, unknown>,
-  signal?: AbortSignal,
-): Promise<unknown> {
-  const api = process.env.CATE_API
-  const token = process.env.CATE_TOKEN
-  if (!api || !token) throw new Error("Cate orchestration is unavailable in this session")
-  const response = await fetch(api, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ method, args }),
-    signal,
-  })
-  const body = await response.json() as { result?: unknown; error?: string }
-  if (!response.ok) throw new Error(body.error || `Cate API failed (${response.status})`)
-  const result = body.result
-  if (result && typeof result === "object" && "error" in result) {
-    throw new Error(String((result as { error: unknown }).error))
-  }
-  return result
-}
-
-function toolResult(result: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-    details: result,
-  }
-}
-
-function objectResult(result: unknown): Record<string, unknown> {
-  return result && typeof result === "object" ? result as Record<string, unknown> : {}
-}
-
-function backgroundUpdateText(result: Record<string, unknown>, changedRunIds: string[]): string {
-  const runs = Array.isArray(result.runs)
-    ? result.runs.filter((run): run is Record<string, unknown> => !!run && typeof run === "object")
-    : []
-  const lines = runs
-    .filter((run) => changedRunIds.includes(String(run.id)))
-    .map((run) => {
-      const label = typeof run.title === "string"
-        ? run.title
-        : typeof run.agentName === "string" ? run.agentName : String(run.id)
-      return `- ${label}: ${String(run.status ?? "changed")} (run ${String(run.id)})`
-    })
-  return [
-    "Coding-agent background update:",
-    ...(lines.length > 0 ? lines : changedRunIds.map((id) => `- run ${id} changed state`)),
-    "Continue supervising these workers. Inspect or review them when appropriate.",
-  ].join("\n")
-}
-
 export default function (pi: ExtensionAPI) {
   let active = false
-  const backgroundRunIds = new Set<string>()
-  const armedBackgroundRunIds = new Set<string>()
-  const backgroundStatuses = new Map<string, string>()
-  let watchController: AbortController | undefined
-  let watchRetry: ReturnType<typeof setTimeout> | undefined
-  let watchEpoch = 0
-
-  const stopBackgroundWatch = (): void => {
-    watchEpoch += 1
-    watchController?.abort()
-    watchController = undefined
-    if (watchRetry) clearTimeout(watchRetry)
-    watchRetry = undefined
-  }
-
-  const restartBackgroundWatch = (): void => {
-    stopBackgroundWatch()
-    const runIds = [...armedBackgroundRunIds]
-    if (!active || runIds.length === 0) return
-
-    const epoch = watchEpoch
-    const controller = new AbortController()
-    watchController = controller
-    void invoke("cate.codingAgent.wait", {
-      runIds,
-      timeoutSeconds: BACKGROUND_WATCH_TIMEOUT_SECONDS,
-      baselineStatuses: Object.fromEntries(runIds.flatMap((runId) => {
-        const status = backgroundStatuses.get(runId)
-        return status ? [[runId, status]] : []
-      })),
-    }, controller.signal).then((rawResult) => {
-      if (controller.signal.aborted || epoch !== watchEpoch) return
-      const result = objectResult(rawResult)
-      const changedRunIds = Array.isArray(result.changedRunIds)
-        ? result.changedRunIds.filter((id): id is string => typeof id === "string")
-        : []
-      if (Array.isArray(result.runs)) {
-        for (const run of result.runs) {
-          if (!run || typeof run !== "object") continue
-          const snapshot = run as Record<string, unknown>
-          if (typeof snapshot.id === "string" && typeof snapshot.status === "string") {
-            backgroundStatuses.set(snapshot.id, snapshot.status)
-          }
-        }
-      }
-      if (changedRunIds.length > 0) {
-        for (const runId of changedRunIds) armedBackgroundRunIds.delete(runId)
-        pi.sendMessage({
-          customType: "cate-coding-agent-background-update",
-          content: backgroundUpdateText(result, changedRunIds),
-          display: true,
-          details: result,
-        }, { triggerTurn: true, deliverAs: "followUp" })
-      }
-      restartBackgroundWatch()
-    }).catch(() => {
-      if (controller.signal.aborted || epoch !== watchEpoch) return
-      watchRetry = setTimeout(restartBackgroundWatch, 1_000)
-    })
-  }
-
-  const setMode = (
-    enabled: boolean,
-    ctx: { ui: { setStatus: (key: string, value: string | undefined) => void } },
-  ): void => {
-    active = enabled
-    ctx.ui.setStatus(STATUS_KEY, enabled ? "Orchestration mode" : undefined)
-    restartBackgroundWatch()
-  }
-
-  const syncActiveTools = (): void => {
-    const current = pi.getActiveTools()
-    const next = active
-      ? [...new Set([...current, ...TOOL_NAMES])]
-      : current.filter((name) => !TOOL_NAME_SET.has(name))
-    if (next.length === current.length && next.every((name, index) => name === current[index])) {
-      return
-    }
-    pi.setActiveTools(next)
-  }
-
-  pi.registerTool({
-    name: "create_coding_agent",
-    label: "Create coding agent",
-    description:
-      "Create a visible coding-agent terminal, bind it to a registered worktree, and give it an initial implementation task. Background workers wake you when they need attention; non-background workers must be monitored with wait_for_coding_agents. Omit agentId to use Cate's first hook-ready registered agent. Returns a runId and panelId.",
-    promptSnippet:
-      "create_coding_agent - start a visible, registered coding-agent worker in a Cate worktree with an initial task.",
-    promptGuidelines: [
-      "Delegate bounded implementation or investigation tasks when parallel work materially helps; keep architectural ownership and final verification yourself.",
-      "Give each worker a self-contained prompt with scope, constraints, and concrete success criteria. Never ask a worker to create more workers.",
-      "Give each worker a short role title that describes its responsibility, such as API implementation or Integration tests.",
-      "For isolated worktrees, ask the worker to run relevant checks and commit completed changes before finishing so Cate can review and integrate the branch safely.",
-      "Use background workers by default so Cate wakes you when they need attention. For a non-background worker, repeatedly call wait_for_coding_agents with a short timeout until it changes state.",
-      "Never create more than five live workers. Reuse a run with send_to_coding_agent when follow-up belongs to the same task.",
-      "Respect followUpSupported in each run result; create a fresh run when that capability is false.",
-      "When a run fails, use its failureReason or inspect it for full output. If the failure is specific to that CLI, such as quota, authentication, or service availability, create a fresh run with a different registered agentId.",
-      "When an isolated worker finishes, call review_coding_agent and summarize its commits, changed files, checks, and any uncommitted work. Never claim the mission is integrated merely because the worker process finished.",
-      "Recommend Apply, Keep worktree, or Discard based on the review, then let the user make that choice from the worker card. Do not imply that reviewing changed the primary checkout.",
-    ],
-    parameters: Type.Object({
-      agentId: Type.Optional(agentIdSchema()),
-      title: Type.Optional(Type.String({ minLength: 1, maxLength: 80, description: "Short responsibility shown to the user, such as Integration tests." })),
-      prompt: Type.String({ minLength: 1, description: "Self-contained task, constraints, and success criteria." }),
-      background: Type.Optional(Type.Boolean({ default: true, description: "Wake this supervisor when the worker needs attention. Set false to monitor it with wait_for_coding_agents." })),
-      worktreeId: Type.Optional(
-        Type.String({ description: "Registered Cate worktree id. Omit to inherit this Cate Agent panel's worktree or use the primary checkout." }),
-      ),
-      newWorktree: Type.Optional(
-        Type.String({ description: "Create a new isolated branch/worktree with this name before launching. Mutually exclusive with worktreeId." }),
-      ),
-      baseRef: Type.Optional(
-        Type.String({ description: "Optional git base ref for newWorktree. Omit to use the repository default." }),
-      ),
-    }),
-    async execute(_id, params, signal) {
-      const result = await invoke("cate.codingAgent.create", params, signal)
-      const snapshot = objectResult(result)
-      const runId = snapshot.id
-      if (params.background !== false && typeof runId === "string") {
-        backgroundRunIds.add(runId)
-        armedBackgroundRunIds.add(runId)
-        if (typeof snapshot.status === "string") backgroundStatuses.set(runId, snapshot.status)
-        restartBackgroundWatch()
-      }
-      return toolResult(result)
-    },
-  })
-
-  pi.registerTool({
-    name: "send_to_coding_agent",
-    label: "Prompt coding agent",
-    description:
-      "Send a follow-up prompt to a live Cate-owned coding agent. The prompt is pasted atomically and submitted to that worker's terminal.",
-    parameters: Type.Object({
-      runId: Type.String(),
-      prompt: Type.String({ minLength: 1 }),
-    }),
-    async execute(_id, params, signal) {
-      const result = await invoke("cate.codingAgent.send", params, signal)
-      if (backgroundRunIds.has(params.runId)) {
-        armedBackgroundRunIds.add(params.runId)
-        const status = objectResult(result).status
-        if (typeof status === "string") backgroundStatuses.set(params.runId, status)
-        restartBackgroundWatch()
-      }
-      return toolResult(result)
-    },
-  })
-
-  pi.registerTool({
-    name: "wait_for_coding_agents",
-    label: "Wait for coding agents",
-    description:
-      "Wait briefly for one or more non-background coding agents. Returns immediately when a worker needs attention, or returns current states after the timeout. Call again while workers are still active.",
-    parameters: Type.Object({
-      runIds: Type.Array(Type.String(), { minItems: 1, maxItems: 5 }),
-      timeoutSeconds: Type.Optional(Type.Number({ minimum: 5, maximum: 60, default: 10 })),
-    }),
-    async execute(_id, params, signal) {
-      return toolResult(await invoke("cate.codingAgent.wait", params, signal))
-    },
-  })
-
-  pi.registerTool({
-    name: "inspect_coding_agent",
-    label: "Inspect coding agent",
-    description:
-      "Inspect a Cate-owned coding agent's live state and recent visible terminal output without focusing or moving the user's canvas.",
-    parameters: Type.Object({ runId: Type.String() }),
-    async execute(_id, params, signal) {
-      return toolResult(await invoke("cate.codingAgent.inspect", params, signal))
-    },
-  })
-
-  pi.registerTool({
-    name: "review_coding_agent",
-    label: "Review coding agent changes",
-    description:
-      "Review an isolated worker branch relative to the current primary branch. Returns commits, changed files, a bounded diff, and whether the branch is clean enough to apply. This is read-only and never merges changes.",
-    parameters: Type.Object({ runId: Type.String() }),
-    async execute(_id, params, signal) {
-      return toolResult(await invoke("cate.codingAgent.review", params, signal))
-    },
-  })
-
-  pi.registerTool({
-    name: "stop_coding_agent",
-    label: "Stop coding agent",
-    description:
-      "Stop a Cate-owned coding agent process. Use for obsolete, stuck, or explicitly cancelled work.",
-    parameters: Type.Object({ runId: Type.String() }),
-    async execute(_id, params, signal) {
-      const result = await invoke("cate.codingAgent.stop", params, signal)
-      backgroundRunIds.delete(params.runId)
-      armedBackgroundRunIds.delete(params.runId)
-      backgroundStatuses.delete(params.runId)
-      restartBackgroundWatch()
-      return toolResult(result)
-    },
-  })
 
   pi.registerCommand("orchestrate", {
     description: "Toggle coding-agent orchestration mode.",
     handler: async (_args, ctx) => {
-      setMode(!active, ctx)
+      active = !active
+      ctx.ui.setStatus(STATUS_KEY, active ? "Orchestration mode" : undefined)
     },
   })
 
   pi.on("before_agent_start", async (event) => {
-    // Changing Pi's active tools inside the /orchestrate command can resume the
-    // agent loop. Defer that rebuild until a real user prompt is about to start.
-    syncActiveTools()
     if (!active) return
     return { systemPrompt: `${event.systemPrompt}\n\n${ORCHESTRATOR_PROMPT}` }
-  })
-
-  // Inactive tools are absent from the provider payload. This hook is a
-  // defensive backstop for a stale tool call already emitted while mode changed.
-  pi.on("tool_call", async (event) => {
-    if (!active && TOOL_NAME_SET.has(event.toolName)) {
-      return {
-        block: true,
-        reason: "Coding-agent orchestration mode is not active.",
-      }
-    }
-  })
-
-  // Extension loading happens before Pi's runtime action methods are available,
-  // so the initial gate belongs in session_start rather than module setup.
-  pi.on("session_start", async () => {
-    syncActiveTools()
-  })
-
-  pi.on("session_shutdown", async () => {
-    stopBackgroundWatch()
   })
 }

--- a/src/cateAgent/extensions/cate-orchestrator/package.json
+++ b/src/cateAgent/extensions/cate-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-orchestrator",
-  "description": "Native tools for Cate Agent to create, prompt, inspect, wait for, and stop visible coding agents.",
+  "description": "Prompt mode that teaches Cate Agent to orchestrate visible coding agents through the cate CLI.",
   "private": true,
   "pi": {
     "extensions": ["./index.ts"]

--- a/src/cateAgent/main/codingManager.test.ts
+++ b/src/cateAgent/main/codingManager.test.ts
@@ -124,14 +124,7 @@ describe('CodingManager worktree skill preparation', () => {
     )
     expect(PiRpcClient).toHaveBeenCalledWith(runtime, expect.objectContaining({
       env: expect.objectContaining({
-        CATE_CODING_AGENT_IDS: JSON.stringify([
-          'claude-code',
-          'codex',
-          'cursor',
-          'grok',
-          'opencode',
-          'pi',
-        ]),
+        CATE_PANEL_ID: 'panel-worktree',
       }),
     }))
   })

--- a/src/cateAgent/main/codingManager.ts
+++ b/src/cateAgent/main/codingManager.ts
@@ -52,7 +52,6 @@ import { workspaceCateApi } from '../../main/extensions/workspaceCateApi'
 import { KeyedLock } from '../../main/keyedLock'
 import { agentMessageText, lastAssistantMessage } from '../../shared/agentMessages'
 import { agentErrorMessage } from '../../shared/agentErrorMessage'
-import { AGENTS } from '../../shared/agents'
 
 interface AgentSession {
   panelId: string
@@ -206,14 +205,12 @@ export class CodingManager {
 
       const env: Record<string, string> = {
         PI_CODING_AGENT_DIR: hostCodingDir(runtimeId, cwd),
-        // The standalone Pi extension cannot import Cate's source tree. Feed
-        // it the canonical registry so its tool schema cannot drift.
-        CATE_CODING_AGENT_IDS: JSON.stringify(AGENTS.map((agent) => agent.id)),
+        CATE_PANEL_ID: opts.panelId,
       }
 
-      // The embedded supervisor gets a panel-bound endpoint with orchestration
-      // scope. Worker terminals receive the ordinary first-party endpoint and
-      // therefore cannot recursively spawn agents.
+      // The embedded agent retains a panel-bound endpoint for native
+      // worktree/window affinity, but uses the same public cate CLI as terminal
+      // agents for orchestration.
       const cateApi = await workspaceCateApi.ensureCateAgentEndpoint(
         opts.workspaceId,
         opts.panelId,

--- a/src/cateAgent/main/extensionInstall.test.ts
+++ b/src/cateAgent/main/extensionInstall.test.ts
@@ -67,7 +67,7 @@ describe('createBundledExtensionInstaller', () => {
       host.file.writeFile.mock.calls.map((call: unknown[]) => [call[0], call[1]]),
     )
     expect(writes.get('/host/.cate/cate-agent/extensions/cate-orchestrator/index.ts'))
-      .toContain('create_coding_agent')
+      .toContain('same recursive workflow')
     expect(JSON.parse(String(
       writes.get('/host/.cate/cate-agent/extensions/cate-orchestrator/package.json'),
     ))).toMatchObject({ name: 'cate-orchestrator' })

--- a/src/cli/cate.test.ts
+++ b/src/cli/cate.test.ts
@@ -9,6 +9,7 @@ import {
   parseCli,
   parseFileTarget,
   resolvePanel,
+  resolveAgentRun,
   run,
   send,
   shortId,
@@ -18,7 +19,7 @@ import {
   type SendDeps,
 } from './cate'
 
-const flags: Flags = { json: false, help: false, version: false }
+const flags: Flags = { json: false, help: false, version: false, foreground: false }
 
 describe('thin browser CLI', () => {
   it('makes open a new tab and keeps replacement navigation explicit', () => {
@@ -127,7 +128,7 @@ describe('global parsing', () => {
       '--panel', 'abc', '--json',
     ])).toEqual({
       positionals: ['browser', 'wait', '#done', '--timeout', '5000'],
-      flags: { panel: 'abc', json: true, help: false, version: false },
+      flags: { panel: 'abc', json: true, help: false, version: false, foreground: false },
     })
   })
 
@@ -171,6 +172,68 @@ describe('non-browser surface', () => {
       args: { panelId: 'abcd1234' },
       resolvePanel: 'panel',
     })
+  })
+})
+
+describe('agent orchestration surface', () => {
+  it('parses create options without changing browser-native argv parsing', () => {
+    const parsed = parseCli([
+      'agent', 'create', 'Implement', 'the API', '--agent', 'codex', '--title', 'API',
+      '--new-worktree', 'agent/api', '--base-ref', 'main', '--foreground',
+    ])
+    expect(buildRequest(parsed.positionals, parsed.flags)).toEqual({
+      method: 'cate.codingAgent.create',
+      args: {
+        prompt: 'Implement the API',
+        agentId: 'codex',
+        title: 'API',
+        newWorktree: 'agent/api',
+        baseRef: 'main',
+        background: false,
+      },
+    })
+  })
+
+  it('maps the complete lifecycle and validates worktree options', () => {
+    expect(buildRequest(['agent', 'list'], flags)).toEqual({
+      method: 'cate.codingAgent.list', args: {},
+    })
+    expect(buildRequest(['agent', 'send', 'abcd1234', 'Run', 'tests'], flags)).toEqual({
+      method: 'cate.codingAgent.send',
+      args: { runId: 'abcd1234', prompt: 'Run tests' },
+      resolveAgentRuns: true,
+    })
+    expect(buildRequest(['agent', 'inspect', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.inspect')
+    expect(buildRequest(['agent', 'review', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.review')
+    expect(buildRequest(['agent', 'apply', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.apply')
+    expect(buildRequest(['agent', 'keep', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.keep')
+    expect(buildRequest(['agent', 'discard', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.discard')
+    expect(buildRequest(['agent', 'stop', 'abcd1234'], flags).method)
+      .toBe('cate.codingAgent.stop')
+    expect(() => buildRequest(
+      ['agent', 'create', 'task'],
+      { ...flags, worktreeId: 'one', newWorktree: 'two' },
+    )).toThrow(/either --worktree or --new-worktree/)
+  })
+
+  it('maps wait milliseconds to the bounded host timeout', () => {
+    expect(buildRequest(
+      ['agent', 'wait', 'abcd1234', 'efgh5678'],
+      { ...flags, waitTimeout: '15000' },
+    )).toEqual({
+      method: 'cate.codingAgent.wait',
+      args: { runIds: ['abcd1234', 'efgh5678'], timeoutSeconds: 15 },
+      resolveAgentRuns: true,
+    })
+    expect(() => buildRequest(
+      ['agent', 'wait'],
+      { ...flags, waitTimeout: '1000' },
+    )).toThrow(/between 5000 and 60000/)
   })
 })
 
@@ -226,6 +289,7 @@ describe('transport and panel resolution', () => {
       method: 'cate.browser.command',
       args: { command: ['snapshot', '-i'], placementGroupId: 'origin-panel' },
       clientId: 'cli-session',
+      callerPanelId: 'origin-panel',
     })
   })
 
@@ -253,6 +317,15 @@ describe('transport and panel resolution', () => {
     await expect(resolvePanel('abcd1234-b', 'browser', deps)).resolves.toBe('abcd1234-browser')
     await expect(resolvePanel('abcd1234-t', 'browser', deps)).rejects.toThrow(/no browser panel/)
   })
+
+  it('resolves exact or unique short agent run ids', async () => {
+    const deps = panelDeps([
+      { id: 'abcd1234-run-one' },
+      { id: 'efgh5678-run-two' },
+    ])
+    await expect(resolveAgentRun('abcd1234', deps)).resolves.toBe('abcd1234-run-one')
+    await expect(resolveAgentRun('missing', deps)).rejects.toThrow(/no agent run/)
+  })
 })
 
 describe('output and run loop', () => {
@@ -266,6 +339,9 @@ describe('output and run loop', () => {
     })).toContain('- button "Save" [ref=s1e1]')
     expect(formatHuman('cate.browser.readCommand', { path: '/tmp/shot.png' })).toBe('/tmp/shot.png')
     expect(formatHuman('cate.terminal.read', { text: 'one\ntwo' })).toBe('one\ntwo')
+    expect(formatHuman('cate.codingAgent.list', [
+      { id: 'abcdefgh-more', status: 'working', title: 'Tests' },
+    ])).toBe('abcdefgh\tworking\tTests')
   })
 
   function runDeps(body: unknown = { result: null }): RunDeps & { out: string[]; err: string[] } {
@@ -306,5 +382,25 @@ describe('output and run loop', () => {
     expect(await run(['browser', 'tab', 'list'], deps)).toBe(2)
     expect(deps.err.join('\n')).toContain('unsupported-browser-command:tab')
     expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves a short agent id before inspecting it', async () => {
+    const deps = runDeps()
+    ;(deps.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({ result: [{ id: 'abcdefgh-full', status: 'ready' }] }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({ result: { id: 'abcdefgh-full', status: 'ready' } }),
+      })
+
+    expect(await run(['agent', 'inspect', 'abcdefgh'], deps)).toBe(0)
+    const request = JSON.parse((deps.fetch as ReturnType<typeof vi.fn>).mock.calls[1][1].body)
+    expect(request).toEqual({
+      method: 'cate.codingAgent.inspect',
+      args: { runId: 'abcdefgh-full' },
+    })
   })
 })

--- a/src/cli/cate.ts
+++ b/src/cli/cate.ts
@@ -7,7 +7,7 @@ import {
   validateAgentBrowserCommand,
 } from '../shared/agentBrowserCommand'
 
-export const CLI_VERSION = '10'
+export const CLI_VERSION = '11'
 export const DEFAULT_TIMEOUT_MS = 30_000
 export const SHORT_ID_LEN = 8
 
@@ -24,6 +24,13 @@ export interface Flags {
   json: boolean
   help: boolean
   version: boolean
+  agentId?: string
+  title?: string
+  worktreeId?: string
+  newWorktree?: string
+  baseRef?: string
+  foreground: boolean
+  waitTimeout?: string
 }
 
 export interface Parsed {
@@ -35,6 +42,7 @@ export interface Request {
   method: string
   args: Record<string, unknown>
   resolvePanel?: 'browser' | 'terminal' | 'panel'
+  resolveAgentRuns?: boolean
 }
 
 function need(value: string | undefined, name: string): string {
@@ -69,8 +77,9 @@ export function parseFileTarget(target: string): Record<string, unknown> {
 /** Extract only Cate's four global flags. Everything else remains byte-for-byte
  * native agent-browser argv after `cate browser`. */
 export function parseCli(argv: string[]): Parsed {
-  const flags: Flags = { json: false, help: false, version: false }
+  const flags: Flags = { json: false, help: false, version: false, foreground: false }
   const positionals: string[] = []
+  const agentCommand = argv[0] === 'agent'
   for (let index = 0; index < argv.length; index += 1) {
     const part = argv[index]
     if (part === '--panel') {
@@ -82,11 +91,109 @@ export function parseCli(argv: string[]): Parsed {
       flags.help = true
     } else if (part === '--version') {
       flags.version = true
+    } else if (agentCommand && part === '--agent') {
+      flags.agentId = need(argv[index + 1], 'agent')
+      index += 1
+    } else if (agentCommand && part === '--title') {
+      flags.title = need(argv[index + 1], 'title')
+      index += 1
+    } else if (agentCommand && part === '--worktree') {
+      flags.worktreeId = need(argv[index + 1], 'worktree')
+      index += 1
+    } else if (agentCommand && part === '--new-worktree') {
+      flags.newWorktree = need(argv[index + 1], 'new-worktree')
+      index += 1
+    } else if (agentCommand && part === '--base-ref') {
+      flags.baseRef = need(argv[index + 1], 'base-ref')
+      index += 1
+    } else if (agentCommand && part === '--foreground') {
+      flags.foreground = true
+    } else if (agentCommand && part === '--wait-timeout') {
+      flags.waitTimeout = need(argv[index + 1], 'wait-timeout')
+      index += 1
     } else {
       positionals.push(part)
     }
   }
   return { positionals, flags }
+}
+
+function agentRequest(args: string[], flags: Flags): Request {
+  const command = need(args[0], 'agent command')
+  const rest = args.slice(1)
+  if (flags.panel) throw new UsageError(`--panel is not valid for agent ${command}`)
+  const hasCreateOptions = Boolean(
+    flags.agentId || flags.title || flags.worktreeId || flags.newWorktree || flags.baseRef || flags.foreground,
+  )
+  if (command !== 'create' && hasCreateOptions) {
+    throw new UsageError(`create options are not valid for agent ${command}`)
+  }
+  if (command !== 'wait' && flags.waitTimeout) {
+    throw new UsageError('--wait-timeout is only valid for agent wait')
+  }
+
+  if (command === 'list') {
+    exact(rest, 0)
+    return { method: 'cate.codingAgent.list', args: {} }
+  }
+  if (command === 'create') {
+    const prompt = need(rest.join(' '), 'prompt')
+    if (flags.worktreeId && flags.newWorktree) {
+      throw new UsageError('use either --worktree or --new-worktree, not both')
+    }
+    if (flags.baseRef && !flags.newWorktree) {
+      throw new UsageError('--base-ref requires --new-worktree')
+    }
+    return {
+      method: 'cate.codingAgent.create',
+      args: {
+        prompt,
+        ...(flags.agentId ? { agentId: flags.agentId } : {}),
+        ...(flags.title ? { title: flags.title } : {}),
+        ...(flags.worktreeId ? { worktreeId: flags.worktreeId } : {}),
+        ...(flags.newWorktree ? { newWorktree: flags.newWorktree } : {}),
+        ...(flags.baseRef ? { baseRef: flags.baseRef } : {}),
+        ...(flags.foreground ? { background: false } : {}),
+      },
+    }
+  }
+  if (command === 'wait') {
+    const runIds = rest.map((runId) => need(runId, 'runId'))
+    const timeoutMs = flags.waitTimeout === undefined
+      ? undefined
+      : positiveInt(flags.waitTimeout, 'wait-timeout')
+    if (timeoutMs !== undefined && (timeoutMs < 5_000 || timeoutMs > 60_000)) {
+      throw new UsageError('--wait-timeout must be between 5000 and 60000 ms')
+    }
+    return {
+      method: 'cate.codingAgent.wait',
+      args: {
+        ...(runIds.length > 0 ? { runIds } : {}),
+        ...(timeoutMs !== undefined ? { timeoutSeconds: timeoutMs / 1_000 } : {}),
+      },
+      resolveAgentRuns: runIds.length > 0,
+    }
+  }
+  if (command === 'send') {
+    const runId = need(rest[0], 'runId')
+    const prompt = need(rest.slice(1).join(' '), 'prompt')
+    return {
+      method: 'cate.codingAgent.send',
+      args: { runId, prompt },
+      resolveAgentRuns: true,
+    }
+  }
+  if (
+    command === 'inspect' || command === 'review' || command === 'apply'
+    || command === 'keep' || command === 'discard' || command === 'stop'
+  ) {
+    return {
+      method: `cate.codingAgent.${command}`,
+      args: { runId: need(exact(rest, 1)[0], 'runId') },
+      resolveAgentRuns: true,
+    }
+  }
+  throw new UsageError(`unknown agent command: ${command}`)
 }
 
 function withPanel(
@@ -185,6 +292,7 @@ export function buildRequest(positionals: string[], flags: Flags): Request {
   const args = positionals.slice(1)
 
   if (group === 'browser') return browserRequest(args, flags)
+  if (group === 'agent') return agentRequest(args, flags)
   if (group === 'version') {
     exact(args, 0)
     if (flags.panel) throw new UsageError('--panel is not valid for version')
@@ -275,6 +383,7 @@ export interface SendDeps {
   fetch: typeof fetch
   env: Record<string, string | undefined>
   timeout: number
+  cwd?: string
 }
 
 export async function send(
@@ -304,7 +413,13 @@ export async function send(
     response = await deps.fetch(api, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ method, args: requestArgs, clientId }),
+      body: JSON.stringify({
+        method,
+        args: requestArgs,
+        clientId,
+        callerPanelId: deps.env.CATE_PANEL_ID,
+        originCwd: deps.cwd,
+      }),
       signal: AbortSignal.timeout(deps.timeout),
     })
   } catch (error) {
@@ -346,6 +461,25 @@ export async function resolvePanel(
   throw new UsageError(`ambiguous ${label} '${prefix}' matches ${matches.map(shortId).join(', ')}`)
 }
 
+export async function resolveAgentRuns(prefixes: string[], deps: SendDeps): Promise<string[]> {
+  const listed = await send('cate.codingAgent.list', {}, deps)
+  const ids = (Array.isArray(listed) ? listed : [])
+    .map(asObject)
+    .map((run) => run?.id)
+    .filter((id): id is string => typeof id === 'string')
+  return prefixes.map((prefix) => {
+    if (ids.includes(prefix)) return prefix
+    const matches = ids.filter((id) => id.startsWith(prefix))
+    if (matches.length === 1) return matches[0]
+    if (matches.length === 0) throw new UsageError(`no agent run matching '${prefix}'`)
+    throw new UsageError(`ambiguous agent run '${prefix}' matches ${matches.map(shortId).join(', ')}`)
+  })
+}
+
+export async function resolveAgentRun(prefix: string, deps: SendDeps): Promise<string> {
+  return (await resolveAgentRuns([prefix], deps))[0]
+}
+
 function renderPanelList(value: unknown): string {
   if (!Array.isArray(value)) return renderGeneric(value)
   return value.map((item) => {
@@ -366,6 +500,16 @@ function renderTabs(value: unknown): string {
   }).join('\n') || '(no tabs)'
 }
 
+function renderAgentRuns(value: unknown): string {
+  if (!Array.isArray(value)) return renderGeneric(value)
+  return value.map((item) => {
+    const run = asObject(item)
+    if (!run) return String(item)
+    const title = run.title ?? run.agentName ?? run.agentId ?? ''
+    return `${shortId(String(run.id ?? '?'))}\t${run.status ?? '?'}${title ? `\t${title}` : ''}`
+  }).join('\n') || '(no agent runs)'
+}
+
 function renderGeneric(value: unknown): string {
   if (value === undefined || value === null) return 'ok'
   if (typeof value === 'string') return value
@@ -375,6 +519,21 @@ function renderGeneric(value: unknown): string {
 export function formatHuman(method: string, value: unknown): string {
   if (method === 'cate.panel.list') return renderPanelList(value)
   if (method === 'cate.browser.tabs') return renderTabs(value)
+  if (method === 'cate.codingAgent.list') return renderAgentRuns(value)
+  if (method === 'cate.codingAgent.wait') {
+    return renderAgentRuns(asObject(value)?.runs)
+  }
+  if (method === 'cate.codingAgent.inspect' || method === 'cate.codingAgent.review') {
+    return JSON.stringify(value, null, 2)
+  }
+  if (
+    (
+      method === 'cate.codingAgent.create' || method === 'cate.codingAgent.send'
+      || method === 'cate.codingAgent.apply' || method === 'cate.codingAgent.keep'
+      || method === 'cate.codingAgent.discard' || method === 'cate.codingAgent.stop'
+    )
+    && asObject(value)
+  ) return renderAgentRuns([value])
   if (method === 'cate.terminal.read') {
     const text = asObject(value)?.text
     return typeof text === 'string' ? text : renderGeneric(value)
@@ -410,6 +569,7 @@ const USAGE = `Usage:
   cate panel list|create|set|current|clear|close [args]
   cate editor open <path[:line[:column]]>
   cate terminal read|type|press [args] [--panel <id>]
+  cate agent list|create|send|wait|inspect|review|apply|keep|discard|stop [args]
   cate version
 
 Browser page commands use native agent-browser syntax. Cate pins them to the
@@ -443,8 +603,20 @@ Page automation uses native agent-browser syntax, for example:
 Snapshot refs are revisioned by Cate (@s1e3) and become stale after the next
 snapshot. Use --panel whenever more than one browser could be the target.`
 
+const AGENT_USAGE = `Usage:
+  cate agent list
+  cate agent create <prompt...> [--agent <id>] [--title <title>]
+      [--worktree <id> | --new-worktree <name> [--base-ref <ref>]] [--foreground]
+  cate agent send <runId> <prompt...>
+  cate agent wait [runId...] [--wait-timeout <ms>]
+  cate agent inspect|review|apply|keep|discard|stop <runId>
+
+Run ids may be full ids or unique prefixes from \`cate agent list\`. A worker
+may use the same commands to create and supervise its own workers.`
+
 function helpFor(positionals: string[]): string {
   if (positionals[0] === 'browser') return BROWSER_USAGE
+  if (positionals[0] === 'agent') return AGENT_USAGE
   if (positionals[0] === 'panel') {
     return 'Usage: cate panel list | create terminal|canvas | set <id> | current | clear | close <id>'
   }
@@ -460,6 +632,7 @@ export interface RunDeps {
   env: Record<string, string | undefined>
   stdout: (text: string) => void
   stderr: (text: string) => void
+  cwd?: string
 }
 
 function usageError(deps: RunDeps, error: unknown): number {
@@ -498,7 +671,10 @@ export async function run(argv: string[], deps: RunDeps): Promise<number> {
   const sendDeps: SendDeps = {
     fetch: deps.fetch,
     env: deps.env,
-    timeout: DEFAULT_TIMEOUT_MS,
+    timeout: request.method === 'cate.codingAgent.wait'
+      ? Math.max(DEFAULT_TIMEOUT_MS, Number(request.args.timeoutSeconds ?? 10) * 1_000 + 5_000)
+      : DEFAULT_TIMEOUT_MS,
+    cwd: deps.cwd,
   }
   try {
     if (request.resolvePanel) {
@@ -507,6 +683,16 @@ export async function run(argv: string[], deps: RunDeps): Promise<number> {
         request.resolvePanel,
         sendDeps,
       )
+    }
+    if (request.resolveAgentRuns) {
+      if (Array.isArray(request.args.runIds)) {
+        request.args.runIds = await resolveAgentRuns(
+          request.args.runIds.map((runId) => String(runId)),
+          sendDeps,
+        )
+      } else if (typeof request.args.runId === 'string') {
+        request.args.runId = await resolveAgentRun(request.args.runId, sendDeps)
+      }
     }
     const value = await send(request.method, request.args, sendDeps)
     deps.stdout(parsed.flags.json ? JSON.stringify(value) : formatHuman(request.method, value))
@@ -526,6 +712,7 @@ if (typeof require !== 'undefined' && require.main === module) {
   run(process.argv.slice(2), {
     fetch: globalThis.fetch,
     env: process.env,
+    cwd: process.cwd(),
     stdout: (text) => process.stdout.write(`${text}\n`),
     stderr: (text) => process.stderr.write(`${text}\n`),
   }).then((code) => {

--- a/src/main/extensions/cateApiHandlers.test.ts
+++ b/src/main/extensions/cateApiHandlers.test.ts
@@ -205,7 +205,7 @@ beforeEach(() => {
 
 describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
   it('reports the API version for feature detection', async () => {
-    expect(await dispatchCateInvoke(scope(), 'cate.version', undefined)).toBe(6)
+    expect(await dispatchCateInvoke(scope(), 'cate.version', undefined)).toBe(7)
   })
 
   it('resolves the workspace root from the locator', async () => {
@@ -341,7 +341,7 @@ describe('dispatchCateInvoke — Kitchen Sink reverse API', () => {
     // panel.* stay allowed (feature detection + panel self-control).
     state.scopes = undefined
     const forward = vi.fn()
-    expect(await dispatchCateInvoke(scope(forward), 'cate.version', undefined)).toBe(6)
+    expect(await dispatchCateInvoke(scope(forward), 'cate.version', undefined)).toBe(7)
     expect(await dispatchCateInvoke(scope(forward), 'cate.storage.get', { key: 'k' })).toEqual({ error: 'scope-denied', method: 'cate.storage.get' })
     expect(await dispatchCateInvoke(scope(forward), 'cate.editor.openFile', { path: 'x' })).toEqual({ error: 'scope-denied', method: 'cate.editor.openFile' })
     expect(await dispatchCateInvoke(scope(forward), 'cate.theme.get', undefined)).toEqual({ error: 'scope-denied', method: 'cate.theme.get' })
@@ -411,11 +411,15 @@ describe('dispatchCateInvoke — Cate Agent orchestration boundary', () => {
 
   it('allows a long monitor call without extending unrelated host actions', () => {
     expect(forwardTimeoutMs('cate.codingAgent.wait')).toBe(65_000)
+    expect(forwardTimeoutMs('cate.codingAgent.apply')).toBe(10_000)
+    expect(forwardTimeoutMs('cate.codingAgent.discard')).toBe(10_000)
     expect(forwardTimeoutMs('cate.editor.openFile')).toBe(10_000)
   })
 
   it('maps every native coding-agent method to its dedicated scope', () => {
-    for (const verb of ['create', 'send', 'wait', 'inspect', 'review', 'stop']) {
+    for (const verb of [
+      'list', 'create', 'send', 'wait', 'inspect', 'review', 'apply', 'keep', 'discard', 'stop',
+    ]) {
       expect(requiredScopeFor(`cate.codingAgent.${verb}`)).toBe('coding-agent')
     }
   })
@@ -497,21 +501,29 @@ describe('dispatchCateInvoke — Cate Agent orchestration boundary', () => {
     expect(forward).not.toHaveBeenCalled()
   })
 
-  it('denies ordinary first-party terminals and extensions even with the scope', async () => {
+  it('allows first-party terminals and denies extensions even with the scope', async () => {
     const forward = vi.fn()
-    for (const caller of ['first-party', 'extension'] as const) {
-      expect(await dispatchCateInvoke({
-        extensionId: caller === 'extension' ? EXT : 'terminal',
-        workspaceId: WS,
-        panelId: undefined,
-        caller,
-        grantedScopes: ['coding-agent'],
-        forward,
-      }, 'cate.codingAgent.create', { agentId: 'codex', prompt: 'No' })).toEqual({
-        error: 'cate-agent-only',
-        method: 'cate.codingAgent.create',
-      })
-    }
+    expect(await dispatchCateInvoke({
+      extensionId: 'terminal',
+      workspaceId: WS,
+      panelId: 'terminal-supervisor',
+      caller: 'first-party',
+      grantedScopes: ['coding-agent'],
+      forward: vi.fn(async () => ({ id: 'run-terminal' })),
+    }, 'cate.codingAgent.create', { agentId: 'codex', prompt: 'Do it' }))
+      .toEqual({ id: 'run-terminal' })
+
+    expect(await dispatchCateInvoke({
+      extensionId: EXT,
+      workspaceId: WS,
+      panelId: undefined,
+      caller: 'extension',
+      grantedScopes: ['coding-agent'],
+      forward,
+    }, 'cate.codingAgent.create', { agentId: 'codex', prompt: 'No' })).toEqual({
+      error: 'first-party-only',
+      method: 'cate.codingAgent.create',
+    })
     expect(forward).not.toHaveBeenCalled()
   })
 
@@ -539,6 +551,36 @@ describe('dispatchCateInvoke — Cate Agent orchestration boundary', () => {
     expect(result).toEqual({ error: 'no-owner', method: 'cate.codingAgent.inspect' })
     expect(send).toHaveBeenCalledOnce()
     expect(fallback).not.toHaveBeenCalled()
+  })
+
+  it('lists direct workers reported by detached owner windows', async () => {
+    const send = vi.fn(() => { throw new Error('closed for test') })
+    windowsById.set(7, { isDestroyed: () => false, webContents: { send } })
+    windowPanelList.value = [{
+      panelId: 'worker-panel',
+      type: 'terminal',
+      workspaceId: WS,
+      ownerWindowId: 7,
+      codingAgentRunId: 'run-detached',
+      codingAgentOwnerPanelId: 'supervisor-1',
+      codingAgentStatus: 'ready',
+    }]
+
+    const result = await dispatchCateInvoke({
+      extensionId: 'terminal',
+      workspaceId: WS,
+      panelId: 'supervisor-1',
+      caller: 'first-party',
+      grantedScopes: ['coding-agent'],
+      forward: vi.fn(async () => []),
+    }, 'cate.codingAgent.list', {})
+
+    expect(result).toEqual([{
+      id: 'run-detached',
+      panelId: 'worker-panel',
+      status: 'ready',
+    }])
+    expect(send).toHaveBeenCalledOnce()
   })
 
   it('coordinates one event-driven wait across workers in different windows', async () => {

--- a/src/main/extensions/cateApiHandlers.test.ts
+++ b/src/main/extensions/cateApiHandlers.test.ts
@@ -52,6 +52,8 @@ const { showOsNotification, settings } = vi.hoisted(() => ({
     cliEditorReadEnabled: true,
     cliEditorControlEnabled: true,
     cliNotifyEnabled: true,
+    cliAgentReadEnabled: true,
+    cliAgentControlEnabled: true,
   },
 }))
 vi.mock('../ipc/notifications', () => ({ showOsNotification }))
@@ -182,6 +184,8 @@ beforeEach(() => {
   settings.cliEditorReadEnabled = true
   settings.cliEditorControlEnabled = true
   settings.cliNotifyEnabled = true
+  settings.cliAgentReadEnabled = true
+  settings.cliAgentControlEnabled = true
   activeWindow.value = undefined
   windowsById.clear()
   windowPanelList.value = []
@@ -448,9 +452,9 @@ describe('dispatchCateInvoke — Cate Agent orchestration boundary', () => {
     }))
   })
 
-  it('keeps native orchestration available when command-line control is off', async () => {
+  it('applies the CLI master switch to Cate Agent orchestration', async () => {
     settings.cliEnabled = false
-    const forward = vi.fn(async () => ({ id: 'run-cli-off' }))
+    const forward = vi.fn()
 
     expect(await dispatchCateInvoke({
       extensionId: 'cate-agent',
@@ -460,9 +464,10 @@ describe('dispatchCateInvoke — Cate Agent orchestration boundary', () => {
       grantedScopes: [...CATE_AGENT_GRANTED_SCOPES],
       forward,
     }, 'cate.codingAgent.create', { agentId: 'codex', prompt: 'Implement it' })).toEqual({
-      id: 'run-cli-off',
+      error: 'cli-disabled: enable Command-line control (cate CLI) in Cate Settings → CLI',
+      method: 'cate.codingAgent.create',
     })
-    expect(forward).toHaveBeenCalledOnce()
+    expect(forward).not.toHaveBeenCalled()
   })
 
   it('applies the CLI master switch to Cate Agent host capabilities', async () => {
@@ -1299,6 +1304,44 @@ describe('dispatchCateInvoke — first-party trust boundary (characterization)',
     expect(showOsNotification).not.toHaveBeenCalled()
   })
 
+  it('gates agent observation and control on separate matrix cells', async () => {
+    const forward = vi.fn(async () => [])
+    const s: InvokeScope = {
+      extensionId: 'cate.terminal', workspaceId: WS, panelId: 'supervisor-1', forward,
+      caller: 'first-party', grantedScopes: [...GRANTED_SCOPES],
+    }
+
+    settings.cliAgentReadEnabled = false
+    expect(await dispatchCateInvoke(s, 'cate.codingAgent.list', {})).toEqual({
+      error: cliPermissionDenied(cliPermissionCellByKey('cliAgentReadEnabled')),
+      method: 'cate.codingAgent.list',
+    })
+    settings.cliAgentReadEnabled = true
+    settings.cliAgentControlEnabled = false
+    expect(await dispatchCateInvoke(s, 'cate.codingAgent.create', { prompt: 'Do it' })).toEqual({
+      error: cliPermissionDenied(cliPermissionCellByKey('cliAgentControlEnabled')),
+      method: 'cate.codingAgent.create',
+    })
+    expect(forward).not.toHaveBeenCalled()
+  })
+
+  it('applies the Agents permission cells to Cate Agent orchestration too', async () => {
+    settings.cliAgentControlEnabled = false
+    const forward = vi.fn()
+    expect(await dispatchCateInvoke({
+      extensionId: 'cate-agent',
+      workspaceId: WS,
+      panelId: 'cate-direct:chat-1',
+      caller: 'cate-agent',
+      grantedScopes: [...CATE_AGENT_GRANTED_SCOPES],
+      forward,
+    }, 'cate.codingAgent.create', { prompt: 'Do it' })).toEqual({
+      error: cliPermissionDenied(cliPermissionCellByKey('cliAgentControlEnabled')),
+      method: 'cate.codingAgent.create',
+    })
+    expect(forward).not.toHaveBeenCalled()
+  })
+
   it('does not let first-party callers change the user view with panel.focus', async () => {
     const forward = vi.fn()
     windowPanelList.value = [{ panelId: 'p1', type: 'editor', ownerWindowId: 1 }]
@@ -1319,6 +1362,7 @@ describe('dispatchCateInvoke — first-party trust boundary (characterization)',
     // New verbs must fail into the stricter half rather than escaping the matrix.
     expect(cliPermissionForMethod('cate.browser.somethingNew')?.key).toBe('cliBrowserControlEnabled')
     expect(cliPermissionForMethod('cate.panel.somethingNew')?.key).toBe('cliPanelControlEnabled')
+    expect(cliPermissionForMethod('cate.codingAgent.somethingNew')?.key).toBe('cliAgentControlEnabled')
     // Namespaces the matrix doesn't cover stay governed by scopes alone.
     expect(cliPermissionForMethod('cate.storage.get')).toBeUndefined()
     expect(cliPermissionForMethod('cate.version')).toBeUndefined()

--- a/src/main/extensions/cateApiHandlers.ts
+++ b/src/main/extensions/cateApiHandlers.ts
@@ -693,15 +693,12 @@ export function authorizeCateInvoke(
     }
   }
 
-  // Security: direct CLI calls and the embedded supervisor's non-orchestration
-  // calls share the Settings → CLI gates. The supervisor endpoint must stay
-  // alive when the master switch is off so its coding-agent orchestration can
-  // still work, but that privileged endpoint must not become a way around the
-  // user's CLI permissions for browser, terminal, panel, editor, or UI access.
-  // Extensions remain governed by manifest scopes plus capability consent.
-  const isCodingAgentOrchestration = method.startsWith('cate.codingAgent.')
-  const usesCliPermissions = scope.caller === 'first-party'
-    || (scope.caller === 'cate-agent' && !isCodingAgentOrchestration)
+  // Security: direct CLI calls and the embedded supervisor share the same
+  // Settings → CLI gates, including the Agents row. The supervisor endpoint
+  // remains available for session lifecycle, but cannot use host capabilities
+  // while the master switch or relevant cell is off. Extensions remain
+  // governed by manifest scopes plus capability consent.
+  const usesCliPermissions = trustedCaller
   if (usesCliPermissions) {
     if (getSetting('cliEnabled') !== true) {
       return {

--- a/src/main/extensions/cateApiHandlers.ts
+++ b/src/main/extensions/cateApiHandlers.ts
@@ -94,20 +94,22 @@ import type { CodingAgentRunStatus } from '../../shared/codingAgentRuns'
  *  history, JS-dialog policy, cross-origin frame evaluation, viewport
  *  emulation, downloads, clipboard, and full-page/element screenshots.
  *
+ *  v7 adds the recursive coding-agent CLI lifecycle: list/create/send/wait,
+ *  inspect/review/apply/keep/discard/stop.
+ *
  *  v4 added generation-scoped browser refs, native fill/click actions,
  *  conditional waits, and action snapshots. v3 removed browser.list and
  *  editor.active (cate.panel.list is the single PANEL enumeration surface —
  *  browser panels carry `url`, the focused entry answers "what is the user
  *  looking at") and agent.run (compose open -> send -> dispose). */
-const CATE_API_VERSION = 6
+const CATE_API_VERSION = 7
 
 const FORWARD_TIMEOUT_MS = 10_000
 const CODING_AGENT_WAIT_FORWARD_TIMEOUT_MS = 65_000
 
 export function forwardTimeoutMs(method: string): number {
-  return method === 'cate.codingAgent.wait'
-    ? CODING_AGENT_WAIT_FORWARD_TIMEOUT_MS
-    : FORWARD_TIMEOUT_MS
+  if (method === 'cate.codingAgent.wait') return CODING_AGENT_WAIT_FORWARD_TIMEOUT_MS
+  return FORWARD_TIMEOUT_MS
 }
 
 /** Stable errors for CLI permission cells (Settings → CLI) that are off. Each
@@ -253,7 +255,8 @@ function resolvePanelTargetWindow(
 
 /** Resolve a mission worker to the renderer currently hosting its terminal.
  * Window reports carry both the run and supervisor identities, preventing one
- * Cate Agent session from using a guessed run id to reach another mission. */
+ * terminal or embedded-agent session from using a guessed run id to reach
+ * another mission. */
 function resolveCodingAgentTargetWindow(
   runIds: string[],
   ownerPanelId: string,
@@ -490,10 +493,14 @@ export function requiredScopeFor(method: string): string | null | undefined {
     case 'cate.ui.notify':
       return 'ui'
     case 'cate.codingAgent.create':
+    case 'cate.codingAgent.list':
     case 'cate.codingAgent.send':
     case 'cate.codingAgent.wait':
     case 'cate.codingAgent.inspect':
     case 'cate.codingAgent.review':
+    case 'cate.codingAgent.apply':
+    case 'cate.codingAgent.keep':
+    case 'cate.codingAgent.discard':
     case 'cate.codingAgent.stop':
       return 'coding-agent'
     case 'cate.editor.openFile':
@@ -653,11 +660,11 @@ export function authorizeCateInvoke(
     return { error: 'not-enabled', method }
   }
 
-  // Coding-agent orchestration is the embedded supervisor's privileged surface.
-  // Ordinary terminals, extension webviews, and spawned workers never receive
-  // its token, even if they self-declare a matching scope.
-  if (method.startsWith('cate.codingAgent.') && scope.caller !== 'cate-agent') {
-    return { error: 'cate-agent-only', method }
+  // Coding-agent orchestration is available to first-party terminal callers
+  // and the embedded Cate Agent. Third-party extensions cannot opt into it by
+  // self-declaring the scope.
+  if (method.startsWith('cate.codingAgent.') && !trustedCaller) {
+    return { error: 'first-party-only', method }
   }
 
   // The terminal/agent endpoint must never move the user's window, panel focus,
@@ -766,6 +773,30 @@ export async function dispatchCateInvoke(
     const forward = (): Promise<InvokeResult> => target
       ? forwardToOwner(target.wc, payload)
       : scope.forward(payload)
+    if (name === 'list') {
+      const local = await forward()
+      if (local && typeof local === 'object' && 'error' in local) return local
+      const runs = Array.isArray(local) ? [...local] : []
+      const seen = new Set(runs.flatMap((run) => {
+        const id = run && typeof run === 'object' ? (run as Record<string, unknown>).id : undefined
+        return typeof id === 'string' ? [id] : []
+      }))
+      const reports = getWindowPanels().filter((report) =>
+        report.workspaceId === workspaceId &&
+        report.type === 'terminal' &&
+        report.codingAgentOwnerPanelId === (panelId ?? '') &&
+        typeof report.codingAgentRunId === 'string' &&
+        !seen.has(report.codingAgentRunId),
+      )
+      const remote = await inspectCodingAgentReports({
+        reports,
+        extensionId,
+        workspaceId,
+        ownerPanelId: panelId ?? '',
+        originCwd: scope.originCwd,
+      })
+      return [...runs, ...remote]
+    }
     if (name === 'create') {
       const admission = await codingAgentAdmission.admit({
         workspaceId,

--- a/src/main/extensions/cateApiReverse.test.ts
+++ b/src/main/extensions/cateApiReverse.test.ts
@@ -19,7 +19,9 @@ const windowPanels = vi.hoisted(() => [] as Array<{
   panelId: string
   type: string
   workspaceId: string
+  ownerWindowId?: number
 }>)
+const windows = vi.hoisted(() => new Map<number, any>())
 vi.mock('./cateApiHandlers', () => ({
   authorizeCateInvoke,
   dispatchCateInvoke,
@@ -28,6 +30,9 @@ vi.mock('./cateApiHandlers', () => ({
 }))
 vi.mock('../windowPanels', () => ({
   getWindowPanels: () => windowPanels,
+}))
+vi.mock('../windowRegistry', () => ({
+  getWindow: (id: number) => windows.get(id),
 }))
 vi.mock('../logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
 
@@ -101,6 +106,7 @@ function request(
 beforeEach(() => {
   store.clear()
   windowPanels.length = 0
+  windows.clear()
   dispatchCateInvoke.mockReset()
   authorizeCateInvoke.mockReset()
   authorizeCateInvoke.mockReturnValue(null)
@@ -225,6 +231,45 @@ describe('createCateApiReverse — server-side CATE_API endpoint', () => {
       'cate.storage.get',
       { key: 'x' },
     )
+    endpoint.dispose()
+  })
+
+  it('binds first-party orchestration to the calling terminal and cwd', async () => {
+    windowPanels.push({
+      panelId: 'terminal-parent',
+      type: 'terminal',
+      workspaceId: 'ws-1',
+      ownerWindowId: 7,
+    })
+    const owner = { isDestroyed: () => false } as never
+    windows.set(7, { isDestroyed: () => false, webContents: owner })
+    const host = makeRuntime()
+    const endpoint = createCateApiReverse({
+      extensionId: 'terminal',
+      workspaceId: 'ws-1',
+      token: TOKEN,
+      runtime: host.runtime,
+      caller: 'first-party',
+      grantedScopes: ['coding-agent'],
+    })
+
+    await request(endpoint, host.output, {
+      json: {
+        method: 'cate.codingAgent.create',
+        args: { prompt: 'Implement it' },
+        callerPanelId: 'terminal-parent',
+        originCwd: '/ws/worktree',
+      },
+    })
+
+    const scope = dispatchCateInvoke.mock.calls[0][0]
+    expect(scope).toMatchObject({
+      caller: 'first-party',
+      panelId: 'terminal-parent',
+      originCwd: '/ws/worktree',
+    })
+    await scope.forward({ method: 'cate.codingAgent.create' })
+    expect(forwardToOwner).toHaveBeenCalledWith(owner, { method: 'cate.codingAgent.create' })
     endpoint.dispose()
   })
 

--- a/src/main/extensions/cateApiReverse.ts
+++ b/src/main/extensions/cateApiReverse.ts
@@ -20,6 +20,7 @@ import type { WebContents } from 'electron'
 import log from '../logger'
 import type { Runtime } from '../runtime/types'
 import { getWindowPanels } from '../windowPanels'
+import { getWindow } from '../windowRegistry'
 import {
   authorizeCateInvoke,
   dispatchCateInvoke,
@@ -109,7 +110,13 @@ export function createCateApiReverse(session: ReverseSession): CateApiReverseEnd
         return
       }
       const raw = await readBody(req)
-      let parsed: { method?: unknown; args?: unknown; clientId?: unknown }
+      let parsed: {
+        method?: unknown
+        args?: unknown
+        clientId?: unknown
+        callerPanelId?: unknown
+        originCwd?: unknown
+      }
       try { parsed = raw ? JSON.parse(raw) : {} } catch { send(400, { error: 'bad-json' }); return }
       const method = typeof parsed.method === 'string' ? parsed.method : ''
       if (!method) { send(400, { error: 'no-method' }); return }
@@ -120,17 +127,38 @@ export function createCateApiReverse(session: ReverseSession): CateApiReverseEnd
       const args = parsed.args && typeof parsed.args === 'object'
         ? parsed.args as Record<string, unknown>
         : {}
+      const callerPanelId = session.caller === 'first-party' && typeof parsed.callerPanelId === 'string'
+        ? parsed.callerPanelId
+        : undefined
+      const callerPanel = callerPanelId
+        ? getWindowPanels().find((candidate) =>
+            candidate.panelId === callerPanelId &&
+            candidate.workspaceId === session.workspaceId &&
+            candidate.type === 'terminal',
+          )
+        : undefined
+      const callerWindow = callerPanel ? getWindow(callerPanel.ownerWindowId) : undefined
+      const callerWebContents = callerWindow && !callerWindow.isDestroyed()
+        ? callerWindow.webContents
+        : undefined
       const invokeScope = {
         extensionId: session.extensionId,
         workspaceId: session.workspaceId,
-        panelId: session.panelId,
-        forward: session.ownerWebContents && !session.ownerWebContents.isDestroyed()
+        panelId: session.panelId ?? callerPanelId,
+        forward: callerWebContents
+          ? (payload: Parameters<InvokeScope['forward']>[0]) =>
+              forwardToOwner(callerWebContents, payload)
+          : session.ownerWebContents && !session.ownerWebContents.isDestroyed()
           ? (payload: Parameters<InvokeScope['forward']>[0]) =>
               forwardToOwner(session.ownerWebContents!, payload)
           : forwardToActiveWindow,
         caller: session.caller,
         grantedScopes: session.grantedScopes,
-        originCwd: session.originCwd,
+        originCwd: session.originCwd ?? (
+          session.caller === 'first-party' && typeof parsed.originCwd === 'string'
+            ? parsed.originCwd
+            : undefined
+        ),
       } as const
 
       if (session.caller === 'first-party' && method.startsWith('cate.panel.target.')) {

--- a/src/main/extensions/workspaceCateApi.test.ts
+++ b/src/main/extensions/workspaceCateApi.test.ts
@@ -65,13 +65,14 @@ describe('GRANTED_SCOPES contract', () => {
     expect(GRANTED_SCOPES).toContain('browser')
     expect(GRANTED_SCOPES).not.toContain('storage')
     expect(GRANTED_SCOPES).not.toContain('agent')
+    expect(GRANTED_SCOPES).toContain('coding-agent')
     // workspace.read/theme are extension-only: a terminal's cwd IS the
     // workspace root, so the CLI has no verbs (and thus no grants) for them.
-    expect([...GRANTED_SCOPES]).toEqual(['browser', 'ui', 'editor', 'canvas', 'panel', 'terminal'])
+    expect([...GRANTED_SCOPES]).toEqual(['browser', 'ui', 'editor', 'canvas', 'panel', 'terminal', 'coding-agent'])
   })
 
-  it('reserves coding-agent orchestration for the embedded supervisor', () => {
-    expect(GRANTED_SCOPES).not.toContain('coding-agent')
+  it('uses the same coding-agent scope for terminal and embedded callers', () => {
+    expect(GRANTED_SCOPES).toContain('coding-agent')
     expect(CATE_AGENT_GRANTED_SCOPES).toContain('coding-agent')
   })
 })
@@ -106,6 +107,7 @@ describe('WorkspaceCateApiManager.ensureEndpoint', () => {
     const session = reverseCalls[0]
     expect(session.caller).toBe('first-party')
     expect(session.grantedScopes).toContain('browser')
+    expect(session.grantedScopes).toContain('coding-agent')
     expect(session.grantedScopes).not.toContain('storage')
     expect(session.grantedScopes).not.toContain('agent')
     expect(session.token).toBe(ep!.token)

--- a/src/main/extensions/workspaceCateApi.ts
+++ b/src/main/extensions/workspaceCateApi.ts
@@ -23,11 +23,11 @@ export const GRANTED_SCOPES: readonly string[] = [
   'canvas',
   'panel',
   'terminal',
+  'coding-agent',
 ]
 
 export const CATE_AGENT_GRANTED_SCOPES: readonly string[] = [
   ...GRANTED_SCOPES,
-  'coding-agent',
 ]
 
 export interface WorkspaceCateApiEndpoint {
@@ -60,10 +60,9 @@ export class WorkspaceCateApiManager {
     }
   }
 
-  /** A token minted only for the embedded Cate Agent. Unlike the token injected
-   *  into ordinary terminals, it may create and supervise coding agents. The
-   *  endpoint is bound to the originating agent panel/session for worktree
-   *  affinity and cannot be obtained by a spawned worker. */
+  /** Panel-bound endpoint for the embedded Cate Agent. It uses the same public
+   *  scopes as terminal CLI callers while retaining native panel/worktree
+   *  affinity for the direct chat session. */
   async ensureCateAgentEndpoint(
     workspaceId: string,
     panelId: string,

--- a/src/main/settingsFile.test.ts
+++ b/src/main/settingsFile.test.ts
@@ -56,6 +56,8 @@ describe('settingsFile', () => {
     expect(fs.existsSync(settingsPath())).toBe(true)
     const onDisk = JSON.parse(fs.readFileSync(settingsPath(), 'utf-8'))
     expect(onDisk.showMinimap).toBe(DEFAULT_SETTINGS.showMinimap)
+    expect(onDisk.cliAgentReadEnabled).toBe(true)
+    expect(onDisk.cliAgentControlEnabled).toBe(true)
     expect(m.getSetting('showMinimap')).toBe(DEFAULT_SETTINGS.showMinimap)
   })
 

--- a/src/main/settingsFile.ts
+++ b/src/main/settingsFile.ts
@@ -70,6 +70,8 @@ const SETTINGS_SCHEMA: Record<keyof AppSettings, string> = {
   cliEditorReadEnabled: 'boolean',
   cliEditorControlEnabled: 'boolean',
   cliNotifyEnabled: 'boolean',
+  cliAgentReadEnabled: 'boolean',
+  cliAgentControlEnabled: 'boolean',
   browserHomepage: 'string',
   browserSearchEngine: 'string',
   browserProxyUrl: 'string',

--- a/src/renderer/lib/agent/codingAgentDriver.test.ts
+++ b/src/renderer/lib/agent/codingAgentDriver.test.ts
@@ -18,6 +18,9 @@ const terminate = vi.hoisted(() => vi.fn())
 const createWorktreeForWorkspace = vi.hoisted(() => vi.fn())
 const discardCreatedWorktreeForWorkspace = vi.hoisted(() => vi.fn())
 const reviewCodingAgentWorktree = vi.hoisted(() => vi.fn())
+const applyCodingAgentWorktree = vi.hoisted(() => vi.fn())
+const keepCodingAgentWorktree = vi.hoisted(() => vi.fn())
+const discardCodingAgentWorktree = vi.hoisted(() => vi.fn())
 
 vi.mock('../../stores/appStore', () => ({
   useAppStore: {
@@ -67,7 +70,12 @@ vi.mock('../../stores/useWorktreeActions', () => ({
   discardCreatedWorktreeForWorkspace,
 }))
 vi.mock('./agentCliHooks', () => ({ resolveDriverAgentCli }))
-vi.mock('./codingAgentIntegration', () => ({ reviewCodingAgentWorktree }))
+vi.mock('./codingAgentIntegration', () => ({
+  reviewCodingAgentWorktree,
+  applyCodingAgentWorktree,
+  keepCodingAgentWorktree,
+  discardCodingAgentWorktree,
+}))
 
 import { AGENTS } from '../../../shared/agents'
 import { codingAgentSnapshot, handleCodingAgentMethod } from './codingAgentDriver'
@@ -143,6 +151,9 @@ describe('codingAgentDriver mission integration', () => {
     discardCreatedWorktreeForWorkspace.mockReset()
     discardCreatedWorktreeForWorkspace.mockResolvedValue(undefined)
     reviewCodingAgentWorktree.mockReset()
+    applyCodingAgentWorktree.mockReset()
+    keepCodingAgentWorktree.mockReset()
+    discardCodingAgentWorktree.mockReset()
   })
 
   it('automatically selects a hook-ready canonical agent and starts its PTY headlessly', async () => {
@@ -216,6 +227,31 @@ describe('codingAgentDriver mission integration', () => {
       result: { background: false },
     })
     expect(state.app.workspaces[0].panels.worker.codingAgentRun.background).toBe(false)
+  })
+
+  it('lists runs owned by the calling terminal for recovery and short-id resolution', async () => {
+    await handleCodingAgentMethod(
+      'ws',
+      'supervisor-1',
+      'cate.codingAgent.create',
+      { title: 'API', prompt: 'Implement it' },
+    )
+
+    await expect(handleCodingAgentMethod(
+      'ws',
+      'supervisor-1',
+      'cate.codingAgent.list',
+      {},
+    )).resolves.toMatchObject({
+      ok: true,
+      result: [expect.objectContaining({ title: 'API', panelId: 'worker' })],
+    })
+    await expect(handleCodingAgentMethod(
+      'ws',
+      'different-supervisor',
+      'cate.codingAgent.list',
+      {},
+    )).resolves.toEqual({ ok: true, result: [] })
   })
 
   it('rejects a non-ready explicit agent before creating a terminal', async () => {
@@ -509,6 +545,86 @@ describe('codingAgentDriver mission integration', () => {
       result: { id: 'run-1', review: { canApply: true } },
     })
     expect(reviewCodingAgentWorktree).toHaveBeenCalledWith('ws', 'worker')
+  })
+
+  it('applies, keeps, and discards an owned isolated worker without a UI card', async () => {
+    state.app.workspaces[0].panels.worker = {
+      id: 'worker',
+      type: 'terminal',
+      worktreeId: 'wt-1',
+      codingAgentRun: {
+        id: 'run-1',
+        agentId: 'codex',
+        panelId: 'worker',
+        ownerPanelId: 'supervisor-1',
+        prompt: 'Implement it',
+        worktreeId: 'wt-1',
+        ownsWorktree: true,
+        createdAt: 1,
+        endedAt: 2,
+        exitCode: 0,
+      },
+    }
+    reviewCodingAgentWorktree.mockResolvedValue({
+      branch: 'agent/api', baseBranch: 'main', canApply: true, commits: [], files: [],
+    })
+    applyCodingAgentWorktree.mockResolvedValue({ ok: true, branch: 'main' })
+    discardCodingAgentWorktree.mockResolvedValue(undefined)
+
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.apply', { runId: 'run-1' },
+    )).resolves.toMatchObject({ ok: true, result: { id: 'run-1' } })
+    expect(applyCodingAgentWorktree).toHaveBeenCalledWith('ws', 'worker', 'main')
+
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.keep', { runId: 'run-1' },
+    )).resolves.toMatchObject({ ok: true, result: { id: 'run-1' } })
+    expect(keepCodingAgentWorktree).toHaveBeenCalledWith('ws', 'worker')
+
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.discard', { runId: 'run-1' },
+    )).resolves.toMatchObject({ ok: true, result: { id: 'run-1' } })
+    expect(discardCodingAgentWorktree).toHaveBeenCalledWith('ws', 'worker')
+  })
+
+  it('does not integrate active workers or discard worktrees the worker does not own', async () => {
+    state.app.workspaces[0].panels.worker = {
+      id: 'worker',
+      type: 'terminal',
+      worktreeId: 'wt-1',
+      codingAgentRun: {
+        id: 'run-1',
+        agentId: 'codex',
+        panelId: 'worker',
+        ownerPanelId: 'supervisor-1',
+        prompt: 'Implement it',
+        worktreeId: 'wt-1',
+        ownsWorktree: false,
+        createdAt: 1,
+      },
+    }
+
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.apply', { runId: 'run-1' },
+    )).resolves.toEqual({ ok: false, error: 'coding-agent-not-ready' })
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.keep', { runId: 'run-1' },
+    )).resolves.toEqual({ ok: false, error: 'coding-agent-not-ready' })
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.discard', { runId: 'run-1' },
+    )).resolves.toEqual({ ok: false, error: 'worker-does-not-own-worktree' })
+
+    state.app.workspaces[0].panels.worker.codingAgentRun = {
+      ...state.app.workspaces[0].panels.worker.codingAgentRun,
+      endedAt: 2,
+      exitCode: 0,
+    }
+    await expect(handleCodingAgentMethod(
+      'ws', 'supervisor-1', 'cate.codingAgent.discard', { runId: 'run-1' },
+    )).resolves.toEqual({ ok: false, error: 'worker-does-not-own-worktree' })
+    expect(applyCodingAgentWorktree).not.toHaveBeenCalled()
+    expect(keepCodingAgentWorktree).not.toHaveBeenCalled()
+    expect(discardCodingAgentWorktree).not.toHaveBeenCalled()
   })
 
   it('enforces follow-up capability and terminal readiness', async () => {

--- a/src/renderer/lib/agent/codingAgentDriver.ts
+++ b/src/renderer/lib/agent/codingAgentDriver.ts
@@ -22,7 +22,12 @@ import {
   type CodingAgentRunStatus,
 } from '../../../shared/codingAgentRuns'
 import { resolveDriverAgentCli } from './agentCliHooks'
-import { reviewCodingAgentWorktree } from './codingAgentIntegration'
+import {
+  applyCodingAgentWorktree,
+  discardCodingAgentWorktree,
+  keepCodingAgentWorktree,
+  reviewCodingAgentWorktree,
+} from './codingAgentIntegration'
 import type { AgentId } from '../../../shared/agents'
 import {
   actionableCodingAgentRunIds,
@@ -467,6 +472,13 @@ export async function handleCodingAgentMethod(
     }
   }
 
+  if (name === 'list') {
+    return {
+      ok: true,
+      result: allSnapshots(workspaceId, ownerPanelId).map(compactCodingAgentSnapshot),
+    }
+  }
+
   const runId = typeof args.runId === 'string' ? args.runId : ''
   if (name !== 'wait' && !runId) return { ok: false, error: 'runId-required' }
 
@@ -496,6 +508,79 @@ export async function handleCodingAgentMethod(
       return {
         ok: false,
         error: error instanceof Error ? `review-failed: ${error.message}` : 'review-failed',
+      }
+    }
+  }
+
+  if (name === 'apply') {
+    const snapshot = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+    if (!snapshot) return { ok: false, error: 'coding-agent-not-found' }
+    if (!snapshot.worktreeId) return { ok: false, error: 'coding-agent-not-isolated' }
+    if (snapshot.status !== 'ready') return { ok: false, error: 'coding-agent-not-ready' }
+    if (snapshot.appliedToBranch) return { ok: false, error: 'coding-agent-already-applied' }
+    try {
+      const review = await reviewCodingAgentWorktree(workspaceId, snapshot.panelId)
+      if (!review.canApply) {
+        return { ok: false, error: review.message ?? 'coding-agent-not-ready-to-apply' }
+      }
+      const applied = await applyCodingAgentWorktree(
+        workspaceId,
+        snapshot.panelId,
+        review.baseBranch,
+      )
+      if (!applied.ok) return { ok: false, error: applied.message }
+      const current = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+      return {
+        ok: true,
+        result: current
+          ? compactCodingAgentSnapshot(current)
+          : { id: runId, appliedToBranch: applied.branch },
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? `apply-failed: ${error.message}` : 'apply-failed',
+      }
+    }
+  }
+
+  if (name === 'keep') {
+    const snapshot = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+    if (!snapshot) return { ok: false, error: 'coding-agent-not-found' }
+    if (!snapshot.worktreeId) return { ok: false, error: 'coding-agent-not-isolated' }
+    if (snapshot.status !== 'ready') return { ok: false, error: 'coding-agent-not-ready' }
+    try {
+      keepCodingAgentWorktree(workspaceId, snapshot.panelId)
+      const current = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+      return {
+        ok: true,
+        result: current ? compactCodingAgentSnapshot(current) : { id: runId, kept: true },
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? `keep-failed: ${error.message}` : 'keep-failed',
+      }
+    }
+  }
+
+  if (name === 'discard') {
+    const snapshot = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+    if (!snapshot) return { ok: false, error: 'coding-agent-not-found' }
+    if (!snapshot.worktreeId) return { ok: false, error: 'coding-agent-not-isolated' }
+    if (!snapshot.ownsWorktree) return { ok: false, error: 'worker-does-not-own-worktree' }
+    if (snapshot.status !== 'ready') return { ok: false, error: 'coding-agent-not-ready' }
+    try {
+      await discardCodingAgentWorktree(workspaceId, snapshot.panelId)
+      const current = codingAgentSnapshot(workspaceId, ownerPanelId, runId)
+      return {
+        ok: true,
+        result: current ? compactCodingAgentSnapshot(current) : { id: runId, discarded: true },
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? `discard-failed: ${error.message}` : 'discard-failed',
       }
     }
   }

--- a/src/renderer/settings/CliSettings.tsx
+++ b/src/renderer/settings/CliSettings.tsx
@@ -89,7 +89,7 @@ export function CliSettings() {
         />
       </SettingRow>
 
-      <SearchableBlock keywords="cli permissions browser terminal panels editor notifications read control screenshot snapshot click type keystrokes create focus close notify">
+      <SearchableBlock keywords="cli permissions browser terminal panels editor notifications agents orchestration workers read control screenshot snapshot click type keystrokes create focus close notify apply keep discard">
         <div className={`py-3 border-b border-subtle ${off ? 'opacity-50' : ''}`}>
           <div className="mb-2">
             <span className="text-sm text-primary">Permissions</span>

--- a/src/shared/cliPermissions.ts
+++ b/src/shared/cliPermissions.ts
@@ -30,6 +30,8 @@ export type CliPermissionKey = Extract<
   | 'cliEditorReadEnabled'
   | 'cliEditorControlEnabled'
   | 'cliNotifyEnabled'
+  | 'cliAgentReadEnabled'
+  | 'cliAgentControlEnabled'
 >
 
 export interface CliPermissionCell {
@@ -151,6 +153,30 @@ export const CLI_PERMISSIONS: CliPermissionSurface[] = [
       access: 'Control',
       code: 'notify-disabled',
       detail: '`cate notify <message>` — post a desktop notification from a terminal.',
+    },
+  },
+  {
+    label: 'Agents',
+    prefixes: ['cate.codingAgent.'],
+    readMethods: [
+      'cate.codingAgent.list',
+      'cate.codingAgent.wait',
+      'cate.codingAgent.inspect',
+      'cate.codingAgent.review',
+    ],
+    read: {
+      key: 'cliAgentReadEnabled',
+      access: 'Read',
+      code: 'agent-read-disabled',
+      detail:
+        '`cate agent list / wait / inspect / review` — observe workers, their terminal output, and isolated worktree changes.',
+    },
+    control: {
+      key: 'cliAgentControlEnabled',
+      access: 'Control',
+      code: 'agent-control-disabled',
+      detail:
+        '`cate agent create / send / apply / keep / discard / stop` — run and steer workers or integrate and remove their worktrees.',
     },
   },
 ]

--- a/src/shared/codingAgentRuns.ts
+++ b/src/shared/codingAgentRuns.ts
@@ -7,7 +7,7 @@ export interface CodingAgentRun {
   panelId: string
   /** Short user-facing responsibility, e.g. “Integration tests”. */
   title?: string
-  /** Cate Agent panel/session that owns and may control this run. */
+  /** Cate terminal or embedded-agent panel that owns and may control this run. */
   ownerPanelId: string
   prompt: string
   createdAt: number

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1333,6 +1333,12 @@ export interface AppSettings {
   cliEditorControlEnabled: boolean
   /** `cate notify` — post a desktop notification. On by default. */
   cliNotifyEnabled: boolean
+  /** Read half of `cate agent *` — list, wait for, inspect, and review workers.
+   *  On by default. */
+  cliAgentReadEnabled: boolean
+  /** Control half of `cate agent *` — create, prompt, apply, keep, discard, and
+   *  stop workers. On by default. */
+  cliAgentControlEnabled: boolean
 
   // Browser
   browserHomepage: string
@@ -1467,6 +1473,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   cliEditorReadEnabled: true,
   cliEditorControlEnabled: true,
   cliNotifyEnabled: true,
+  cliAgentReadEnabled: true,
+  cliAgentControlEnabled: true,
 
   // Browser
   browserHomepage: '',


### PR DESCRIPTION
## Summary

- expose Cate coding-agent orchestration through the existing `cate agent` CLI
- support recursive workers with per-terminal ownership, cwd/worktree inheritance, short run IDs, and cross-window routing
- add the complete lifecycle: list, create, send, wait, inspect, review, apply, keep, discard, and stop
- add Agents Read/Control permissions to Settings → CLI and enforce them for terminal and Cate Agent orchestration
- convert Cate Agent orchestration mode into a prompt/status mode that uses the same public CLI instead of private Pi tools
- update both bundled `cate-cli` skill copies with delegation, agent-to-agent communication, review, and integration guidance

## Why

Agent orchestration was implemented as a privileged Cate Agent-only extension even though the underlying workers are ordinary Cate terminal panels. This made the feature unavailable to users working directly in Codex or another terminal agent and duplicated the interaction surface.

The CLI is now the shared orchestration contract. Cate Agent and terminal-based agents create and supervise the same visible workers, and workers may recursively create their own children.

## Behavior

- `cate agent create` launches a visible Cate-managed terminal worker.
- `--worktree` reuses a registered worktree; `--new-worktree` creates one through Cate's existing worktree path.
- `apply`, `keep`, and `discard` use the same integration implementation as the historical Cate Agent worker card.
- Apply requires a completed, clean, mergeable isolated worker.
- Discard only removes worktrees created and owned by that worker and does not show an interactive confirmation.
- The Agents Read and Control permissions default on, preserving the existing orchestration availability; the CLI master switch applies to both terminal and Cate Agent callers.
- Third-party extensions remain unable to invoke coding-agent orchestration.

## Validation

- 194 focused tests passed
- `npm run typecheck`
- `npm run build`
- ESLint on changed TypeScript files
- `git diff --check`
