### PR TITLE
Release 1.6.1-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.6.1-beta.5] - 2026-09-03
+
+This beta adds a unified review workflow for changes across entire commits, branches, and working trees.
+
+### Added
+
+- **Multi-file Diff Review panel**: inspect every changed file and its individual diff together for uncommitted, unstaged, staged, commit, and merge-base branch comparisons.
+- **Focused review workflows**: launch reviews from Source Control or the canvas, jump directly to a selected file, switch between unified and split layouts, filter files, preview image changes, and add exportable local file or line notes.
+- **Review-time Git actions**: stage, unstage, or discard files and commit, push, or open a pull request directly from eligible reviews across local, SSH, and WSL workspaces.
+
+### Fixed
+
+- **Nested workspace comparisons**: Diff Review resolves repository-root paths correctly when the open workspace is inside a repository subdirectory.
+
 ## [1.6.1-beta.4] - 2026-08-30
 
 This beta keeps browser panels visually synchronized during canvas navigation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.4",
+  "version": "1.6.1-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "1.6.1-beta.4",
+      "version": "1.6.1-beta.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "1.6.1-beta.4",
+  "version": "1.6.1-beta.5",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",

--- a/src/runtime/version.ts
+++ b/src/runtime/version.ts
@@ -6,4 +6,4 @@
 // matching runtime tarballs (see runtimeArtifacts.ts).
 // =============================================================================
 
-export const RUNTIME_VERSION = '1.6.1-beta.4'
+export const RUNTIME_VERSION = '1.6.1-beta.5'


### PR DESCRIPTION
## Summary

- add the complete 1.6.1-beta.5 changelog entry dated 2026-09-03
- document the new multi-file Diff Review workflow and nested-workspace comparison fix
- bump the app, lockfile, and bundled runtime versions to 1.6.1-beta.5

## Validation

- npm run typecheck
- npm run build
- npm test -- src/shared/changelog.test.ts src/main/semver.test.ts src/renderer/lib/workspace/sessionSerialize.roundTrip.test.ts (24 passed)