### PR TITLE
Fix remote terminals after runtime reconnect

### DIFF
--- a/src/main/ipc/terminal.test.ts
+++ b/src/main/ipc/terminal.test.ts
@@ -65,7 +65,10 @@ vi.mock('../../runtime/capabilities/shellResolver', () => ({ resolveShell: () =>
 
 // Hoisted spies shared with the module mocks below (vi.mock factories are
 // hoisted above all other code, so the spies they reference must be too).
-const diag = vi.hoisted(() => ({ warn: vi.fn(), ptyCreate: vi.fn() }))
+const diag = vi.hoisted(() => ({ warn: vi.fn(), ptyCreate: vi.fn(), ptyWrite: vi.fn() }))
+const runtimeEvents = vi.hoisted(() => ({
+  disconnected: undefined as ((runtimeId: string) => void) | undefined,
+}))
 vi.mock('../logger', () => ({ default: { warn: diag.warn, info: () => {}, error: () => {}, debug: () => {} } }))
 
 // First-party CATE_API endpoint provider. spawnTerminal awaits
@@ -90,13 +93,20 @@ vi.mock('../runtime/runtimeManager', () => ({
     resolve: () => ({
       validateCwd: (p: string) => p,
       validatePathStrict: (p: string) => Promise.resolve(p),
-      process: { create: diag.ptyCreate },
+      process: { create: diag.ptyCreate, write: diag.ptyWrite },
     }),
+    onDisconnected: (cb: (runtimeId: string) => void) => {
+      runtimeEvents.disconnected = cb
+      return () => { runtimeEvents.disconnected = undefined }
+    },
     disposeAll: () => Promise.resolve(),
   },
 }))
 vi.mock('../../shared/runtimeLocator', () => ({
-  parseLocator: (cwd: string) => ({ runtimeId: 'local', path: cwd }),
+  parseLocator: (cwd: string) => ({
+    runtimeId: cwd.startsWith('/remote/') ? 'remote-1' : 'local',
+    path: cwd,
+  }),
   formatLocator: ({ path }: { path: string }) => path,
 }))
 
@@ -146,6 +156,44 @@ vi.mock('../../renderer/stores/appStore', () => ({
   useAppStore: { getState: () => ({ updatePanelTitleFromAgent: () => {} }) },
 }))
 vi.mock('../../renderer/lib/workspace/session', () => ({ replayTerminalLog: () => Promise.resolve() }))
+
+describe('runtime disconnect terminal invalidation (#584)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    handlers.clear()
+    diag.ptyCreate.mockReset()
+    diag.ptyWrite.mockClear()
+    runtimeEvents.disconnected = undefined
+  })
+
+  it('removes remote PTY mappings and reports an exit when their runtime drops', async () => {
+    diag.ptyCreate.mockResolvedValue({ id: 'pty-remote', pid: 123, shell: '/bin/zsh' })
+    const terminal = await import('./terminal')
+    terminal.registerHandlers()
+
+    await handlers.get('terminal:create')!(
+      {},
+      { cols: 80, rows: 24, cwd: '/remote/repo' },
+    )
+    expect(terminal.getTerminalIds()).toContain('pty-remote')
+
+    expect(runtimeEvents.disconnected).toBeTypeOf('function')
+    runtimeEvents.disconnected?.('remote-1')
+
+    expect(terminal.getTerminalIds()).not.toContain('pty-remote')
+    await handlers.get('terminal:write')!({}, 'pty-remote', 'echo stale\r')
+    expect(diag.ptyWrite).not.toHaveBeenCalled()
+
+    const { __sent } = await import('../windowRegistry') as unknown as {
+      __sent: Array<{ channel: string; args: unknown[] }>
+    }
+    expect(__sent).toContainEqual({
+      windowId: -1,
+      channel: 'terminal:exit',
+      args: ['pty-remote', 255],
+    })
+  })
+})
 
 describe('cross-window drop terminal ownership transfer', () => {
   beforeEach(() => {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -231,6 +231,26 @@ function cleanupTerminal(id: string): void {
   emitSessionsChanged()
 }
 
+// A dropped runtime destroys every PTY hosted by its daemon. Remove their
+// routing entries immediately and tell the owning renderer they exited; keeping
+// those ids would route input to the fresh daemon after reconnect, where the ids
+// do not exist, leaving the terminal apparently alive but permanently frozen.
+function invalidateRuntimeTerminals(runtimeId: RuntimeId): void {
+  for (const [id, terminalRuntimeId] of [...terminalRuntime]) {
+    if (terminalRuntimeId !== runtimeId) continue
+    const ownerWindowId = terminalOwners.get(id)
+    const transfer = transferStates.get(id)
+    if (transfer) {
+      clearTimeout(transfer.timer)
+      transferStates.delete(id)
+    }
+    cleanupTerminal(id)
+    if (ownerWindowId != null) {
+      try { sendToWindow(ownerWindowId, TERMINAL_EXIT, id, 255) } catch { /* owner gone */ }
+    }
+  }
+}
+
 async function spawnTerminal(
   options: {
     cols: number
@@ -406,6 +426,8 @@ function killTerminal(id: string): void {
 }
 
 export function registerHandlers(): void {
+  runtimes.onDisconnected(invalidateRuntimeTerminals)
+
   // Complete/abandon in-flight terminal transfers when a window closes so a
   // running PTY's ownership follows the panel instead of orphaning on a dead window.
   onWindowClosed(handleWindowClosedTerminalTransfers)

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -253,6 +253,11 @@ export async function getOrCreate(panelId: string, opts: CreateOpts): Promise<Re
       // must never be shared across workspaces, so tear the stale one down and
       // build a fresh terminal for the requesting workspace below.
       dispose(panelId)
+    } else if (!existing.alive) {
+      // A runtime drop destroys its daemon-side PTYs. TERMINAL_EXIT marks the
+      // retained xterm dead; once the runtime reconnects, replace that entry
+      // instead of returning its stale PTY id forever.
+      dispose(panelId)
     } else {
       if (pendingTerminalStarts.get(panelId)?.kind === 'transfer') pendingTerminalStarts.delete(panelId)
       return existing

--- a/src/renderer/lib/terminal/terminalRegistry.test.ts
+++ b/src/renderer/lib/terminal/terminalRegistry.test.ts
@@ -707,6 +707,31 @@ describe('terminal identity bimap', () => {
     terminalRegistry.dispose('panel-E')
     expect(terminalRegistry.isAlive('panel-E')).toBeUndefined()
   })
+
+  it('replaces a dead PTY instead of reusing it after a runtime reconnect', async () => {
+    const { terminalRegistry } = await import('./terminalRegistry')
+    let exitListener: ((id: string, code: number) => void) | undefined
+    ;(window.electronAPI as any).onTerminalExit = vi.fn((cb: (id: string, code: number) => void) => {
+      exitListener = cb
+      return () => {}
+    })
+    terminalCreate
+      .mockResolvedValueOnce('pty-before-drop')
+      .mockResolvedValueOnce('pty-after-reconnect')
+
+    const before = await terminalRegistry.getOrCreate('panel-reconnect', { workspaceId: 'ws-remote' })
+    exitListener?.('pty-before-drop', 255)
+    expect(terminalRegistry.isAlive('panel-reconnect')).toBe(false)
+
+    const after = await terminalRegistry.getOrCreate('panel-reconnect', { workspaceId: 'ws-remote' })
+
+    expect(after).not.toBe(before)
+    expect(after.ptyId).toBe('pty-after-reconnect')
+    expect(terminalRegistry.isAlive('panel-reconnect')).toBe(true)
+    expect(terminalCreate).toHaveBeenCalledTimes(2)
+
+    terminalRegistry.dispose('panel-reconnect')
+  })
 })
 
 describe('WebGL glyph-atlas resync on a shared-config change', () => {

--- a/src/renderer/panels/TerminalPanel.tsx
+++ b/src/renderer/panels/TerminalPanel.tsx
@@ -34,6 +34,7 @@ import { resolveWorktree } from '../../shared/worktrees'
 import { resumeCommandForAgent } from '../../shared/agents'
 import { CATE_FILE_MIME, hasChatDrag, readCateFileLocation, readCateFilePaths } from '../drag/fileDragPayload'
 import { parseLocator } from '../../shared/runtimeLocator'
+import { isRemoteRuntimeConnection } from '../../shared/runtimeConnection'
 
 // ---------------------------------------------------------------------------
 // Component
@@ -193,6 +194,12 @@ export default function TerminalPanel({
   const ptyEpoch = useAppStore(
     (state) => state.workspaces.find((w) => w.id === workspaceId)?.panels[panelId]?.ptyEpoch ?? 0,
   )
+  const runtimePhase = useAppStore((state) => {
+    const workspace = state.workspaces.find((w) => w.id === workspaceId)
+    return isRemoteRuntimeConnection(workspace?.connection)
+      ? workspace?.runtime?.phase
+      : state.localRuntimePhase
+  })
   const workspaceRoot = workspaces.find((w) => w.id === workspaceId)?.rootPath
   // Tagged worktree wins; else an explicit per-panel cwd (drag-drop folder); else
   // the workspace root.
@@ -408,6 +415,11 @@ export default function TerminalPanel({
       ? resumeCommandForAgent(agentSession.agentId, agentSession.sessionId) ?? undefined
       : undefined
 
+    // Keep the dead xterm visible behind the runtime lock while disconnected.
+    // The connected phase re-runs this effect; getOrCreate then replaces the
+    // entry that TERMINAL_EXIT marked dead with a fresh PTY on the new daemon.
+    if (runtimePhase && runtimePhase !== 'connected') return
+
     // 1. Ensure the terminal + PTY exist in the registry (no-op if already live)
     terminalRegistry
       .getOrCreate(panelId, {
@@ -462,7 +474,7 @@ export default function TerminalPanel({
 
       detachAndDisconnect()
     }
-  }, [panelId, workspaceId, nodeId, initialInput, codingAgentLaunch, placementGroupId, retryKey, ptyEpoch])
+  }, [panelId, workspaceId, nodeId, initialInput, codingAgentLaunch, placementGroupId, retryKey, ptyEpoch, runtimePhase])
 
   // -------------------------------------------------------------------------
   // Focus xterm when this node becomes the focused node


### PR DESCRIPTION
## Summary
- invalidate PTY mappings when their runtime disconnects
- mark affected terminals exited instead of routing input to stale PTY IDs
- recreate dead terminal sessions when the runtime reconnects

The original shell cannot survive the drop because the daemon terminates its process groups; Cate now starts a fresh terminal rather than leaving a frozen session.

Closes #584

## Tests
- Regression first: focused tests failed on the missing disconnect subscriber and dead-entry reuse before the fix
- `npm test -- src/main/ipc/terminal.test.ts src/renderer/lib/terminal/terminalRegistry.test.ts` — 66 passed
- `npm test -- src/main/runtime/connection.test.ts src/renderer/lib/terminal/terminalLifecycle.test.ts src/renderer/panels/TerminalPanel.renderScale.test.tsx` — 56 passed
- `npm run typecheck` — passed

Full `npm test` was also run; unrelated socket/file-watcher tests failed in the sandbox with `EPERM` and watcher timeouts.
