### PR TITLE
Add shortcut to rename the focused panel

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -165,6 +165,9 @@ export function buildApplicationMenu(): void {
         { type: 'separator' },
         { ...actionMeta('saveFile'), label: 'Save', click: dispatch('saveFile') },
         { type: 'separator' },
+        // Deliberately no native accelerator: Cmd+R must still reach a focused
+        // browser so its panel-local reload handling can take precedence.
+        { label: SHORTCUT_DISPLAY_NAMES.renamePanel, click: dispatch('renamePanel') },
         { ...actionMeta('closePanel'), click: dispatch('closePanel') },
         { role: 'close', label: 'Close Window', accelerator: 'CmdOrCtrl+Shift+W' },
       ],

--- a/src/renderer/docking/useDockTabActions.rename.test.tsx
+++ b/src/renderer/docking/useDockTabActions.rename.test.tsx
@@ -74,6 +74,23 @@ afterEach(() => {
 })
 
 describe('useDockTabActions — commitRename seed regression', () => {
+  it('begins renaming when the global request targets a tab in this stack', () => {
+    act(() => {
+      window.dispatchEvent(new CustomEvent('rename-panel', { detail: { panelId: 'p1' } }))
+    })
+
+    expect(api.current!.renameId).toBe('p1')
+    expect(api.current!.renameValue).toBe('Agent · foo')
+  })
+
+  it('ignores rename requests for tabs owned by another stack', () => {
+    act(() => {
+      window.dispatchEvent(new CustomEvent('rename-panel', { detail: { panelId: 'other' } }))
+    })
+
+    expect(api.current!.renameId).toBeNull()
+  })
+
   it('committing the seeded value unchanged does NOT rename', () => {
     act(() => { api.current!.beginRename('p1', 'Agent · foo') })
     expect(api.current!.renameId).toBe('p1')

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -15,6 +15,10 @@ import { getPanelDef } from '../panels/registry'
 import { setActivePanel } from '../lib/activePanel'
 import { useMultiNodeSelection } from '../canvas/useMultiNodeSelection'
 import type { NativeContextMenuItem } from '../../shared/electron-api'
+import {
+  RENAME_PANEL_EVENT,
+  type RenamePanelEventDetail,
+} from '../lib/focusedPanel'
 
 export interface DockTabActionsParams {
   stack: DockTabStackType
@@ -93,11 +97,11 @@ export function useDockTabActions(params: DockTabActionsParams) {
     }
     setRenameId(null)
   }
-  const beginRename = (panelId: string, currentTitle: string) => {
+  const beginRename = useCallback((panelId: string, currentTitle: string) => {
     renameSeedRef.current = currentTitle
     setRenameValue(currentTitle)
     setRenameId(panelId)
-  }
+  }, [])
 
   const getPanelLocal = useCallback(
     (panelId: string): PanelState | undefined => {
@@ -108,6 +112,17 @@ export function useDockTabActions(params: DockTabActionsParams) {
     },
     [getPanelProp],
   )
+
+  useEffect(() => {
+    const onRenamePanel = (event: Event) => {
+      const panelId = (event as CustomEvent<RenamePanelEventDetail>).detail?.panelId
+      if (!panelId || !stack.panelIds.includes(panelId)) return
+      const panel = getPanelLocal(panelId)
+      if (panel) beginRename(panelId, panel.title)
+    }
+    window.addEventListener(RENAME_PANEL_EVENT, onRenamePanel)
+    return () => window.removeEventListener(RENAME_PANEL_EVENT, onRenamePanel)
+  }, [beginRename, getPanelLocal, stack.panelIds])
 
   // --- Move to new window ---------------------------------------------------
   const moveTabToNewWindow = useCallback(
@@ -250,7 +265,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
           break
       }
     },
-    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, workspaceId, splitWithType, showMultiSelectionMenu, showCloseAll],
+    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, splitWithType, showMultiSelectionMenu, showCloseAll, beginRename],
   )
 
   // Tab-bar (empty-area) context menu — split/new menus. Returns a handler

--- a/src/renderer/hooks/useShortcuts.renamePanel.test.tsx
+++ b/src/renderer/hooks/useShortcuts.renamePanel.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: { release: vi.fn(), setPendingTransfer: vi.fn(), dispose: vi.fn() },
+}))
+vi.mock('../lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+import React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { useShortcuts } from './useShortcuts'
+import { setActivePanel } from '../lib/activePanel'
+import { useAppStore } from '../stores/appStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { storedShortcut } from '../../shared/types'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const WS = 'ws-rename-shortcut'
+let host: HTMLDivElement
+let root: Root
+let renamed: string[]
+
+function Harness() {
+  useShortcuts()
+  return null
+}
+
+function dispatchKey(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  act(() => { document.dispatchEvent(event) })
+  return event
+}
+
+beforeEach(() => {
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    onMenuTriggerAction: () => () => {},
+    onMenuLoadLayout: () => () => {},
+  }
+  useSettingsStore.setState({ customShortcuts: {} })
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    workspaces: [{
+      id: WS,
+      rootPath: '/repo',
+      panels: {
+        editor: { id: 'editor', type: 'editor', title: 'Editor' },
+        browser: { id: 'browser', type: 'browser', title: 'Browser' },
+      },
+    }],
+  } as never)
+  renamed = []
+  window.addEventListener('rename-panel', captureRename)
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => { root.render(<Harness />) })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  window.removeEventListener('rename-panel', captureRename)
+  setActivePanel(null)
+  useSettingsStore.setState({ customShortcuts: {} })
+  useAppStore.setState({ workspaces: [], selectedWorkspaceId: null } as never)
+})
+
+function captureRename(event: Event) {
+  renamed.push((event as CustomEvent<{ panelId: string }>).detail.panelId)
+}
+
+describe('rename focused panel shortcut', () => {
+  it('dispatches the default Cmd+R to the focused non-browser panel', () => {
+    setActivePanel('editor')
+    const event = dispatchKey({ key: 'r', code: 'KeyR', metaKey: true })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(renamed).toEqual(['editor'])
+  })
+
+  it('leaves Cmd+R to a focused browser panel for reload', () => {
+    setActivePanel('browser')
+    const event = dispatchKey({ key: 'r', code: 'KeyR', metaKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(renamed).toEqual([])
+  })
+
+  it('honours a customized rename binding', () => {
+    useSettingsStore.setState({
+      customShortcuts: {
+        renamePanel: storedShortcut('y', { command: true, shift: true }),
+      },
+    })
+    setActivePanel('editor')
+
+    dispatchKey({ key: 'r', code: 'KeyR', metaKey: true })
+    expect(renamed).toEqual([])
+
+    dispatchKey({ key: 'y', code: 'KeyY', metaKey: true, shiftKey: true })
+    expect(renamed).toEqual(['editor'])
+  })
+})

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -21,6 +21,7 @@ import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionMode
 import type { ShortcutAction } from '../../shared/types'
 import { runAction } from '../lib/runAction'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
+import { getFocusedLeafPanelId } from '../lib/focusedPanel'
 
 // ensureWorkspaceFolder lives in lib/runAction now; re-exported here for the
 // panels/pages that still import it from this module.
@@ -280,6 +281,14 @@ export function useShortcuts(windowCanvasStore?: StoreApi<CanvasStore>): void {
         // — let it bubble to the sidebar's own keydown handler instead of
         // closing a canvas panel.
         if (isSidebarKeyNavFocused()) return
+      }
+
+      // Cmd+R belongs to browser reload whenever the focused leaf is a browser.
+      // Returning before preventDefault lets BrowserPanel handle chrome keys;
+      // webview guest keys are forwarded by the main process instead.
+      if (action === 'renamePanel') {
+        const panelId = getFocusedLeafPanelId()
+        if (panelId && resolvePanelById(panelId)?.type === 'browser') return
       }
 
       // Keyboard-only passthrough: when a browser panel is focused, let

--- a/src/renderer/lib/focusedPanel.test.ts
+++ b/src/renderer/lib/focusedPanel.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./terminal/terminalRegistry', () => ({
+  terminalRegistry: { release: vi.fn(), setPendingTransfer: vi.fn(), dispose: vi.fn() },
+}))
+vi.mock('./logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
+}))
+
+import { getFocusedLeafPanelId } from './focusedPanel'
+import { setActivePanel } from './activePanel'
+import { useAppStore } from '../stores/appStore'
+import {
+  getOrCreateCanvasStoreForPanel,
+  releaseCanvasStoreForPanel,
+} from '../stores/canvasStore'
+import {
+  registerNodeDockStore,
+  unregisterNodeDockStore,
+} from '../panels/nodeDockRegistry'
+import { createDockStore } from '../stores/dockStore'
+
+const WS = 'ws-focused-panel'
+const CANVAS = 'canvas-focused-panel'
+const NODE_PANEL = 'node-editor'
+
+beforeEach(() => {
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    workspaces: [{
+      id: WS,
+      rootPath: '/repo',
+      panels: {
+        [CANVAS]: { id: CANVAS, type: 'canvas', title: 'Canvas' },
+        docked: { id: 'docked', type: 'terminal', title: 'Terminal' },
+        [NODE_PANEL]: { id: NODE_PANEL, type: 'editor', title: 'Editor' },
+      },
+    }],
+  } as never)
+})
+
+afterEach(() => {
+  releaseCanvasStoreForPanel(CANVAS)
+  setActivePanel(null)
+  useAppStore.setState({ workspaces: [], selectedWorkspaceId: null } as never)
+})
+
+describe('getFocusedLeafPanelId', () => {
+  it('returns the canonical active panel for a regular dock stack', () => {
+    setActivePanel('docked')
+    expect(getFocusedLeafPanelId()).toBe('docked')
+  })
+
+  it('descends from an active canvas into the focused node mini-dock', () => {
+    const canvas = getOrCreateCanvasStoreForPanel(CANVAS)
+    const nodeId = canvas.getState().addNode('seed', 'terminal')
+    canvas.getState().focusNode(nodeId)
+
+    const nodeDock = createDockStore()
+    nodeDock.getState().dockPanel('seed', 'center')
+    nodeDock.getState().dockPanel(NODE_PANEL, 'center')
+    registerNodeDockStore(CANVAS, nodeId, nodeDock)
+
+    setActivePanel(CANVAS)
+    expect(getFocusedLeafPanelId()).toBe(NODE_PANEL)
+
+    unregisterNodeDockStore(CANVAS, nodeId)
+  })
+})

