### PR TITLE
Fix opening remote files from untitled editors

### DIFF
--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useRef, useCallback, useState } from 'react'
 import type { ReactNode } from 'react'
-import { Check, Copy } from '@phosphor-icons/react'
+import { Check, Copy, FolderOpen } from '@phosphor-icons/react'
 import { useRenderCount } from '../lib/perf/perfClient'
 import log from '../lib/logger'
 import * as monaco from 'monaco-editor'
@@ -39,6 +39,7 @@ import { useFileSync } from '../lib/editor/useFileSync'
 import EditorConflictBanner from './EditorConflictBanner'
 import { Tooltip } from '../ui/Tooltip'
 import { isRuntimeLocator } from '../../shared/runtimeLocator'
+import { useUIStore } from '../stores/uiStore'
 
 // -----------------------------------------------------------------------------
 // Editor font
@@ -338,6 +339,8 @@ export default function EditorPanel({
   }, [isFocused, markdownPreview])
   const rootPath = ws?.rootPath
   const isMarkdown = !!filePath && /\.mdx?$/i.test(filePath)
+  const isDirty = !!ws?.panels[panelId]?.isDirty
+  const openFilePalette = useUIStore((s) => s.openFilePalette)
 
   const markdownPreviewRef = useRef(markdownPreview)
   markdownPreviewRef.current = markdownPreview
@@ -797,6 +800,16 @@ export default function EditorPanel({
           </div>
         )}
         <div ref={containerRef} className={`w-full h-full ${(markdownPreview && isMarkdown) || loadError ? 'hidden' : ''}`} />
