### PR TITLE
Fix persistent browser surface stacking

### DIFF
--- a/e2e/browser-background-automation.spec.ts
+++ b/e2e/browser-background-automation.spec.ts
@@ -104,3 +104,54 @@ test('agent-browser controls a mounted webview while its workspace is inactive',
     result: { value: 'Filled from another workspace' },
   })
 })
+
+test('persistent browser surfaces respect canvas clipping and canvas node order', async () => {
+  const browser = await page.evaluate(() => (
+    window.__cateE2E!.createBrowser('data:text/html,<title>Stacking test</title>', { x: -100, y: 120 })
+  ))
+
+  await expect.poll(() => page.evaluate((panelId) => {
+    const surface = document.querySelector<HTMLElement>(`[data-browser-surface="${panelId}"]`)
+    return surface?.dataset.browserSurfaceVisible
+  }, browser.panelId)).toBe('true')
+
+  const clippedUnderSidebar = await page.evaluate((panelId) => {
+    const sidebar = document.querySelector<HTMLElement>('[data-app-sidebar="left"]')!
+    const surface = document.querySelector<HTMLElement>(`[data-browser-surface="${panelId}"]`)!
+    const sidebarRect = sidebar.getBoundingClientRect()
+    const surfaceRect = surface.getBoundingClientRect()
+    const x = Math.min(sidebarRect.right - 10, surfaceRect.right - 10)
+    const y = surfaceRect.top + Math.min(100, surfaceRect.height / 2)
+    return document.elementFromPoint(x, y)?.closest('[data-app-sidebar="left"]') !== null
+  }, browser.panelId)
+  expect(clippedUnderSidebar).toBe(true)
+
+  const browserNodeId = await page.evaluate(
+    (panelId) => window.__cateE2E!.nodeForPanel(panelId),
+    browser.panelId,
+  )
+  expect(browserNodeId).not.toBeNull()
+  const terminalNodeId = await page.evaluate(() => window.__cateE2E!.createTerminal({ x: 200, y: 180 }))
+  await page.evaluate(({ browserNodeId, terminalNodeId }) => {
+    window.__cateE2E!.resetViewport()
+    window.__cateE2E!.moveNode(browserNodeId!, { x: 100, y: 120 })
+    window.__cateE2E!.moveNode(terminalNodeId, { x: 200, y: 180 })
+  }, { browserNodeId, terminalNodeId })
+
+  await page.waitForSelector(`[data-node-id="${terminalNodeId}"]`)
+  await expect.poll(() => page.evaluate(({ panelId, terminalNodeId }) => {
+    const surface = document.querySelector<HTMLElement>(`[data-browser-surface="${panelId}"]`)
+    const terminal = document.querySelector<HTMLElement>(`[data-node-id="${terminalNodeId}"]`)
+    if (!surface || !terminal || !surface.style.clipPath.startsWith('path(')) return false
+    const a = surface.getBoundingClientRect()
+    const b = terminal.getBoundingClientRect()
+    const left = Math.max(a.left, b.left)
+    const top = Math.max(a.top, b.top)
+    const right = Math.min(a.right, b.right)
+    const bottom = Math.min(a.bottom, b.bottom)
+    if (right <= left || bottom <= top) return false
+    return document.elementFromPoint((left + right) / 2, (top + bottom) / 2)
+      ?.closest('[data-node-id]')
+      ?.getAttribute('data-node-id') === terminalNodeId
+  }, { panelId: browser.panelId, terminalNodeId })).toBe(true)
+})

--- a/src/renderer/panels/BackgroundBrowserHost.test.tsx
+++ b/src/renderer/panels/BackgroundBrowserHost.test.tsx
@@ -21,7 +21,22 @@ let root: Root
 
 Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
   configurable: true,
-  value: () => ({ x: 10, y: 20, left: 10, top: 20, right: 210, bottom: 120, width: 200, height: 100, toJSON: () => ({}) }),
+  value(this: HTMLElement) {
+    const [left, top, right, bottom] = (this.dataset.testRect ?? '10,20,210,120')
+      .split(',')
+      .map(Number)
+    return {
+      x: left,
+      y: top,
+      left,
+      top,
+      right,
+      bottom,
+      width: right - left,
+      height: bottom - top,
+      toJSON: () => ({}),
+    }
+  },
 })
 Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
   configurable: true,
