### PR TITLE
Fix Command+Arrow navigation from T3 and other canvas panels

### DIFF
--- a/src/main/webSecurity.test.ts
+++ b/src/main/webSecurity.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock('./settingsFile', () => ({ getSetting: () => ({}) }))
+const { customShortcuts } = vi.hoisted(() => ({ customShortcuts: { value: {} as Record<string, unknown> } }))
+vi.mock('./settingsFile', () => ({ getSetting: () => customShortcuts.value }))
 vi.mock('./featureFlags', () => ({ disableWebviewHardening: () => false }))
 vi.mock('./logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
 
@@ -50,6 +51,7 @@ function attachHandlerForWebview(): (event: unknown, wp: Record<string, unknown>
 }
 
 beforeEach(() => {
+  customShortcuts.value = {}
   createdHandlers.length = 0
   installWebContentsSecurity()
 })
@@ -124,5 +126,52 @@ describe('app-window navigation', () => {
     const unsafeNavigation = { preventDefault: vi.fn() }
     listeners['will-navigate'](unsafeNavigation, 'javascript:alert(1)')
     expect(unsafeNavigation.preventDefault).toHaveBeenCalledOnce()
+  })
+})
+
+// Both T3 and BrowserPanel use this shared webview input boundary.
+describe('webview canvas navigation shortcuts', () => {
+  function input(key: string, extra = {}) {
+    return {
+      type: 'keyDown', key, code: key,
+      meta: process.platform === 'darwin',
+      control: process.platform !== 'darwin', alt: false, shift: false,
+      ...extra,
+    }
+  }
+
+  it.each([
+    ['ArrowUp', 'navigateUp'], ['ArrowDown', 'navigateDown'],
+    ['ArrowLeft', 'navigateLeft'], ['ArrowRight', 'navigateRight'],
+  ])('forwards Command+%s to the host', (key, action) => {
+    const { contents, listeners } = webviewHarness()
+    const event = { preventDefault: vi.fn() }
+    listeners['before-input-event'](event, input(key))
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(contents.hostWebContents.send).toHaveBeenCalledWith('menu:triggerAction', action)
+  })
+
+  it('respects remapped and disabled navigation bindings', () => {
+    customShortcuts.value = {
+      navigateRight: { key: 'j', command: true, control: false, option: false, shift: false },
+      navigateLeft: { key: '', command: false, control: false, option: false, shift: false },
+    }
+    const { contents, listeners } = webviewHarness()
+    const event = { preventDefault: vi.fn() }
+    listeners['before-input-event'](event, input('ArrowRight'))
+    listeners['before-input-event'](event, input('ArrowLeft'))
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    listeners['before-input-event'](event, input('j'))
+    expect(contents.hostWebContents.send).toHaveBeenCalledWith('menu:triggerAction', 'navigateRight')
+  })
+
+  it('leaves bare arrows, text selection and key-up events in the guest', () => {
+    const { contents, listeners } = webviewHarness()
+    const event = { preventDefault: vi.fn() }
+    listeners['before-input-event'](event, input('ArrowRight', { meta: false, control: false }))
+    listeners['before-input-event'](event, input('ArrowRight', { meta: false, control: false, shift: true }))
+    listeners['before-input-event'](event, input('ArrowRight', { type: 'keyUp' }))
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(contents.hostWebContents.send).not.toHaveBeenCalled()
   })
 })

--- a/src/main/webSecurity.ts
+++ b/src/main/webSecurity.ts
@@ -5,7 +5,7 @@ import log from './logger'
 import { disableWebviewHardening } from './featureFlags'
 import { BROWSER_OPEN_TAB_REQUEST, BROWSER_SHORTCUT, MENU_TRIGGER_ACTION } from '../shared/ipc-channels'
 import { getSetting } from './settingsFile'
