### PR TITLE
feat(canvas): visualize cross-panel agent activity

### DIFF
--- a/src/renderer/canvas/Canvas.topOverlay.test.tsx
+++ b/src/renderer/canvas/Canvas.topOverlay.test.tsx
@@ -1,0 +1,85 @@
+import React, { act } from 'react'
+import { createPortal } from 'react-dom'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../hooks/useCanvasInteraction', () => ({
+  useCanvasInteraction: () => ({
+    handleWheel: vi.fn(),
+    handleMouseDown: vi.fn(),
+    handleMouseMove: vi.fn(),
+    handleMouseUp: vi.fn(),
+    handleContextMenu: vi.fn(),
+    canvasContextMenu: null,
+    closeCanvasContextMenu: vi.fn(),
+  }),
+}))
+vi.mock('../hooks/useAutoFocusLargestVisible', () => ({ useAutoFocusLargestVisible: vi.fn() }))
+vi.mock('./CanvasGrid', () => ({ default: () => null }))
+vi.mock('./CanvasBackgroundImage', () => ({ default: () => null }))
+vi.mock('./SnapGuides', () => ({ default: () => null }))
+vi.mock('./GhostPlacementLayer', () => ({ default: () => null }))
+vi.mock('./placementViz/PlacementVizOverlay', () => ({ default: () => null }))
+vi.mock('./worktree', () => ({ WorktreeTerritoryLayer: () => null }))
+
+import Canvas from './Canvas'
+import { CanvasTopOverlayContext } from './CanvasTopOverlayContext'
+import { CanvasStoreProvider } from '../stores/CanvasStoreContext'
+import { createCanvasStore } from '../stores/canvasStore'
+import { useUIStore } from '../stores/uiStore'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+function PortalledGlowProbe(): React.ReactElement | null {
+  const target = React.useContext(CanvasTopOverlayContext)
+  return target ? createPortal(<div data-glow-probe />, target) : null
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe(): void {}
+    disconnect(): void {}
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useUIStore.setState({
+    activeTool: 'select',
+    marquee: { startX: 10, startY: 20, currentX: 60, currentY: 80 },
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  useUIStore.setState({ marquee: null })
+  vi.unstubAllGlobals()
+})
+
+describe('Canvas top overlay', () => {
+  it('portals above-panel canvas chrome into one transformed screen-space layer', () => {
+    const store = createCanvasStore()
+    act(() => store.getState().setZoomAndOffset(2, { x: 30, y: 40 }))
+
+    act(() => root.render(
+      <CanvasStoreProvider store={store}>
+        <Canvas panelId="canvas-one" overlayChildren={<div data-toolbar-probe />}>
+          <PortalledGlowProbe />
+        </Canvas>
+      </CanvasStoreProvider>,
+    ))
+
+    const overlay = document.body.querySelector<HTMLElement>('[data-canvas-top-overlay="canvas-one"]')!
+    const marquee = overlay.querySelector<HTMLElement>('[data-canvas-marquee]')!
+    const world = marquee.parentElement!
+    expect(overlay.style.position).toBe('fixed')
+    expect(overlay.style.zIndex).toBe('1')
+    expect(world.style.transform).toBe('scale(2) translate(15px, 20px)')
+    expect(overlay.querySelector('[data-glow-probe]')).not.toBeNull()
+    expect(overlay.querySelector('[data-toolbar-probe]')).not.toBeNull()
+    expect(container.querySelector('[data-canvas-marquee]')).toBeNull()
+  })
+})

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -3,7 +3,7 @@
 // Ported from CanvasView.swift.
 // =============================================================================
 
-import React, { useRef, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useRef, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useCanvasStoreContext, useCanvasStoreApi } from '../stores/CanvasStoreContext'
 import { useAppStore, type PanelPlacement } from '../stores/appStore'
@@ -26,6 +26,7 @@ import { CHAT_DRAG_MIME, readChatDrag } from '../drag/fileDragPayload'
 import { createSeededChatPanel } from '../drag/openChatDrop'
 import { endChatDrag } from '../drag/chatDragState'
 import { seedAgentPanelWithWorktreeChat } from '../../cateAgent/renderer/seedWorktreeChat'
+import { CanvasTopOverlayContext } from './CanvasTopOverlayContext'
 
 // Module-level style injection — shared across all Canvas instances
 let canvasStyleInjected = false
@@ -40,6 +41,10 @@ function injectCanvasInteractingStyle(): void {
     .canvas-interacting .xterm,
     .canvas-interacting .xterm-screen,
     .canvas-interacting .xterm-helper-textarea {
+      pointer-events: none !important;
+    }
+    .canvas-dragging [data-browser-surface],
+    .canvas-interacting [data-browser-surface] {
       pointer-events: none !important;
     }
     .canvas-interacting .xterm,
@@ -149,15 +154,24 @@ const PlacementHint: React.FC<{ canvasRef: React.RefObject<HTMLDivElement> }> = 
 
 interface CanvasProps {
   children?: React.ReactNode
+  /** Screen-space canvas chrome that must remain above persistent browser surfaces. */
+  overlayChildren?: React.ReactNode
   /** Called when the user right-clicks empty canvas and picks a panel type. */
   onCreateAtPoint?: (type: PanelType, canvasPoint: Point) => void
   /** Stamped onto the container so resolveDrop can map back to a CanvasStore. */
   panelId?: string
 }
 
-const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) => {
+const Canvas: React.FC<CanvasProps> = ({ children, overlayChildren, onCreateAtPoint, panelId }) => {
   const canvasRef = useRef<HTMLDivElement>(null)
   const worldRef = useRef<HTMLDivElement>(null)
+  const topOverlayRef = useRef<HTMLDivElement>(null)
+  const topOverlayWorldRef = useRef<HTMLDivElement | null>(null)
+  const [topOverlayWorld, setTopOverlayWorld] = useState<HTMLDivElement | null>(null)
+  const setTopOverlayWorldRef = useCallback((element: HTMLDivElement | null) => {
+    topOverlayWorldRef.current = element
+    setTopOverlayWorld(element)
+  }, [])
   // Debounce handle for de-promoting the world layer after pan/zoom settles.
   const willChangeResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const canvasApi = useCanvasStoreApi()
@@ -203,21 +217,28 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
   // Canvas itself never re-renders during pan/zoom — only the world div moves.
   useEffect(() => {
     const applyTransform = (zoom: number, offset: { x: number; y: number }) => {
-      const el = worldRef.current
-      if (!el) return
-      el.style.transform = `scale(${zoom}) translate(${offset.x / zoom}px, ${offset.y / zoom}px)`
-      el.style.setProperty('--zoom', String(zoom))
+      const transform = `scale(${zoom}) translate(${offset.x / zoom}px, ${offset.y / zoom}px)`
+      const layers = [worldRef.current, topOverlayWorldRef.current]
+      if (!layers.some(Boolean)) return
+      for (const el of layers) {
+        if (!el) continue
+        el.style.transform = transform
+        el.style.setProperty('--zoom', String(zoom))
+      }
 
       // Promote the world to its own GPU layer for the duration of the gesture so
       // pan/zoom stays smooth, then de-promote once it settles. While promoted,
       // Chromium bitmap-scales the layer's cached texture (blurs thin SVG icon
       // strokes); removing will-change forces a crisp re-raster at the resting
       // transform. Debounced so it only fires after the user stops interacting.
-      el.style.willChange = 'transform'
+      for (const el of layers) {
+        if (el) el.style.willChange = 'transform'
+      }
       if (willChangeResetRef.current) clearTimeout(willChangeResetRef.current)
       willChangeResetRef.current = setTimeout(() => {
-        const node = worldRef.current
-        if (node) node.style.willChange = 'auto'
+        for (const node of [worldRef.current, topOverlayWorldRef.current]) {
+          if (node) node.style.willChange = 'auto'
+        }
         willChangeResetRef.current = null
       }, 150)
     }
@@ -237,6 +258,33 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
       if (willChangeResetRef.current) clearTimeout(willChangeResetRef.current)
     }
   }, []) // mount-only
+
+  // The persistent browser host is fixed at the window root, outside this
+  // canvas's stacking context. Keep a fixed overlay clipped and aligned to the
+  // canvas viewport so above-panel chrome can share screen space with it.
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const sync = () => {
+      const overlay = topOverlayRef.current
+      if (!overlay) return
+      const rect = canvas.getBoundingClientRect()
+      overlay.style.left = `${rect.left}px`
+      overlay.style.top = `${rect.top}px`
+      overlay.style.width = `${rect.width}px`
+      overlay.style.height = `${rect.height}px`
+    }
+    sync()
+    const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(sync)
+    resize?.observe(canvas)
+    window.addEventListener('resize', sync)
+    window.addEventListener('scroll', sync, true)
+    return () => {
+      resize?.disconnect()
+      window.removeEventListener('resize', sync)
+      window.removeEventListener('scroll', sync, true)
+    }
+  }, [])
 
   // Auto-focus the node that occupies the most visible viewport area (opt-in).
   useAutoFocusLargestVisible(canvasApi)
