### PR TITLE
Restore macOS signing files for beta.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ dist-runtime/
 *.tsbuildinfo
 .worktrees/
 
-# Build artifacts
-build/
+# Build artifacts (keep signing entitlements tracked)
+build/*
 !build/entitlements.mac.plist
 !build/entitlements.runtime.plist
 # src/runtime/build/ is hand-authored source (the runtime esbuild config used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This beta brings T3 conversations into Cate, improves worktree-aware panels and 
 
 ### Fixed
 
+- **macOS packaging**: restored the signing entitlements required to build Apple silicon and Intel releases.
 - **Fresh T3 conversations**: starting a new chat no longer returns to the existing conversation; switching and restart preserve the selected chat.
 - **Provider configuration**: multiline launch arguments use T3's expected format, and secret settings save correctly through symlinked storage paths.
 - **Panel geometry**: maximizing canvas panels respects spacing, and locked panels retain their geometry during drag and resize actions.

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>

--- a/build/entitlements.runtime.plist
+++ b/build/entitlements.runtime.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the runtime's bundled native binaries (node, rg, node-pty's
+  pty.node + spawn-helper), signed before they are packed into the runtime
+  tarball. Apple's notarytool recurses into runtime-host.tgz and requires every
+  Mach-O to carry a Developer ID + hardened-runtime signature. The bundled `node`
+  additionally needs these so it still runs once hardened: allow-jit /
+  unsigned-executable-memory for V8, and disable-library-validation so it can load
+  pty.node (signed by us, a different team than the Node.js binary's original).
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/macos-entitlements.test.mjs
+++ b/scripts/macos-entitlements.test.mjs
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+for (const name of ['mac', 'runtime']) {
+  const relative = `build/entitlements.${name}.plist`
+  describe(relative, () => {
+    it('ships in a clean checkout for release signing', () => {
+      expect(execFileSync('git', ['ls-files', '--error-unmatch', relative], { cwd: root, encoding: 'utf8' }).trim()).toBe(relative)
+    })
+
+    it.skipIf(process.platform !== 'darwin')('is accepted by codesign with hardened runtime', () => {
+      const directory = mkdtempSync(path.join(tmpdir(), 'cate-signing-test-'))
+      try {
+        const binary = path.join(directory, 'true')
+        copyFileSync('/usr/bin/true', binary)
+        execFileSync('plutil', ['-lint', path.join(root, relative)])
+        execFileSync('codesign', ['--force', '--timestamp=none', '--options', 'runtime', '--entitlements', path.join(root, relative), '--sign', '-', binary])
+        execFileSync('codesign', ['--verify', '--strict', binary])
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    })
+  })
+}


### PR DESCRIPTION
The beta.6 release failed while signing both macOS runtime tarballs because `build/entitlements.runtime.plist` was missing. The app entitlement file was also deleted and would have blocked app packaging next.

Restore both entitlement files unchanged from their last working revision. Correct the `build/` ignore rule so the existing entitlement exceptions work. Add regression checks that require the files to be tracked and, on macOS, lint each plist and sign/verify a disposable binary with hardened runtime.

Validation: all four new regression checks failed before restoration and pass afterward, including real local `codesign` validation. The full darwin-arm64 runtime tarball build also passed with `CATE_MAC_SIGN_IDENTITY=-`, signing and verifying all bundled native binaries with an ad-hoc identity. The beta.6 changelog records the packaging correction.

Beta.6 remains an unpublished draft. After this fix merges, update its tag to the corrected merge commit and rebuild the release.