--- a/src/renderer/lib/focusedPanel.ts
+++ b/src/renderer/lib/focusedPanel.ts
@@ -1,0 +1,41 @@
+import { activeDockPanelId } from '../../shared/collectPanelIds'
+import { getActivePanelId } from './activePanel'
+import { getCanvasOpsById } from './workspace/canvasAccess'
+import { useAppStore } from '../stores/appStore'
+import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
+import { getNodeActivePanelId } from '../panels/nodeDockRegistry'
+
+/** The leaf panel that currently owns the user's attention. A regular dock
+ * records the leaf directly; a canvas records its container, so descend into
+ * the focused node's live mini-dock. */
+export function getFocusedLeafPanelId(): string | null {
+  const activeId = getActivePanelId()
+  if (!activeId) return null
+
+  const app = useAppStore.getState()
+  const activePanel = app.workspaces
+    .find((workspace) => workspace.id === app.selectedWorkspaceId)
+    ?.panels[activeId]
+  if (activePanel?.type !== 'canvas') return activeId
+
+  const canvas = getCanvasOpsById(activeId)?.storeApi.getState()
+  const focusedNodeId = canvas ? focusedNodeIdOf(canvas) : null
+  if (!canvas || !focusedNodeId) return activeId
+
+  return getNodeActivePanelId(activeId, focusedNodeId)
+    ?? activeDockPanelId(canvas.nodes[focusedNodeId]?.dockLayout)
+    ?? activeId
+}
+
+export const RENAME_PANEL_EVENT = 'rename-panel'
+
+export interface RenamePanelEventDetail {
+  panelId: string
+}
+
+export function requestPanelRename(panelId: string): void {
+  window.dispatchEvent(new CustomEvent<RenamePanelEventDetail>(
+    RENAME_PANEL_EVENT,
+    { detail: { panelId } },
+  ))
+}

