### PR TITLE
feat(dock): add Copy Path / Copy Relative Path to file-backed tab context menus

### DIFF
--- a/src/renderer/docking/useDockTabActions.copyPath.test.tsx
+++ b/src/renderer/docking/useDockTabActions.copyPath.test.tsx
@@ -1,0 +1,165 @@
+// =============================================================================
+// useDockTabActions tab menu — Copy Path / Copy Relative Path. The pair mirrors
+// the file explorer's items and is gated on panel.filePath: a scratch editor
+// has no file yet, so offering the items there would copy nothing. Relative
+// resolves against the workspace rootPath, falling back to the absolute host
+// path; remote locators copy the host path, not the cate-runtime:// URI.
+// =============================================================================
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../lib/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
+vi.mock('../lib/terminal/terminalRegistry', () => ({
+  terminalRegistry: { entries: () => [], panelIdForPty: () => null, ptyIdForPanel: () => null, has: () => false, getEntry: () => undefined, dispose: vi.fn(), release: vi.fn(), disposeWorkspace: vi.fn(), resetRendering: vi.fn() },
+}))
+import { useDockTabActions } from './useDockTabActions'
+import { CanvasStoreProvider } from '../stores/CanvasStoreContext'
+import { useAppStore } from '../stores/appStore'
+import { createDockStore } from '../stores/dockStore'
+import { getOrCreateCanvasStoreForPanel, releaseCanvasStoreForPanel } from '../stores/canvasStore'
+import type { NativeContextMenuItem } from '../../shared/electron-api'
+import type { DockTabStack, PanelState } from '../../shared/types'
+
+const WS = 'ws-copy-path'
+const STACK: DockTabStack = { type: 'tabs', id: 'stack-1', panelIds: ['p1'], activeIndex: 0 }
+
+const EDITOR_PANEL = { id: 'p1', type: 'editor', title: 'a.md', isDirty: false, filePath: '/root/sub/a.md' } as PanelState
+const SCRATCH_PANEL = { id: 'p1', type: 'editor', title: 'Untitled', isDirty: false, unsavedContent: 'draft' } as PanelState
+const REMOTE_PANEL = { id: 'p1', type: 'editor', title: 'a.ts', isDirty: false, filePath: 'cate-runtime://srv_1/home/u/proj/a.ts' } as PanelState
+
+type Actions = ReturnType<typeof useDockTabActions>
+const api: { current: Actions | null } = { current: null }
+
+const dockStore = createDockStore()
+const showContextMenu = vi.fn<(items: NativeContextMenuItem[]) => Promise<string | null>>()
+const clipboardWriteText = vi.fn()
+
+// getPanelProp reads the fixture at call time, so a test can swap which panel
+// the single tab stands for before it opens the menu — no re-render needed.
+let panelFixture: PanelState = EDITOR_PANEL
+
+const Harness: React.FC = () => {
+  api.current = useDockTabActions({
+    stack: STACK,
+    zone: 'center',
+    dockStoreApi: dockStore,
+    workspaceId: WS,
+    getPanelProp: () => panelFixture,
+  })
+  return null
+}
+
+let host: HTMLDivElement
+let root: Root
+const initialAppState = useAppStore.getState()
+const originalClipboard = Object.getOwnPropertyDescriptor(window.navigator, 'clipboard')
+
+async function openTabMenu(): Promise<void> {
+  await act(async () => {
+    await api.current!.handleTabContextMenu({
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as never, 'p1')
+  })
+}
+
+function lastMenuItems(): NativeContextMenuItem[] {
+  const calls = showContextMenu.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  return calls[calls.length - 1][0]
+}
+
+beforeEach(() => {
+  panelFixture = EDITOR_PANEL
+  showContextMenu.mockReset().mockResolvedValue(null)
+  clipboardWriteText.mockClear()
+  useAppStore.setState({
+    workspaces: [{ id: WS, rootPath: '/root', panels: {} }],
+    selectedWorkspaceId: WS,
+  } as never)
+  Object.defineProperty(window.electronAPI, 'showContextMenu', {
+    configurable: true,
+    value: showContextMenu,
+  })
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: { writeText: clipboardWriteText },
+    configurable: true,
+  })
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  act(() => {
+    root.render(
+      <CanvasStoreProvider store={getOrCreateCanvasStoreForPanel('copy-path-harness-cv')}>
+        <Harness />
+      </CanvasStoreProvider>,
+    )
+  })
+})
+
+afterEach(() => {
+  act(() => { root.unmount() })
+  host.remove()
+  releaseCanvasStoreForPanel('copy-path-harness-cv')
+  useAppStore.setState(initialAppState, true)
+  if (originalClipboard) Object.defineProperty(window.navigator, 'clipboard', originalClipboard)
+  else delete (window.navigator as { clipboard?: unknown }).clipboard
+  api.current = null
+})
+
+describe('useDockTabActions — Copy Path / Copy Relative Path', () => {
+  it('offers both items for a file-backed tab and copies the absolute path', async () => {
+    showContextMenu.mockResolvedValue('copy-path')
+
+    await openTabMenu()
+
+    const items = lastMenuItems()
+    expect(items).toContainEqual({ id: 'copy-path', label: 'Copy Path' })
+    expect(items).toContainEqual({ id: 'copy-rel-path', label: 'Copy Relative Path' })
+    expect(clipboardWriteText).toHaveBeenCalledWith('/root/sub/a.md')
+  })
+
+  it('copies the workspace-relative path when the workspace has a rootPath', async () => {
+    showContextMenu.mockResolvedValue('copy-rel-path')
+
+    await openTabMenu()
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('sub/a.md')
+  })
+
+  it('copies the host path, not the locator URI, for a remote file', async () => {
+    panelFixture = REMOTE_PANEL
+    showContextMenu.mockResolvedValue('copy-path')
+
+    await openTabMenu()
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('/home/u/proj/a.ts')
+  })
+
+  it('falls back to the absolute path for Copy Relative Path when the workspace has no rootPath', async () => {
+    useAppStore.setState({
+      workspaces: [{ id: WS, rootPath: '', panels: {} }],
+      selectedWorkspaceId: WS,
+    } as never)
+    showContextMenu.mockResolvedValue('copy-rel-path')
+
+    await openTabMenu()
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('/root/sub/a.md')
+  })
+
+  it('omits both items for a scratch editor with no filePath', async () => {
+    panelFixture = SCRATCH_PANEL
+
+    await openTabMenu()
+
+    const ids = lastMenuItems().map((item) => item.id)
+    expect(ids).not.toContain('copy-path')
+    expect(ids).not.toContain('copy-rel-path')
+  })
+})

