### PR TITLE
Fix skill mirroring for ordinary subdirectories

### DIFF
--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -65,7 +65,7 @@ vi.mock('../../runtime/capabilities/shellResolver', () => ({ resolveShell: () =>
 
 // Hoisted spies shared with the module mocks below (vi.mock factories are
 // hoisted above all other code, so the spies they reference must be too).
-const diag = vi.hoisted(() => ({ warn: vi.fn(), ptyCreate: vi.fn() }))
+const diag = vi.hoisted(() => ({ warn: vi.fn(), ptyCreate: vi.fn(), worktreeList: vi.fn() }))
 vi.mock('../logger', () => ({ default: { warn: diag.warn, info: () => {}, error: () => {}, debug: () => {} } }))
 
 // First-party CATE_API endpoint provider. spawnTerminal awaits
@@ -90,6 +90,7 @@ vi.mock('../runtime/runtimeManager', () => ({
     resolve: () => ({
       validateCwd: (p: string) => p,
       validatePathStrict: (p: string) => Promise.resolve(p),
+      vcs: { worktreeList: diag.worktreeList },
       process: { create: diag.ptyCreate },
     }),
     disposeAll: () => Promise.resolve(),
@@ -464,6 +465,9 @@ describe('CATE_API env injection into spawned terminals', () => {
   beforeEach(() => {
     vi.resetModules()
     diag.ptyCreate.mockReset()
+    diag.worktreeList.mockReset().mockResolvedValue([
+      { path: '/repo/base', branch: 'main', isBare: false },
+    ])
     cateApi.ensureEndpoint.mockReset()
   })
 
@@ -504,6 +508,10 @@ describe('CATE_API env injection into spawned terminals', () => {
   it('passes the base workspace cwd as the agent hook auto reference', async () => {
     cateApi.ensureEndpoint.mockResolvedValue(null)
     workspaceInfo.get.mockReturnValueOnce({ rootPath: '/repo/base' })
+    diag.worktreeList.mockResolvedValueOnce([
+      { path: '/repo/base', branch: 'main', isBare: false },
+      { path: '/repo/worktree', branch: 'feature', isBare: false },
+    ])
     diag.ptyCreate.mockResolvedValue({ id: 'pty-hooks', pid: 123, shell: '/bin/zsh' })
     const mod = await import('./terminal')
     mod.registerHandlers()
@@ -520,6 +528,22 @@ describe('CATE_API env injection into spawned terminals', () => {
       scopeId: 'ws-1',
       workspaceBaseCwd: '/repo/base',
     })
+  })
+
+  it('does not mirror workspace skills into an ordinary subdirectory terminal', async () => {
+    cateApi.ensureEndpoint.mockResolvedValue(null)
+    workspaceInfo.get.mockReturnValueOnce({ rootPath: '/repo/base' })
+    skillsSync.run.mockClear()
+    diag.ptyCreate.mockResolvedValue({ id: 'pty-subdir', pid: 123, shell: '/bin/zsh' })
+    const mod = await import('./terminal')
+    mod.registerHandlers()
+
+    await handlers.get('terminal:create')!(
+      {},
+      { cols: 80, rows: 24, cwd: '/repo/base/packages/app', workspaceId: 'ws-1' },
+    )
+
+    expect(skillsSync.run).not.toHaveBeenCalled()
   })
 
   it('injects CATE_PANEL_ID when the PTY belongs to a Cate terminal panel', async () => {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -48,7 +48,12 @@ import { createStringDispatcher } from './batchedDispatcher'
 import { workspaceCateApi } from '../extensions/workspaceCateApi'
 import { getWorkspaceInfo } from '../workspaceManager'
 import { syncWorkspaceSkills } from '../../skills/main/skillsMirror'
-import { resolveWorktreeContext, validateWorktreeContext } from '../worktreeContext'
+import {
+  listWorktreeCheckouts,
+  resolveWorktreeContext,
+  validateWorktreeContext,
+  type WorktreeContext,
+} from '../worktreeContext'
 import { codingAgentCommand, type CodingAgentLaunch } from '../../shared/codingAgentRuns'
 
 // Set true during app shutdown so PTY data/exit callbacks no-op instead of
@@ -345,9 +350,29 @@ async function spawnTerminal(
   const unresolvedWorktree = workspaceRoot && options.cwd
     ? resolveWorktreeContext(workspaceRoot, options.cwd)
     : undefined
-  const worktree = unresolvedWorktree && options.workspaceId
-    ? await validateWorktreeContext(unresolvedWorktree, runtime, ownerWindowId, options.workspaceId)
-    : undefined
+  let worktree: WorktreeContext | undefined
+  if (
+    unresolvedWorktree
+    && unresolvedWorktree.checkout.locator !== unresolvedWorktree.base.locator
+    && options.workspaceId
+  ) {
+    try {
+      const checkouts = await listWorktreeCheckouts(unresolvedWorktree.base.locator, runtime, {
+        ownerWindowId,
+        scopeId: options.workspaceId,
+      })
+      if (checkouts.includes(unresolvedWorktree.checkout.locator)) {
+        worktree = await validateWorktreeContext(
+          unresolvedWorktree,
+          runtime,
+          ownerWindowId,
+          options.workspaceId,
+        )
+      }
+    } catch (err) {
+      log.warn('[terminal] worktree detection failed: %O', err)
+    }
+  }
   // Existing or externally-created worktrees may predate Cate's eager mirror
   // triggers. Hydrate managed skills before the shell can launch an agent.
   if (worktree) {


### PR DESCRIPTION
## Summary
- verify a terminal checkout against Git's worktree list before mirroring managed skills
- keep skill hydration for real linked worktrees
- let terminal creation continue when worktree detection is unavailable

## Regression evidence
Before the fix, the focused regression failed because opening /repo/base/packages/app called syncWorkspaceSkills for that ordinary subdirectory.

After the fix:
- npm test -- src/main/ipc/terminal.test.ts src/main/worktreeContext.test.ts src/main/ipc/gitSkillsMirror.test.ts (29 passed)
- npm run typecheck (passed)

Closes #586