@@ -587,13 +635,32 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
     return () => { cancelled = true }
   }, [canvasContextMenu, onCreateAtPoint, canvasApi, closeCanvasContextMenu, here])
 
-  return (
+  const marqueeElement = marqueeRect ? (
     <div
-      ref={canvasRef}
-      data-canvas-container
-      data-canvas-panel-id={panelId}
-      data-filedrop="canvas"
-      data-filedrop-id={panelId}
+      data-canvas-marquee
+      style={{
+        position: 'absolute',
+        left: marqueeRect.x,
+        top: marqueeRect.y,
+        width: marqueeRect.w,
+        height: marqueeRect.h,
+        backgroundColor: 'rgba(74, 158, 255, 0.1)',
+        border: '1px solid rgba(74, 158, 255, 0.5)',
+        borderRadius: 2,
+        pointerEvents: 'none',
+        zIndex: 99999,
+      }}
+    />
+  ) : null
+
+  return (
+    <CanvasTopOverlayContext.Provider value={topOverlayWorld}>
+      <div
+        ref={canvasRef}
+        data-canvas-container
+        data-canvas-panel-id={panelId}
+        data-filedrop="canvas"
+        data-filedrop-id={panelId}
       // overflow-clip, not overflow-hidden: the canvas pans via the world
       // transform and must never become a scroll container. `hidden` clips
       // visually but still allows *programmatic* scrolling — when a panel's
@@ -648,29 +715,44 @@ const Canvas: React.FC<CanvasProps> = ({ children, onCreateAtPoint, panelId }) =
         onClick={handleWorldClick}
       >
         <SnapGuides />
-        {marqueeRect && (
-          <div
-            style={{
-              position: 'absolute',
-              left: marqueeRect.x,
-              top: marqueeRect.y,
-              width: marqueeRect.w,
-              height: marqueeRect.h,
-              backgroundColor: 'rgba(74, 158, 255, 0.1)',
-              border: '1px solid rgba(74, 158, 255, 0.5)',
-              borderRadius: 2,
-              pointerEvents: 'none',
-              zIndex: 99999,
-            }}
-          />
-        )}
         {children}
-        <GhostPlacementLayer />
-        {(import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV && <PlacementVizOverlay />}
       </div>
 
+      {createPortal(
+        <div
+          ref={topOverlayRef}
+          data-canvas-top-overlay={panelId ?? ''}
+          style={{
+            position: 'fixed',
+            overflow: 'clip',
+            pointerEvents: 'none',
+            zIndex: 1,
+          }}
+        >
+          <div
+            ref={setTopOverlayWorldRef}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: 1,
+              height: 1,
+              transformOrigin: '0 0',
+              pointerEvents: 'none',
+            }}
+          >
+            {marqueeElement}
+            <GhostPlacementLayer canvasRef={canvasRef} />
+            {(import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV && <PlacementVizOverlay />}
+          </div>
+          {overlayChildren}
+        </div>,
+        document.body,
+      )}
+
       <PlacementHint canvasRef={canvasRef} />
-    </div>
+      </div>
+    </CanvasTopOverlayContext.Provider>
   )
 }
 

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -7,6 +7,7 @@
 // =============================================================================
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useRenderCount } from '../lib/perf/perfClient'
 import type { StoreApi } from 'zustand'
 import type { NodeActivityState, DockTabStack as DockTabStackNode, PanelType } from '../../shared/types'
@@ -37,6 +38,7 @@ import { isWorktreePanelType, PANEL_DEFINITIONS } from '../../shared/panels'
 import { captureRendererException } from '../lib/sentry'
 import { useCateAgentStore } from '../../cateAgent/renderer/cateAgentStore'
 import { useChatsStore } from '../stores/chatsStore'
+import { useCanvasTopOverlayTarget } from './CanvasTopOverlayContext'
 
 // Node ids already reported for missing geometry, so a bad node that keeps
 // re-rendering warns/reports once instead of spamming.
@@ -158,6 +160,7 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   useRenderCount('CanvasNode')
 
   const canvasApi = useCanvasStoreApi()
+  const topOverlayTarget = useCanvasTopOverlayTarget()
   const nodeRef = useRef<HTMLDivElement>(null)
   const [isHovered, setIsHovered] = useState(false)
   const [isAnimatingLayout, setIsAnimatingLayout] = useState(false)