--- a/src/renderer/docking/useDockTabActions.ts
+++ b/src/renderer/docking/useDockTabActions.ts
@@ -7,6 +7,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { StoreApi } from 'zustand'
 import type { DockTabStack as DockTabStackType, PanelState, PanelType } from '../../shared/types'
+import { parseLocator } from '../../shared/runtimeLocator'
+import { relativeDisplayPath } from '../lib/fs/displayPath'
 import { createTransferSnapshot } from '../lib/panelTransfer'
 import { removePanelFromWindow } from '../lib/panels/removePanelFromWindow'
 import { useAppStore } from '../stores/appStore'
@@ -217,6 +219,16 @@ export function useDockTabActions(params: DockTabActionsParams) {
             ] as NativeContextMenuItem[]
           : []),
         { id: 'rename', label: 'Rename' },
+        // Path copies only for panels backed by a file, grouped with Rename as
+        // in the explorer menu. The explorer's Alt+Cmd+C accelerators are
+        // display-only labels (bound nowhere), so they're omitted here rather
+        // than advertising chords that don't fire.
+        ...(panel?.filePath
+          ? ([
+              { id: 'copy-path', label: 'Copy Path' },
+              { id: 'copy-rel-path', label: 'Copy Relative Path' },
+            ] as NativeContextMenuItem[])
+          : []),
         { type: 'separator' },
         { id: 'close', label: 'Close', accelerator: 'Cmd+W' },
         { id: 'close-others', label: 'Close Others', enabled: hasOthers },
