### PR TITLE
Sync T3 panel colors with Cate themes

### DIFF
--- a/e2e/t3-agent.spec.ts
+++ b/e2e/t3-agent.spec.ts
@@ -306,6 +306,43 @@ test('explains an unchanged Homebrew update once without claiming success', asyn
   await expect(native.getByRole('button', { name: 'Update provider', exact: true })).toBeVisible()
 })
 
+test('real T3 follows Cate theme changes without reloading the conversation', async () => {
+  await expect.poll(() => guestEval(agentWebview(), `Boolean(document.querySelector('[contenteditable=true]'))`)).toBe(true)
+  await guestEval(agentWebview(), `(() => {
+    window.__themeSurvival = 'same guest';
+    document.querySelector('[contenteditable=true]').focus();
+  })()`)
+  const guestId = await agentWebview().evaluate(element => (element as HTMLElement & { getWebContentsId(): number }).getWebContentsId())
+  await electronApp!.evaluate(({ webContents }, id) => webContents.fromId(id)!.insertText('Draft through theme changes'), guestId)
+  await expect.poll(() => guestEval(agentWebview(), `document.querySelector('[contenteditable=true]').textContent`)).toBe('Draft through theme changes')
+  for (const id of ['dark-cold', 'light-subtle', 'dracula']) {
+    const expected = await page.evaluate((themeId) => {
+      window.__cateE2E!.setTheme(themeId)
+      const root = document.documentElement
+      return {
+        background: root.style.getPropertyValue('--surface-4'),
+        foreground: root.style.getPropertyValue('--text-primary'),
+        primary: root.style.getPropertyValue('--focus-blue'),
+        mode: root.dataset.theme,
+      }
+    }, id)
+    await expect.poll(() => guestEval(agentWebview(), `(() => {
+      const css = getComputedStyle(document.documentElement);
+      return { background: css.getPropertyValue('--background').trim(), foreground: css.getPropertyValue('--foreground').trim(),
+        primary: css.getPropertyValue('--primary').trim(), mode: css.colorScheme };
+    })()`)).toEqual(expected)
+    expect(await guestEval(agentWebview(), `({ marker: window.__themeSurvival, draft: document.querySelector('[contenteditable=true]').textContent })`))
+      .toEqual({ marker: 'same guest', draft: 'Draft through theme changes' })
+    await guestEval(agentWebview(), `new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))`)
+    // Buttons animate their color; wait for the theme transition before QA.
+    await expect.poll(() => guestEval(agentWebview(), `(() => {
+      const button = document.querySelector('button[aria-label="Change project"]');
+      return getComputedStyle(button).color === getComputedStyle(document.querySelector('h1')).color;
+    })()`)).toBe(true)
+    await page.screenshot({ path: test.info().outputPath(`t3-theme-${id}.png`) })
+  }
+})
+
 test('docked T3 hides when switching to its sibling canvas tab and preserves the conversation', async () => {
   expect(agent.nodeId).toBeNull()
   const agentTab = page.locator(`[data-tab-panel-id="${agent.panelId}"]`)

--- a/src/renderer/lib/agentHarnessTheme.test.ts
+++ b/src/renderer/lib/agentHarnessTheme.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it } from 'vitest'
+import { agentHarnessThemeScript } from './agentHarnessTheme'
+import { BUILT_IN_BY_ID } from '../../shared/themes'
+
+const guestWindow = window as typeof window & { __cateThemeObserver?: MutationObserver }
+afterEach(() => {
+  guestWindow.__cateThemeObserver?.disconnect()
+  document.getElementById('cate-agent-theme')?.remove()
+  document.documentElement.className = ''
+  delete document.documentElement.dataset.themeId
+})
+
+it('resolves partial custom palettes and replaces the guest theme without touching its content', async () => {
+  const draft = document.createElement('textarea')
+  draft.value = 'Keep this draft'
+  document.body.appendChild(draft)
+  const custom = { ...BUILT_IN_BY_ID['dark-cold'], id: 'custom', app: { 'surface-4': '#123456', 'focus-blue': '#abcdef' } }
+  new Function(agentHarnessThemeScript(custom))()
+  expect(getComputedStyle(document.documentElement).getPropertyValue('--background').trim()).toBe('#123456')
+  expect(getComputedStyle(document.documentElement).getPropertyValue('--primary').trim()).toBe('#abcdef')
+  expect(getComputedStyle(document.documentElement).getPropertyValue('--foreground').trim()).toBe('#e8e6e3')
+  expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+  new Function(agentHarnessThemeScript(BUILT_IN_BY_ID['light-subtle']))()
+  expect(document.querySelectorAll('#cate-agent-theme')).toHaveLength(1)
+  expect(document.documentElement.classList.contains('dark')).toBe(false)
+  expect(getComputedStyle(document.documentElement).colorScheme).toBe('light')
+  expect(draft.value).toBe('Keep this draft')
+
+  // Late upstream theme initialization must not restore its own dark mode.
+  document.documentElement.classList.add('dark')
+  document.documentElement.dataset.themeId = 'upstream'
+  await new Promise(resolve => setTimeout(resolve, 0))
+  expect(document.documentElement.classList.contains('dark')).toBe(false)
+  expect(document.documentElement.dataset.themeId).toBe('cate')
+  draft.remove()
+})

--- a/src/renderer/lib/agentHarnessTheme.ts
+++ b/src/renderer/lib/agentHarnessTheme.ts
@@ -1,0 +1,79 @@
+import type { Theme, AppColorKey } from '../../shared/theme'
+import { mergeThemeApp } from '../../shared/themeResolution'
+
+// T3's semantic tokens, mapped to the same resolved palette as Cate's chrome.
+const APP_TOKENS: Record<string, AppColorKey> = {
+  background: 'surface-4', foreground: 'text-primary',
+  'app-chrome-background': 'surface-1',
+  'toolbar-background': 'surface-2', 'toolbar-foreground': 'text-primary',
+  'toolbar-border': 'border-subtle', 'toolbar-control': 'surface-3',
+  'toolbar-control-foreground': 'text-primary', 'toolbar-control-hover': 'surface-hover',
+  card: 'surface-3', 'card-foreground': 'text-primary',
+  popover: 'surface-2', 'popover-foreground': 'text-primary',
+  'surface-raised': 'surface-3',
+  primary: 'focus-blue', 'primary-foreground': 'text-inverse',
+  secondary: 'surface-2', 'secondary-foreground': 'text-secondary',
+  muted: 'surface-3', 'muted-foreground': 'text-muted',
+  placeholder: 'text-muted', 'secondary-label': 'text-secondary', 'icon-muted': 'text-muted',
+  accent: 'surface-hover', 'accent-foreground': 'text-primary',
+  'message-surface': 'surface-2', 'message-foreground': 'text-primary',
+  'message-action': 'focus-blue', 'message-action-foreground': 'text-inverse',
+  'message-action-hover': 'focus-blue',
+  border: 'border-subtle', input: 'border-strong', ring: 'border-focus',
+  error: 'git-deleted', 'error-foreground': 'git-deleted',
+  destructive: 'git-deleted', 'destructive-foreground': 'git-deleted',
+  warning: 'activity-orange', 'warning-foreground': 'activity-orange',
+  success: 'activity-green', 'success-foreground': 'activity-green',
+  info: 'focus-blue', 'info-foreground': 'focus-blue',
+  update: 'focus-blue', 'update-foreground': 'focus-blue',
+  'code-background': 'surface-1', 'code-foreground': 'text-primary',
+}
+
+// Some composer styles use the upstream theme palette directly.
+const PALETTE_ALIASES: Record<string, string> = {
+  canvas: 'background', text: 'foreground', 'text-muted': 'muted-foreground',
+  chrome: 'app-chrome-background', toolbar: 'toolbar-background',
+  surface: 'card', 'surface-overlay': 'popover',
+  'accent-surface': 'accent', 'accent-surface-foreground': 'accent-foreground', focus: 'ring',
+}
+
+export function agentHarnessThemeScript(theme: Theme): string {
+  const app = mergeThemeApp(theme)
+  const tokens = Object.fromEntries(Object.entries(APP_TOKENS).map(([key, value]) => [key, app[value]]))
+  for (const key of ['error', 'warning', 'update']) {
+    tokens[`${key}-surface`] = `color-mix(in srgb, ${tokens[key]} 12%, transparent)`
+  }
+  tokens['terminal-background'] = theme.terminal.background
+  tokens['terminal-foreground'] = theme.terminal.foreground
+  tokens['terminal-cursor'] = theme.terminal.cursor ?? theme.terminal.foreground
+  tokens['terminal-selection-background'] = theme.terminal.selectionBackground ?? app['surface-hover-strong']
+  const declarations = Object.entries(tokens).flatMap(([key, value]) => [
+    `--${key}: ${value} !important;`, `--app-theme-${key}: ${value} !important;`,
+  ])
+  for (const [alias, token] of Object.entries(PALETTE_ALIASES)) {
+    declarations.push(`--app-theme-${alias}: ${tokens[token]} !important;`)
+  }
+  const css = `:root { color-scheme: ${theme.type} !important; ${declarations.join('\n')} }`
+  return `(() => {
+    const root = document.documentElement;
+    let style = document.getElementById('cate-agent-theme');
+    if (!style) {
+      style = document.createElement('style');
+      style.id = 'cate-agent-theme';
+      document.head.appendChild(style);
+    }
+    style.textContent = ${JSON.stringify(css)};
+    window.__cateThemeObserver?.disconnect();
+    const applyAppearance = () => {
+      if (root.classList.contains('dark') !== ${theme.type === 'dark'}) root.classList.toggle('dark', ${theme.type === 'dark'});
+      if (root.classList.contains('light') !== ${theme.type === 'light'}) root.classList.toggle('light', ${theme.type === 'light'});
+      if (root.dataset.themeId !== 'cate') root.dataset.themeId = 'cate';
+    };
+    applyAppearance();
+    // Upstream initializes its own persisted/system theme after dom-ready.
+    // Keep Cate authoritative without altering T3's saved preferences.
+    window.__cateThemeObserver = new MutationObserver(applyAppearance);
+    window.__cateThemeObserver.observe(root, { attributes: true, attributeFilter: ['class', 'data-theme-id'] });
+    root.dataset.cateTheme = ${JSON.stringify(theme.id)};
+  })()`
+}

--- a/src/renderer/panels/AgentPanel.tsx
+++ b/src/renderer/panels/AgentPanel.tsx
@@ -17,6 +17,8 @@ import { useActivePanelStore } from '../lib/activePanel'
 import { useOptionalCanvasStoreContext } from '../stores/CanvasStoreContext'
 import { focusedNodeId } from '../stores/canvas/selectionModel'
 import { useUIStore } from '../stores/uiStore'
+import { getActiveTheme, subscribeTheme } from '../lib/themeManager'
+import { agentHarnessThemeScript } from '../lib/agentHarnessTheme'
 
 interface WebviewElement extends HTMLElement {
   getURL(): string
@@ -195,6 +197,8 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
         if (webviewRef.current !== webview) return
         await webview.executeJavaScript(agentHarnessBrandingScript('thread')).catch(() => undefined)
         if (webviewRef.current !== webview) return
+        await webview.executeJavaScript(agentHarnessThemeScript(getActiveTheme())).catch(() => undefined)
+        if (webviewRef.current !== webview) return
         persistThreadFromLocation()
         setGuestReady(true)
       })()
