### PR TITLE
Fix terminal file-drop indicator stacking and clipping

### DIFF
--- a/e2e/drag-indicator-clip.spec.ts
+++ b/e2e/drag-indicator-clip.spec.ts
@@ -69,3 +69,50 @@ test('dock-split indicator is clamped to the canvas, never over the sidebar', as
   expect(diag.indicatorLeft).not.toBeNull()
   expect(diag.indicatorLeft!).toBeGreaterThanOrEqual(diag.sidebarRight - 1)
 })
+
+// Native image drags use a separate overlay from panel drags. It must inherit
+// the terminal's clipping and stacking order, including the hidden left half.
+test('image drop indicator stays behind the sidebar covering its terminal', async () => {
+  const target = await seedTerminal(page, { x: -250, y: 100 })
+  await resetViewport(page)
+  const terminal = page.locator(`[data-node-id="${target}"] [data-filedrop="terminal"]`)
+  await expect(terminal).toBeVisible()
+
+  const points = await terminal.evaluate((host) => {
+    const rect = host.getBoundingClientRect()
+    const canvas = host.closest('[data-canvas-container]')!.getBoundingClientRect()
+    const sidebar = document.querySelector('[data-app-sidebar="left"]')!.getBoundingClientRect()
+    const y = rect.top + rect.height / 2
+    return {
+      visible: { x: Math.max(rect.left, canvas.left) + 30, y },
+      covered: { x: (Math.max(rect.left, sidebar.left) + Math.min(rect.right, sidebar.right)) / 2, y },
+    }
+  })
+  await page.evaluate(({ visible }) => {
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(new File(['image'], 'example.png', { type: 'image/png' }))
+    document.elementFromPoint(visible.x, visible.y)!.dispatchEvent(new DragEvent('dragover', {
+      bubbles: true, cancelable: true, clientX: visible.x, clientY: visible.y, dataTransfer,
+    }))
+  }, points)
+  const indicator = page.locator('[data-file-drop-indicator="terminal"]')
+  await expect(indicator).toBeVisible()
+  await expect(indicator).toHaveText('Drop to paste path')
+
+  const hit = await page.evaluate(({ visible, covered }) => {
+    const indicator = document.querySelector<HTMLElement>('[data-file-drop-indicator="terminal"]')!
+    // Opt the visual into hit-testing to inspect the browser's paint order.
+    indicator.style.pointerEvents = 'auto'
+    const visibleHit = document.elementFromPoint(visible.x, visible.y)
+    const coveredHit = document.elementFromPoint(covered.x, covered.y)
+    indicator.style.pointerEvents = 'none'
+    return {
+      visibleIndicator: !!visibleHit?.closest('[data-file-drop-indicator]'),
+      coveredSidebar: !!coveredHit?.closest('[data-app-sidebar="left"]'),
+    }
+  }, points)
+  expect(hit.visibleIndicator).toBe(true)
+  expect(hit.coveredSidebar).toBe(true)
+  await page.evaluate(() => window.dispatchEvent(new Event('dragend')))
+  await expect(indicator).toHaveCount(0)
+})

--- a/src/renderer/drag/fileDropTarget.tsx
+++ b/src/renderer/drag/fileDropTarget.tsx
@@ -9,6 +9,7 @@
 // =============================================================================
 
 import React, { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { create } from 'zustand'
 import { CATE_FILE_MIME, CATE_FILES_MIME } from './fileDragPayload'
 
@@ -17,7 +18,7 @@ export type FileDropKind = 'canvas' | 'dock' | 'terminal'
 interface FileDropTarget {
   kind: FileDropKind
   id: string
-  rect: { left: number; top: number; width: number; height: number }
+  host: HTMLElement
 }
 
 interface FileDropState {
@@ -56,10 +57,8 @@ export function useFileDropTracker(): void {
       }
       const kind = host.getAttribute('data-filedrop') as FileDropKind
       const id = host.getAttribute('data-filedrop-id') ?? ''
-      // Avoid churn: only recompute the rect when the target element changes.
-      if (store.target && store.target.kind === kind && store.target.id === id) return
-      const r = host.getBoundingClientRect()
-      store.set({ kind, id, rect: { left: r.left, top: r.top, width: r.width, height: r.height } })
+      if (store.target?.host === host) return
+      store.set({ kind, id, host })
     }
     const clear = (): void => {
       if (useFileDropStore.getState().target) useFileDropStore.getState().set(null)
@@ -94,16 +93,15 @@ const LABEL: Record<FileDropKind, string> = {
 export const FileDropOverlay: React.FC = () => {
   const target = useFileDropStore((s) => s.target)
   if (!target) return null
-  const { rect, kind } = target
-  return (
+  const { host, kind } = target
+  // All file-drop hosts are positioned containers. Render inside the target so
+  // the indicator inherits its clipping, transforms, and panel stacking order.
+  return createPortal(
     <div
       data-file-drop-indicator={kind}
       style={{
-        position: 'fixed',
-        left: rect.left,
-        top: rect.top,
-        width: rect.width,
-        height: rect.height,
+        position: 'absolute',
+        inset: 0,
         pointerEvents: 'none',
         zIndex: 60,
         boxSizing: 'border-box',
@@ -128,6 +126,7 @@ export const FileDropOverlay: React.FC = () => {
       >
         {LABEL[kind]}
       </span>
-    </div>
+    </div>,
+    host,
   )
 }


### PR DESCRIPTION
When an image is dragged over a terminal partially hidden behind the sidebar, the file-drop indicator paints above the sidebar because it uses a window-level fixed rectangle. Portal the indicator into its positioned drop target so it inherits the target's clipping, transforms, and stacking order.

Adds an Electron regression that drags an image over a partially obscured terminal and checks browser paint order: the indicator covers the visible terminal while the sidebar remains above the hidden portion. The test failed at the sidebar assertion before the fix and passes after it; it also checks indicator cleanup after drag end.

Validation: both drag-indicator Electron tests passed, all five file-drop/payload unit tests passed, production build and TypeScript check passed, and ESLint passed for both changed files.
