### PR TITLE
fix: reuse runtime signing keychain for macOS packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,11 +181,12 @@ jobs:
         # under app.asar.unpacked, and the macOS runner's default soft limit
         # (256) is exhausted now that the full node_modules tree is unpacked,
         # surfacing as `EMFILE: too many open files` during signing.
+        # Reuse CSC_KEYCHAIN from the successful runtime-signing setup. Passing
+        # CSC_LINK here makes electron-builder create a second keychain and use
+        # the certificate password where macOS expects the keychain password.
         run: ulimit -n 65536 && npx electron-builder --mac --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.MAC_CERTS }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This beta brings T3 conversations into Cate, improves worktree-aware panels and 
 
 ### Fixed
 
-- **macOS packaging**: restored the signing entitlements required to build Apple silicon and Intel releases.
+- **macOS packaging**: restored the signing entitlements required to build Apple silicon and Intel releases, and fixed app signing to reuse the imported certificate keychain.
 - **Fresh T3 conversations**: starting a new chat no longer returns to the existing conversation; switching and restart preserve the selected chat.
 - **Provider configuration**: multiline launch arguments use T3's expected format, and secret settings save correctly through symlinked storage paths.
 - **Panel geometry**: maximizing canvas panels respects spacing, and locked panels retain their geometry during drag and resize actions.

--- a/scripts/ci-mac-signing-keychain.sh
+++ b/scripts/ci-mac-signing-keychain.sh
@@ -11,8 +11,8 @@
 # binaries must carry a Developer ID + hardened-runtime signature like the app.
 #
 # The keychain is added to the search list so codesign can locate the identity
-# (codesign --keychain alone is unreliable). electron-builder later signs the app
-# with its OWN --keychain, so this extra keychain doesn't make that ambiguous.
+# (codesign --keychain alone is unreliable). electron-builder reuses this
+# imported keychain through CSC_KEYCHAIN instead of importing the cert again.
 #
 # No-op (exit 0, no identity exported) when MAC_CERTS is absent — the build then
 # stays unsigned and notarization fails loudly, same as before.
@@ -46,8 +46,8 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KPASS" "
 # login keychain) so codesign can locate the identity. `codesign --keychain
 # <path>` alone is unreliable for a keychain not in the search list ("The
 # specified item could not be found in the keychain"), so the build script signs
-# via the search list. electron-builder later signs the app with its OWN
-# `--keychain`, so this extra keychain doesn't make its lookup ambiguous.
+# via the search list. electron-builder also receives this exact keychain
+# through CSC_KEYCHAIN when it signs the app.
 security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/"//g')
 
 IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
@@ -59,4 +59,5 @@ if [ -z "$IDENTITY" ]; then
 fi
 
 echo "CATE_MAC_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
 echo "Runtime natives will be signed with Developer ID identity $IDENTITY"

--- a/scripts/macos-keychain.test.mjs
+++ b/scripts/macos-keychain.test.mjs
@@ -1,0 +1,54 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, it, vi } from 'vitest'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+require('app-builder-lib')
+const { MacPackager } = require('app-builder-lib/out/macPackager.js')
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+it('does not ask electron-builder to re-import the macOS certificate', () => {
+  const workflow = readFileSync(path.join(root, '.github/workflows/release.yml'), 'utf8')
+  const macPackage = workflow.match(/- name: Package \(macOS\)([\s\S]*?)(?=\n      - name:)/)[1]
+  expect(macPackage).not.toMatch(/\bCSC_LINK:/)
+  expect(macPackage).not.toMatch(/\bCSC_KEY_PASSWORD:/)
+})
+
+it.skipIf(process.platform === 'win32')('exports the imported keychain and electron-builder uses it without re-importing', async () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'cate-keychain-test-'))
+  try {
+    // Only the macOS security CLI is simulated; no real certificate or keychain
+    // is accessed. Execute the actual setup script and builder selection code.
+    const security = path.join(directory, 'security')
+    writeFileSync(security, '#!/bin/sh\ncase "$1" in\nfind-identity) echo "1) AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \\"Developer ID Application: Fixture\\"";;\nesac\n')
+    chmodSync(security, 0o755)
+    const uuidgen = path.join(directory, 'uuidgen')
+    writeFileSync(uuidgen, '#!/bin/sh\necho fixture-keychain-password\n')
+    chmodSync(uuidgen, 0o755)
+    const envFile = path.join(directory, 'github-env')
+    execFileSync('bash', [path.join(root, 'scripts/ci-mac-signing-keychain.sh')], {
+      env: { ...process.env, PATH: directory + path.delimiter + process.env.PATH, RUNNER_TEMP: directory, GITHUB_ENV: envFile, CSC_LINK: 'Zml4dHVyZQ==', CSC_KEY_PASSWORD: 'fixture-certificate-password' },
+    })
+    const exported = Object.fromEntries(readFileSync(envFile, 'utf8').trim().split('\n').map(line => {
+      const index = line.indexOf('=')
+      return [line.slice(0, index), line.slice(index + 1)]
+    }))
+    expect(exported.CSC_KEYCHAIN).toBe(path.join(directory, 'cate-runtime-signing.keychain-db'))
+    expect(exported.CATE_MAC_SIGN_IDENTITY).toBe('A'.repeat(40))
+    vi.stubEnv('CSC_LINK', undefined)
+    vi.stubEnv('CSC_KEYCHAIN', exported.CSC_KEYCHAIN)
+    class SigningOnlyPackager extends MacPackager {
+      prepareAppInfo() { return {} }
+    }
+    const packager = new SigningOnlyPackager({ config: { mac: {} } })
+    await expect(packager.codeSigningInfo.value).resolves.toEqual({ keychainFile: exported.CSC_KEYCHAIN })
+  } finally {
+    vi.unstubAllEnvs()
+    rmSync(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
macOS app packaging failed because electron-builder created a new keychain with a random password, then used the certificate password to unlock it for key partition setup. Reuse the keychain already imported and verified by runtime signing via `CSC_KEYCHAIN`, and stop passing certificate import credentials to the app packaging step.

Added regression coverage for the exported keychain, the real electron-builder keychain selection, and the release workflow environment. All six signing tests pass; Bash syntax, workflow YAML, and diff checks pass. Linux and Windows packaging already succeeded in the failed beta release run.
