### PR TITLE
Release 1.6.1-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.6.1-beta.4] - 2026-08-30
+
+This beta keeps browser panels visually synchronized during canvas navigation.
+
+### Fixed
+
+- **Browser pan and zoom synchronization**: persistent webviews now update their position and scale continuously while the canvas pans or zooms, instead of snapping into place only after the gesture ends.
+
 ## [1.6.1-beta.3] - 2026-08-29
 
 This beta expands terminal-agent support and sharpens everyday panel, remote-workspace, and browser workflows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.3",
+  "version": "1.6.1-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.1-beta.3",
+      "version": "1.6.1-beta.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.3",
+  "version": "1.6.1-beta.4",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.1-beta.3'
+export const RUNTIME_VERSION = '1.6.1-beta.4'


### PR DESCRIPTION
## Summary
- add the complete 1.6.1-beta.4 changelog entry dated 2026-08-30
- bump the app, lockfile, and bundled runtime versions to 1.6.1-beta.4

## Verification
- `npm test` (3080 passed, 5 skipped)
- `npm run typecheck`
- `npm run build`