### PR TITLE
fix: support older glibc in Linux runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build the same native addon shipped in Linux runtime tarballs and inspect
+      # its ELF symbol versions. This catches a future image/toolchain change
+      # that would make terminals fail on glibc 2.28–2.31 hosts (#604).
+      - name: Linux runtime glibc compatibility regression
+        if: runner.os == 'Linux'
+        run: npm run test:runtime:linux-glibc
+
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
             platform: mac
           - os: ubuntu-latest
             platform: linux
+            docker: true
           - os: windows-latest
             platform: win
 
@@ -96,9 +97,9 @@ jobs:
 
       # The runtime tarball stages node-pty's native binary from build/Release.
       # On macOS/Windows `npm install` satisfies node-pty from a shipped prebuild
-      # and never populates build/Release, so compile from source here. On Linux
-      # node-pty ships NO prebuild, so `npm install` already built it from source
-      # into build/Release — a rebuild would just duplicate that, so skip it.
+      # and never populates build/Release, so compile from source here. Linux is
+      # rebuilt later in the pinned old-glibc container instead of using the
+      # ubuntu-latest output.
       # (node-pty is N-API: the node-20 binary runs under the bundled node-22.)
       - name: Compile node-pty from source (mac/win; Linux builds it at install)
         if: runner.os != 'Linux'
@@ -124,7 +125,7 @@ jobs:
       - name: Build + stage host runtime tarball
         shell: bash
         run: |
-          node scripts/build-runtime-tarball.mjs
+          node scripts/build-runtime-tarball.mjs ${{ matrix.docker && '--docker' || '' }}
           cp dist-runtime/cate-runtime-*.tgz dist-runtime/runtime-host.tgz
 
       # A single macOS .app can run on either CPU (x64 natively on Intel, arm64
@@ -237,9 +238,9 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-  # Per-target cate-runtime daemon tarballs. Built on the matching runner so
-  # node-pty's native binary is correct for the target; linux-arm64 is cross-
-  # built in a QEMU-emulated container (--docker). Uploaded to the same release
+  # Per-target cate-runtime daemon tarballs. macOS/Windows build on matching
+  # runners; both Linux targets use the pinned old-glibc container, with arm64
+  # running under QEMU. Uploaded to the same release
   # so a connecting host can pull its tarball straight from the release URL
   # (see src/main/runtime/runtimeArtifacts.ts).
   runtime:
@@ -250,6 +251,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
+            docker: true
           - os: ubuntu-latest
             target: linux-arm64
             docker: true
@@ -283,17 +285,16 @@ jobs:
         run: pip install setuptools
 
       - name: Set up QEMU (linux-arm64 cross-build)
-        if: matrix.docker
+        if: matrix.target == 'linux-arm64'
         uses: docker/setup-qemu-action@v4
 
       - name: Install dependencies
         run: npm ci
 
       # Stage node-pty from build/Release. macOS/Windows installs use a shipped
-      # prebuild (build/Release empty) so compile from source; Linux ships no
-      # prebuild, so `npm install` already built it from source. The --docker
-      # linux-arm64 cross-build compiles node-pty in the container — all of these
-      # Linux cases are exactly the ones runner.os != 'Linux' skips.
+      # prebuild (build/Release empty) so compile from source. Both Linux targets
+      # are compiled later in the pinned old-glibc container; the host build
+      # produced by npm ci is deliberately ignored.
       # The windows runner image ships Visual Studio 2026 (18.x), which node-gyp
       # only learned to detect in 12.1.0 — hence the node-gyp override in
       # package.json. Without it this step fails with "could not find any Visual

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:ssh:loopback": "CATE_LOCAL_SSH_E2E=1 vitest run --config vitest.live.config.ts sshLoopback",
+    "test:runtime:linux-glibc": "node scripts/test-linux-node-pty-baseline.mjs",
     "test:agent-contracts": "CATE_LIVE_AGENT_CLIS=1 vitest run --config vitest.live.config.ts agentHookContracts",
     "test:e2e": "playwright test",
     "test:e2e:ci": "E2E_SKIP_PERF=1 playwright test",