+        {!filePath && !diffMode && !isDirty && (
+          <button
+            onClick={() => openFilePalette(panelId)}
+            className="absolute top-2 right-3 z-40 flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium bg-surface-3 text-secondary shadow-sm hover:bg-surface-4 hover:text-primary transition-colors"
+            title="Open an existing workspace file"
+          >
+            <FolderOpen size={13} />
+            Open File…
+          </button>
+        )}
         {/* Source/Preview toggle — floats over the content's top-right instead
             of taking a header row. right-3 (12px) clears Monaco's 8px vertical
             scrollbar lane; z-40 keeps it above the diff (z-30) and load-error

--- a/src/renderer/stores/uiStore.ts
+++ b/src/renderer/stores/uiStore.ts
@@ -42,6 +42,8 @@ export function getSidebarLayout(): SidebarLayout {
 
 interface UIStoreState {
   showCommandPalette: boolean
+  /** Untitled editor to reuse when the palette was opened as an Open File picker. */
+  openFileTargetPanelId: string | null
   showLayoutsDialog: boolean
   showSkillsDialog: boolean
   /** Bumped whenever a saved layout is created/deleted, so open surfaces
@@ -83,6 +85,7 @@ interface UIStoreState {
 
 interface UIStoreActions {
   setShowCommandPalette: (show: boolean) => void
+  openFilePalette: (targetPanelId: string) => void
   setShowLayoutsDialog: (show: boolean) => void
   setShowSkillsDialog: (show: boolean) => void
   bumpLayoutsVersion: () => void
@@ -125,6 +128,7 @@ export type UIStore = UIStoreState & UIStoreActions
 export const useUIStore = create<UIStore>((set, get) => ({
   // --- State ---
   showCommandPalette: false,
+  openFileTargetPanelId: null,
   showLayoutsDialog: false,
   showSkillsDialog: false,
   layoutsVersion: 0,
@@ -144,7 +148,11 @@ export const useUIStore = create<UIStore>((set, get) => ({
   // --- Actions ---
 
   setShowCommandPalette(show) {
-    set({ showCommandPalette: show })
+    set({ showCommandPalette: show, ...(!show ? { openFileTargetPanelId: null } : {}) })
+  },
+
+  openFilePalette(targetPanelId) {
+    set({ showCommandPalette: true, openFileTargetPanelId: targetPanelId })
   },
 
   setShowLayoutsDialog(show) {

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -45,7 +45,7 @@ import { runAction } from '../lib/runAction'
 import { useWorkspacePanelTree } from '../lib/workspace/useWorkspacePanelTree'
 import { revealPanel } from '../lib/workspace/panelReveal'
 import { openFileAsPanel } from '../lib/fs/fileRouting'
-import { getRecentFiles } from '../lib/fs/recentFiles'
+import { getRecentFiles, recordRecentFile } from '../lib/fs/recentFiles'
 import { pathDisplayName, relativeDisplayPath } from '../lib/fs/displayPath'
 
 // -----------------------------------------------------------------------------
@@ -125,6 +125,7 @@ type FlatItem =
 
 export const CommandPalette: React.FC = () => {
   const showCommandPalette = useUIStore((s) => s.showCommandPalette)
+  const openFileTargetPanelId = useUIStore((s) => s.openFileTargetPanelId)
   const setShowCommandPalette = useUIStore((s) => s.setShowCommandPalette)
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
   const workspaces = useAppStore((s) => s.workspaces)
@@ -333,12 +334,15 @@ export const CommandPalette: React.FC = () => {
   const displayedFiles = query ? fileResults : recentFileResults
 
   // Flat list of every navigable item, in render order. Drives keyboard nav.
+  const visibleCommands = openFileTargetPanelId ? [] : filteredCommands
+  const visibleWorkspaces = openFileTargetPanelId ? [] : filteredWorkspaces
+  const visiblePanels = openFileTargetPanelId ? [] : filteredPanels
   const flatItems = useMemo<FlatItem[]>(() => [
-    ...filteredCommands.map((command) => ({ kind: 'command', command }) as FlatItem),
-    ...filteredWorkspaces.map((workspace) => ({ kind: 'workspace', workspace }) as FlatItem),
-    ...filteredPanels.map((panel) => ({ kind: 'panel', panel }) as FlatItem),
+    ...(openFileTargetPanelId ? [] : filteredCommands.map((command) => ({ kind: 'command', command }) as FlatItem)),
+    ...(openFileTargetPanelId ? [] : filteredWorkspaces.map((workspace) => ({ kind: 'workspace', workspace }) as FlatItem)),
+    ...(openFileTargetPanelId ? [] : filteredPanels.map((panel) => ({ kind: 'panel', panel }) as FlatItem)),
     ...displayedFiles.map((file) => ({ kind: 'file', file }) as FlatItem),
-  ], [filteredCommands, filteredWorkspaces, filteredPanels, displayedFiles])
+  ], [openFileTargetPanelId, filteredCommands, filteredWorkspaces, filteredPanels, displayedFiles])
 
   const totalItems = flatItems.length
 
@@ -378,6 +382,13 @@ export const CommandPalette: React.FC = () => {
       const ws = appStore.workspaces.find((w) => w.id === wsId)
       let panelId: string | undefined
       if (ws) {
+        const target = openFileTargetPanelId ? ws.panels[openFileTargetPanelId] : undefined
+        if (target?.type === 'editor' && !target.filePath && !target.isDirty) {
+          appStore.updatePanelFilePath(wsId, target.id, file.path)
+          appStore.updatePanelTitle(wsId, target.id, pathDisplayName(file.path) || 'Untitled')
+          recordRecentFile(wsId, file.path)
+          return
+        }
         const existing = Object.values(ws.panels).find(
           (p) => (p.type === 'editor' || p.type === 'document') && p.filePath === file.path,
         )
@@ -389,7 +400,7 @@ export const CommandPalette: React.FC = () => {
       const nodeId = panelId ? cs.nodeForPanel(panelId) : null
       if (nodeId) cs.focusAndCenter(nodeId)
     },
-    [canvasApi],
+    [canvasApi, openFileTargetPanelId],
   )
 
   const activate = useCallback(
@@ -419,9 +430,9 @@ export const CommandPalette: React.FC = () => {
   if (!showCommandPalette) return null
 
   // Section boundaries within the flat list.
-  const workspaceStart = filteredCommands.length
-  const panelStart = workspaceStart + filteredWorkspaces.length
-  const fileStart = panelStart + filteredPanels.length
+  const workspaceStart = visibleCommands.length
+  const panelStart = workspaceStart + visibleWorkspaces.length
+  const fileStart = panelStart + visiblePanels.length
   const filesLabel = query ? 'Files' : 'Recent Files'
 
   return (
@@ -462,7 +473,7 @@ export const CommandPalette: React.FC = () => {
                     break
                 }
               }}
-              placeholder="Search commands, workspaces, panels and files"
+              placeholder={openFileTargetPanelId ? 'Search workspace files' : 'Search commands, workspaces, panels and files'}
               className="flex-1 bg-transparent text-primary text-[13px] outline-none placeholder:text-muted"
             />
           </div>
@@ -477,10 +488,10 @@ export const CommandPalette: React.FC = () => {
           ) : (
             <>
               {/* Commands */}
