### PR TITLE
Release 1.6.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.6.1-beta.2] - 2026-08-19
+
+This beta makes browser panels faster and more reliable across canvas, focus, and workspace changes.
+
+### Changed
+
+- **Persistent webview rendering**: browser panels now use connected Electron webviews instead of native browser views, preserving page state while panels move between active and background workspaces.
+
+### Fixed
+
+- **Background browser automation**: browser commands keep working while a panel is unfocused or its workspace is inactive, with faster and more reliable target binding.
+- **Browser sizing and overlays**: browser surfaces track panel resize, canvas pan, and zoom correctly so content and automation overlays stay aligned.
+- **Workspace state retention**: switching away and back no longer reloads browser pages or clears live form state.
+
 ## [1.6.1-beta.1] - 2026-08-13
 
 This beta opens Cate's coding-agent orchestration to terminal-based agents, improves agent follow-ups, and hardens Windows workspace paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.1",
+  "version": "1.6.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.1-beta.1",
+      "version": "1.6.1-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.1",
+  "version": "1.6.1-beta.2",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.1-beta.1'
+export const RUNTIME_VERSION = '1.6.1-beta.2'


### PR DESCRIPTION
## Summary

- bump Cate and its bundled runtime to `1.6.1-beta.2`
- add the dated beta 2 changelog entry
- document the persistent webview migration, background automation reliability, sizing/overlay alignment, and workspace state retention

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- --run src/shared/changelog.test.ts`: 2 passed
- full Vitest run: 2,990 passed and 30 skipped; 38 sandbox-only localhost/file-watcher tests failed because the restricted environment cannot bind `127.0.0.1` or receive native watcher events
- version consistency check across `package.json`, `package-lock.json`, and `src/runtime/version.ts`
- `git diff --check`
