### PR TITLE
Fix hidden interactive targets in browser snapshots

### DIFF
--- a/e2e/browser-background-automation.spec.ts
+++ b/e2e/browser-background-automation.spec.ts
@@ -127,3 +127,39 @@ test('user clicks and types directly in the live webview at non-default zoom', a
     workspaceId, 'readCommand', { panelId, command: ['get', 'attr', 'body', 'data-saved'] },
   ), browser), { timeout: 20_000 }).toMatchObject({ ok: true, result: { value: 'Typed inside Cate' } })
 })
+
+test('snapshots omit hidden and boxless links while keeping off-screen links clickable', async () => {
+  const url = `data:text/html,${encodeURIComponent(`
+    <title>Snapshot visibility</title>
+    <a href="#" onclick="event.preventDefault();document.body.dataset.clicked='yes'">Visible link</a>
+    <a href="#" hidden>Hidden attribute</a>
+    <div style="display:none"><a href="#">Hidden ancestor</a></div>
+    <a href="#" style="visibility:hidden">Hidden visibility</a>
+    <a href="#" style="opacity:0">Transparent link</a>
+    <a href="#" style="display:contents">Boxless link</a>
+    <a href="#" style="display:block;width:0;height:0;overflow:hidden">Zero size link</a>
+    <a href="#" style="position:absolute;top:3000px" onclick="event.preventDefault();document.body.dataset.clicked='offscreen'">Offscreen link</a>
+  `)}`
+  const browser = await page.evaluate((fixtureUrl) => window.__cateE2E!.createBrowser(fixtureUrl, { x: 120, y: 120 }), url)
+  await expect.poll(
+    () => page.evaluate((panelId) => window.__cateE2E!.browserWebContentsId(panelId), browser.panelId),
+    { timeout: 20_000 },
+  ).not.toBeNull()
+  for (const command of [['snapshot'], ['snapshot', '-i']]) {
+    const snapshot = await page.evaluate(({ browser, command }) => window.__cateE2E!.browserInvoke(
+      browser.workspaceId, 'readCommand', { panelId: browser.panelId, command },
+    ), { browser, command })
+    expect(snapshot.ok).toBe(true)
+    const refs = (snapshot.result as { refs: Array<{ ref: string; role: string; name: string }> }).refs
+    const links = refs.filter((ref) => ref.role === 'link')
+    expect(links.map((ref) => ref.name)).toEqual(['Visible link', 'Offscreen link'])
+    for (const [index, link] of links.entries()) {
+      expect(await page.evaluate(({ browser, ref }) => window.__cateE2E!.browserInvoke(
+        browser.workspaceId, 'command', { panelId: browser.panelId, command: ['click', ref] },
+      ), { browser, ref: link.ref })).toMatchObject({ ok: true })
+      expect(await page.evaluate((browser) => window.__cateE2E!.browserInvoke(
+        browser.workspaceId, 'readCommand', { panelId: browser.panelId, command: ['get', 'attr', 'body', 'data-clicked'] },
+      ), browser)).toMatchObject({ ok: true, result: { value: index === 0 ? 'yes' : 'offscreen' } })
+    }
+  }
+})