-              {filteredCommands.length > 0 && (
+              {visibleCommands.length > 0 && (
                 <>
                   <SectionHeader>Commands</SectionHeader>
-                  {filteredCommands.map((cmd, i) => {
+                  {visibleCommands.map((cmd, i) => {
                     const isSelected = i === selectedIndex
                     return (
                       <Row
@@ -499,11 +510,11 @@ export const CommandPalette: React.FC = () => {
               )}
 
               {/* Workspaces */}
-              {filteredWorkspaces.length > 0 && (
+              {visibleWorkspaces.length > 0 && (
                 <>
-                  {filteredCommands.length > 0 && <Separator />}
+                  {visibleCommands.length > 0 && <Separator />}
                   <SectionHeader>Workspaces</SectionHeader>
-                  {filteredWorkspaces.map((workspace, i) => {
+                  {visibleWorkspaces.map((workspace, i) => {
                     const itemIndex = workspaceStart + i
                     const isSelected = itemIndex === selectedIndex
                     return (
@@ -532,11 +543,11 @@ export const CommandPalette: React.FC = () => {
               )}
 
               {/* Panels */}
-              {filteredPanels.length > 0 && (
+              {visiblePanels.length > 0 && (
                 <>
-                  {(filteredCommands.length > 0 || filteredWorkspaces.length > 0) && <Separator />}
+                  {(visibleCommands.length > 0 || visibleWorkspaces.length > 0) && <Separator />}
                   <SectionHeader>Panels</SectionHeader>
-                  {filteredPanels.map((panel, i) => {
+                  {visiblePanels.map((panel, i) => {
                     const itemIndex = panelStart + i
                     const isSelected = itemIndex === selectedIndex
                     return (
@@ -559,7 +570,7 @@ export const CommandPalette: React.FC = () => {
               {/* Files */}
               {displayedFiles.length > 0 && (
                 <>
-                  {(filteredCommands.length > 0 || filteredWorkspaces.length > 0 || filteredPanels.length > 0) && <Separator />}
+                  {(visibleCommands.length > 0 || visibleWorkspaces.length > 0 || visiblePanels.length > 0) && <Separator />}
                   <SectionHeader>{filesLabel}</SectionHeader>
                   {displayedFiles.map((file, i) => {
                     const itemIndex = fileStart + i

--- a/src/renderer/ui/CommandPalette.windowPanels.test.tsx
+++ b/src/renderer/ui/CommandPalette.windowPanels.test.tsx
@@ -25,6 +25,7 @@ import { WindowTypeContext } from '../stores/WindowTypeContext'
 import { useUIStore } from '../stores/uiStore'
 import { useAppStore } from '../stores/appStore'
 import { useWindowPanelStore } from '../stores/windowPanelStore'
+import { recordRecentFile } from '../lib/fs/recentFiles'
 import type { CateWindowType, WindowPanelInfo } from '../../shared/types'
 
 let host: HTMLDivElement
@@ -85,6 +86,37 @@ function rowWithText(text: string): HTMLElement | undefined {
 }
 
 describe('CommandPalette in the main window', () => {
+  it('opens a remote workspace file in the untitled editor that launched the picker', () => {
+    const filePath = 'cate-runtime://ssh_devbox/home/dev/project/src/main.ts'
+    useAppStore.setState({
+      workspaces: [{
+        id: 'ws-A',
+        name: 'Remote project',
+        color: '',
+        rootPath: 'cate-runtime://ssh_devbox/home/dev/project',
+        panels: {
+          'editor-1': { id: 'editor-1', type: 'editor', title: 'Untitled', isDirty: false },
+        },
+      } as never],
+      selectedWorkspaceId: 'ws-A',
+    })
+    recordRecentFile('ws-A', filePath)
+    useUIStore.getState().openFilePalette('editor-1')
+
+    renderPalette('main')
+
+    expect(host.querySelector('input')?.placeholder).toBe('Search workspace files')
+    expect(host.textContent).not.toContain('New Terminal')
+    const row = rowWithText('main.ts')
+    expect(row).toBeTruthy()
+    act(() => { row!.click() })
+
+    const panel = useAppStore.getState().workspaces[0].panels['editor-1']
+    expect(panel.filePath).toBe(filePath)
+    expect(panel.title).toBe('main.ts')
+    expect(useUIStore.getState().showCommandPalette).toBe(false)
+  })
+
   it('lists workspaces and switches to the selected one', () => {
     useAppStore.setState({
       workspaces: [


### PR DESCRIPTION
Closes #577

## What changed

- Added an **Open File…** affordance to clean, untitled editor panels.
- Reused the workspace command palette in a file-only mode, so local and `cate-runtime://` workspace search follow the same filesystem path.
- Reused the untitled editor for the selected file instead of creating a duplicate panel.

## Root cause

The editor creation flow always produced a new untitled buffer and exposed no action for choosing an existing path. Remote file loading itself already worked, but it was only reachable through the explorer/command palette rather than from the editor the user had just created.

## Impact

Users can now open an existing local or remote workspace file directly from a new editor without losing a dirty buffer or creating an extra editor.

## Checks

- Full Vitest suite: 352 files / 3,009 tests passed (50 skipped)
- `npm test -- --run src/renderer/ui/CommandPalette.windowPanels.test.tsx` (6 passed)
- `npm run typecheck`
- `npm run lint` (0 errors; existing repository warnings only)
- `npm run build`