--- a/scripts/build-runtime-tarball.mjs
+++ b/scripts/build-runtime-tarball.mjs
@@ -29,10 +29,9 @@
 //   node scripts/build-runtime-tarball.mjs --target linux-x64
 //   node scripts/build-runtime-tarball.mjs --target linux-x64 --docker
 //
-// On CI, run this NATIVELY on the matching runner (ubuntu for linux-*, macos
-// for darwin-*) so node-pty's binary is the runner's own compiled output. The
-// --docker flag cross-builds the linux node-pty binary on a non-linux host
-// (e.g. a Mac) for local end-to-end testing before CI exists.
+// On CI, macOS/Windows run natively on matching runners. Linux release builds
+// always pass --docker so node-pty is compiled in the pinned old-glibc image;
+// the same flag also supports local Linux cross-builds from a Mac.
 // =============================================================================
 
 import { existsSync, mkdirSync, cpSync, rmSync, chmodSync, readFileSync, renameSync, readdirSync, openSync, readSync, closeSync } from 'node:fs'
@@ -44,6 +43,7 @@ import os from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { build } from 'esbuild'
 import { runtimeBuildOptions, syncRuntimeVersion } from '../src/runtime/build/esbuild.config.mjs'
+import { buildLinuxNodePty } from './linux-node-pty.mjs'
 
 // Bundled runtime version. MUST satisfy pi's `engines.node` (currently
 // >=22.19.0 — its undici build calls webidl APIs absent on Node 20, which