@@ -663,7 +666,9 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
 
   return (
     <>
-    {glowStyle && <div aria-hidden data-glow-for={nodeId} style={glowStyle} />}
+    {glowStyle && (topOverlayTarget
+      ? createPortal(<div aria-hidden data-glow-for={nodeId} style={glowStyle} />, topOverlayTarget)
+      : <div aria-hidden data-glow-for={nodeId} style={glowStyle} />)}
     <div
       ref={nodeRef}
       data-node-id={nodeId}

--- a/src/renderer/canvas/CanvasTopOverlayContext.ts
+++ b/src/renderer/canvas/CanvasTopOverlayContext.ts
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react'
+
+// Browser panels in the main window live in a persistent, fixed host outside
+// the transformed canvas. Canvas chrome that must paint above every panel is
+// portalled into this screen-level layer so it can cross that stacking boundary.
+export const CanvasTopOverlayContext = createContext<HTMLElement | null>(null)
+
+export function useCanvasTopOverlayTarget(): HTMLElement | null {
+  return useContext(CanvasTopOverlayContext)
+}

--- a/src/renderer/canvas/GhostPlacementLayer.tsx
+++ b/src/renderer/canvas/GhostPlacementLayer.tsx
@@ -34,7 +34,7 @@ function injectStyles() {
   document.head.appendChild(style)
 }
 
-const GhostPlacementLayer: React.FC = () => {
+const GhostPlacementLayer: React.FC<{ canvasRef?: React.RefObject<HTMLDivElement> }> = ({ canvasRef }) => {
   const pending = useCanvasStoreContext((s) => s.pendingPlacement)
   const focusedId = useCanvasStoreContext((s) => focusedNodeIdOf(s))
   const zoom = useCanvasStoreContext((s) => s.zoomLevel)
@@ -110,7 +110,8 @@ const GhostPlacementLayer: React.FC = () => {
 
   const armed = pending.freeArmed
   const toCanvas = (clientX: number, clientY: number, el: HTMLElement) => {
-    const container = el.closest('[data-canvas-container]') as HTMLElement | null
+    const container = canvasRef?.current
+      ?? el.closest('[data-canvas-container]') as HTMLElement | null
     if (!container) return null
     const rect = container.getBoundingClientRect()
     return api.getState().viewToCanvas({ x: clientX - rect.left, y: clientY - rect.top })

--- a/src/renderer/canvas/PanelConnectionLayer.test.tsx
+++ b/src/renderer/canvas/PanelConnectionLayer.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import type { StoreApi } from 'zustand'
+import { CanvasStoreProvider } from '../stores/CanvasStoreContext'
+import { createCanvasStore, type CanvasStore } from '../stores/canvasStore'
+import { useAppStore } from '../stores/appStore'
+import { beginPanelInteraction, clearPanelInteractions } from '../lib/panelInteractions'
+import { PanelConnectionLayer } from './PanelConnectionLayer'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const WS = 'ws-connections'
+let container: HTMLDivElement
+let root: Root
+let initialAppState: ReturnType<typeof useAppStore.getState>
+
+function canvasStore(): StoreApi<CanvasStore> {
+  const store = createCanvasStore()
+  store.getState().loadWorkspaceCanvas({
+    source: {
+      id: 'source',
+      origin: { x: 0, y: 0 },
+      size: { width: 200, height: 120 },
+      zOrder: 0,
+      creationIndex: 0,
+      animationState: 'idle',
+      dockLayout: { type: 'tabs', id: 'source-tabs', panelIds: ['agent'], activeIndex: 0 },
+    },
+    target: {
+      id: 'target',
+      origin: { x: 400, y: 0 },
+      size: { width: 200, height: 120 },
+      zOrder: 1,
+      creationIndex: 1,
+      animationState: 'idle',
+      dockLayout: { type: 'tabs', id: 'target-tabs', panelIds: ['worker', 'browser'], activeIndex: 0 },
+    },
+  }, { x: 0, y: 0 }, 1)
+  return store
+}
+
+beforeEach(() => {
+  initialAppState = useAppStore.getState()
+  clearPanelInteractions()
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    workspaces: [{
+      id: WS,
+      panels: {
+        agent: { id: 'agent', type: 'cateAgent', title: 'Agent' },
+        worker: {
+          id: 'worker',
+          type: 'terminal',
+          title: 'Worker',
+          codingAgentRun: {
+            id: 'run-1',
+            agentId: 'codex',
+            panelId: 'worker',
+            ownerPanelId: 'agent',
+            prompt: 'private prompt',
+            createdAt: 1,
+          },
+        },
+        browser: { id: 'browser', type: 'browser', title: 'Browser' },
+      },
+    }],
+  } as never)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  clearPanelInteractions()
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('PanelConnectionLayer', () => {
+  it('renders durable supervisor-to-worker ownership as a directed path', () => {
+    const store = canvasStore()
+    act(() => {
+      root.render(
+        <CanvasStoreProvider store={store}>
+          <PanelConnectionLayer workspaceId={WS} />
+        </CanvasStoreProvider>,
+      )
+    })
+
+    const path = container.querySelector('[data-panel-connection="persistent"]')
+    expect(path).not.toBeNull()
+    expect(path?.getAttribute('marker-end')).toContain('persistent')
+  })
+
+  it('overlays resolved CLI activity and never renders request contents', () => {
+    const store = canvasStore()
+    act(() => {
+      root.render(
+        <CanvasStoreProvider store={store}>
+          <PanelConnectionLayer workspaceId={WS} />
+        </CanvasStoreProvider>,
+      )
+    })
+    act(() => {
+      beginPanelInteraction({
+        workspaceId: WS,
+        sourcePanelId: 'agent',
+        targetPanelId: 'browser',
+        kind: 'control',
+      })
+    })
+
+    expect(container.querySelector('[data-panel-connection="active"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('private prompt')
+  })
+})

--- a/src/renderer/canvas/PanelConnectionLayer.tsx
+++ b/src/renderer/canvas/PanelConnectionLayer.tsx
@@ -1,0 +1,142 @@
+import React, { useId, useMemo } from 'react'
+import type { CanvasNodeState, PanelState } from '../../shared/types'
+import { collectPanelIds } from '../../shared/collectPanelIds'
+import { useCanvasStoreContext } from '../stores/CanvasStoreContext'
+import { useAppStore } from '../stores/appStore'
+import { usePanelInteractionStore, type PanelInteraction } from '../lib/panelInteractions'
+import { panelConnectionPath } from './panelConnectionGeometry'
+
+interface RenderedConnection {
+  key: string
+  source: CanvasNodeState
+  target: CanvasNodeState
+  persistent: boolean
+  interaction?: PanelInteraction
+}
+
+const EMPTY_PANELS: Record<string, PanelState> = {}
+
+export function PanelConnectionLayer({ workspaceId }: { workspaceId: string }) {
+  const markerPrefix = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  const nodes = useCanvasStoreContext((state) => state.nodes)
+  const panels = useAppStore(
+    (state) => state.workspaces.find((workspace) => workspace.id === workspaceId)?.panels ?? EMPTY_PANELS,
+  )
+  const interactions = usePanelInteractionStore((state) => state.interactions)
+
+  const connections = useMemo(() => {
+    const panelToNode = new Map<string, CanvasNodeState>()
+    for (const node of Object.values(nodes)) {
+      for (const panelId of collectPanelIds(node.dockLayout)) panelToNode.set(panelId, node)
+    }
+
+    const byNodePair = new Map<string, RenderedConnection>()
+    const add = (
+      sourcePanelId: string,
+      targetPanelId: string,
+      persistent: boolean,
+      interaction?: PanelInteraction,
+    ) => {
+      const source = panelToNode.get(sourcePanelId)
+      const target = panelToNode.get(targetPanelId)
+      if (!source || !target || source.id === target.id) return
+      const key = `${source.id}\0${target.id}`
+      const previous = byNodePair.get(key)
+      byNodePair.set(key, {
+        key,
+        source,
+        target,
+        persistent: persistent || previous?.persistent === true,
+        interaction: !interaction
+          ? previous?.interaction
+          : !previous?.interaction || interaction.updatedAt >= previous.interaction.updatedAt
+            ? interaction
+            : previous.interaction,
+      })
+    }
+
+    for (const panel of Object.values(panels)) {
+      const ownerPanelId = panel.codingAgentRun?.ownerPanelId
+      if (ownerPanelId) add(ownerPanelId, panel.id, true)
+    }
+    for (const interaction of Object.values(interactions)) {
+      if (interaction.workspaceId !== workspaceId) continue
+      add(interaction.sourcePanelId, interaction.targetPanelId, false, interaction)
+    }
+    return [...byNodePair.values()]
+  }, [interactions, nodes, panels, workspaceId])
+
+  if (connections.length === 0) return null
+
+  const marker = (phase: 'persistent' | 'active' | 'succeeded' | 'failed') => `${markerPrefix}-${phase}`
+  return (
+    <svg
+      aria-hidden
+      data-panel-connection-layer
+      width="1"
+      height="1"
+      style={{ position: 'absolute', left: 0, top: 0, overflow: 'visible', pointerEvents: 'none', zIndex: 500 }}
+    >
+      <defs>
+        {(['persistent', 'active', 'succeeded', 'failed'] as const).map((phase) => (
+          <marker
+            key={phase}
+            id={marker(phase)}
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="8"
+            markerHeight="8"
+            orient="auto"
+            markerUnits="userSpaceOnUse"
+          >
+            <path
+              d="M 0 0 L 8 4 L 0 8 z"
+              fill={phase === 'persistent'
+                ? 'var(--text-muted)'
+                : phase === 'failed' ? 'var(--git-deleted)' : 'var(--focus-blue)'}
+            />
+          </marker>
+        ))}
+      </defs>
+      {connections.flatMap((connection) => {
+        const path = panelConnectionPath(
+          { origin: connection.source.origin, size: connection.source.size },
+          { origin: connection.target.origin, size: connection.target.size },
+        )
+        if (!path) return []
+        const phase = connection.interaction?.phase
+        return [
+          connection.persistent ? (
+            <path
+              key={`${connection.key}-persistent`}
+              data-panel-connection="persistent"
+              d={path}
+              fill="none"
+              stroke="var(--text-muted)"
+              strokeWidth="1.5"
+              strokeDasharray="5 7"
+              opacity="0.32"
+              markerEnd={`url(#${marker('persistent')})`}
+              vectorEffect="non-scaling-stroke"
+            />
+          ) : null,
+          phase ? (
+            <path
+              key={`${connection.key}-${connection.interaction!.pulse}-${phase}`}
+              data-panel-connection={phase}
+              d={path}
+              fill="none"
+              stroke={phase === 'failed' ? 'var(--git-deleted)' : 'var(--focus-blue)'}
+              strokeWidth="2.25"
+              strokeLinecap="round"
+              markerEnd={`url(#${marker(phase)})`}
+              vectorEffect="non-scaling-stroke"
+              className={phase === 'active' ? 'cate-panel-connection-active' : 'cate-panel-connection-finished'}
+            />
+          ) : null,
+        ]
+      })}
+    </svg>
+  )
+}

--- a/src/renderer/canvas/panelConnectionGeometry.test.ts
+++ b/src/renderer/canvas/panelConnectionGeometry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { Rect } from '../../shared/types'
+import { panelConnectionPath } from './panelConnectionGeometry'
+
+const rect = (x: number, y: number, width = 100, height = 80): Rect => ({
+  origin: { x, y },
+  size: { width, height },
+})
+
+describe('panelConnectionPath', () => {
+  it('connects horizontal rectangles at their facing edges with a gap', () => {
+    expect(panelConnectionPath(rect(0, 0), rect(300, 0))).toBe(
+      'M 107 40 C 203 40, 197 40, 293 40',
+    )
+  })
+
+  it('connects vertical rectangles at their facing edges', () => {
+    const path = panelConnectionPath(rect(0, 0), rect(0, 240))
+    expect(path).toMatch(/^M 50 87 C /)
+    expect(path).toMatch(/, 50 233$/)
+  })
+
+  it('does not invent a direction for coincident rectangles', () => {
+    expect(panelConnectionPath(rect(10, 20), rect(10, 20))).toBeNull()
+  })
+})

--- a/src/renderer/canvas/panelConnectionGeometry.ts
+++ b/src/renderer/canvas/panelConnectionGeometry.ts
@@ -1,0 +1,52 @@
+import type { Point, Rect } from '../../shared/types'
+
+const ENDPOINT_GAP = 7
+
+function center(rect: Rect): Point {
+  return {
+    x: rect.origin.x + rect.size.width / 2,
+    y: rect.origin.y + rect.size.height / 2,
+  }
+}
+
+function boundaryPoint(rect: Rect, toward: Point): Point {
+  const from = center(rect)
+  const dx = toward.x - from.x
+  const dy = toward.y - from.y
+  const halfWidth = Math.max(1, rect.size.width / 2)
+  const halfHeight = Math.max(1, rect.size.height / 2)
+  const scale = 1 / Math.max(Math.abs(dx) / halfWidth, Math.abs(dy) / halfHeight)
+  return { x: from.x + dx * scale, y: from.y + dy * scale }
+}
+
+/** A stable canvas-space cubic path between the nearest rectangle edges. */
+export function panelConnectionPath(source: Rect, target: Rect): string | null {
+  const sourceCenter = center(source)
+  const targetCenter = center(target)
+  const dx = targetCenter.x - sourceCenter.x
+  const dy = targetCenter.y - sourceCenter.y
+  const distance = Math.hypot(dx, dy)
+  if (distance < 1) return null
+
+  const unit = { x: dx / distance, y: dy / distance }
+  const startBoundary = boundaryPoint(source, targetCenter)
+  const endBoundary = boundaryPoint(target, sourceCenter)
+  const start = {
+    x: startBoundary.x + unit.x * ENDPOINT_GAP,
+    y: startBoundary.y + unit.y * ENDPOINT_GAP,
+  }
+  const end = {
+    x: endBoundary.x - unit.x * ENDPOINT_GAP,
+    y: endBoundary.y - unit.y * ENDPOINT_GAP,
+  }
+  const bend = Math.min(180, Math.max(36, distance * 0.32))
+  const horizontal = Math.abs(dx) >= Math.abs(dy)
+  const c1 = horizontal
+    ? { x: start.x + Math.sign(dx) * bend, y: start.y }
+    : { x: start.x, y: start.y + Math.sign(dy) * bend }
+  const c2 = horizontal
+    ? { x: end.x - Math.sign(dx) * bend, y: end.y }
+    : { x: end.x, y: end.y - Math.sign(dy) * bend }
+
+  return `M ${start.x} ${start.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${end.x} ${end.y}`
+}

--- a/src/renderer/docking/DockTabBar.tsx
+++ b/src/renderer/docking/DockTabBar.tsx
@@ -13,12 +13,44 @@ import { useDragStore, useTabSourceVisibility } from '../drag'
 import { PANEL_REGISTRY, getPanelDef } from '../panels/registry'
 import { useAppStore } from '../stores/appStore'
 import { useAgentInfoByPanel } from '../hooks/useAgentPanelInfo'
-import { worktreeTitleStyle } from '../lib/worktreeTitleStyle'
+import { AgentActivityTitle, AwaitingIndicator } from '../ui/AgentActivityTitle'
 import { isMiddleClick } from '../lib/mouse'
 import { isWorktreePanelType } from '../../shared/panels'
 import { useActiveChatWorktreeByPanel } from '../../cateAgent/renderer/cateAgentStore'
+import { usePanelInteractionStore } from '../lib/panelInteractions'
 
-const AWAIT_COLOR = '#c08a5a'
+function PanelInteractionDot({ panelId }: { panelId: string }) {
+  const signal = usePanelInteractionStore((state) => {
+    let newest: (typeof state.interactions)[string] | undefined
+    let role: 'source' | 'target' = 'source'
+    for (const interaction of Object.values(state.interactions)) {
+      const nextRole = interaction.targetPanelId === panelId
+        ? 'target'
+        : interaction.sourcePanelId === panelId ? 'source' : null
+      if (!nextRole || (newest && newest.updatedAt > interaction.updatedAt)) continue
+      newest = interaction
+      role = nextRole
+    }
+    return newest ? `${newest.phase}\0${newest.pulse}\0${role}` : ''
+  })
+  if (!signal) return null
+  const [phase, _pulse, role] = signal.split('\0')
+  const color = phase === 'failed' ? 'var(--git-deleted)' : 'var(--focus-blue)'
+  return (
+    <span
+      aria-label={`panel interaction ${role}`}
+      data-panel-interaction={role}
+      className={`shrink-0 rounded-full ${phase === 'active' ? 'cate-panel-interaction-dot-active' : ''}`}
+      style={{
+        width: 6,
+        height: 6,
+        transformOrigin: 'center',
+        backgroundColor: role === 'target' ? color : 'transparent',
+        border: role === 'source' ? `1.5px solid ${color}` : undefined,
+      }}
+    />
+  )
+}
 
 // Lookup: panelId → worktree color. Only returns a color when the panel's
 // workspace has 2+ worktrees. Both terminal and Agent tabs retain this light
@@ -263,15 +295,15 @@ export function DockTabBar(props: DockTabBarProps) {
                 style={{ font: 'inherit' }}
               />
             ) : (
-              <span
-                className={`truncate flex-1 min-w-0 ${agentInfoByPanel[panelId]?.state === 'running' ? 'cate-notif-pulse' : ''}`}
-                style={worktreeTitleStyle(worktreeColorByPanel[panelId], agentInfoByPanel[panelId]?.state === 'running')}
-              >{getPanelTitle(panelId)}</span>
+              <AgentActivityTitle
+                className="min-w-0 flex-1 truncate"
+                running={agentInfoByPanel[panelId]?.state === 'running'}
+                worktreeColor={worktreeColorByPanel[panelId]}
+              >{getPanelTitle(panelId)}</AgentActivityTitle>
             )}
+            <PanelInteractionDot panelId={panelId} />
             {agentInfoByPanel[panelId]?.state === 'waitingForInput' && (
-              <span className="cate-await-indicator shrink-0" aria-label="awaiting input">
-                <span className="cate-await-dot" style={{ backgroundColor: AWAIT_COLOR }} />
-              </span>
+              <AwaitingIndicator />
             )}
             {onClosePanel && (
               <span

--- a/src/renderer/hooks/useCateHostActionResponder.test.tsx
+++ b/src/renderer/hooks/useCateHostActionResponder.test.tsx
@@ -37,7 +37,15 @@ const h = vi.hoisted(() => ({
 }))
 
 const terminalDriver = vi.hoisted(() => ({
-  handleTerminalMethod: vi.fn(async () => ({ ok: true as const, result: { panelId: 't1', alt: false, text: 'x' } })),
+  handleTerminalMethod: vi.fn(async (
+    _workspaceId: string,
+    _method: string,
+    _args: unknown,
+    onTargetResolved?: (panelId: string) => void,
+  ) => {
+    onTargetResolved?.('t1')
+    return { ok: true as const, result: { panelId: 't1', alt: false, text: 'x' } }
+  }),
 }))
 vi.mock('../lib/terminal/terminalDriver', () => ({ handleTerminalMethod: terminalDriver.handleTerminalMethod }))
 
@@ -91,6 +99,7 @@ vi.mock('../stores/appStore', () => ({
 }))
 
 import { useCateHostActionResponder } from './useCateHostActionResponder'
+import { clearPanelInteractions, usePanelInteractionStore } from '../lib/panelInteractions'
 
 // Capture the action callback main would invoke, and the replies the hook sends.
 let actionCb: ((payload: unknown) => unknown) | null = null
@@ -138,6 +147,7 @@ const BACKGROUND_PLACEMENT = { target: 'canvas', canvasPanelId: 'canvas-1', focu
 
 beforeEach(() => {
   vi.clearAllMocks()
+  clearPanelInteractions()
   fsStat.mockResolvedValue({ isDirectory: false, isFile: true })
   h.placementForBackgroundPanel.mockReturnValue(BACKGROUND_PLACEMENT)
   h.activePanelId = null
@@ -153,6 +163,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => { root.unmount() })
   container.remove()
+  clearPanelInteractions()
 })
 
 describe('useCateHostActionResponder', () => {
@@ -332,11 +343,23 @@ describe('useCateHostActionResponder', () => {
 
   it('delegates cate.terminal.* to the terminal driver and relays its result', async () => {
     await fire('cate.terminal.read', { panelId: 't1' })
-    expect(terminalDriver.handleTerminalMethod).toHaveBeenCalledWith(WS, 'cate.terminal.read', { panelId: 't1' })
+    expect(terminalDriver.handleTerminalMethod).toHaveBeenCalledWith(
+      WS,
+      'cate.terminal.read',
+      { panelId: 't1' },
+      expect.any(Function),
+    )
     expect(replies).toContainEqual({
       requestId: 'req-cate.terminal.read',
       ok: true,
       result: { panelId: 't1', alt: false, text: 'x' },
+    })
+    expect(Object.values(usePanelInteractionStore.getState().interactions)[0]).toMatchObject({
+      workspaceId: WS,
+      sourcePanelId: 'host-panel',
+      targetPanelId: 't1',
+      kind: 'read',
+      phase: 'active',
     })
   })
 

--- a/src/renderer/hooks/useCateHostActionResponder.ts
+++ b/src/renderer/hooks/useCateHostActionResponder.ts
@@ -25,7 +25,12 @@ import { toAbsolutePath, pathKey } from '../../shared/pathUtils'
 import { parseLocator, formatLocator } from '../../shared/runtimeLocator'
 import { handleBrowserMethod } from '../lib/browser/browserDriver'
 import { handleTerminalMethod } from '../lib/terminal/terminalDriver'
-import { handleCodingAgentMethod } from '../lib/agent/codingAgentDriver'
+import { codingAgentInteractionTargets, handleCodingAgentMethod } from '../lib/agent/codingAgentDriver'
+import {
+  beginPanelInteraction,
+  type PanelInteractionKind,
+  type PanelTargetObserver,
+} from '../lib/panelInteractions'
 import { browserPanelUrl, isStartPageUrl, type PanelType, type Point } from '../../shared/types'
 import type { PanelPlacement } from '../stores/appStore'
 
@@ -55,6 +60,58 @@ interface HostActionPayload {
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+const BROWSER_READ_METHODS = new Set([
+  'cate.browser.current',
+  'cate.browser.downloads',
+  'cate.browser.readCommand',
+  'cate.browser.snapshot',
+  'cate.browser.screenshot',
+  'cate.browser.tabs',
+])
+
+function interactionTracker(
+  workspaceId: string,
+  sourcePanelId: string,
+  kind: PanelInteractionKind,
+): { observe: PanelTargetObserver; finish: (succeeded: boolean) => void } {
+  const completions = new Map<string, (succeeded: boolean) => void>()
+  let completed: boolean | undefined
+  return {
+    observe(targetPanelId) {
+      if (completions.has(targetPanelId)) return
+      const complete = beginPanelInteraction({
+        workspaceId,
+        sourcePanelId,
+        targetPanelId,
+        kind,
+      })
+      completions.set(targetPanelId, complete)
+      // Creation calls learn the new panel id from their result, after the
+      // tracked operation itself has completed.
+      if (completed !== undefined) complete(completed)
+    },
+    finish(succeeded) {
+      completed = succeeded
+      for (const complete of completions.values()) complete(succeeded)
+    },
+  }
+}
+
+async function finishTracked<T>(
+  tracker: ReturnType<typeof interactionTracker>,
+  action: () => Promise<T>,
+  succeeded: (value: T) => boolean,
+): Promise<T> {
+  try {
+    const value = await action()
+    tracker.finish(succeeded(value))
+    return value
+  } catch (error) {
+    tracker.finish(false)
+    throw error
+  }
 }
 
 // Extensions address files by a path relative to the workspace root (e.g.
@@ -124,7 +181,16 @@ export function useCateHostActionResponder(): void {
         // driver, which resolves the target browser panel and drives its live
         // <webview>. Delegating here keeps this switch focused on store mutations.
         if (method.startsWith('cate.browser.')) {
-          const outcome = await handleBrowserMethod(workspaceId, method, args)
+          const tracker = interactionTracker(
+            workspaceId,
+            payload.panelId,
+            BROWSER_READ_METHODS.has(method) ? 'read' : 'control',
+          )
+          const outcome = await finishTracked(
+            tracker,
+            () => handleBrowserMethod(workspaceId, method, args, tracker.observe),
+            (result) => result.ok,
+          )
           return outcome.ok
             ? reply(true, outcome.result !== undefined ? { result: outcome.result } : undefined)
             : reply(false, { error: outcome.error })
@@ -134,14 +200,42 @@ export function useCateHostActionResponder(): void {
         // resolves the target terminal panel and reads its xterm buffer /
         // writes to its PTY via the terminalRegistry.
         if (method.startsWith('cate.terminal.')) {
-          const outcome = await handleTerminalMethod(workspaceId, method, args)
+          const tracker = interactionTracker(
+            workspaceId,
+            payload.panelId,
+            method === 'cate.terminal.read' ? 'read' : 'control',
+          )
+          const outcome = await finishTracked(
+            tracker,
+            () => handleTerminalMethod(workspaceId, method, args, tracker.observe),
+            (result) => result.ok,
+          )
           return outcome.ok
             ? reply(true, outcome.result !== undefined ? { result: outcome.result } : undefined)
             : reply(false, { error: outcome.error })
         }
 
         if (method.startsWith('cate.codingAgent.')) {
-          const outcome = await handleCodingAgentMethod(workspaceId, payload.panelId, method, args)
+          const tracker = interactionTracker(workspaceId, payload.panelId, 'agent')
+          for (const targetPanelId of codingAgentInteractionTargets(
+            workspaceId,
+            payload.panelId,
+            method,
+            args,
+          )) {
+            tracker.observe(targetPanelId)
+          }
+          const outcome = await finishTracked(
+            tracker,
+            () => handleCodingAgentMethod(workspaceId, payload.panelId, method, args),
+            (result) => result.ok,
+          )
+          if (outcome.ok && method === 'cate.codingAgent.create') {
+            const created = outcome.result && typeof outcome.result === 'object'
+              ? outcome.result as Record<string, unknown>
+              : null
+            if (typeof created?.panelId === 'string') tracker.observe(created.panelId)
+          }
           return outcome.ok
             ? reply(true, { result: outcome.result })
             : reply(false, { error: outcome.error })
@@ -171,6 +265,9 @@ export function useCateHostActionResponder(): void {
               placementFromArgs(workspaceId, args),
             )
             if (!newPanelId) return reply(false, { error: 'open failed' })
+            const tracker = interactionTracker(workspaceId, payload.panelId, 'create')
+            tracker.observe(newPanelId)
+            tracker.finish(true)
             // Honor an optional { line } (and column) by stashing a one-shot
             // editor reveal — the SAME path search results and terminal file
             // links use, consumed by EditorPanel once Monaco mounts.
@@ -207,6 +304,9 @@ export function useCateHostActionResponder(): void {
               })
             }
             if (!newPanelId) return reply(false, { error: 'panel creation failed' })
+            const tracker = interactionTracker(workspaceId, payload.panelId, 'create')
+            tracker.observe(newPanelId)
+            tracker.finish(true)
             return reply(true, { result: { panelId: newPanelId } })
           }
 
@@ -238,7 +338,9 @@ export function useCateHostActionResponder(): void {
               .getState()
               .workspaces.find((w) => w.id === workspaceId)?.panels?.[targetPanelId]
             if (!panel) return reply(false, { error: 'panel-not-in-window' })
-            const revealed = await revealPanel(workspaceId, targetPanelId)
+            const tracker = interactionTracker(workspaceId, payload.panelId, 'control')
+            tracker.observe(targetPanelId)
+            const revealed = await finishTracked(tracker, () => revealPanel(workspaceId, targetPanelId), Boolean)
             if (!revealed) return reply(false, { error: 'panel-not-revealable' })
             return reply(true)
           }
@@ -250,7 +352,13 @@ export function useCateHostActionResponder(): void {
               .getState()
               .workspaces.find((w) => w.id === workspaceId)?.panels?.[targetPanelId]
             if (!panel) return reply(false, { error: 'panel-not-in-window' })
-            const closed = await closePanelWithConfirm(workspaceId, targetPanelId)
+            const tracker = interactionTracker(workspaceId, payload.panelId, 'control')
+            tracker.observe(targetPanelId)
+            const closed = await finishTracked(
+              tracker,
+              () => closePanelWithConfirm(workspaceId, targetPanelId),
+              Boolean,
+            )
             return closed ? reply(true) : reply(false, { error: 'close-cancelled' })
           }
 

--- a/src/renderer/lib/agent/codingAgentDriver.test.ts
+++ b/src/renderer/lib/agent/codingAgentDriver.test.ts
@@ -78,7 +78,11 @@ vi.mock('./codingAgentIntegration', () => ({
 }))
 
 import { AGENTS } from '../../../shared/agents'
-import { codingAgentSnapshot, handleCodingAgentMethod } from './codingAgentDriver'
+import {
+  codingAgentInteractionTargets,
+  codingAgentSnapshot,
+  handleCodingAgentMethod,
+} from './codingAgentDriver'
 
 describe('codingAgentDriver mission integration', () => {
   beforeEach(() => {
@@ -154,6 +158,30 @@ describe('codingAgentDriver mission integration', () => {
     applyCodingAgentWorktree.mockReset()
     keepCodingAgentWorktree.mockReset()
     discardCodingAgentWorktree.mockReset()
+  })
+
+  it('resolves interaction targets through the same supervisor ownership check', async () => {
+    const created = await handleCodingAgentMethod(
+      'ws',
+      'supervisor-1',
+      'cate.codingAgent.create',
+      { prompt: 'Implement it', agentId: 'codex' },
+    )
+    expect(created.ok).toBe(true)
+    const runId = state.app.workspaces[0].panels.worker.codingAgentRun.id
+
+    expect(codingAgentInteractionTargets(
+      'ws',
+      'supervisor-1',
+      'cate.codingAgent.send',
+      { runId },
+    )).toEqual(['worker'])
+    expect(codingAgentInteractionTargets(
+      'ws',
+      'another-supervisor',
+      'cate.codingAgent.send',
+      { runId },
+    )).toEqual([])
   })
 
   it('automatically selects a hook-ready canonical agent and starts its PTY headlessly', async () => {

--- a/src/renderer/lib/agent/codingAgentDriver.ts
+++ b/src/renderer/lib/agent/codingAgentDriver.ts
@@ -58,6 +58,34 @@ function runPanel(workspaceId: string, ownerPanelId: string, runId: string) {
   )
 }
 
+/** Resolve the worker terminal panels a mission command addresses. Kept next
+ * to runPanel so interaction visualization uses the same ownership checks as
+ * command execution instead of guessing from a raw run id. */
+export function codingAgentInteractionTargets(
+  workspaceId: string,
+  ownerPanelId: string,
+  method: string,
+  args: Record<string, unknown>,
+): string[] {
+  const name = method.slice('cate.codingAgent.'.length)
+  if (name === 'create' || name === 'list') return []
+  const runIds = name === 'wait'
+    ? Array.isArray(args.runIds)
+      ? args.runIds.filter((id): id is string => typeof id === 'string')
+      : []
+    : typeof args.runId === 'string' ? [args.runId] : []
+  if (name === 'wait' && runIds.length === 0) {
+    const ws = workspace(workspaceId)
+    return Object.values(ws?.panels ?? {})
+      .filter((panel) => panel.codingAgentRun?.ownerPanelId === ownerPanelId)
+      .map((panel) => panel.id)
+  }
+  return runIds.flatMap((runId) => {
+    const panel = runPanel(workspaceId, ownerPanelId, runId)
+    return panel ? [panel.id] : []
+  })
+}
+
 function terminalText(panelId: string, maxChars = 4_000): string {
   const terminal = terminalRegistry.getEntry(panelId)?.terminal
   return terminal ? terminalBufferTail(terminal, maxChars) : ''

--- a/src/renderer/lib/browser/browserDriver.ts
+++ b/src/renderer/lib/browser/browserDriver.ts
@@ -13,6 +13,7 @@ import {
   browserCommandShowsActivity,
   validateBrowserCommand,
 } from '../../../shared/browserCommand'
+import type { PanelTargetObserver } from '../panelInteractions'
 
 export type BrowserOutcome = { ok: true; result?: unknown } | { ok: false; error: string }
 
@@ -133,6 +134,7 @@ export async function handleBrowserMethod(
   workspaceId: string,
   method: string,
   args: Record<string, unknown>,
+  onTargetResolved?: PanelTargetObserver,
 ): Promise<BrowserOutcome> {
   const name = method.slice('cate.browser.'.length)
 
@@ -140,13 +142,16 @@ export async function handleBrowserMethod(
     const url = stringArg(args, 'url')
     if (!url) return { ok: false, error: 'url-required' }
     if (args.newPanel === true) {
-      return createBrowserPanel(workspaceId, url, args)
+      const created = await createBrowserPanel(workspaceId, url, args)
+      if (created.ok && created.result && typeof created.result === 'object') onTargetResolved?.((created.result as { panelId: string }).panelId)
+      return created
     }
     const target = resolveTargetPanel(workspaceId, args)
     if ('error' in target) {
       if (target.error === 'no-browser') return createBrowserPanel(workspaceId, url, args)
       return { ok: false, error: target.error }
     }
+    onTargetResolved?.(target.panel.id)
     const controller = await waitForController(target.panel.id)
     if (!controller) return { ok: false, error: 'panel-not-mounted' }
     if (args.newTab === true) {
@@ -168,6 +173,7 @@ export async function handleBrowserMethod(
   if ('error' in target) return { ok: false, error: target.error }
   const panel = target.panel
   if (!panel.activeTabId) return { ok: false, error: 'invalid-browser-tab-state' }
+  onTargetResolved?.(panel.id)
 
   if (name === 'tabs' || name === 'tabNew' || name === 'tabSelect' || name === 'tabClose') {
     const controller = await waitForController(panel.id)

--- a/src/renderer/lib/panelInteractions.test.ts
+++ b/src/renderer/lib/panelInteractions.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  beginPanelInteraction,
+  clearPanelInteractions,
+  usePanelInteractionStore,
+} from './panelInteractions'
+
+describe('panelInteractions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    clearPanelInteractions()
+  })
+
+  afterEach(() => {
+    clearPanelInteractions()
+    vi.useRealTimers()
+  })
+
+  it('tracks a resolved operation without retaining request contents', () => {
+    const finish = beginPanelInteraction({
+      workspaceId: 'ws',
+      sourcePanelId: 'agent',
+      targetPanelId: 'browser',
+      kind: 'control',
+    })
+
+    expect(Object.values(usePanelInteractionStore.getState().interactions)).toEqual([
+      expect.objectContaining({
+        workspaceId: 'ws',
+        sourcePanelId: 'agent',
+        targetPanelId: 'browser',
+        kind: 'control',
+        phase: 'active',
+        activeCount: 1,
+      }),
+    ])
+
+    finish(true)
+    expect(Object.values(usePanelInteractionStore.getState().interactions)[0]?.phase).toBe('active')
+    vi.advanceTimersByTime(4_999)
+    expect(Object.values(usePanelInteractionStore.getState().interactions)[0]?.phase).toBe('active')
+    vi.advanceTimersByTime(1)
+    expect(Object.values(usePanelInteractionStore.getState().interactions)[0]?.phase).toBe('succeeded')
+    vi.advanceTimersByTime(39_999)
+    expect(Object.values(usePanelInteractionStore.getState().interactions)[0]?.phase).toBe('succeeded')
+    vi.advanceTimersByTime(1)
+    expect(usePanelInteractionStore.getState().interactions).toEqual({})
+  })
+
+  it('coalesces concurrent calls for the same directed pair', () => {
+    const input = {
+      workspaceId: 'ws',
+      sourcePanelId: 'terminal-a',
+      targetPanelId: 'terminal-b',
+      kind: 'control' as const,
+    }
+    const finishFirst = beginPanelInteraction(input)
+    const finishSecond = beginPanelInteraction(input)
+    const interaction = () => Object.values(usePanelInteractionStore.getState().interactions)[0]
+
+    expect(interaction()?.activeCount).toBe(2)
+    finishFirst(false)
+    expect(interaction()).toMatchObject({ activeCount: 1, phase: 'active' })
+    finishSecond(true)
+    expect(interaction()).toMatchObject({ activeCount: 0, phase: 'active' })
+    vi.advanceTimersByTime(5_000)
+    expect(interaction()).toMatchObject({ activeCount: 0, phase: 'succeeded' })
+  })
+
+  it('extends one continuous active state when quick calls repeat', () => {
+    const input = {
+      workspaceId: 'ws',
+      sourcePanelId: 'agent',
+      targetPanelId: 'browser',
+      kind: 'control' as const,
+    }
+    const interaction = () => Object.values(usePanelInteractionStore.getState().interactions)[0]
+
+    beginPanelInteraction(input)(true)
+    vi.advanceTimersByTime(2_000)
+    beginPanelInteraction(input)(true)
+    vi.advanceTimersByTime(4_999)
+    expect(interaction()?.phase).toBe('active')
+
+    vi.advanceTimersByTime(1)
+    expect(interaction()?.phase).toBe('succeeded')
+  })
+
+  it('ignores self-interactions and stale completion callbacks', () => {
+    const finish = beginPanelInteraction({
+      workspaceId: 'ws',
+      sourcePanelId: 'same',
+      targetPanelId: 'same',
+      kind: 'read',
+    })
+    finish(false)
+    finish(true)
+    expect(usePanelInteractionStore.getState().interactions).toEqual({})
+  })
+
+})

--- a/src/renderer/lib/panelInteractions.ts
+++ b/src/renderer/lib/panelInteractions.ts
@@ -1,0 +1,163 @@
+// =============================================================================
+// panelInteractions — ephemeral observation state for cross-panel agent work.
+//
+// The CLI/host action remains authoritative. This store only mirrors the
+// lifecycle of an already-resolved panel interaction so the canvas can explain
+// what is happening. It is deliberately not persisted and never stores request
+// arguments (prompts, typed text, URLs, selectors, etc.).
+// =============================================================================
+
+import { create } from 'zustand'
+
+export type PanelInteractionKind = 'read' | 'control' | 'create' | 'agent'
+export type PanelInteractionPhase = 'active' | 'succeeded' | 'failed'
+export type PanelTargetObserver = (targetPanelId: string) => void
+
+export interface PanelInteraction {
+  key: string
+  workspaceId: string
+  sourcePanelId: string
+  targetPanelId: string
+  kind: PanelInteractionKind
+  phase: PanelInteractionPhase
+  activeCount: number
+  pulse: number
+  updatedAt: number
+}
+
+interface PanelInteractionState {
+  interactions: Record<string, PanelInteraction>
+}
+
+// Fast browser-control calls often complete in a few hundred milliseconds.
+// Hold the active treatment long enough to read, then keep the result fully
+// visible before the renderer begins its slow fade.
+const MIN_ACTIVE_MS = 5_000
+const SETTLED_HOLD_MS = 30_000
+const FADE_MS = 10_000
+const lifecycleTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+export const usePanelInteractionStore = create<PanelInteractionState>(() => ({ interactions: {} }))
+
+function interactionKey(workspaceId: string, sourcePanelId: string, targetPanelId: string): string {
+  return `${workspaceId}\0${sourcePanelId}\0${targetPanelId}`
+}
+
+/** Begin one resolved cross-panel operation. The returned callback completes
+ * exactly that operation; repeated completion calls are ignored. */
+export function beginPanelInteraction(input: {
+  workspaceId: string
+  sourcePanelId: string
+  targetPanelId: string
+  kind: PanelInteractionKind
+}): (succeeded: boolean) => void {
+  const { workspaceId, sourcePanelId, targetPanelId, kind } = input
+  if (!workspaceId || !sourcePanelId || !targetPanelId || sourcePanelId === targetPanelId) {
+    return () => {}
+  }
+
+  const key = interactionKey(workspaceId, sourcePanelId, targetPanelId)
+  const pendingLifecycle = lifecycleTimers.get(key)
+  if (pendingLifecycle) {
+    clearTimeout(pendingLifecycle)
+    lifecycleTimers.delete(key)
+  }
+
+  usePanelInteractionStore.setState((state) => {
+    const previous = state.interactions[key]
+    return {
+      interactions: {
+        ...state.interactions,
+        [key]: {
+          key,
+          workspaceId,
+          sourcePanelId,
+          targetPanelId,
+          kind,
+          phase: 'active',
+          activeCount: (previous?.activeCount ?? 0) + 1,
+          pulse: (previous?.pulse ?? 0) + 1,
+          updatedAt: Date.now(),
+        },
+      },
+    }
+  })
+
+  let finished = false
+  return (succeeded: boolean) => {
+    if (finished) return
+    finished = true
+
+    let completedPulse = 0
+    let shouldSettle = false
+    let settleDelay = 0
+    usePanelInteractionStore.setState((state) => {
+      const current = state.interactions[key]
+      if (!current) return state
+      const activeCount = Math.max(0, current.activeCount - 1)
+      completedPulse = current.pulse
+      shouldSettle = activeCount === 0
+      settleDelay = Math.max(0, MIN_ACTIVE_MS - (Date.now() - current.updatedAt))
+      return {
+        interactions: {
+          ...state.interactions,
+          [key]: {
+            ...current,
+            // Keep completed short calls visually active until the minimum
+            // active window elapses. A new call for this pair cancels the
+            // pending transition and extends the continuous active state.
+            phase: 'active',
+            activeCount,
+          },
+        },
+      }
+    })
+
+    if (!shouldSettle) return
+    const settle = () => {
+      lifecycleTimers.delete(key)
+      let didSettle = false
+      usePanelInteractionStore.setState((state) => {
+        const current = state.interactions[key]
+        if (!current || current.activeCount > 0 || current.pulse !== completedPulse) return state
+        didSettle = true
+        return {
+          interactions: {
+            ...state.interactions,
+            [key]: {
+              ...current,
+              phase: succeeded ? 'succeeded' : 'failed',
+              updatedAt: Date.now(),
+            },
+          },
+        }
+      })
+      if (!didSettle) return
+
+      const expiry = setTimeout(() => {
+        lifecycleTimers.delete(key)
+        usePanelInteractionStore.setState((state) => {
+          const current = state.interactions[key]
+          if (!current || current.activeCount > 0 || current.pulse !== completedPulse) return state
+          const { [key]: _removed, ...interactions } = state.interactions
+          return { interactions }
+        })
+      }, SETTLED_HOLD_MS + FADE_MS)
+      lifecycleTimers.set(key, expiry)
+    }
+
+    if (settleDelay === 0) {
+      settle()
+    } else {
+      const timer = setTimeout(settle, settleDelay)
+      lifecycleTimers.set(key, timer)
+    }
+  }
+}
+
+/** Test/session cleanup. Normal app use relies on expiry and renderer teardown. */
+export function clearPanelInteractions(): void {
+  for (const timer of lifecycleTimers.values()) clearTimeout(timer)
+  lifecycleTimers.clear()
+  usePanelInteractionStore.setState({ interactions: {} })
+}

--- a/src/renderer/lib/terminal/terminalDriver.test.ts
+++ b/src/renderer/lib/terminal/terminalDriver.test.ts
@@ -79,8 +79,10 @@ beforeEach(() => {
 describe('target resolution', () => {
   it('read routes to an explicit args.panelId', async () => {
     h.entries.set('t2', makeEntry(['from t2']))
-    const out = await handleTerminalMethod(WS, M('read'), { panelId: 't2' })
+    const onTargetResolved = vi.fn()
+    const out = await handleTerminalMethod(WS, M('read'), { panelId: 't2' }, onTargetResolved)
     expect(out).toEqual({ ok: true, result: { panelId: 't2', alt: false, text: 'from t2' } })
+    expect(onTargetResolved).toHaveBeenCalledWith('t2')
   })
 
   it('read defaults to the focused panel when it is a terminal', async () => {

--- a/src/renderer/lib/terminal/terminalDriver.ts
+++ b/src/renderer/lib/terminal/terminalDriver.ts
@@ -26,6 +26,7 @@ import { useAppStore } from '../../stores/appStore'
 import { getActivePanelId } from '../activePanel'
 import { getEntry } from './registryState'
 import { readTerminalBuffer } from './terminalBuffer'
+import type { PanelTargetObserver } from '../panelInteractions'
 
 export type TerminalOutcome = { ok: true; result?: unknown } | { ok: false; error: string }
 
@@ -113,6 +114,7 @@ export async function handleTerminalMethod(
   workspaceId: string,
   method: string,
   args: Record<string, unknown>,
+  onTargetResolved?: PanelTargetObserver,
 ): Promise<TerminalOutcome> {
   const name = method.slice('cate.terminal.'.length)
   if (name !== 'read' && name !== 'type' && name !== 'press') {
@@ -121,6 +123,7 @@ export async function handleTerminalMethod(
 
   const target = resolveTargetPanelId(workspaceId, args, name === 'read')
   if ('error' in target) return { ok: false, error: target.error }
+  onTargetResolved?.(target.panelId)
   const entry = getEntry(target.panelId)
   if (!entry) return { ok: false, error: 'terminal-not-ready' }
 

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -33,6 +33,7 @@ import { getPanelDef } from '../panels/registry'
 import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
 import { seedAgentPanelWithWorktreeChat } from '../../cateAgent/renderer/seedWorktreeChat'
+import { PanelConnectionLayer } from '../canvas/PanelConnectionLayer'
 
 // Re-export the lookup helpers so existing callers (drag dispatcher, drop
 // resolver) keep working through the same import path. New code should import
@@ -286,7 +287,22 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
           <EmptyCanvasOverlay workspaceId={workspaceId} panelId={panelId} canvasApi={store} />
         )}
 
-        <Canvas onCreateAtPoint={onCreateAtPoint} panelId={panelId}>
+        <Canvas
+          onCreateAtPoint={onCreateAtPoint}
+          panelId={panelId}
+          overlayChildren={(nodeIds.length > 0 || workspaceRootPath) ? (
+            <CanvasToolbar
+              canvasPanelId={panelId}
+              workspaceId={workspaceId}
+              rootPath={workspaceRootPath}
+              onNewTerminal={onNewTerminal}
+              onNewBrowser={onNewBrowser}
+              onNewEditor={onNewEditor}
+              onNewAgent={onNewAgent}
+            />
+          ) : null}
+        >
+          <PanelConnectionLayer workspaceId={workspaceId} />
           {visibleNodeIds.map((nId) => (
             <CanvasNodeWrapper
               key={nId}
@@ -297,17 +313,6 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
           ))}
         </Canvas>
 
-        {(nodeIds.length > 0 || workspaceRootPath) && (
-          <CanvasToolbar
-            canvasPanelId={panelId}
-            workspaceId={workspaceId}
-            rootPath={workspaceRootPath}
-            onNewTerminal={onNewTerminal}
-            onNewBrowser={onNewBrowser}
-            onNewEditor={onNewEditor}
-            onNewAgent={onNewAgent}
-          />
-        )}
       </div>
     </CanvasStoreProvider>
   )

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -146,6 +146,41 @@
   .border-danger { border-color: color-mix(in srgb, var(--git-deleted) 36%, transparent); }
   .border-warning { border-color: color-mix(in srgb, var(--activity-orange) 30%, transparent); }
 
+  @keyframes catePanelConnectionFlow {
+    to { stroke-dashoffset: -18; }
+  }
+
+  @keyframes catePanelConnectionFade {
+    from { opacity: 0.72; }
+    to { opacity: 0; }
+  }
+
+  @keyframes catePanelInteractionPulse {
+    0%, 100% { transform: scale(0.8); opacity: 0.55; }
+    50% { transform: scale(1.15); opacity: 1; }
+  }
+
+  .cate-panel-connection-active {
+    stroke-dasharray: 10 8;
+    animation: catePanelConnectionFlow 700ms linear infinite;
+  }
+
+  .cate-panel-connection-finished {
+    animation: catePanelConnectionFade 10s ease-out 30s forwards;
+  }
+
+  .cate-panel-interaction-dot-active {
+    animation: catePanelInteractionPulse 900ms ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cate-panel-connection-active,
+    .cate-panel-connection-finished,
+    .cate-panel-interaction-dot-active {
+      animation: none;
+    }
+  }
+
   /* Inline diff add/remove rows — themed via the git add/delete colors. */
   .bg-diff-add { background-color: color-mix(in srgb, var(--git-added) 12%, transparent); }
   .bg-diff-del { background-color: color-mix(in srgb, var(--git-deleted) 12%, transparent); }


### PR DESCRIPTION
## Summary

- render persistent mission links and transient host-action connections between canvas panels
- expose resolved browser, terminal, panel, and coding-agent targets without retaining request payloads
- keep canvas chrome, focus glow, and interaction feedback above persistent browser surfaces with reduced-motion support

## Stack

Depends on the live-webview browser runtime PR for its target-resolution hook and browser surface layering.

## Verification

- focused canvas, host responder, and driver suite: 100 tests passed
- npm run typecheck