--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -23,6 +23,7 @@ import { inheritedWorktreeFromSelection } from './inheritWorktree'
 import { closePanelWithConfirm } from './closePanelWithConfirm'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
 import { seedAgentPanelWithWorktreeChat } from '../../cateAgent/renderer/seedWorktreeChat'
+import { getFocusedLeafPanelId, requestPanelRename } from './focusedPanel'
 
 /**
  * Ensures the workspace has a rootPath before proceeding.
@@ -207,6 +208,11 @@ export async function runAction(
     case 'saveFile':
       window.dispatchEvent(new CustomEvent('save-file'))
       break
+    case 'renamePanel': {
+      const panelId = getFocusedLeafPanelId()
+      if (panelId) requestPanelRename(panelId)
+      break
+    }
     case 'zoomToFit':
       canvasStore()?.zoomToFit()
       break

--- a/src/renderer/ui/CommandPalette.tsx
+++ b/src/renderer/ui/CommandPalette.tsx
@@ -173,6 +173,7 @@ export const CommandPalette: React.FC = () => {
       { id: 'newAgent', title: shortcutTitle('newAgent'), icon: <AgentIcon />, action: run('newAgent') },
       { id: 'newCanvas', title: shortcutTitle('newCanvas'), icon: <LayoutIcon />, action: run('newCanvas') },
       { id: 'closePanel', title: shortcutTitle('closePanel'), icon: <CloseIcon />, action: run('closePanel') },
+      { id: 'renamePanel', title: shortcutTitle('renamePanel'), icon: <FileText size={18} />, action: run('renamePanel') },
       { id: 'saveFile', title: shortcutTitle('saveFile'), icon: <SaveIcon />, action: run('saveFile') },
       // Sidebar toggles only exist in the main window; hidden in detached windows.
       ...(isMainWindow

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -672,6 +672,7 @@ export const SHORTCUT_DEFINITIONS = {
   focusNext: { label: 'Focus Next Panel', shortcut: storedShortcut('\t', { control: true }) },
   focusPrevious: { label: 'Focus Previous Panel', shortcut: storedShortcut('\t', { shift: true, control: true }) },
   saveFile: { label: 'Save File', shortcut: storedShortcut('s', { command: true }) },
+  renamePanel: { label: 'Rename Focused Panel', shortcut: storedShortcut('r', { command: true }) },
   zoomToFit: { label: 'Zoom to Fit', shortcut: storedShortcut('1', { command: true }) },
   zoomToSelection: { label: 'Zoom to Selection', shortcut: storedShortcut('2', { command: true }) },
   autoLayout: { label: 'Auto Layout Canvas', shortcut: storedShortcut('l', { command: true, shift: true }) },


### PR DESCRIPTION
## Summary
- add a customizable Rename Focused Panel action, defaulting to Cmd+R
- target regular dock tabs and focused canvas mini-dock tabs
- keep Cmd+R available for browser reload

## Tests
- npm test -- src/renderer/lib/activePanel.test.ts src/renderer/hooks/useShortcuts.activeCanvas.test.tsx src/renderer/hooks/useShortcuts.renamePanel.test.tsx src/renderer/stores/shortcutStore.test.ts src/renderer/docking/useDockTabActions.rename.test.tsx src/renderer/lib/focusedPanel.test.ts
- npm run typecheck
- focused ESLint pass

Closes #585