@@ -238,6 +250,20 @@ export function useDockTabActions(params: DockTabActionsParams) {
         case 'rename':
           if (panel) beginRename(panelId, panel.title)
           break
+        case 'copy-path':
+          // parseLocator strips the cate-runtime:// wrapper so a remote file
+          // copies its host path, not the internal URI.
+          if (panel?.filePath) navigator.clipboard.writeText(parseLocator(panel.filePath).path)
+          break
+        case 'copy-rel-path': {
+          if (!panel?.filePath) break
+          const wsId = workspaceId ?? useAppStore.getState().selectedWorkspaceId
+          const root = useAppStore.getState().workspaces.find((w) => w.id === wsId)?.rootPath
+          navigator.clipboard.writeText(
+            root ? relativeDisplayPath(panel.filePath, root) : parseLocator(panel.filePath).path,
+          )
+          break
+        }
         case 'close':
           onClosePanel?.(panelId)
           break
@@ -265,7 +291,7 @@ export function useDockTabActions(params: DockTabActionsParams) {
           break
       }
     },
-    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, splitWithType, showMultiSelectionMenu, showCloseAll, beginRename],
+    [stack.panelIds, onClosePanel, getPanelLocal, moveTabToNewWindow, splitWithType, showMultiSelectionMenu, showCloseAll, beginRename, workspaceId],
   )
 
   // Tab-bar (empty-area) context menu — split/new menus. Returns a handler


### PR DESCRIPTION
Closes #591

Adds **Copy Path** and **Copy Relative Path** to the tab context menu (dock tabs and canvas file windows), shown only for panels backed by a file.

Today these actions exist only in the file explorer's context menu. When a file is already open — especially as a canvas window — copying its path means going back to the explorer, finding the node, and right-clicking there. The tab you're looking at already knows its path; this removes the detour. The concrete workflow it serves: create/edit a note or log on the canvas, copy its path from the tab, paste it into an agent prompt.

- `Copy Path` — absolute host path (remote `cate-runtime://` locators copy the host path, not the internal URI, via the existing `parseLocator`)
- `Copy Relative Path` — workspace-relative via the existing `relativeDisplayPath`, falling back to the absolute path when the file sits outside the workspace root or no root is set

Implementation is a single gated group in `handleTabContextMenu` (`src/renderer/docking/useDockTabActions.ts`), so it covers side/center dock zones, canvas mini-docks, and detached dock windows in one place. Both helpers are reused as-is from the explorer path — no new path logic. The explorer's `Alt+Cmd+C` accelerators are display-only labels (bound nowhere), so they're intentionally omitted here rather than advertising chords that don't fire.

Purely additive: panels without a `filePath` (terminals, browsers, scratch editors) see the menu exactly as before.

Tests: `useDockTabActions.copyPath.test.tsx` (mirrors the existing rename-test harness) — items offered and absolute path copied; workspace-relative copy; remote-locator host path; no-rootPath fallback; items absent for a scratch editor.

Local checks (this branch): `npm run typecheck` clean; `npm run lint` clean on changed files; `npm test` = 3018 passed, 50 skipped — the 7 failures in the two sidebar tree-collapse suites reproduce identically on unmodified `main` (pre-existing, unrelated); `npm run build` succeeds.

Screenshot (canvas file window):

![Tab context menu with Copy Path and Copy Relative Path](https://raw.githubusercontent.com/wyddy7/cate/assets/tab-copy-path-menu.png)
