### PR TITLE
Fix canvas panel maximize spacing and locked geometry

### DIFF
--- a/src/renderer/canvas/CanvasNode.groupDrag.test.tsx
+++ b/src/renderer/canvas/CanvasNode.groupDrag.test.tsx
@@ -186,6 +186,37 @@ describe('CanvasNode — group drag from the title bar', () => {
     dispatchMouse(window, 'mouseup', { x: 60, y: 10 })
   })
 
+  it.each(['A', 'B'])('respects locked node %s when dragging a selection', (lockedId) => {
+    const wsId = useAppStore.getState().addWorkspace('WS', '/tmp/ws', 'ws-locked')
+    useAppStore.getState().addPanel(wsId, { id: 'panel-A', type: 'editor', title: 'A', isDirty: false })
+    const store = freshCanvasStore()
+    addNode(store, 'A', 'panel-A', { x: 0, y: 0 }, { width: 200, height: 150 })
+    addNode(store, 'B', 'panel-B', { x: 400, y: 0 }, { width: 200, height: 150 })
+    act(() => {
+      store.getState().togglePin(lockedId)
+      store.getState().selectNodes(['A', 'B'], false)
+      root.render(
+        <CanvasStoreProvider store={store}>
+          <CanvasNode nodeId="A" isFocused={false} dockStoreApi={tabsDockStore('panel-A')}
+            renderPanel={() => <div />} />
+        </CanvasStoreProvider>,
+      )
+    })
+    const tabBar = container.querySelector<HTMLElement>('.dock-tab-bar')!
+    dispatchMouse(tabBar, 'mousedown', { x: 50, y: 10 })
+    dispatchMouse(window, 'mousemove', { x: 60, y: 10 })
+    const source = useDragStore.getState().source
+    if (lockedId === 'A') {
+      expect(source).toBeNull()
+    } else {
+      expect(source?.origin.kind).toBe('canvas-node')
+      if (source?.origin.kind !== 'canvas-node') throw new Error('expected canvas-node source')
+      expect(source.origin.members).toEqual([])
+    }
+    dispatchMouse(window, 'mouseup', { x: 60, y: 10 })
+    expect(store.getState().nodes[lockedId].origin).toEqual({ x: lockedId === 'A' ? 0 : 400, y: 0 })
+  })
+
   it('clicking an already-focused node keeps it active (no blue-ring de-focus on the second click)', () => {
     const wsId = useAppStore.getState().addWorkspace('WS', '/tmp/ws', 'ws-refocus')
     useAppStore.getState().addPanel(wsId, { id: 'panel-A', type: 'editor', title: 'A', isDirty: false })

--- a/src/renderer/canvas/useCanvasNodeDrag.ts
+++ b/src/renderer/canvas/useCanvasNodeDrag.ts
@@ -42,13 +42,14 @@ export function useCanvasNodeDrag(
     if (!panel) return
     const state = canvasApi.getState()
     const node = state.nodes[nodeId]
+    if (!node || node.isPinned) return
     const grouped = node && isGroupDragMember(state.selection, nodeId)
     const startOrigin = grouped ? { x: node.origin.x, y: node.origin.y } : undefined
     const members = grouped
       ? state.selection
           .filter((id) => id !== nodeId)
           .map((id) => state.nodes[id])
-          .filter((n): n is NonNullable<typeof n> => !!n)
+          .filter((n): n is NonNullable<typeof n> => !!n && !n.isPinned)
           .map((n) => ({ nodeId: n.id, startOrigin: { x: n.origin.x, y: n.origin.y } }))
       : undefined
     rawHandleDragStart(e, {

--- a/src/renderer/hooks/useNodeResize.gesture.test.tsx
+++ b/src/renderer/hooks/useNodeResize.gesture.test.tsx
@@ -245,6 +245,23 @@ describe('useNodeResize — gesture', () => {
     expect(store.getState().nodes['A'].size.width).toBe(513)
   })
 
+  it('leaves a locked shared-border neighbor unchanged', () => {
+    const store = setupScene(
+      [
+        { id: 'A', origin: { x: 100, y: 100 }, size: { width: 400, height: 400 } },
+        { id: 'B', origin: { x: 500, y: 100 }, size: { width: 700, height: 400 } },
+      ],
+      { nodeId: 'A', edge: 'right' },
+    )
+    act(() => store.getState().togglePin('B'))
+    down(500, 300)
+    move(513, 300)
+    up(513, 300, { altKey: true })
+    expect(store.getState().nodes['A'].size.width).toBe(413)
+    expect(store.getState().nodes['B'].origin).toEqual({ x: 500, y: 100 })
+    expect(store.getState().nodes['B'].size).toEqual({ width: 700, height: 400 })
+  })
+
   it('snaps a shared-border neighbor together with the primary on release', () => {
     useSettingsStore.setState({ snapToGrid: true })
     // A.right and B.left share the border at x = 500 over the y-range [100,500].

--- a/src/renderer/hooks/useNodeResize.ts
+++ b/src/renderer/hooks/useNodeResize.ts
@@ -125,6 +125,7 @@ export function useNodeResize(
       // Detect shared borders for cardinal edges
       if (isCardinalEdge(edge)) {
         const borders = findSharedBorders(nodeId, edge, state.nodes)
+          .filter((border) => !state.nodes[border.neighborId].isPinned)
         sharedBordersRef.current = borders
 
         // Capture neighbor start state and min sizes

--- a/src/renderer/stores/canvas/nodesSlice.ts
+++ b/src/renderer/stores/canvas/nodesSlice.ts
@@ -220,19 +220,21 @@ export function createNodesSlice(set: CanvasSet, get: CanvasGet): NodesActions {
           x: cs.width || viewportSize.width,
           y: cs.height || viewportSize.height,
         })
-        const padding = 20 / state.zoomLevel
+        // The canvas tab bar floats over the viewport (32px tall). Leave
+        // another 8px below it, but fill the left, right, and bottom edges.
+        const topInset = 40 / state.zoomLevel
 
         updated = {
           ...node,
           preMaximizeOrigin: { ...node.origin },
           preMaximizeSize: { ...node.size },
           origin: {
-            x: topLeft.x + padding,
-            y: topLeft.y + padding,
+            x: topLeft.x,
+            y: topLeft.y + topInset,
           },
           size: {
-            width: (bottomRight.x - topLeft.x) - padding * 2,
-            height: (bottomRight.y - topLeft.y) - padding * 2,
+            width: bottomRight.x - topLeft.x,
+            height: (bottomRight.y - topLeft.y) - topInset,
           },
         }
       }

--- a/src/renderer/stores/canvasStore.lifecycle.test.ts
+++ b/src/renderer/stores/canvasStore.lifecycle.test.ts
@@ -243,8 +243,8 @@ describe('viewport math', () => {
 
     store.getState().toggleMaximize(id, { width: 1200, height: 800 })
     const maxed = store.getState().nodes[id]
-    expect(maxed.origin).toEqual({ x: 20, y: 20 })
-    expect(maxed.size).toEqual({ width: 1160, height: 760 })
+    expect(maxed.origin).toEqual({ x: 0, y: 40 })
+    expect(maxed.size).toEqual({ width: 1200, height: 760 })
     expect(maxed.preMaximizeOrigin).toEqual({ x: 100, y: 100 })
     expect(focusedNodeId(store.getState())).toBe(id)
 
@@ -254,6 +254,26 @@ describe('viewport math', () => {
     expect(restored.size).toEqual({ width: 300, height: 200 })
     expect(restored.preMaximizeOrigin).toBeUndefined()
     expect(restored.preMaximizeSize).toBeUndefined()
+  })
+
+  it.each([0.5, 1.04, 2])('maximize keeps screen-space edges and header spacing at zoom %s', (zoom) => {
+    const store = createCanvasStore()
+    const id = store.getState().addNode('p', 'editor', { x: 100, y: 100 }, { width: 300, height: 200 })
+    store.getState().setContainerSize({ width: 1200, height: 800 })
+    store.getState().setZoomAndOffset(zoom, { x: 137, y: -83 })
+
+    // The canvas can be smaller than the window because of sidebars/docks.
+    store.getState().toggleMaximize(id, { width: 1600, height: 1000 })
+    const node = store.getState().nodes[id]
+    const topLeft = store.getState().canvasToView(node.origin)
+    const bottomRight = store.getState().canvasToView({
+      x: node.origin.x + node.size.width,
+      y: node.origin.y + node.size.height,
+    })
+    expect(topLeft.x).toBeCloseTo(0)
+    expect(topLeft.y).toBeCloseTo(40)
+    expect(bottomRight.x).toBeCloseTo(1200)
+    expect(bottomRight.y).toBeCloseTo(800)
   })
 })
 


### PR DESCRIPTION
Maximizing a canvas panel still left 20px gaps on every edge, and Lock no longer prevented movement through the unified drag path. Maximized panels now fill the left, right, and bottom canvas edges while reserving 32px for the floating tab bar plus 8px spacing below it.

Locked panels now stay in place when dragged directly or as part of a selection, and resizing an adjacent panel leaves a locked shared-border neighbor unchanged.

Validation: 201 tests pass across nine targeted suites, covering maximize/restore and zoom/pan geometry, locked drag and shared-border resize regressions, canvas selection, dock layouts, rename/copy actions, and detached-window closure. `git diff --check` passes. No live UI verification performed.
