### PR TITLE
fix(browser): sync webview during canvas transforms

### DIFF
--- a/src/renderer/panels/BackgroundBrowserHost.test.tsx
+++ b/src/renderer/panels/BackgroundBrowserHost.test.tsx
@@ -55,7 +55,7 @@ function VisibleBrowserSlot(): React.ReactElement {
 function ClippedStackedBrowserSlot(): React.ReactElement {
   return (
     <div data-test-rect="100,0,400,300" style={{ overflow: 'clip' }}>
-      <div>
+      <div data-canvas-world>
         <div data-node-id="browser-node" style={{ zIndex: 1001 }}>
           <BrowserPanelSurfaceSlot panelId="browser-one" />
         </div>
@@ -159,5 +159,27 @@ describe('BackgroundBrowserHost', () => {
     expect(surface?.style.clipPath).toBe(
       'path(evenodd, "M 90 0 H 200 V 100 H 90 Z M 140 20 H 200 V 80 H 140 Z")',
     )
+  })
+
+  it('keeps a persistent surface aligned while the canvas world transform changes', async () => {
+    act(() => root.render(
+      <PersistentBrowserHostContext.Provider value>
+        <ClippedStackedBrowserSlot />
+        <BackgroundBrowserHost />
+      </PersistentBrowserHostContext.Provider>,
+    ))
+
+    const slot = container.querySelector<HTMLElement>('[data-browser-surface-slot="browser-one"]')!
+    const world = container.querySelector<HTMLElement>('[data-canvas-world]')!
+    const surface = container.querySelector<HTMLElement>('[data-browser-surface="browser-one"]')!
+    slot.dataset.testRect = '120,40,420,190'
+
+    act(() => {
+      world.style.transform = 'scale(1.5) translate(20px, 10px)'
+    })
+
+    await vi.waitFor(() => {
+      expect(surface.style.transform).toBe('translate3d(120px, 40px, 0) scale(1.5, 1.5)')
+    })
   })
 })

--- a/src/renderer/panels/browserSurfaceRegistry.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.tsx
@@ -211,7 +211,14 @@ function watchSurface(panelId: string): void {
   const node = slot.closest<HTMLElement>('[data-node-id]')
   const nodeLayer = node?.parentElement
   if (nodeLayer) {
-    mutation?.observe(nodeLayer, { childList: true })
+    // nodeLayer is also one of the ancestors observed above. Calling observe()
+    // again replaces that target's options, so retain attribute observation:
+    // its transform changes on every canvas pan/zoom frame.
+    mutation?.observe(nodeLayer, {
+      attributes: true,
+      attributeFilter: ['style', 'class', 'aria-hidden'],
+      childList: true,
+    })
     for (const sibling of Array.from(nodeLayer.children)) {
       if (!(sibling instanceof HTMLElement) || !sibling.hasAttribute('data-node-id')) continue
       mutation?.observe(sibling, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] })


### PR DESCRIPTION
## Summary
- preserve canvas-world style observation while also watching canvas-node child changes
- keep persistent browser surfaces aligned during every pan/zoom frame
- add a regression test covering an in-progress world transform

## Verification
- `npm test` (3080 passed, 5 skipped)
- `npm run typecheck`
- `npm run build`
- `npx eslint src/renderer/panels/browserSurfaceRegistry.tsx src/renderer/panels/BackgroundBrowserHost.test.tsx`