### PR TITLE
Fix T3 awaiting-input indicators and unfocused webview file drags

### DIFF
--- a/src/renderer/canvas/CanvasNode.groupDrag.test.tsx
+++ b/src/renderer/canvas/CanvasNode.groupDrag.test.tsx
@@ -135,6 +135,47 @@ function dispatchMouse(el: EventTarget, type: string, client: Point, button = 0)
 
 // =============================================================================
 
+describe('CanvasNode — file drags into an unfocused webview', () => {
+  it.each(['agent', 'browser'] as const)('keeps the %s overlay transparent across the guest boundary and restores it after leaving or dropping', (type) => {
+    const wsId = useAppStore.getState().addWorkspace('WS', '/tmp/ws', 'ws-file-drag')
+    useAppStore.getState().addPanel(wsId, { id: 'panel-A', type, title: type, isDirty: false })
+    const store = freshCanvasStore()
+    addNode(store, 'A', 'panel-A', { x: 0, y: 0 }, { width: 200, height: 150 })
+    act(() => root.render(
+      <CanvasStoreProvider store={store}>
+        <CanvasNode nodeId="A" isFocused={false} dockStoreApi={tabsDockStore('panel-A')}
+          renderPanel={() => <div data-testid="guest" />} />
+      </CanvasStoreProvider>,
+    ))
+    const overlay = container.querySelector<HTMLElement>('[data-unfocused-overlay]')!
+    const content = overlay.parentElement!
+    const node = container.querySelector<HTMLElement>('[data-node-id="A"]')!
+    const rect = { left: 0, top: 0, right: 200, bottom: 150 } as DOMRect
+    vi.spyOn(content, 'getBoundingClientRect').mockReturnValue(rect)
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(rect)
+    const drag = (target: EventTarget, type: string, x = 50) => act(() => {
+      const event = new MouseEvent(type, { bubbles: true, clientX: x, clientY: 50, relatedTarget: null })
+      Object.defineProperty(event, 'dataTransfer', { value: { types: ['Files'] } })
+      target.dispatchEvent(event)
+    })
+
+    expect(overlay.style.pointerEvents).toBe('auto')
+    drag(overlay, 'dragenter')
+    expect(overlay.style.pointerEvents).toBe('none')
+    drag(overlay, 'dragleave') // Chromium hands the drag to the guest.
+    expect(overlay.style.pointerEvents).toBe('none')
+    drag(window, 'dragover', 250) // Guest events don't bubble; host sees the exit.
+    expect(overlay.style.pointerEvents).toBe('auto')
+    drag(overlay, 'dragenter')
+    drag(overlay, 'dragleave')
+    dispatchMouse(window, 'mousemove', { x: 50, y: 50 }) // After a guest drop.
+    expect(overlay.style.pointerEvents).toBe('auto')
+    drag(overlay, 'dragenter')
+    drag(window, 'drop')
+    expect(overlay.style.pointerEvents).toBe('auto')
+  })
+})
+
 describe('CanvasNode — group drag from the title bar', () => {
   it('grabbing a multi-selected node by its tab bar arms a GROUP drag carrying the whole selection', () => {
     const wsId = useAppStore.getState().addWorkspace('WS', '/tmp/ws', 'ws-group-drag')

--- a/src/renderer/canvas/CanvasNode.tsx
+++ b/src/renderer/canvas/CanvasNode.tsx
@@ -166,6 +166,27 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
   // True while a file/panel drag is hovering an unfocused node, so the dim
   // overlay lets the drop fall through to the panel content that owns it.
   const [fileDragOver, setFileDragOver] = useState(false)
+  useEffect(() => {
+    if (!fileDragOver) return
+    const clear = () => setFileDragOver(false)
+    // Guest webviews don't bubble their drop/leave events into this document.
+    // Restore click-to-focus when the drag returns outside this node, ends in
+    // the host, or ordinary mouse movement resumes after a guest drop.
+    const onDragOver = (e: DragEvent) => {
+      const rect = nodeRef.current?.getBoundingClientRect()
+      if (!rect || e.clientX < rect.left || e.clientX >= rect.right || e.clientY < rect.top || e.clientY >= rect.bottom) clear()
+    }
+    window.addEventListener('dragover', onDragOver, true)
+    window.addEventListener('drop', clear, true)
+    window.addEventListener('dragend', clear, true)
+    window.addEventListener('mousemove', clear, true)
+    return () => {
+      window.removeEventListener('dragover', onDragOver, true)
+      window.removeEventListener('drop', clear, true)
+      window.removeEventListener('dragend', clear, true)
+      window.removeEventListener('mousemove', clear, true)
+    }
+  }, [fileDragOver])
   const animationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const node = useCanvasStoreContext(
@@ -701,6 +722,11 @@ const CanvasNode: React.FC<CanvasNodeProps> = ({
         onDragLeave={(e) => {
           // Left the panel entirely (not just moving between children): the
           // overlay goes back to blocking so an unfocused node stays click-to-focus.
+          // Entering a webview reports relatedTarget=null even inside the panel.
+          if (!e.relatedTarget) {
+            const rect = e.currentTarget.getBoundingClientRect()
+            if (e.clientX >= rect.left && e.clientX < rect.right && e.clientY >= rect.top && e.clientY < rect.bottom) return
+          }
           if (!e.currentTarget.contains(e.relatedTarget as Node)) setFileDragOver(false)
         }}
         onDrop={() => setFileDragOver(false)}

--- a/src/renderer/hooks/useAgentPanelInfo.t3.test.ts
+++ b/src/renderer/hooks/useAgentPanelInfo.t3.test.ts
@@ -18,9 +18,15 @@ it('reports each bound T3 conversation independently and disconnected activity a
   expect(info.first.state).toBe('running')
   expect(info.second.state).toBe('waitingForInput')
   expect(selectT3InfoByPanel(useT3ActivityStore.getState(), 'other')).toEqual({})
+  store.update('runtime-checkout', { ...snapshot, revision: 2, sequence: 2, threads: {
+    ...snapshot.threads,
+    one: { ...snapshot.threads.one, latestTurn: { state: 'completed' } },
+  } }, 'first')
+  info = selectT3InfoByPanel(useT3ActivityStore.getState(), 'ws')
+  expect(info.first.state).toBe('waitingForInput')
   store.update('runtime-checkout', { connected: false, revision: 2, threads: {} }, 'second')
   info = selectT3InfoByPanel(useT3ActivityStore.getState(), 'ws')
-  expect(info.first.state).toBe('running')
+  expect(info.first.state).toBe('waitingForInput')
   expect(info.second.state).toBeUndefined()
   expect(info.second.name).toContain('disconnected')
   useT3ActivityStore.setState({ instances: {}, panels: {} })

--- a/src/renderer/lib/t3ThreadState.test.ts
+++ b/src/renderer/lib/t3ThreadState.test.ts
@@ -6,11 +6,18 @@ describe('T3 conversation state', () => {
   it('distinguishes waiting, active turns, background work, and completed conversations', () => {
     const thread = { id: 'a', title: 'A' }
     expect(t3ThreadActivity(thread)).toBe('notRunning')
-    expect(t3ThreadActivity({ ...thread, latestTurn: { state: 'completed' } })).toBe('finished')
+    expect(t3ThreadActivity({ ...thread, latestTurn: { state: 'completed' } })).toBe('waitingForInput')
     expect(t3ThreadActivity({ ...thread, latestTurn: { state: 'running' } })).toBe('running')
     expect(t3ThreadActivity({ ...thread, backgroundLiveness: 'monitoring' })).toBe('running')
     expect(t3ThreadActivity({ ...thread, latestTurn: { state: 'running' }, hasPendingApprovals: true })).toBe('waitingForInput')
     expect(t3ThreadActivity({ ...thread, hasPendingUserInput: true })).toBe('waitingForInput')
+  })
+
+  it.each(['completed', 'interrupted', 'error'])('waits for input after a %s turn unless work continues', (state) => {
+    const thread = { id: 'a', title: 'A', latestTurn: { state } }
+    expect(t3ThreadActivity(thread)).toBe('waitingForInput')
+    expect(t3ThreadActivity({ ...thread, backgroundLiveness: 'working' })).toBe('running')
+    expect(t3ThreadActivity({ ...thread, session: { status: 'ready', activeTurnId: 'next' } })).toBe('running')
   })
 
   it('subscribes once, tracks multiple conversations, and clears connectivity on disconnect', () => {

--- a/src/renderer/lib/t3ThreadState.ts
+++ b/src/renderer/lib/t3ThreadState.ts
@@ -15,7 +15,9 @@ export interface T3Thread {
 export function t3ThreadActivity(thread: T3Thread): AgentState {
   if (thread.hasPendingApprovals || thread.hasPendingUserInput || thread.hasActionableProposedPlan) return 'waitingForInput'
   if (thread.session?.status === 'starting' || thread.latestTurn?.state === 'running' || thread.session?.activeTurnId || thread.backgroundLiveness) return 'running'
-  return thread.latestTurn ? 'finished' : 'notRunning'
+  // A stopped turn leaves the conversation ready for the user's next message,
+  // just like a terminal agent returning to its prompt.
+  return thread.latestTurn ? 'waitingForInput' : 'notRunning'
 }
 
 /** A separate authenticated subscription in the guest's persistent session.


### PR DESCRIPTION
T3 conversations now show the awaiting-input dot after completed, interrupted, or failed turns, while active turns and background work retain their running state.

Dragging files into an unfocused T3 or browser webview no longer reactivates the canvas node overlay at the guest boundary. The overlay stays transparent while the drag is inside and restores click-to-focus when the drag leaves or ends.

Validation: 31 focused tests passed, including both agent and browser overlay regressions; `npm run typecheck` passed. Native OS image dragging has not been manually verified in Electron.