@@ -370,6 +370,17 @@ async function resolveWinNodePtyPrebuild() {
 async function resolveNativeBinaries() {
   const hostTarget = `${plat(process.platform)}-${process.arch}`
 
+  // Linux release binaries must always be built in the pinned old-glibc
+  // container, even when the runner has the target architecture natively.
+  // Otherwise ubuntu-latest leaks its newer glibc into pty.node (#604).
+  if (useDocker && targetPlatform === 'linux') {
+    return buildLinuxNodePty({
+      targetArch,
+      nodePtyVersion: NODE_PTY_VERSION,
+      outDir: path.join(dist, 'native', `node-pty-${targetArg}-${NODE_PTY_VERSION}`),
+    })
+  }
+
   // Native build: use the installed node-pty's host binary. Prefer the host's
   // own compiled output (build/Release, e.g. a from-source `node-gyp rebuild`)
   // and fall back to the prebuild node-pty ships for this platform. Both are
@@ -393,38 +404,12 @@ async function resolveNativeBinaries() {
     )
   }
 
-  // Cross build of the linux binary via a linux container (QEMU for arm64).
-  if (useDocker && targetPlatform === 'linux') {
-    return dockerBuildLinuxPty()
-  }
-
   throw new Error(
     `Cannot produce a ${targetArg} node-pty binary on a ${hostTarget} host. ` +
       (targetPlatform === 'linux'
         ? 'Pass --docker to cross-build it, or run this on a matching CI runner.'
         : 'Run this on a matching runner (e.g. macos-13 for darwin-x64).'),
   )
-}
-
-/** Compile node-pty inside `node:20` for the target arch and extract its binaries. */
-async function dockerBuildLinuxPty() {
-  const outDir = path.join(os.tmpdir(), `cate-pty-${targetArg}-${NODE_PTY_VERSION}`)
-  rmSync(outDir, { recursive: true, force: true })
-  mkdirSync(outDir, { recursive: true })
-  // node-pty builds spawn-helper on darwin only; on linux pty.node forks itself.
-  const script =
-    `set -e; mkdir -p /b && cd /b && npm init -y >/dev/null 2>&1 && ` +
-    `npm i node-pty@${NODE_PTY_VERSION} --build-from-source >/dev/null 2>&1 && ` +
-    `cp node_modules/node-pty/build/Release/pty.node /out/ && ` +
-    `(cp node_modules/node-pty/build/Release/spawn-helper /out/ 2>/dev/null || true)`
-  console.log(`[runtime] docker cross-building node-pty for ${targetArg} (QEMU; may be slow)…`)
-  execFileSync(
-    'docker',
-    ['run', '--rm', '--platform', `linux/${targetArch === 'x64' ? 'amd64' : 'arm64'}`, '-v', `${outDir}:/out`, 'node:22', 'bash', '-lc', script],
-    { stdio: 'inherit' },
-  )
-  const helper = path.join(outDir, 'spawn-helper')
-  return { ptyNode: path.join(outDir, 'pty.node'), spawnHelper: existsSync(helper) ? helper : null }
 }
 
 /** Download just the `node` binary for the target into `outBin`. On win32 the

--- a/scripts/linux-node-pty.mjs
+++ b/scripts/linux-node-pty.mjs
@@ -1,0 +1,77 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
+import path from 'node:path'
+
+// Keep the native addon on the same practical glibc floor as the official
+// bundled Node binary. These immutable per-platform manifests are from the
+// official node:22.19.0-bullseye image.
+export const LINUX_GLIBC_BASELINE = '2.28'
+export const LINUX_NODE_PTY_BUILD_IMAGES = {
+  x64: 'node@sha256:518f8f89a5a95cbe7c006b40b5f6db0dac6387161fff83694595455e01023156',
+  arm64: 'node@sha256:38a9218715c147fb40c9a970fe74ad3e11017df1d03b4738f4604fed3ea4dfd4',
+}
+
+function compareVersions(a, b) {
+  const aParts = a.split('.').map(Number)
+  const bParts = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i += 1) {
+    const difference = (aParts[i] ?? 0) - (bParts[i] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
+}
+
+export function requiredGlibcVersions(versionInfo) {
+  return [...new Set([...versionInfo.matchAll(/GLIBC_(\d+(?:\.\d+)+)/g)].map((match) => match[1]))]
+    .sort(compareVersions)
+}
+
+export function assertLinuxGlibcBaseline(versionInfo, baseline = LINUX_GLIBC_BASELINE) {
+  const versions = requiredGlibcVersions(versionInfo)
+  if (versions.length === 0) throw new Error('readelf did not report any GLIBC symbol versions for pty.node')
+  const newest = versions.at(-1)
+  if (compareVersions(newest, baseline) > 0) {
+    throw new Error(`pty.node requires GLIBC_${newest}, newer than the supported GLIBC_${baseline} baseline`)
+  }
+  return newest
+}
+
+export function buildLinuxNodePty({ targetArch, nodePtyVersion, outDir }) {
+  if (targetArch !== 'x64' && targetArch !== 'arm64') {
+    throw new Error(`Unsupported Linux node-pty architecture: ${targetArch}`)
+  }
+  if (!/^[0-9A-Za-z.+-]+$/.test(nodePtyVersion)) {
+    throw new Error(`Invalid node-pty version: ${nodePtyVersion}`)
+  }
+
+  rmSync(outDir, { recursive: true, force: true })
+  mkdirSync(outDir, { recursive: true })
+  const ptyNode = path.join(outDir, 'pty.node')
+  const versionInfo = path.join(outDir, 'pty.node.version-info')
+  const script =
+    `set -e; mkdir -p /b && cd /b && npm init -y >/dev/null 2>&1 && ` +
+    `npm i node-pty@${nodePtyVersion} --build-from-source --no-audit --no-fund >/dev/null 2>&1 && ` +
+    `cp node_modules/node-pty/build/Release/pty.node /out/ && ` +
+    `readelf --version-info --wide node_modules/node-pty/build/Release/pty.node > /out/pty.node.version-info`
+
+  console.log(`[runtime] docker building node-pty for linux-${targetArch} with a GLIBC_${LINUX_GLIBC_BASELINE} ceiling…`)
+  execFileSync(
+    'docker',
+    [
+      'run', '--rm',
+      '--platform', `linux/${targetArch === 'x64' ? 'amd64' : 'arm64'}`,
+      '-v', `${outDir}:/out`,
+      LINUX_NODE_PTY_BUILD_IMAGES[targetArch],
+      'bash', '-lc', script,
+    ],
+    { stdio: 'inherit' },
+  )
+
+  if (!existsSync(ptyNode) || !existsSync(versionInfo)) {
+    throw new Error(`Linux node-pty build did not produce pty.node and its readelf report in ${outDir}`)
+  }
+  const newestGlibc = assertLinuxGlibcBaseline(readFileSync(versionInfo, 'utf-8'))
+  rmSync(versionInfo, { force: true })
+  console.log(`[runtime] verified linux-${targetArch} node-pty requires at most GLIBC_${newestGlibc}`)
+  return { ptyNode, spawnHelper: null }
+}

--- a/scripts/linux-node-pty.test.mjs
+++ b/scripts/linux-node-pty.test.mjs
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { assertLinuxGlibcBaseline, requiredGlibcVersions } from './linux-node-pty.mjs'
+
+describe('Linux node-pty glibc baseline', () => {
+  it('accepts a binary at the supported baseline', () => {
+    const versionInfo = 'Name: GLIBC_2.2.5\nName: GLIBC_2.28\nName: GLIBC_2.14'
+    expect(requiredGlibcVersions(versionInfo)).toEqual(['2.2.5', '2.14', '2.28'])
+    expect(assertLinuxGlibcBaseline(versionInfo)).toBe('2.28')
+  })
+
+  it('rejects the GLIBC_2.34 regression from issue #604', () => {
+    const versionInfo = 'Name: GLIBC_2.28\nName: GLIBC_2.32\nName: GLIBC_2.34'
+    expect(() => assertLinuxGlibcBaseline(versionInfo)).toThrow(
+      'pty.node requires GLIBC_2.34, newer than the supported GLIBC_2.28 baseline',
+    )
+  })
+})

--- a/scripts/test-linux-node-pty-baseline.mjs
+++ b/scripts/test-linux-node-pty-baseline.mjs
@@ -1,0 +1,22 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildLinuxNodePty } from './linux-node-pty.mjs'
+
+if (process.platform !== 'linux' || process.arch !== 'x64') {
+  throw new Error('The Linux node-pty baseline regression test must run on a linux-x64 CI runner')
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const nodePtyVersion = JSON.parse(
+  readFileSync(path.join(repoRoot, 'node_modules', 'node-pty', 'package.json'), 'utf-8'),
+).version
+const outDir = mkdtempSync(path.join(os.tmpdir(), 'cate-linux-node-pty-test-'))
+
+try {
+  buildLinuxNodePty({ targetArch: 'x64', nodePtyVersion, outDir })
+  console.log(`[runtime] linux-x64 node-pty ${nodePtyVersion} passed the glibc compatibility regression test`)
+} finally {
+  rmSync(outDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- build Linux x64 and ARM64 node-pty binaries in pinned Node 22.19.0 Bullseye images
- enforce a `GLIBC_2.28` symbol ceiling while producing runtime artifacts
- run the real Linux node-pty build and ELF compatibility check in Ubuntu CI

Closes #604.

## Validation

- `npm test -- --run scripts/linux-node-pty.test.mjs`
- `npm run typecheck`
- `npm run build`
- `npm run runtime:tarball -- --target linux-x64 --docker`
- verified x64 and ARM64 `pty.node` builds require at most `GLIBC_2.28`
- loaded the packaged x64 runtime and spawned a PTY successfully in an Ubuntu 20.04 container (`cate-pty-ok`)

## Test environment

The focused checks pass locally. The complete Vitest suite is left to GitHub CI because the local sandbox blocks loopback listeners and its Node 24 runtime is outside the repository-supported Node range.