### PR TITLE
Release 1.6.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.6.1-beta.1] - 2026-08-13
+
+This beta opens Cate's coding-agent orchestration to terminal-based agents, improves agent follow-ups, and hardens Windows workspace paths.
+
+### Added
+
+- **Recursive agent orchestration through Cate CLI**: terminal agents can create, inspect, message, wait for, review, apply, keep, discard, and stop visible coding-agent workers, including nested workers and isolated worktrees.
+- **Agent CLI permissions**: Settings now exposes separate read and control permissions for coding-agent orchestration.
+
+### Changed
+
+- **Shared orchestration contract**: Cate Agent now uses the public Cate CLI workflow instead of a private orchestration tool, so built-in and terminal-based agents manage the same workers.
+- **OpenCode follow-ups**: running OpenCode workers can receive additional instructions through the shared agent workflow.
+- **Updated skills and document support**: refreshed the bundled skills index and updated PDF and YAML dependencies.
+
+### Fixed
+
+- **Windows network-drive workspaces**: mapped and UNC paths are normalized and validated consistently when opening workspaces and saving sessions.
+
 ## [1.6.0] - 2026-08-07
 
 Cate 1.6 brings agent mission orchestration, native browser automation, safer remote workspaces, and a more reliable terminal and agent experience.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.0",
+      "version": "1.6.1-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.0'
+export const RUNTIME_VERSION = '1.6.1-beta.1'


### PR DESCRIPTION
## Summary

- document the complete 1.6.1 beta changes before the version bump
- bump app, lockfile, and runtime metadata to 1.6.1-beta.1

## Validation

- npm test (3,052 passed, 5 skipped)
- npm run typecheck
- npm run build
- git diff --check