@@ -221,6 +225,15 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
       webview.removeEventListener('did-fail-load', onFailed)
     }
   }, [panelId, state, threadId, workspaceId])
+
+  useEffect(() => {
+    if (state.phase !== 'ready' || !guestReady) return
+    const guest = webviewRef.current
+    if (!guest) return
+    const apply = () => { void guest.executeJavaScript(agentHarnessThemeScript(getActiveTheme())).catch(() => undefined) }
+    apply()
+    return subscribeTheme(apply)
+  }, [state, guestReady])
 
   useEffect(() => {
     if (state.phase !== 'ready') return


### PR DESCRIPTION
The embedded T3 panel previously kept its own colors when Cate's theme changed. Map T3's chat, composer, menu, status, and code-surface colors to Cate's resolved palette, including partial custom themes and the terminal palette.

Apply the theme before revealing a newly loaded guest and subscribe to live Cate theme changes. Synchronize light/dark appearance without reloading the conversation or changing T3's saved preferences; guard against late upstream theme initialization restoring a different appearance.

Validation:
- 11 unit tests passed, including custom-palette fallback, repeated theme updates, and late upstream appearance changes.
- Real T3 Electron test passed for Dark Cold, Light Subtle, and Dracula; native typing verifies the draft and guest survive each change, and control colors settle correctly. Screenshots visually reviewed.
- Existing dock visibility, canvas focus, and reload-branding Electron regressions passed.
- Production build, TypeScript checking, targeted ESLint, and diff whitespace checks passed.

Electron tests used the existing beta.5 runtime dependency tarball with the current runtime bundle because this checkout lacks a beta.6 dependency tarball.
