### PR TITLE
Add draggable recent screenshot to action bar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { createWindow } from './windows/windowFactory'
 import { IS_E2E } from './windows/reveal'
 import { registerDialogHandlers } from './ipc/dialogs'
 import { registerCaptureHandlers } from './ipc/capture'
+import { registerRecentScreenshotHandlers } from './ipc/recentScreenshot'
 import { registerBrowserControlHandlers } from './ipc/browserControl'
 import { registerBrowserCredentialHandlers } from './ipc/browserCredentials'
 import { registerWindowControlHandlers } from './ipc/windowControls'
@@ -94,6 +95,7 @@ function registerCriticalHandlers(): void {
   // modules; the panel/dock/drag handlers need the window factory injected.
   registerDialogHandlers()
   registerCaptureHandlers()
+  registerRecentScreenshotHandlers()
   registerBrowserControlHandlers()
   registerBrowserCredentialHandlers()
   registerWindowControlHandlers()

--- a/src/main/ipc/recentScreenshot.test.ts
+++ b/src/main/ipc/recentScreenshot.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RECENT_SCREENSHOT_GET, RECENT_SCREENSHOT_DRAG, RECENT_SCREENSHOT_CHANGED } from '../../shared/ipc-channels'
 import { registerRecentScreenshotHandlers } from './recentScreenshot'