@@ -35,6 +50,23 @@ Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
 function VisibleBrowserSlot(): React.ReactElement {
   const selectedWorkspaceId = useAppStore((state) => state.selectedWorkspaceId)
   return <BrowserPanelSurfaceSlot panelId={`browser-${selectedWorkspaceId}`} />
+}
+
+function ClippedStackedBrowserSlot(): React.ReactElement {
+  return (
+    <div data-test-rect="100,0,400,300" style={{ overflow: 'clip' }}>
+      <div>
+        <div data-node-id="browser-node" style={{ zIndex: 1001 }}>
+          <BrowserPanelSurfaceSlot panelId="browser-one" />
+        </div>
+        <div
+          data-node-id="terminal-node"
+          data-test-rect="150,40,210,100"
+          style={{ position: 'absolute', zIndex: 1002 }}
+        />
+      </div>
+    </div>
+  )
 }
 
 function renderHost(): void {
@@ -113,5 +145,19 @@ describe('BackgroundBrowserHost', () => {
     expect(container.querySelector('[data-browser-panel="browser-one"]')).toBe(original)
     expect(container.querySelector('[data-browser-surface="browser-one"]')
       ?.getAttribute('data-browser-surface-visible')).toBe('true')
+  })
+
+  it('clips a persistent surface to its canvas and punches out higher canvas nodes', () => {
+    act(() => root.render(
+      <PersistentBrowserHostContext.Provider value>
+        <ClippedStackedBrowserSlot />
+        <BackgroundBrowserHost />
+      </PersistentBrowserHostContext.Provider>,
+    ))
+
+    const surface = container.querySelector<HTMLElement>('[data-browser-surface="browser-one"]')
+    expect(surface?.style.clipPath).toBe(
+      'path(evenodd, "M 90 0 H 200 V 100 H 90 Z M 140 20 H 200 V 80 H 140 Z")',
+    )
   })
 })