-import { resolveShortcuts, type BrowserShortcutAction } from '../shared/types'
+import { normaliseShortcutKey, resolveShortcuts, type BrowserShortcutAction } from '../shared/types'
 
 function getBrowserGuestPreloadPath(): string {
   const base =
@@ -185,15 +185,22 @@ export function installWebContentsSecurity(): void {
       // focused BrowserPanel can act. Scoped to webview guests, so Monaco's
       // Cmd+[ / Cmd+] / Cmd+L are never affected.
       contents.on('before-input-event', (event, input) => {
-        const palette = resolveShortcuts(getSetting('customShortcuts')).commandPalette
+        // Guest key events never bubble to the host document. Forward canvas
+        // navigation from both browser and T3 guests using the user's bindings.
+        const shortcuts = resolveShortcuts(getSetting('customShortcuts'))
         const command = process.platform === 'darwin' ? input.meta : input.control
         const control = process.platform === 'darwin' ? input.control : false
-        if (input.type === 'keyDown' && palette.key && input.key.toLowerCase() === palette.key.toLowerCase()
-          && !!command === palette.command && !!control === palette.control
-          && !!input.alt === palette.option && !!input.shift === palette.shift) {
-          event.preventDefault()
-          contents.hostWebContents?.send(MENU_TRIGGER_ACTION, 'commandPalette')
-          return
+        if (input.type === 'keyDown') {
+          for (const action of ['commandPalette', 'navigateUp', 'navigateDown', 'navigateLeft', 'navigateRight'] as const) {
+            const shortcut = shortcuts[action]
+            if (shortcut.key && normaliseShortcutKey(input.key) === shortcut.key
+              && !!command === shortcut.command && !!control === shortcut.control
+              && !!input.alt === shortcut.option && !!input.shift === shortcut.shift) {
+              event.preventDefault()
+              contents.hostWebContents?.send(MENU_TRIGGER_ACTION, action)
+              return
+            }
+          }
         }
         const action = browserActionForInput(input)
         if (!action) return

--- a/src/renderer/hooks/useShortcuts.activeCanvas.test.tsx
+++ b/src/renderer/hooks/useShortcuts.activeCanvas.test.tsx
@@ -34,7 +34,8 @@ import {
   releaseCanvasStoreForPanel,
   type CanvasStore,
 } from '../stores/canvasStore'
-import { setActivePanel } from '../lib/activePanel'
+import type { MenuActionId, PanelType } from '../../shared/types'
+import { getActivePanelId, setActivePanel } from '../lib/activePanel'
 
 // Tell React this is an act() environment (silences the act warning + flushes effects).
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -46,6 +47,7 @@ let primary: StoreApi<CanvasStore>
 let active: StoreApi<CanvasStore>
 let container: HTMLDivElement
 let root: Root
+let menuAction: (action: MenuActionId) => void
 
 function Harness({ store }: { store: StoreApi<CanvasStore> }) {
   useShortcuts(store)
@@ -61,7 +63,7 @@ function dispatchKey(init: Partial<KeyboardEventInit> & { key: string }) {
 beforeEach(() => {
   // electronAPI is consumed in useShortcuts' effect (menu subscriptions).
   ;(window as unknown as { electronAPI: unknown }).electronAPI = {
-    onMenuTriggerAction: () => () => {},
+    onMenuTriggerAction: (callback: typeof menuAction) => { menuAction = callback; return () => {} },
     onMenuLoadLayout: () => () => {},
   }
 
@@ -116,5 +118,45 @@ describe('useShortcuts active-canvas routing', () => {
     expect(primary.getState().suppressAutoFocus).toBe(false)
     expect(primaryBefore).toBe(primary.getState().viewportOffset)
     void before
+  })
+})
+
+
+describe('navigation from panel content', () => {
+  it.each<PanelType>(['agent', 'browser', 'terminal', 'editor', 'canvas', 'document', 'review'])(
+    'supports chained jumps starting from a %s panel', (type) => {
+      const left = active.getState().addNode('source', type, { x: 0, y: 0 })
+      const middle = active.getState().addNode('middle', 'editor', { x: 2000, y: 0 })
+      const right = active.getState().addNode('right', 'editor', { x: 4000, y: 0 })
+      act(() => { active.getState().selectNodes([left]) })
+      const surface = document.createElement(type === 'agent' || type === 'browser' ? 'webview' : 'textarea')
+      surface.tabIndex = 0
+      container.appendChild(surface)
+      surface.focus()
+      expect(document.activeElement).toBe(surface)
+
+      if (type === 'agent' || type === 'browser') {
+        act(() => { menuAction('navigateRight') })
+      } else {
+        act(() => { surface.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', metaKey: true, bubbles: true })) })
+      }
+      expect(active.getState().selection).toEqual([middle])
+      expect(document.activeElement).not.toBe(surface)
+      expect(getActivePanelId()).toBe(ACTIVE)
+      dispatchKey({ key: 'ArrowRight', metaKey: true })
+      expect(active.getState().selection).toEqual([right])
+      dispatchKey({ key: 'Enter' })
+      expect(active.getState().selectionActive).toBe(true)
+    },
+  )
+
+  it('preserves Shift+Arrow text selection', () => {
+    const surface = document.createElement('textarea')
+    container.appendChild(surface)
+    surface.focus()
+    const pan = vi.spyOn(active.getState(), 'panViewport')
+    dispatchKey({ key: 'ArrowRight', shiftKey: true })
+    expect(pan).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(surface)
   })
 })

--- a/src/renderer/hooks/useShortcuts.ts
+++ b/src/renderer/hooks/useShortcuts.ts
@@ -14,7 +14,7 @@ import {
   getWorkspaceCanvasStore,
 } from '../stores/appStore'
 import { useUIStore } from '../stores/uiStore'
-import { getActivePanelId, setActivePanel } from '../lib/activePanel'
+import { getActivePanelId } from '../lib/activePanel'
 import { resolvePanelById } from '../lib/workspace/panelReveal'
 import { getNodeActivePanelId } from '../panels/nodeDockRegistry'
 import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
@@ -245,23 +245,9 @@ export function useShortcuts(windowCanvasStore?: StoreApi<CanvasStore>): void {
         // Let a keyboard-navigable list (e.g. the Search results tree, marked
         // data-keynav) keep its own arrow keys instead of moving the canvas.
         if (isKeyNavFocused()) return
-        // Defer to a real text editor (Monaco / input / textarea /
-        // contenteditable) so its own Cmd/Shift+Arrow editing keys keep
-        // working. Terminals don't rely on those chords, so canvas navigation
-        // overrides a focused terminal — letting the user jump/pan straight out
-        // of one and keep going.
-        if (!terminalHasFocus && isTextSurfaceFocused()) return
-        // Navigating deliberately doesn't activate the destination, so drop
-        // keyboard focus out of a focused terminal — otherwise its cursor keeps
-        // capturing input and the next arrow never reaches the canvas. Also
-        // repoint the canonical active panel at the canvas itself: the leaf
-        // pointer otherwise stays on the terminal, so computeTerminalHasFocus
-        // keeps reporting a focused terminal and bare-key shortcuts (Enter to
-        // activate the jump target, Delete, Escape) wrongly stand down.
-        if (NAVIGATE_ACTIONS.has(action) && terminalHasFocus) {
-          ;(document.activeElement as HTMLElement | null)?.blur()
-          setActivePanel(getActiveCanvasPanelId())
-        }
+        // Panel navigation works from every surface. Shift+Arrow panning
+        // still yields to text selection in editors and inputs.
+        if (PAN_ACTIONS.has(action) && !terminalHasFocus && isTextSurfaceFocused()) return
       }
       // Context-aware guard: when a real text editor (Monaco, input, textarea,
       // contenteditable) has focus, let Cmd+Z/Y fall through to it natively.

--- a/src/renderer/lib/runAction.ts
+++ b/src/renderer/lib/runAction.ts
@@ -11,16 +11,18 @@ import type { StoreApi } from 'zustand'
 import {
   useAppStore,
   getActiveCanvasOps,
+  getActiveCanvasPanelId,
   placementForActivePanel,
 } from '../stores/appStore'
 import { useUIStore, getSidebarLayout } from '../stores/uiStore'
 import { useSearchStore } from '../stores/searchStore'
-import type { MenuActionId, ShortcutAction } from '../../shared/types'
+import type { MenuActionId } from '../../shared/types'
 import type { CanvasStore } from '../stores/canvasStore'
 import { focusedNodeId as focusedNodeIdOf } from '../stores/canvas/selectionModel'
 import { provideAppStoreForHistory } from '../stores/canvas/historySlice'
 import { inheritedWorktreeFromSelection } from './inheritWorktree'
 import { closePanelWithConfirm } from './closePanelWithConfirm'
+import { setActivePanel } from './activePanel'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
 import { getFocusedLeafPanelId, requestPanelRename } from './focusedPanel'
 
@@ -89,7 +91,7 @@ export async function runAction(
     return
   }
 
-  switch (action as ShortcutAction) {
+  switch (action) {
     case 'newTerminal': {
       const placement = placementForActivePanel()
       const wsId = await ensureWorkspaceFolder(selectedWorkspaceId)
@@ -228,17 +230,24 @@ export async function runAction(
       break
     }
     case 'navigateUp':
-      canvasStore()?.navigateSelect('up')
-      break
     case 'navigateDown':
-      canvasStore()?.navigateSelect('down')
-      break
     case 'navigateLeft':
-      canvasStore()?.navigateSelect('left')
+    case 'navigateRight': {
+      if (useUIStore.getState().showCommandPalette) break
+      const canvas = canvasStore()
+      if (!canvas) break
+      // Release the source surface for chained jumps and Enter-to-activate.
+      // This must also run for shortcuts forwarded from webview guests.
+      const canvasPanelId = getActiveCanvasPanelId()
+      ;(document.activeElement as HTMLElement | null)?.blur()
+      setActivePanel(canvasPanelId)
+      const direction = {
+        navigateUp: 'up', navigateDown: 'down',
+        navigateLeft: 'left', navigateRight: 'right',
+      } as const
+      canvas.navigateSelect(direction[action])
       break
-    case 'navigateRight':
-      canvasStore()?.navigateSelect('right')
-      break
+    }
     case 'panUp':
       canvasStore()?.panViewport('up')
       break


### PR DESCRIPTION
Command+Arrow did not leave a focused T3 or browser webview because guest key events never reached Cate's renderer shortcut listener. Focused editor and text surfaces also suppressed panel navigation.

Forward configured navigation shortcuts from Electron's webview input handler, allow navigation from renderer text surfaces, and release source focus in the shared action handler so repeated jumps and Enter-to-activate work consistently. Shift+Arrow continues to select text in editors and inputs.

Validation: `npm run typecheck` and 97 tests across webview security, shortcut routing, shortcut settings, and canvas state pass. Regression coverage includes all four guest navigation directions, remapped/disabled bindings, and simulated content focus for all seven panel types. Live Electron interaction has not been manually verified.
