### PR TITLE
Fix CLI agent status after terminal approval input

### DIFF
--- a/src/main/ipc/agentSessionStamps.test.ts
+++ b/src/main/ipc/agentSessionStamps.test.ts
@@ -144,9 +144,9 @@ describe('cwd fallback (payloads that carry no cwd)', () => {
 })
 
 describe('emit mechanics', () => {
-  it('ignores title metadata because it does not change resume identity', () => {
+  it.each(['session-title', 'input-submit', 'input-interrupt'] as const)('ignores %s because it does not change resume identity', (kind) => {
     ingestAgentSessionStamp(runtime, {
-      ...ev(tid, 'codex', 'session-title', 'id-1', '/w'),
+      ...ev(tid, 'codex', kind, 'id-1', '/w'),
       title: 'Fix terminal titles',
     })
     expect(stamps(tid)).toEqual([])

--- a/src/main/ipc/agentSessionStamps.ts
+++ b/src/main/ipc/agentSessionStamps.ts
@@ -100,7 +100,7 @@ function emit(terminalId: string, session: TerminalAgentSession | null): void {
  */
 export function ingestAgentSessionStamp(runtime: Runtime, event: AgentHookEvent): void {
   const { terminalId } = event
-  if (event.kind === 'session-title') return
+  if (event.kind === 'session-title' || event.kind === 'input-submit' || event.kind === 'input-interrupt') return
   const st = stateFor(terminalId)
   st.seq++
   if (event.kind === 'session-end') {

--- a/src/renderer/lib/agent/agentScreenDetector.ts
+++ b/src/renderer/lib/agent/agentScreenDetector.ts
@@ -10,9 +10,9 @@
 // flips to 'waitingForInput' immediately with a "needs permission"
 // notification whose body carries the blocked command; turn-resume (the
 // CLI reported a permission reply or a tool completed) flips back to 'running'
-// silently. For CLIs with no approval-reply hook, terminal Enter supplies the
-// earlier resume edge. The signals are authoritative, so no settle timer is
-// involved.
+// silently. For CLIs with no approval-reply hook, runtime PTY input supplies the
+// earlier resume edge on the same ordered stream as the hooks. The signals
+// are authoritative, so no settle timer is involved.
 //
 // Presence (noteAgentPresence, fed 1 Hz from main's activity scan) stays
 // authoritative for EXISTENCE — but it is itself hook-anchored now: the
@@ -175,6 +175,12 @@ export function noteAgentHookEvent(event: AgentHookEvent): void {
   const t = trackerFor(event.terminalId)
   t.agentId = event.agentId
   switch (event.kind) {
+    case 'input-submit':
+      noteAgentInputSubmitted(event.terminalId)
+      break
+    case 'input-interrupt':
+      noteAgentInterruptSubmitted(event.terminalId)
+      break
     case 'turn-start':
       t.sessionId = event.sessionId
       t.activeTurnId = event.turnId ?? null
@@ -241,8 +247,8 @@ export function noteAgentHookEvent(event: AgentHookEvent): void {
 /** The user submitted a response while the CLI was parked on a permission
  *  prompt. Claude, Codex, and Grok do not expose an "approval answered" hook:
  *  their next hook is PostToolUse, after the approved tool has FINISHED. The
- *  terminal Enter is therefore the earliest truthful resume edge. A denial
- *  also resumes the agent while it processes that answer, before its Stop. */
+ *  runtime-observed Enter supplies the earlier resume edge. A denial also
+ *  resumes the agent while it processes that answer, before its Stop. */
 export function noteAgentInputSubmitted(terminalId: string): void {
   const t = trackers.get(terminalId)
   if (!t?.hookPermissionWait) return

--- a/src/renderer/lib/terminal/terminalLifecycle.test.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.test.ts
@@ -226,6 +226,7 @@ beforeEach(() => {
   replayTerminalLog.mockClear()
   replayTerminalLog.mockImplementation(async () => {})
   noteAgentInputSubmitted.mockClear()
+  noteAgentInterruptSubmitted.mockClear()
 })
 
 // ===========================================================================
@@ -272,23 +273,23 @@ describe('spawn → wire → dispose happy path', () => {
     expect(dataDisposers[0]).toHaveBeenCalledTimes(1)
   })
 
-  it('reports a submitted terminal line to the agent status coordinator', async () => {
+  it('forwards Enter without racing the runtime hook stream', async () => {
     terminalCreate.mockResolvedValueOnce('pty-input')
     await LC.getOrCreate('panel-input', { workspaceId: 'ws-1' })
 
     terminalInstances[0].emitData('\r')
 
-    expect(noteAgentInputSubmitted).toHaveBeenCalledWith('pty-input')
+    expect(noteAgentInputSubmitted).not.toHaveBeenCalled()
     expect(terminalWrite).toHaveBeenCalledWith('pty-input', '\r')
   })
 
-  it('reports Ctrl-C to the agent status coordinator', async () => {
+  it('forwards Ctrl-C without racing the runtime hook stream', async () => {
     terminalCreate.mockResolvedValueOnce('pty-interrupt')
     await LC.getOrCreate('panel-interrupt', { workspaceId: 'ws-1' })
 
     terminalInstances[0].emitData('\x03')
 
-    expect(noteAgentInterruptSubmitted).toHaveBeenCalledWith('pty-interrupt')
+    expect(noteAgentInterruptSubmitted).not.toHaveBeenCalled()
     expect(terminalWrite).toHaveBeenCalledWith('pty-interrupt', '\x03')
   })
 

--- a/src/renderer/lib/terminal/terminalLifecycle.ts
+++ b/src/renderer/lib/terminal/terminalLifecycle.ts
@@ -40,7 +40,6 @@ import { useStatusStore } from '../../stores/statusStore'
 import { awaitWorkspaceSync, useAppStore } from '../../stores/appStore'
 import { replayTerminalLog } from '../workspace/session'
 import type { CodingAgentLaunch } from '../../../shared/codingAgentRuns'
-import { noteAgentInputSubmitted, noteAgentInterruptSubmitted } from '../agent/agentScreenDetector'
 
 interface CreateOpts {
   workspaceId: string
@@ -217,12 +216,8 @@ export function wireTerminalListeners(args: {
 
   // xterm -> PTY: keystrokes (standard path for all other input)
   const dataDisposable = terminal.onData((data) => {
-    // Permission hooks report the wait, but several CLIs expose no matching
-    // "user answered" event until after the approved tool finishes. Enter is
-    // the real resume edge; the detector ignores it unless this terminal is
-    // currently parked on a permission prompt.
-    if (data.includes('\r')) noteAgentInputSubmitted(ptyId)
-    if (data.includes('\x03')) noteAgentInterruptSubmitted(ptyId)
+    // The runtime reports submission/interrupt edges alongside hooks, for
+    // every write path (including automated input) and in delivery order.
     electronAPI.terminalWrite(ptyId, data)
   })
   cleanupListeners.push(() => dataDisposable.dispose())

--- a/src/runtime/capabilities/agentHooks.ts
+++ b/src/runtime/capabilities/agentHooks.ts
@@ -89,6 +89,11 @@ export interface AgentHooksCapability {
    *  folder is already in the repo (the 'auto' signal), and whether Cate has
    *  injected there. Read-only; runs on the host that owns the workspace. */
   inspectWorkspace(cwd: string): Promise<AgentHookAgentState[]>
+  /** Report accepted PTY input on the same ordered stream as lifecycle hooks.
+   *  Only terminals identified by a hook emit events; typed text is never sent. */
+  noteInput(terminalId: string, data: string): void
+  /** Forget the input correlation when a PTY exits or is killed. */
+  forgetTerminal(terminalId: string): void
   /** Subscribe to normalized hook events. Returns an unsubscribe. */
   subscribe(onEvent: (event: AgentHookEvent) => void): () => void
   /** The ingestion endpoint (boots it if needed) — for tests/diagnostics.
@@ -214,9 +219,14 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
   const listeners = new Set<(event: AgentHookEvent) => void>()
   let ready: Promise<HookState> | null = null
   let disposed = false
+  const inputSessions = new Map<string, Pick<AgentHookEvent, 'agentId' | 'sessionId'>>()
 
   let titleTracker: ReturnType<typeof createAgentTitleTracker> | null = null
   const emit = (event: AgentHookEvent): void => {
+    if (event.kind === 'session-end') inputSessions.delete(event.terminalId)
+    else if (event.kind !== 'session-title' && event.kind !== 'input-submit' && event.kind !== 'input-interrupt') {
+      inputSessions.set(event.terminalId, { agentId: event.agentId, sessionId: event.sessionId })
+    }
     for (const cb of listeners) {
       try { cb(event) } catch { /* a subscriber must not break ingestion */ }
     }
@@ -483,6 +493,18 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
   }
 
   return {
+    noteInput(terminalId, data) {
+      const session = inputSessions.get(terminalId)
+      if (!session || disposed) return
+      // The PTY write and hook ingestion run on this host. A busy renderer
+      // therefore receives permission-wait before its corresponding input,
+      // even when both events are still queued for delivery.
+      if (data.includes('\r')) emit({ terminalId, ...session, kind: 'input-submit', raw: {} })
+      if (data.includes('\x03')) emit({ terminalId, ...session, kind: 'input-interrupt', raw: {} })
+    },
+    forgetTerminal(terminalId) {
+      inputSessions.delete(terminalId)
+    },
     async envForPty(ptyId, env) {
       if (disposed) return env
       let state: HookState
@@ -616,6 +638,7 @@ export function createAgentHooksCapability(deps: AgentHooksDeps = {}): AgentHook
       titleTracker?.dispose()
       titleTracker = null
       listeners.clear()
+      inputSessions.clear()
       interruptWatches.clear()
       if (interruptTimer) {
         clearInterval(interruptTimer)

--- a/src/runtime/capabilities/agentTitles/tracker.ts
+++ b/src/runtime/capabilities/agentTitles/tracker.ts
@@ -107,7 +107,7 @@ export function createAgentTitleTracker(options: AgentTitleTrackerOptions): Agen
 
   return {
     note(event) {
-      if (disposed || event.kind === 'session-title') return
+      if (disposed || event.kind === 'session-title' || event.kind === 'input-submit' || event.kind === 'input-interrupt') return
       if (event.kind === 'session-end') {
         clearTimer(event.terminalId)
         generations.set(event.terminalId, (generations.get(event.terminalId) ?? 0) + 1)

--- a/src/runtime/capabilities/index.ts
+++ b/src/runtime/capabilities/index.ts
@@ -198,6 +198,8 @@ export function buildDaemonRuntime(config: DaemonRuntimeConfig): DaemonRuntime {
     getEnv: cleanEnv,
     idleSuspend: config.idleSuspend,
     hooks: {
+      noteInput: (ptyId, data) => agentHooks.noteInput(ptyId, data),
+      forgetTerminal: (ptyId) => agentHooks.forgetTerminal(ptyId),
       envForPty: (ptyId, env) => agentHooks.envForPty(ptyId, env),
       prepareWorkspace: (cwd, config, baseCwd) => agentHooks.prepareWorkspace(cwd, config, baseCwd),
     },

--- a/src/runtime/capabilities/process.agentStatus.test.ts
+++ b/src/runtime/capabilities/process.agentStatus.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAgentHooksCapability } from './agentHooks'
+import { createProcessCapability } from './process'
+import { AGENTS } from '../../shared/agents'
+import type { AgentHookEvent } from '../../shared/agentHooks'
+import {
+  noteAgentHookEvent, noteAgentPresence, startAgentScreenDetector, stopAgentScreenDetector,
+} from '../../renderer/lib/agent/agentScreenDetector'
+import { setTerminalWorkspaceResolver, useStatusStore } from '../../renderer/stores/statusStore'
+
+vi.mock('../../renderer/lib/notifications/osNotificationSend', () => ({ sendOsNotification: vi.fn() }))
+const pty = vi.hoisted(() => ({
+  pid: 2147483647, write: vi.fn(), resize: vi.fn(), kill: vi.fn(), onData: vi.fn(), onExit: vi.fn(),
+}))
+vi.mock('node-pty', () => ({ spawn: () => pty }))
+
+const fixtures = [
+  { agentId: 'codex', start: { hook_event_name: 'UserPromptSubmit' }, wait: { hook_event_name: 'PermissionRequest' } },
+  { agentId: 'claude-code', start: { hook_event_name: 'UserPromptSubmit' }, wait: { hook_event_name: 'PermissionRequest' } },
+  { agentId: 'grok', start: { hookEventName: 'user_prompt_submit' }, wait: { hookEventName: 'notification', notificationType: 'permission_prompt' } },
+  { agentId: 'opencode', start: { type: 'session.status', status: { type: 'busy' } }, wait: { type: 'permission.asked' } },
+  // These CLIs have no permission-wait hook. Input must preserve their running state.
+  { agentId: 'cursor', start: { hook_event_name: 'beforeSubmitPrompt' }, wait: null },
+  { agentId: 'kiro', start: { hook_event_name: 'UserPromptSubmit' }, wait: null },
+] as const
+
+const terminalId = 'pty-status'
+const workspaceId = 'ws-status'
+let cleanup: () => void
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useStatusStore.setState({ workspaces: {} })
+  setTerminalWorkspaceResolver((id) => id === terminalId ? workspaceId : undefined)
+  useStatusStore.getState().registerTerminal(terminalId, workspaceId)
+  window.electronAPI = { shellReportAgentScreenState: vi.fn() } as unknown as typeof window.electronAPI
+  startAgentScreenDetector()
+  noteAgentPresence(terminalId, true)
+})
+afterEach(() => {
+  cleanup?.()
+  stopAgentScreenDetector()
+})
+
+async function setup() {
+  const dir = mkdtempSync(join(tmpdir(), 'cate-status-regression-'))
+  const hooks = createAgentHooksCapability({ hooksDir: dir, homeDir: dir })
+  const process = createProcessCapability({
+    resolveShell: () => ({ path: '/bin/sh', args: [] }), getEnv: () => ({}), hooks,
+  })
+  cleanup = () => {
+    process.kill(terminalId)
+    hooks.dispose()
+    rmSync(dir, { recursive: true, force: true })
+  }
+  await process.create({ id: terminalId, cols: 80, rows: 24, cwd: dir }, () => {}, () => {})
+  const endpoint = await hooks.endpoint()
+  const queued: AgentHookEvent[] = []
+  hooks.subscribe((event) => queued.push(event))
+  const flush = () => { for (const event of queued.splice(0)) noteAgentHookEvent(event) }
+  const post = async (agentId: string, payload: Record<string, unknown>) => {
+    const response = await fetch(`${endpoint.url}/hook`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${endpoint.tokenFor(terminalId)}` },
+      body: JSON.stringify({ agentId, terminalId, payload: {
+        session_id: 'session', sessionId: 'session', sessionID: 'session', ...payload,
+      } }),
+    })
+    expect(response.status).toBe(204)
+  }
+  return { process, queued, flush, post }
+}
+
+function state() {
+  return useStatusStore.getState().workspaces[workspaceId]?.terminals[terminalId]?.agentState
+}
+
+describe('PTY input and agent hooks share an ordered status stream', () => {
+  it('covers every CLI agent', () => {
+    expect(fixtures.map(f => f.agentId).sort()).toEqual(AGENTS.map(a => a.id).sort())
+  })
+
+  for (const delayedRenderer of [false, true]) {
+    it.each(fixtures)(`$agentId stays running after approval (delayed renderer: ${delayedRenderer})`, async ({ agentId, start, wait }) => {
+      const { process, post, flush, queued } = await setup()
+      await post(agentId, start)
+      flush()
+      expect(state()).toBe('running')
+      if (wait) await post(agentId, wait)
+      if (!delayedRenderer) {
+        flush()
+        expect(state()).toBe(wait ? 'waitingForInput' : 'running')
+      }
+      // The common runtime write is used by physical keys AND cate.terminal.press.
+      // Delaying delivery reproduces approval arriving before the renderer sees the wait.
+      process.write(terminalId, '\r')
+      expect(pty.write).toHaveBeenCalledWith('\r')
+      flush()
+      expect(state()).toBe('running')
+      noteAgentPresence(terminalId, true)
+      expect(state()).toBe('running') // no PostToolUse; the command is still executing
+      expect(queued).toEqual([])
+    })
+  }
+
+  it('does not resume for typing, navigation, failed writes, or a different terminal', async () => {
+    const { process, post, flush, queued } = await setup()
+    await post('codex', { hook_event_name: 'UserPromptSubmit' })
+    await post('codex', { hook_event_name: 'PermissionRequest' })
+    flush()
+    process.write(terminalId, 'some text')
+    process.write(terminalId, '\x1b[B')
+    process.write('other-terminal', '\r')
+    pty.write.mockImplementationOnce(() => { throw new Error('closed') })
+    process.write(terminalId, '\r')
+    expect(queued).toEqual([])
+    flush()
+    expect(state()).toBe('waitingForInput')
+  })
+
+  it('never forwards typed text and does not turn an idle agent into running', async () => {
+    const { process, post, flush, queued } = await setup()
+    process.write(terminalId, '\r')
+    expect(queued).toEqual([]) // no agent has identified this terminal
+    await post('codex', { hook_event_name: 'SessionStart' })
+    flush()
+    process.write(terminalId, 'private input\r')
+    expect(queued).toEqual([{
+      terminalId, agentId: 'codex', sessionId: 'session', kind: 'input-submit', raw: {},
+    }])
+    flush()
+    expect(state()).toBe('waitingForInput')
+  })
+
+  it.each(['exit', 'kill'] as const)('forgets the agent when the PTY is removed by %s', async (reason) => {
+    const { process, post, flush, queued } = await setup()
+    await post('codex', { hook_event_name: 'UserPromptSubmit' })
+    await post('codex', { hook_event_name: 'PermissionRequest' })
+    flush()
+    if (reason === 'kill') process.kill(terminalId)
+    else pty.onExit.mock.calls[0][0]({ exitCode: 0 })
+    // Reuse the id for a fresh shell. It must prove agent identity again.
+    await process.create({ id: terminalId, cols: 80, rows: 24, cwd: tmpdir() }, () => {}, () => {})
+    process.write(terminalId, '\r')
+    expect(queued).toEqual([])
+  })
+
+  it('preserves Kiro Ctrl-C recovery through automated PTY input', async () => {
+    const { process, post, flush } = await setup()
+    await post('kiro', { hook_event_name: 'UserPromptSubmit' })
+    flush()
+    expect(state()).toBe('running')
+    process.write(terminalId, '\x03')
+    flush()
+    expect(state()).toBe('waitingForInput')
+  })
+})

--- a/src/runtime/capabilities/process.ts
+++ b/src/runtime/capabilities/process.ts
@@ -185,6 +185,8 @@ export interface ProcessDeps {
   hooks?: {
     envForPty(ptyId: string, env: Record<string, string>): Promise<Record<string, string>>
     prepareWorkspace(cwd: string, config?: AgentHookConfig, baseCwd?: string): Promise<void>
+    noteInput?(ptyId: string, data: string): void
+    forgetTerminal?(ptyId: string): void
   }
   /**
    * Hook-anchored agent presence (agentPresence.ts): scanActivity reads each
@@ -314,6 +316,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
         ptys.delete(id)
         idle.delete(id)
         deps.agentPresence?.drop(id)
+        deps.hooks?.forgetTerminal?.(id)
         onExit(id, exitCode)
       })
       return {
@@ -328,7 +331,8 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
       const pty = ptys.get(id)
       if (!pty) return
       if (idle.get(id)?.suspended) resume(id)
-      try { pty.write(data) } catch { /* fd closed between exit and write */ }
+      try { pty.write(data) } catch { return /* fd closed between exit and write */ }
+      deps.hooks?.noteInput?.(id, data)
     },
 
     resize(id: string, cols: number, rows: number): void {
@@ -350,6 +354,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
       ptys.delete(id)
       idle.delete(id)
       deps.agentPresence?.drop(id)
+      deps.hooks?.forgetTerminal?.(id)
     },
 
     async getCwd(id: string): Promise<string | null> {

--- a/src/shared/agentHooks.ts
+++ b/src/shared/agentHooks.ts
@@ -53,9 +53,13 @@ export type AgentHookEventKind =
   | 'permission-wait'
   /** An idempotent "the turn is running" re-assertion. OpenCode emits it when
    *  a permission reply arrives; other CLIs emit it after a tool completes.
-   *  Claude/Codex/Grok do not hook the actual approval reply, so renderer
-   *  terminal input supplies that earlier resume edge. */
+   *  Claude/Codex/Grok do not hook the actual approval reply, so
+   *  runtime PTY input supplies that earlier resume edge. */
   | 'turn-resume'
+  /** Runtime-observed PTY input, ordered with hooks rather than guessed in
+   *  the renderer. These events carry no typed text. */
+  | 'input-submit'
+  | 'input-interrupt'
 
 export interface AgentHookEvent {
   /** The pty id whose env the hook echoed back (CATE_TERMINAL_ID). */


### PR DESCRIPTION
CLI agents could remain “awaiting input” throughout an approved command because approval recovery only observed Enter in xterm's renderer callback. Automated PTY writes bypassed that callback, and a delayed permission hook could overwrite the renderer's earlier input signal.

Move submission and interrupt observation to the shared runtime PTY write path and deliver those events in order with lifecycle hooks. This covers keyboard and automated input for all six CLI agents, preserves Kiro interrupt recovery, and keeps input events out of session/title tracking. Events contain no typed text; failed writes and closed terminals do not resume an agent.

Regression coverage uses the real HTTP hook ingestion, PTY capability, and renderer status coordinator, with a mocked PTY. Nine cases failed before the fix. All 18 cases now pass, including delayed renderer delivery, every registered CLI, failed writes, terminal cleanup, and no premature resume for ordinary typing.

Validation:
- Full suite: 2,976 tests passed; 1 skipped.
- `npm run typecheck`
- `npm run build`
- `npm run build:runtime`
- ESLint on changed files: no errors; two existing unused-import warnings in `agentHooks.ts`.