--- a/src/renderer/panels/browserSurfaceRegistry.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.tsx
@@ -9,6 +9,119 @@ interface SurfaceEntry {
 const slots = new Map<string, HTMLDivElement>()
 const surfaces = new Map<string, SurfaceEntry>()
 
+interface SurfaceRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+const CLIPPING_OVERFLOWS = new Set(['auto', 'clip', 'hidden', 'scroll'])
+
+function intersectRects(a: SurfaceRect, b: SurfaceRect): SurfaceRect | null {
+  const rect = {
+    left: Math.max(a.left, b.left),
+    top: Math.max(a.top, b.top),
+    right: Math.min(a.right, b.right),
+    bottom: Math.min(a.bottom, b.bottom),
+  }
+  return rect.right > rect.left && rect.bottom > rect.top ? rect : null
+}
+
+function clippingRect(slot: HTMLElement, rect: DOMRect): SurfaceRect | null {
+  let visible: SurfaceRect | null = intersectRects(rect, {
+    left: 0,
+    top: 0,
+    right: window.innerWidth,
+    bottom: window.innerHeight,
+  })
+  for (let element = slot.parentElement; visible && element; element = element.parentElement) {
+    const style = getComputedStyle(element)
+    const shorthand = style.overflow.trim().split(/\s+/)
+    const overflowX = style.overflowX && style.overflowX !== 'visible'
+      ? style.overflowX
+      : shorthand[0]
+    const overflowY = style.overflowY && style.overflowY !== 'visible'
+      ? style.overflowY
+      : (shorthand[1] ?? shorthand[0])
+    const clipsX = CLIPPING_OVERFLOWS.has(overflowX)
+    const clipsY = CLIPPING_OVERFLOWS.has(overflowY)
+    if (!clipsX && !clipsY) continue
+    const ancestor = element.getBoundingClientRect()
+    visible = intersectRects(visible, {
+      left: clipsX ? ancestor.left : visible.left,
+      top: clipsY ? ancestor.top : visible.top,
+      right: clipsX ? ancestor.right : visible.right,
+      bottom: clipsY ? ancestor.bottom : visible.bottom,
+    })
+  }
+  return visible
+}
+
+function cssNumber(value: number): string {
+  return String(Math.round(value * 1000) / 1000)
+}
+
+function surfaceClipPath(
+  slot: HTMLElement,
+  rect: DOMRect,
+  logicalWidth: number,
+  logicalHeight: number,
+): string | null {
+  const visible = clippingRect(slot, rect)
+  if (!visible) return null
+
+  const scaleX = rect.width / logicalWidth
+  const scaleY = rect.height / logicalHeight
+  const local = (screenRect: SurfaceRect): SurfaceRect => ({
+    left: (screenRect.left - rect.left) / scaleX,
+    top: (screenRect.top - rect.top) / scaleY,
+    right: (screenRect.right - rect.left) / scaleX,
+    bottom: (screenRect.bottom - rect.top) / scaleY,
+  })
+  const outer = local(visible)
+
+  // The persistent surface lives outside the canvas transform, so matching the
+  // node's z-index alone cannot interleave it with regular canvas children.
+  // Punch out higher nodes and let their real DOM show through those regions.
+  const node = slot.closest<HTMLElement>('[data-node-id]')
+  const nodeLayer = node?.parentElement
+  const nodeZIndex = node ? Number.parseFloat(getComputedStyle(node).zIndex) : Number.NaN
+  const occluders = nodeLayer && Number.isFinite(nodeZIndex)
+    ? Array.from(nodeLayer.children)
+      .filter((element): element is HTMLElement => (
+        element instanceof HTMLElement
+        && element !== node
+        && element.hasAttribute('data-node-id')
+      ))
+      .filter((element) => {
+        const style = getComputedStyle(element)
+        return Number.parseFloat(style.zIndex) > nodeZIndex
+          && style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && Number.parseFloat(style.opacity || '1') > 0
+      })
+      .map((element) => intersectRects(visible, element.getBoundingClientRect()))
+      .filter((value): value is SurfaceRect => value !== null)
+      .map(local)
+    : []
+
+  if (occluders.length === 0) {
+    return `inset(${cssNumber(outer.top)}px ${cssNumber(logicalWidth - outer.right)}px ${cssNumber(logicalHeight - outer.bottom)}px ${cssNumber(outer.left)}px)`
+  }
+
+  const path = [
+    `M ${cssNumber(outer.left)} ${cssNumber(outer.top)}`,
+    `H ${cssNumber(outer.right)}`,
+    `V ${cssNumber(outer.bottom)}`,
+    `H ${cssNumber(outer.left)} Z`,
+    ...occluders.map((hole) => (
+      `M ${cssNumber(hole.left)} ${cssNumber(hole.top)} H ${cssNumber(hole.right)} V ${cssNumber(hole.bottom)} H ${cssNumber(hole.left)} Z`
+    )),
+  ].join(' ')
+  return `path(evenodd, "${path}")`
+}
+
 function parkSurface(surface: SurfaceEntry): void {
   const { container } = surface
   container.dataset.browserSurfaceVisible = 'false'
@@ -18,6 +131,7 @@ function parkSurface(surface: SurfaceEntry): void {
   container.style.width = '1200px'
   container.style.height = '800px'
   container.style.transform = 'none'
+  container.style.clipPath = 'none'
   container.style.opacity = '0'
   container.style.pointerEvents = 'none'
 }
@@ -41,6 +155,12 @@ function updateSurface(panelId: string): void {
     return
   }
 
+  const clipPath = surfaceClipPath(slot, rect, logicalWidth, logicalHeight)
+  if (!clipPath) {
+    parkSurface(surface)
+    return
+  }
+
   const node = slot.closest<HTMLElement>('[data-node-id]')
   const nodeZIndex = node ? getComputedStyle(node).zIndex : 'auto'
   const { container } = surface
@@ -52,6 +172,7 @@ function updateSurface(panelId: string): void {
   container.style.height = `${logicalHeight}px`
   container.style.transformOrigin = '0 0'
   container.style.transform = `translate3d(${rect.left}px, ${rect.top}px, 0) scale(${rect.width / logicalWidth}, ${rect.height / logicalHeight})`
+  container.style.clipPath = clipPath
   container.style.zIndex = nodeZIndex === 'auto' ? '1' : nodeZIndex
   container.style.opacity = '1'
   container.style.pointerEvents = 'auto'
@@ -75,9 +196,27 @@ function watchSurface(panelId: string): void {
   }
   const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(schedule)
   resize?.observe(slot)
-  const mutation = typeof MutationObserver === 'undefined' ? null : new MutationObserver(schedule)
+  const mutation = typeof MutationObserver === 'undefined' ? null : new MutationObserver((records) => {
+    // A new/removed canvas node changes the occlusion set. Rebuild observers so
+    // subsequent z-order and geometry changes on the new siblings are tracked.
+    if (records.some((record) => record.type === 'childList')) {
+      watchSurface(panelId)
+      return
+    }
+    schedule()
+  })
   for (let element: HTMLElement | null = slot; element; element = element.parentElement) {
     mutation?.observe(element, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] })
+  }
+  const node = slot.closest<HTMLElement>('[data-node-id]')
+  const nodeLayer = node?.parentElement
+  if (nodeLayer) {
+    mutation?.observe(nodeLayer, { childList: true })
+    for (const sibling of Array.from(nodeLayer.children)) {
+      if (!(sibling instanceof HTMLElement) || !sibling.hasAttribute('data-node-id')) continue
+      mutation?.observe(sibling, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] })
+      resize?.observe(sibling)
+    }
   }
   window.addEventListener('resize', schedule)
   window.addEventListener('scroll', schedule, true)


### PR DESCRIPTION
## Summary
- clip persistent browser surfaces to their visible canvas ancestry
- let higher-order canvas nodes paint and receive input above browser surfaces
- track sibling geometry and z-order changes without remounting webviews

## Verification
- npm test -- --run src/renderer/panels/BackgroundBrowserHost.test.tsx
- npm run typecheck
- npm run build
- npx playwright test e2e/browser-background-automation.spec.ts
- full Vitest suite: 3054 passed, 5 skipped