@@ -89,7 +90,7 @@ describe('recent macOS screenshot', () => {
   it('switches to a custom screenshot directory and closes watchers on quit', async () => {
     mocks.run.mockImplementation((_command, _args, _options, callback) => callback(null, '~/Pictures/Shots\n', ''))
     await vi.advanceTimersByTimeAsync(5000)
-    expect(mocks.watch).toHaveBeenLastCalledWith('/home/Pictures/Shots', expect.anything())
+    expect(mocks.watch).toHaveBeenLastCalledWith(path.join('/home', 'Pictures/Shots'), expect.anything())
     expect(mocks.close).toHaveBeenCalledTimes(1)
     mocks.on.mock.calls.find(([name]) => name === 'will-quit')![1]()
     expect(mocks.close).toHaveBeenCalledTimes(2)

--- a/src/main/ipc/recentScreenshot.test.ts
+++ b/src/main/ipc/recentScreenshot.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RECENT_SCREENSHOT_GET, RECENT_SCREENSHOT_DRAG, RECENT_SCREENSHOT_CHANGED } from '../../shared/ipc-channels'
+import { registerRecentScreenshotHandlers } from './recentScreenshot'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(), on: vi.fn(), watch: vi.fn(), close: vi.fn(), watcherOn: vi.fn(),
+  run: vi.fn(), stat: vi.fn(), thumbnail: vi.fn(), broadcast: vi.fn(), grant: vi.fn(), drag: vi.fn(),
+}))
+vi.mock('node:child_process', () => ({ execFile: (...args: unknown[]) => mocks.run(...args) }))
+vi.mock('node:util', () => ({ promisify: () => (...args: unknown[]) => new Promise((resolve, reject) => {
+  mocks.run(...args, (error: Error | null, stdout: string, stderr: string) => error ? reject(error) : resolve({ stdout, stderr }))
+}) }))
+vi.mock('node:fs/promises', () => ({ stat: mocks.stat }))
+vi.mock('chokidar', () => ({ watch: mocks.watch }))
+vi.mock('electron', () => ({
+  app: { getPath: (key: string) => key === 'desktop' ? '/desktop' : '/home', on: mocks.on },
+  ipcMain: { handle: mocks.handle },
+  BrowserWindow: { getAllWindows: () => [{ id: 1 }, { id: 2 }] },
+  nativeImage: { createThumbnailFromPath: mocks.thumbnail, createFromDataURL: () => 'icon' },
+}))
+vi.mock('../windowRegistry', () => ({ broadcastToAll: mocks.broadcast, windowFromEvent: () => ({ id: 1 }) }))
+vi.mock('./pathValidation', () => ({ grantFileAccess: mocks.grant }))
+
+const invoke = (channel: string, value?: string) => mocks.handle.mock.calls.find(([name]) => name === channel)![1]({ sender: { startDrag: mocks.drag } }, value)
+const settle = async () => { for (let i = 0; i < 20; i++) await Promise.resolve() }
+const emit = async (event: string, filePath: string) => {
+  mocks.watcherOn.mock.calls.find(([name]) => name === event)![1](filePath)
+  await settle()
+}
+
+beforeEach(async () => {
+  vi.resetAllMocks()
+  vi.useFakeTimers()
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  mocks.run.mockImplementation((_command, _args, _options, callback) => callback(null, '', ''))
+  mocks.watch.mockReturnValue({ on: mocks.watcherOn, close: mocks.close })
+  mocks.stat.mockImplementation(async () => ({ isFile: () => true, mtimeMs: Date.now() }))
+  mocks.thumbnail.mockResolvedValue({ isEmpty: () => false, toDataURL: () => 'data:image/png;base64,test' })
+  registerRecentScreenshotHandlers()
+  await settle()
+})
+afterEach(() => {
+  mocks.on.mock.calls.find(([name]) => name === 'will-quit')?.[1]()
+  vi.useRealTimers()
+})
+
+describe('recent macOS screenshot', () => {
+  it('ignores existing files and grants new screenshots to every open window', async () => {
+    expect(mocks.watch).toHaveBeenCalledWith('/desktop', expect.objectContaining({ ignoreInitial: true }))
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toBeNull()
+    await emit('add', '/desktop/localized-name.png')
+    expect(mocks.run).toHaveBeenCalledWith('/usr/bin/xattr', ['-p', 'com.apple.metadata:kMDItemIsScreenCapture', '/desktop/localized-name.png'], expect.anything(), expect.any(Function))
+    expect(mocks.grant).toHaveBeenCalledWith(1, '/desktop/localized-name.png')
+    expect(mocks.grant).toHaveBeenCalledWith(2, '/desktop/localized-name.png')
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toMatchObject({ filePath: '/desktop/localized-name.png' })
+  })
+
+  it('replaces the previous screenshot and expires one minute after the replacement', async () => {
+    await emit('add', '/desktop/first.png')
+    await vi.advanceTimersByTimeAsync(30_000)
+    await emit('add', '/desktop/second.png')
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toMatchObject({ filePath: '/desktop/second.png' })
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toBeNull()
+  })
+
+  it('exports the full file and consumes globally without resurfacing on a duplicate event', async () => {
+    await emit('add', '/desktop/shot.png')
+    const screenshot = await invoke(RECENT_SCREENSHOT_GET)
+    await invoke(RECENT_SCREENSHOT_DRAG, 'stale-id')
+    expect(mocks.drag).not.toHaveBeenCalled()
+    await invoke(RECENT_SCREENSHOT_DRAG, screenshot.id)
+    expect(mocks.drag).toHaveBeenCalledWith({ file: '/desktop/shot.png', icon: 'icon' })
+    expect(mocks.broadcast).toHaveBeenLastCalledWith(RECENT_SCREENSHOT_CHANGED, null)
+    await emit('change', '/desktop/shot.png')
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toBeNull()
+  })
+
+  it('ignores ordinary images and removes a deleted screenshot', async () => {
+    mocks.run.mockImplementationOnce((_command, _args, _options, callback) => callback(new Error('No attribute')))
+    await emit('add', '/desktop/photo.png')
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toBeNull()
+    await emit('add', '/desktop/shot.png')
+    await emit('unlink', '/desktop/shot.png')
+    expect(await invoke(RECENT_SCREENSHOT_GET)).toBeNull()
+  })
+
+  it('switches to a custom screenshot directory and closes watchers on quit', async () => {
+    mocks.run.mockImplementation((_command, _args, _options, callback) => callback(null, '~/Pictures/Shots\n', ''))
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(mocks.watch).toHaveBeenLastCalledWith('/home/Pictures/Shots', expect.anything())
+    expect(mocks.close).toHaveBeenCalledTimes(1)
+    mocks.on.mock.calls.find(([name]) => name === 'will-quit')![1]()
+    expect(mocks.close).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/ipc/recentScreenshot.ts
+++ b/src/main/ipc/recentScreenshot.ts
@@ -1,0 +1,103 @@
+import { app, BrowserWindow, ipcMain, nativeImage } from 'electron'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import path from 'node:path'
+import { stat } from 'node:fs/promises'
+import { watch, type FSWatcher } from 'chokidar'
+import type { RecentScreenshot } from '../../shared/recentScreenshot'
+import { RECENT_SCREENSHOT_GET, RECENT_SCREENSHOT_CHANGED, RECENT_SCREENSHOT_DRAG } from '../../shared/ipc-channels'
+import { broadcastToAll, windowFromEvent } from '../windowRegistry'
+import { grantFileAccess } from './pathValidation'
+import { wrapHandler } from './handlerError'
+import log from '../logger'
+
+const run = promisify(execFile)
+
+export function registerRecentScreenshotHandlers(): void {
+  let current: RecentScreenshot | null = null
+  let expiry: ReturnType<typeof setTimeout> | undefined
+  let watcher: FSWatcher | undefined
+  let stopped = false
+  let directory = ''
+  let newestMtime = 0
+  const startedAt = Date.now()
+
+  const clear = () => {
+    clearTimeout(expiry)
+    current = null
+    broadcastToAll(RECENT_SCREENSHOT_CHANGED, null)
+  }
+  const getCurrent = () => {
+    if (current && current.expiresAt <= Date.now()) clear()
+    return current
+  }
+
+  ipcMain.handle(RECENT_SCREENSHOT_GET, wrapHandler('[recentScreenshot:get]', async (event) => {
+    const screenshot = getCurrent()
+    const win = windowFromEvent(event)
+    if (!win || !screenshot) return null
+    await grantFileAccess(win.id, screenshot.filePath)
+    return getCurrent()?.id === screenshot.id ? screenshot : null
+  }))
+  ipcMain.handle(RECENT_SCREENSHOT_DRAG, wrapHandler('[recentScreenshot:drag]', async (event, id: string) => {
+    const screenshot = getCurrent()
+    if (!windowFromEvent(event) || !screenshot || screenshot.id !== id) return
+    // Export the actual file, so native file drops work in terminals, panels,
+    // and other applications. Consuming the shortcut never deletes the file.
+    event.sender.startDrag({
+      file: screenshot.filePath,
+      icon: nativeImage.createFromDataURL(screenshot.dataUrl),
+    })
+    if (current?.id === id) clear()
+  }))
+
+  if (process.platform !== 'darwin') return
+
+  const inspect = async (filePath: string) => {
+    if (!/\.(png|jpe?g|tiff?|heic|gif|webp)$/i.test(filePath)) return
+    try {
+      const info = await stat(filePath)
+      if (!info.isFile() || info.mtimeMs < startedAt || info.mtimeMs <= newestMtime) return
+      // macOS marks screenshots independently of their localized/custom name.
+      await run('/usr/bin/xattr', ['-p', 'com.apple.metadata:kMDItemIsScreenCapture', filePath], { timeout: 2000 })
+      const thumbnail = await nativeImage.createThumbnailFromPath(filePath, { width: 128, height: 128 })
+      if (stopped || thumbnail.isEmpty() || info.mtimeMs <= newestMtime) return
+      await Promise.all(BrowserWindow.getAllWindows().map(win => grantFileAccess(win.id, filePath)))
+      if (stopped || info.mtimeMs <= newestMtime) return
+      newestMtime = info.mtimeMs
+      clearTimeout(expiry)
+      current = { id: `${filePath}:${info.mtimeMs}`, filePath, dataUrl: thumbnail.toDataURL(), expiresAt: Date.now() + 60_000 }
+      broadcastToAll(RECENT_SCREENSHOT_CHANGED, current)
+      expiry = setTimeout(clear, 60_000)
+    } catch {
+      // Ordinary images have no screenshot attribute; files may also disappear
+      // before inspection when the user moves or deletes them.
+    }
+  }
+
+  const refreshDirectory = async () => {
+    let next = app.getPath('desktop')
+    try {
+      const { stdout } = await run('/usr/bin/defaults', ['read', 'com.apple.screencapture', 'location'], { timeout: 2000 })
+      const value = stdout.trim()
+      if (value) next = value.startsWith('~/') ? path.join(app.getPath('home'), value.slice(2)) : value
+    } catch { /* No custom location: macOS defaults to Desktop. */ }
+    if (stopped || !path.isAbsolute(next) || next === directory) return
+    directory = next
+    await watcher?.close()
+    if (stopped) return
+    watcher = watch(directory, { depth: 0, ignoreInitial: true, awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 } })
+    watcher.on('add', filePath => { void inspect(filePath) })
+    watcher.on('change', filePath => { void inspect(filePath) })
+    watcher.on('unlink', filePath => { if (current?.filePath === filePath) clear() })
+    watcher.on('error', error => log.warn('[recentScreenshot] Cannot watch screenshot folder', error))
+  }
+  void refreshDirectory()
+  const refresh = setInterval(() => { void refreshDirectory() }, 5000)
+  app.on('will-quit', () => {
+    stopped = true
+    clearInterval(refresh)
+    clearTimeout(expiry)
+    void watcher?.close()
+  })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,3 +1,4 @@
+import type { RecentScreenshot } from '../shared/recentScreenshot'
 import { contextBridge, ipcRenderer, webUtils, webFrame } from 'electron'
 
 // Phase 0 perf marker — capture preload entry as early as possible.
@@ -206,6 +207,9 @@ import {
   BROWSER_CREDENTIAL_FILL,
   BROWSER_CREDENTIAL_CLEAR,
   NATIVE_FILE_DRAG,
+  RECENT_SCREENSHOT_GET,
+  RECENT_SCREENSHOT_CHANGED,
+  RECENT_SCREENSHOT_DRAG,
   AGENT_HARNESS_GET_PANEL_URL,
   AGENT_HARNESS_LIST_CONVERSATIONS,
   AGENT_HARNESS_DELETE_CONVERSATION,
@@ -455,6 +459,11 @@ const invokeForwarders = {
   browserCredentialFill: makeInvoker<'browserCredentialFill'>(BROWSER_CREDENTIAL_FILL),
   browserCredentialClear: makeInvoker<'browserCredentialClear'>(BROWSER_CREDENTIAL_CLEAR),
   nativeFileDrag: makeInvoker<'nativeFileDrag'>(NATIVE_FILE_DRAG),
+  getRecentScreenshot: makeInvoker<'getRecentScreenshot'>(RECENT_SCREENSHOT_GET),
+  dragRecentScreenshot: makeInvoker<'dragRecentScreenshot'>(RECENT_SCREENSHOT_DRAG),
+  onRecentScreenshotChanged(callback: (screenshot: RecentScreenshot | null) => void): () => void {
+    return createIpcListener(RECENT_SCREENSHOT_CHANGED, callback)
+  },
 
   // T3 provider harness
   agentHarnessDeleteConversation: makeInvoker<'agentHarnessDeleteConversation'>(AGENT_HARNESS_DELETE_CONVERSATION),

--- a/src/renderer/canvas/CanvasToolbar.tsx
+++ b/src/renderer/canvas/CanvasToolbar.tsx
@@ -30,6 +30,7 @@ import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
 import { Tooltip } from '../ui/Tooltip'
 import { CanvasToolbarButton } from './CanvasToolbarButton'
 import { KeepAwakeButton } from './KeepAwakeButton'
+import { RecentScreenshotButton } from './RecentScreenshotButton'
 
 interface CanvasToolbarProps {
   canvasPanelId: string
@@ -222,6 +223,7 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   const items = (
     <>
       <KeepAwakeButton tooltipPlacement={place} />
+      <RecentScreenshotButton tooltipPlacement={place} />
       {divider}
       <CanvasToolbarButton
         onClick={() => setActiveTool('select')}

--- a/src/renderer/canvas/RecentScreenshotButton.tsx
+++ b/src/renderer/canvas/RecentScreenshotButton.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import type { RecentScreenshot } from '../../shared/recentScreenshot'
+import { CanvasToolbarButton } from './CanvasToolbarButton'
+
+export function RecentScreenshotButton({ tooltipPlacement }: { tooltipPlacement: 'top' | 'right' }) {
+  const [screenshot, setScreenshot] = useState<RecentScreenshot | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    let receivedChange = false
+    const unsubscribe = window.electronAPI.onRecentScreenshotChanged(value => {
+      receivedChange = true
+      setScreenshot(value)
+    })
+    void window.electronAPI.getRecentScreenshot().then(value => {
+      if (mounted && !receivedChange) setScreenshot(value)
+    }).catch(() => { /* Screenshot monitoring is optional. */ })
+    return () => { mounted = false; unsubscribe() }
+  }, [])
+
+  useEffect(() => {
+    if (!screenshot) return
+    const timeout = setTimeout(() => setScreenshot(null), Math.max(0, screenshot.expiresAt - Date.now()))
+    return () => clearTimeout(timeout)
+  }, [screenshot])
+
+  if (!screenshot) return null
+  return (
+    <CanvasToolbarButton
+      label="Drag recent screenshot"
+      tooltipPlacement={tooltipPlacement}
+      draggable
+      onDragStart={event => {
+        event.preventDefault()
+        void window.electronAPI.dragRecentScreenshot(screenshot.id).catch(() => {
+          // Keep the shortcut available if the native drag could not start.
+        })
+      }}
+    >
+      <img src={screenshot.dataUrl} alt="Recent screenshot" draggable={false}
+        className="h-8 w-8 rounded-full object-cover ring-1 ring-white/20 cursor-grab" />
+    </CanvasToolbarButton>
+  )
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -1,3 +1,4 @@
+import type { RecentScreenshot } from './recentScreenshot'
 // =============================================================================
 // Type declaration for window.electronAPI exposed via contextBridge
 // =============================================================================
@@ -705,6 +706,9 @@ export interface ElectronAPI {
   }): Promise<{ ok?: true; error?: string }>
   browserCredentialClear(): Promise<void>
 
+  getRecentScreenshot(): Promise<RecentScreenshot | null>
+  onRecentScreenshotChanged(callback: (screenshot: RecentScreenshot | null) => void): () => void
+  dragRecentScreenshot(id: string): Promise<void>
   /** Initiate a native OS file drag from the renderer. */
   nativeFileDrag(filePath: string): Promise<void>
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -407,3 +407,7 @@ export const AGENT_HARNESS_LIST_CONVERSATIONS = 'agentHarness:listConversations'
 export const AGENT_HARNESS_DELETE_CONVERSATION = 'agentHarness:deleteConversation'
 
 export const AGENT_CONVERSATION_DELETED = 'agentHarness:conversationDeleted'
+
+export const RECENT_SCREENSHOT_GET = 'recentScreenshot:get'
+export const RECENT_SCREENSHOT_CHANGED = 'recentScreenshot:changed'
+export const RECENT_SCREENSHOT_DRAG = 'recentScreenshot:drag'

--- a/src/shared/recentScreenshot.ts
+++ b/src/shared/recentScreenshot.ts
@@ -1,0 +1,6 @@
+export interface RecentScreenshot {
+  id: string
+  filePath: string
+  dataUrl: string
+  expiresAt: number
+}


### PR DESCRIPTION
Keep the latest saved macOS screenshot within reach when opening a terminal or starting a chat. A circular preview appears beside the coffee mug in the action bar, replaces the previous screenshot, and disappears after one minute or when dragged out. Native dragging exports the complete file and leaves the saved original intact.

Watches the macOS screenshot save folder, including custom locations, identifies screenshots by macOS metadata, and synchronizes the shortcut across windows. The preview appears after macOS saves the file, once its floating thumbnail closes.

Validation: TypeScript check and 12 focused tests covering screenshot replacement, expiration, consumption, deletion, folder changes, existing capture behavior, and toolbar behavior. Production build and targeted lint passed during implementation. Physical native dragging still needs a manual macOS check.