--- a/src/main/browser/browserRuntime.test.ts
+++ b/src/main/browser/browserRuntime.test.ts
@@ -13,6 +13,8 @@ function guest(id: number, command?: (method: string, params?: Record<string, un
     if (method === 'Accessibility.getFullAXTree') return {
       nodes: [{ role: { value: 'button' }, name: { value: 'Save' }, backendDOMNodeId: 7 }],
     }
+    if (method === 'DOM.resolveNode') return { object: { objectId: 'save' } }
+    if (method === 'Runtime.callFunctionOn') return { result: { value: true } }
     return {}
   })
   return {
@@ -78,6 +80,30 @@ describe('BrowserRuntimeRegistry', () => {
       .resolves.toEqual({ error: 'stale-browser-ref' })
   })
 
+  it.each([false, true])('omits invisible and detached interactive refs (interactiveOnly=%s)', async (interactiveOnly) => {
+    const contents = guest(48, async (method, params) => {
+      if (method === 'Accessibility.getFullAXTree') return {
+        nodes: ['Hidden', 'Detached', 'Visible'].map((name, index) => ({
+          role: { value: 'link' }, name: { value: name }, backendDOMNodeId: index + 1,
+        })),
+      }
+      if (method === 'DOM.resolveNode') {
+        if (params?.backendNodeId === 2) throw new Error('No node with given id found')
+        return { object: { objectId: String(params?.backendNodeId) } }
+      }
+      if (method === 'Runtime.callFunctionOn') return { result: { value: params?.objectId === '3' } }
+      return {}
+    })
+    const identity = { workspaceId: 'workspace-1', panelId: 'browser-1', tabId: 'tab-1' }
+    await runtime.attach(contents as never, identity)
+    await expect(runtime.execute(48, identity, 'snapshot', { interactiveOnly })).resolves.toMatchObject({
+      result: {
+        refs: [{ ref: '@s1e1', role: 'link', name: 'Visible' }],
+        snapshot: '- link "Visible" [ref=s1e1]',
+      },
+    })
+  })
+
   it('merges same-origin and cross-origin frame trees and keeps refs session-bound', async () => {
     const contents = guest(45, async (method, params, sessionId) => {
       if (method === 'Page.getFrameTree') return {
@@ -95,7 +121,7 @@ describe('BrowserRuntimeRegistry', () => {
         return { nodes: [] }
       }
       if (method === 'DOM.resolveNode') return { object: { objectId: sessionId === 'cross-session' ? 'cross-object' : 'same-object' } }
-      if (method === 'Runtime.callFunctionOn') return { result: { value: 'yes' } }
+      if (method === 'Runtime.callFunctionOn') return { result: { value: String(params?.functionDeclaration).includes('checkVisibility') ? true : 'yes' } }
       return {}
     })
     const identity = { workspaceId: 'workspace-1', panelId: 'browser-1', tabId: 'tab-1' }

--- a/src/main/browser/browserRuntime.ts
+++ b/src/main/browser/browserRuntime.ts
@@ -675,6 +675,21 @@ class BrowserTargetRuntime {
         const identity = `${source.sessionId ?? 'root'}:${backendNodeId}`
         if (seen.has(identity)) continue
         seen.add(identity)
+        // AX can expose interactive nodes without a rendered box (for example
+        // display:contents links), which cannot be targeted by box()/click.
+        // Keep off-screen controls: visibility here does not mean in-viewport.
+        if (INTERACTIVE_ROLES.has(role)) {
+          try {
+            const visible = await this.callOn({ backendNodeId, sessionId: source.sessionId }, `function () {
+              if (!(this instanceof Element) || !this.checkVisibility({ opacityProperty: true, visibilityProperty: true })) return false;
+              return Array.from(this.getClientRects()).some(rect => rect.width > 0 && rect.height > 0);
+            }`)
+            if (visible.value !== true) continue
+          } catch {
+            // The node/frame may disappear between the AX query and this check.
+            continue
+          }
+        }
         index += 1
         const ref = `@${snapshotId}e${index}`
         this.refs.set(ref, {


### PR DESCRIPTION
Browser snapshots could assign refs to hidden or boxless interactive nodes. For example, Chromium exposes a `display: contents` link in its accessibility tree, but clicking its ref fails because it cannot compute a box model.

Check rendered visibility and nonzero client rectangles before assigning interactive refs in both full and interactive-only snapshots. Skip nodes that detach during the check, and retain off-screen controls so they can still be scrolled into view and clicked.

Validation:
- 16 browser runtime and browser control integration tests pass.
- Electron regression covers hidden attributes/ancestors, visibility, opacity, boxless and zero-size links, and successful visible/off-screen ref clicks in both snapshot modes.
- Production build and TypeScript check pass.
