### PR TITLE
Stop browser tabs advertising WebDriver automation

### DIFF
--- a/src/main/browser/agentBrowser.test.ts
+++ b/src/main/browser/agentBrowser.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   app: {
-    commandLine: { hasSwitch: vi.fn(() => false), appendSwitch: vi.fn() },
+    commandLine: { hasSwitch: vi.fn(() => false), getSwitchValue: vi.fn(() => ''), appendSwitch: vi.fn() },
     getPath: vi.fn(() => '/tmp/cate-agent-browser-test'),
   },
 }))
 
-import { AgentBrowserService } from './agentBrowser'
+import { app } from 'electron'
+import { AgentBrowserService, enableAgentBrowserBackend } from './agentBrowser'
 
 function fakeContents() {
   let marker = ''
@@ -46,6 +47,22 @@ function fakeContents() {
 
 describe('AgentBrowserService', () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it('connects automation through an explicit debugging port', async () => {
+    const guest = fakeContents()
+    const runner = vi.fn(async (args: string[]) => {
+      if (args[0] === 'tab' && args.length === 1) return { tabs: [{ tabId: 't1', type: 'webview' }] }
+      if (args[0] === 'eval') return { result: guest.marker() }
+      return {}
+    })
+
+    enableAgentBrowserBackend(54_321)
+    const service = new AgentBrowserService({ runner })
+    await service.register(guest.contents, 'panel-1', 'tab-1')
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('remote-debugging-port', '54321')
+    expect(runner).toHaveBeenCalledWith(['connect', '54321'])
+  })
 
   it('marks the exact guest in its CDP page world', async () => {
     const guest = fakeContents()

--- a/src/main/browser/agentBrowser.ts
+++ b/src/main/browser/agentBrowser.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process'
-import { randomUUID } from 'crypto'
+import { randomInt, randomUUID } from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import { app, type WebContents } from 'electron'
@@ -20,9 +20,12 @@ const MAX_OUTPUT_BYTES = 16 * 1024 * 1024
 const SESSION = 'cate'
 const NAMESPACE = 'cate'
 const AUTOFILL_USERNAME_MARKER = 'data-cate-autofill-username-target'
+const EPHEMERAL_PORT_MIN = 49_152
+const EPHEMERAL_PORT_MAX_EXCLUSIVE = 65_536
 type Runner = (args: string[]) => Promise<unknown>
 
 let runtimeSocketDir: string | null = null
+let configuredDevToolsPort: string | null = null
 
 interface RegisteredTarget {
   contents: WebContents
@@ -54,11 +57,20 @@ export interface AgentBrowserResult {
 
 type BrowserArgs = Record<string, unknown>
 
-/** Enable Chromium's loopback CDP endpoint before Electron becomes ready. */
-export function enableAgentBrowserBackend(): void {
-  if (!app.commandLine.hasSwitch('remote-debugging-port')) {
-    app.commandLine.appendSwitch('remote-debugging-port', '0')
+/** Enable Chromium's loopback CDP endpoint before Electron becomes ready.
+ * Chromium's special port `0` also enables AutomationControlled and exposes
+ * `navigator.webdriver` to every browser guest. An explicit port keeps the CDP
+ * bridge available without changing the identity of normal browsing pages. */
+export function enableAgentBrowserBackend(
+  port = randomInt(EPHEMERAL_PORT_MIN, EPHEMERAL_PORT_MAX_EXCLUSIVE),
+): void {
+  if (app.commandLine.hasSwitch('remote-debugging-port')) {
+    const existing = app.commandLine.getSwitchValue('remote-debugging-port')
+    configuredDevToolsPort = /^\d+$/.test(existing) && existing !== '0' ? existing : null
+    return
   }
+  configuredDevToolsPort = String(port)
+  app.commandLine.appendSwitch('remote-debugging-port', configuredDevToolsPort)
 }
 
 function binaryName(): string {
@@ -93,6 +105,7 @@ export function agentBrowserBinaryPath(): string {
 }
 
 async function readDevToolsPort(): Promise<string> {
+  if (configuredDevToolsPort) return configuredDevToolsPort
   const file = path.join(app.getPath('userData'), 'DevToolsActivePort')
   const deadline = Date.now() + CONNECT_TIMEOUT_MS
   for (;;) {


### PR DESCRIPTION
Closes #576

## What changed

- Start Cate's loopback Chrome DevTools endpoint on an explicit randomized high port instead of Chromium's special port `0`.
- Keep the selected endpoint in process so the bundled `agent-browser` bridge connects to the same port.
- Added coverage proving startup and the automation bridge share the explicit endpoint.

## Root cause

Chromium treats `--remote-debugging-port=0` specially: besides allocating a port, it enables `AutomationControlled`, which makes every browser guest expose `navigator.webdriver === true`. Bot-verification providers can reject that browser identity before login, producing the reported Cloudflare verification loop on ChatGPT.

## Impact

Normal browser-panel pages no longer advertise a WebDriver-controlled browser, while Cate's browser automation remains connected over CDP.

## Checks

- Full Vitest suite: 352 files / 3,009 tests passed (50 skipped)
- `npm run typecheck`
- `npm run lint` (0 errors; 23 existing warnings)
- `npm run build`
- `npx playwright test e2e/browser-background-automation.spec.ts` (passed: snapshot, fill, inactive-workspace control, remount)
- Electron smoke comparison: port `0` reported `navigator.webdriver: true`; explicit port `54321` reported `false`
