### PR TITLE
Reduce T3 panel loading and polling overhead

### DIFF
--- a/src/main/t3Agent/T3HarnessManager.test.ts
+++ b/src/main/t3Agent/T3HarnessManager.test.ts
@@ -65,6 +65,19 @@ describe('T3 harness lifecycle', () => {
     expect(manager.getStatus('/alias').phase).toBe('running')
   })
 
+  it('reopens a conversation without repeating provider file synchronization', async () => {
+    const boundary = manager as unknown as { ensureLocalThreadMode(): Promise<void> }
+    const first = await manager.getPanelTarget({ ...request, threadId: 'saved' }, 1)
+    manager.panelClosed(request.panelId)
+    const reopened = await manager.getPanelTarget({ ...request, threadId: 'saved' }, 1)
+    expect(reopened).toEqual(first)
+    expect(start).toHaveBeenCalledOnce()
+    // startInstance is mocked above; settings sync belongs inside startup,
+    // never on the per-panel URL resolution path.
+    expect(boundary.ensureLocalThreadMode).not.toHaveBeenCalled()
+    expect(local.validatePathStrict).toHaveBeenCalledTimes(2)
+  })
+
   it('isolates worktrees and remote runtimes, including disconnect and reconnect', async () => {
     const main = await manager.getPanelTarget(request, 1)
     const worktree = await manager.getPanelTarget({ ...request, panelId: 'worktree', cwd: '/feature' }, 1)

--- a/src/main/t3Agent/T3HarnessManager.ts
+++ b/src/main/t3Agent/T3HarnessManager.ts
@@ -349,7 +349,8 @@ export class T3HarnessManager {
       cwd,
       request.workspaceId,
     )
-    await this.ensureLocalThreadMode(instance)
+    // Startup and provider-profile publication already synchronize settings.
+    // Reopening a webview must not recopy provider secrets (especially over SSH).
     if (!instance.environmentId) throw new Error('T3 environment descriptor did not include an environment ID')
 
     const previousKey = this.panelHarness.get(request.panelId)

--- a/src/renderer/lib/t3ThreadState.test.ts
+++ b/src/renderer/lib/t3ThreadState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { runInNewContext } from 'node:vm'
-import { T3_THREAD_SUBSCRIPTION_SCRIPT, t3ThreadActivity } from './t3ThreadState'
+import { T3_THREAD_SUBSCRIPTION_SCRIPT, t3ThreadActivity, t3ThreadPollScript } from './t3ThreadState'
 
 describe('T3 conversation state', () => {
   it('distinguishes waiting, active turns, background work, and completed conversations', () => {
@@ -41,4 +41,33 @@ describe('T3 conversation state', () => {
     expect(window.__cateT3Threads.connected).toBe(false)
     expect(context.setTimeout).toHaveBeenCalled()
   })
+})
+
+
+it('copies thread metadata only when changed and can force a fresh read', () => {
+  const state = { connected: true, revision: 7, sequence: 12, threads: { a: { id: 'a', title: 'First' } } }
+  const context = { window: { __cateT3Threads: state } }
+  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual(state)
+  expect(runInNewContext(t3ThreadPollScript(7), context)).toBeUndefined()
+  state.threads.a.title = 'Updated'
+  state.revision++
+  expect(runInNewContext(t3ThreadPollScript(7), context)).toEqual(state)
+  expect(runInNewContext(t3ThreadPollScript(8), context)).toBeUndefined()
+  // Disconnects must still reach the host, even with unchanged thread content.
+  state.connected = false
+  state.revision++
+  expect(runInNewContext(t3ThreadPollScript(8), context)?.connected).toBe(false)
+  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual(state)
+})
+
+it('installs a single subscription when polling an uninitialized guest', () => {
+  const sockets = vi.fn()
+  class FakeSocket { constructor() { sockets() } }
+  const context = {
+    window: { addEventListener: vi.fn() }, WebSocket: FakeSocket,
+    location: { origin: 'http://127.0.0.1:1234' },
+  }
+  expect(runInNewContext(t3ThreadPollScript(), context)?.revision).toBe(0)
+  for (let i = 0; i < 20; i++) expect(runInNewContext(t3ThreadPollScript(0), context)).toBeUndefined()
+  expect(sockets).toHaveBeenCalledOnce()
 })

--- a/src/renderer/lib/t3ThreadState.ts
+++ b/src/renderer/lib/t3ThreadState.ts
@@ -61,3 +61,15 @@ export const T3_THREAD_SUBSCRIPTION_SCRIPT = `(() => {
   window.addEventListener('pagehide', () => { clearTimeout(timer); socket.onclose = null; socket.close(); }, { once: true });
   connect();
 })()`
+
+
+/** Keep unchanged thread lists inside the guest instead of cloning them over
+ * IPC on every tick. A fresh consumer (or a failed read) requests a full copy. */
+export function t3ThreadPollScript(previousRevision?: number): string {
+  return `/* cate-t3-poll */ (() => {
+    ${T3_THREAD_SUBSCRIPTION_SCRIPT};
+    const state = window.__cateT3Threads;
+    if (state.revision === ${previousRevision === undefined ? 'null' : JSON.stringify(previousRevision)}) return;
+    return { connected: state.connected, threads: state.threads, revision: state.revision, sequence: state.sequence };
+  })()`
+}

--- a/src/renderer/panels/AgentPanel.test.tsx
+++ b/src/renderer/panels/AgentPanel.test.tsx
@@ -136,6 +136,8 @@ describe('AgentPanel', () => {
     let finishCss!: (key: string) => void
     oldGuest.insertCSS.mockImplementation(() => new Promise(resolve => { finishCss = resolve }))
     await act(async () => oldGuest.dispatchEvent(new Event('dom-ready')))
+    expect(oldGuest.executeJavaScript).toHaveBeenCalledOnce()
+    oldGuest.executeJavaScript.mockClear()
     await act(async () => useAppStore.getState().setPanelAgentThreadId('ws', 'agent', 'next-chat'))
     const nextGuest = mockGuest()
     expect(nextGuest).not.toBe(oldGuest)
@@ -221,6 +223,9 @@ describe('AgentPanel', () => {
     expect(webview.classList.contains('invisible')).toBe(true)
     await act(async () => webview.dispatchEvent(new Event('dom-ready')))
     expect(webview.classList.contains('invisible')).toBe(true)
+    // Guest setup starts while CSS is still pending, in a single round trip.
+    expect(webview.executeJavaScript).toHaveBeenCalledTimes(1)
+    expect(() => new Function(webview.executeJavaScript.mock.calls[0][0])).not.toThrow()
 
     await act(async () => {
       finishCss?.()
@@ -258,7 +263,7 @@ it('uses only the bound connected thread title, preserves user titles, and ignor
     let snapshot = { connected: true, revision: 1, threads: { first: { id: 'first', title: 'Extracted title' }, other: { id: 'other', title: 'Wrong conversation' } } }
     guest.getURL = () => 'http://127.0.0.1:49152/local-env/first'
     guest.insertCSS = vi.fn().mockResolvedValue('css')
-    guest.executeJavaScript = vi.fn(async (script: string) => script.startsWith('window.__cateT3Threads &&') ? snapshot : undefined)
+    guest.executeJavaScript = vi.fn(async (script: string) => script.startsWith('/* cate-t3-poll */') ? snapshot : undefined)
     const title = () => useAppStore.getState().workspaces[0].panels.agent.title
     await act(async () => guest.dispatchEvent(new Event('dom-ready')))
     expect(title()).toBe('Extracted title')
@@ -273,7 +278,7 @@ it('uses only the bound connected thread title, preserves user titles, and ignor
     await act(async () => vi.advanceTimersByTimeAsync(1000))
     expect(title()).toBe('My chosen title')
     let release: ((value: unknown) => void) | undefined
-    guest.executeJavaScript.mockImplementation((script: string) => script.startsWith('window.__cateT3Threads &&') ? new Promise(resolve => { release = resolve }) : Promise.resolve())
+    guest.executeJavaScript.mockImplementation((script: string) => script.startsWith('/* cate-t3-poll */') ? new Promise(resolve => { release = resolve }) : Promise.resolve())
     await act(async () => vi.advanceTimersByTimeAsync(1000))
     expect(release).toBeDefined()
     await act(async () => useAppStore.getState().setPanelAgentThreadId('ws', 'agent', 'other'))

--- a/src/renderer/panels/AgentPanel.tsx
+++ b/src/renderer/panels/AgentPanel.tsx
@@ -1,7 +1,7 @@
 import { LoadingState } from '../ui/Spinner'
-import { T3_THREAD_SUBSCRIPTION_SCRIPT } from '../lib/t3ThreadState'
+import { t3ThreadPollScript } from '../lib/t3ThreadState'
 import { useT3ActivityStore, type T3Snapshot } from '../stores/t3ActivityStore'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ArrowClockwise, ChatsCircle } from '@phosphor-icons/react'
 import type { AgentPanelProps } from './types'
 import { agentProductCopy } from '../../shared/agentProductCopy'
@@ -63,14 +63,14 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     return () => cancelAnimationFrame(frame)
   }, [isFocused, guestReady, focusEpoch, paletteOpen])
 
-  const workspace = useAppStore((s) => s.workspaces.find((item) => item.id === workspaceId))
-  const panel = workspace?.panels[panelId]
-  const cwd = useMemo(() => {
+  const cwd = useAppStore((s) => {
+    const workspace = s.workspaces.find((item) => item.id === workspaceId)
+    const panel = workspace?.panels[panelId]
     if (panel?.cwd) return panel.cwd
     const worktree = workspace?.worktrees?.find((item) => item.id === panel?.worktreeId)
     return worktree?.path ?? workspace?.rootPath ?? ''
-  }, [panel?.cwd, panel?.worktreeId, workspace?.rootPath, workspace?.worktrees])
-  const threadId = panel?.agentThreadId
+  })
+  const threadId = useAppStore((s) => s.workspaces.find((item) => item.id === workspaceId)?.panels[panelId]?.agentThreadId)
   useEffect(() => window.electronAPI.onAgentConversationDeleted?.((event) => {
     if (state.phase === 'ready' && event.partition === state.partition && event.workspaceId === workspaceId && event.threadId === threadId) {
       void window.electronAPI.closeWindowPanel(panelId)
@@ -136,6 +136,7 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     const webview = webviewRef.current
     if (!webview) return
 
+    let disposed = false
     const boundUrl = threadId
       ? `${new URL(state.url).origin}/${encodeURIComponent(state.environmentId)}/${encodeURIComponent(threadId)}`
       : state.url
@@ -192,13 +193,17 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     }
     const onReady = (): void => {
       void (async () => {
-        await webview.insertCSS(AGENT_CHAT_ONLY_CSS).catch(() => undefined)
-        // A host chat selection can replace the guest while branding is pending.
-        if (webviewRef.current !== webview) return
-        await webview.executeJavaScript(agentHarnessBrandingScript('thread')).catch(() => undefined)
-        if (webviewRef.current !== webview) return
-        await webview.executeJavaScript(agentHarnessThemeScript(getActiveTheme())).catch(() => undefined)
-        if (webviewRef.current !== webview) return
+        // CSS and guest setup are independent. Batch the scripts into one
+        // guest call, and reveal only after both styling and setup finish.
+        const setup = [
+          agentHarnessBrandingScript('thread'),
+          agentHarnessThemeScript(getActiveTheme()),
+        ].map((script) => `try { ${script}; } catch {}`).join('\n')
+        await Promise.allSettled([
+          webview.insertCSS(AGENT_CHAT_ONLY_CSS),
+          webview.executeJavaScript(setup),
+        ])
+        if (disposed || webviewRef.current !== webview) return
         persistThreadFromLocation()
         setGuestReady(true)
       })()
@@ -216,6 +221,7 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     webview.addEventListener('dom-ready', onReady)
     webview.addEventListener('did-fail-load', onFailed)
     return () => {
+      disposed = true
       webview.removeEventListener('will-navigate', onWillNavigate)
       webview.removeEventListener('new-window', onNewWindow)
       webview.removeEventListener('did-navigate', persistThreadFromLocation)
@@ -250,17 +256,19 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     const store = useT3ActivityStore.getState()
     let cancelled = false
     let timer: ReturnType<typeof setTimeout>
+    let previousRevision: number | undefined
     const poll = async () => {
       try {
-        await guest.executeJavaScript(T3_THREAD_SUBSCRIPTION_SCRIPT)
-        const snapshot = await guest.executeJavaScript('window.__cateT3Threads && ({ connected: window.__cateT3Threads.connected, threads: window.__cateT3Threads.threads, revision: window.__cateT3Threads.revision, sequence: window.__cateT3Threads.sequence })') as T3Snapshot | undefined
+        const snapshot = await guest.executeJavaScript(t3ThreadPollScript(previousRevision)) as T3Snapshot | undefined
         if (cancelled) return
         if (snapshot) {
+          previousRevision = snapshot.revision
           store.update(state.partition, snapshot, panelId)
           const thread = threadId ? snapshot.threads[threadId] : undefined
           if (snapshot.connected && thread?.title) useAppStore.getState().updatePanelTitleFromAgent(workspaceId, panelId, thread.title)
         }
       } catch {
+        previousRevision = undefined
         if (!cancelled) store.update(state.partition, { connected: false, threads: {}, revision: -1 }, panelId)
       }
       if (!cancelled) timer = setTimeout(poll, 1000)


### PR DESCRIPTION
Reopening a T3 conversation during workspace switching repeated provider settings and secret-file synchronization, then waited for sequential webview setup calls. Skip the redundant synchronization and run CSS insertion alongside a single batched branding/theme call, while keeping the spinner until setup completes.

Reduce ongoing overhead by returning thread metadata only when its revision changes, combining activity checks into one guest call, and subscribing to only the panel state needed for rendering. T3 webviews still unmount on workspace switches; this change does not retain background guests.

Validation: 26 targeted tests pass, including startup reuse, stale-guest readiness, batched-script syntax, and change-only activity snapshots. `npm run typecheck` and `git diff --check` pass. Live Electron loading time has not been benchmarked.
