### PR TITLE
Fix browser layout and improve workspace transition performance

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -59,3 +59,39 @@ When comparing runs, keep hardware, display refresh rate, app build, panel
 counts, viewport, and workload consistent. Record cold-start and warmed-up
 measurements separately. Short samples and high host-renderer FPS cannot prove
 that a large browser/agent workspace has low memory use or responsive guest UIs.
+
+## Workspace transitions
+
+```sh
+npx playwright test e2e/workspace-transition-perf.spec.ts --reporter=list,html
+```
+
+This baseline creates two real local Git workspaces with 200 files each and
+18 visible panels per workspace: eight terminals, six scratch editors with
+200 lines of content, three browser guests, and one T3 guest. After warming both
+workspaces, it measures eight alternating switches and checks panel readiness,
+browser guest identity, and PTY identity. T3 uses the deterministic `fake-t3`
+server, so this does not benchmark production conversation-history rendering.
+
+`workspace-transitions.json` contains each switch's selection-promise duration,
+second animation-frame boundary, panel-ready duration, full-window frame and
+long-task statistics, renderer counter deltas, and guest recreation results.
+Readiness includes automation polling latency; the frame boundary is not a
+presented-frame or input-to-photon measurement. Frame statistics include one
+second of settling after readiness to capture delayed fit/repaint work.
+`runtime-snapshots.json` contains resource samples before and after the sequence,
+not per-transition CPU peaks. Focus events are simulated because test windows
+remain hidden. The test is excluded when `E2E_SKIP_PERF=1`.
+
+For a diagnostic CPU profile of the first warm switch:
+
+```sh
+CATE_TRANSITION_CPU_PROFILE=1 npx playwright test e2e/workspace-transition-perf.spec.ts --reporter=list,html
+```
+
+Open the attached `transition.cpuprofile` in Chromium DevTools' Performance/CPU
+profiler. Sampling adds overhead; compare latency using runs without this flag.
+The transition counters now include `editorCreate`, `terminalWebglCreate`, and
+`terminalAtlasPass`. They distinguish editor reconstruction, GPU context creation,
+and window-wide atlas recovery from React render counts. The test asserts that
+T3 guests survive a warm return and bounds atlas recovery passes.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,61 @@
+# Performance profiling
+
+Build both the app and its runtime daemon before collecting measurements:
+
+```sh
+npm run build:runtime
+npm run build
+npx playwright test e2e/perf-stress.spec.ts
+```
+
+The suite uses an isolated Electron session. Run it without other CPU-heavy
+workloads. It covers terminal output, canvas movement, editor typing, background
+activity, and 10/25 overlapping browser panels. Each test attaches
+`performance.json` to its Playwright result. Use the HTML or JSON Playwright
+reporter when retaining or comparing artifacts. Thresholds are generous local
+regression guards, not a claim about performance on every machine.
+
+For interactive investigation, run `CATE_PERF=1 npm run dev`. Toggle the overlay
+with Cmd/Ctrl+Alt+P. Profiling is disabled during normal app launches.
+
+## Reading the measurements
+
+- **Frame times:** mean, p95, maximum and sample count cover the explicit test
+  window. FPS is derived from those frame intervals. It measures the host
+  renderer's animation-frame cadence, not guest-page FPS or input latency.
+- **Long tasks:** tasks longer than 50 ms accumulate for the full test window.
+  The overlay has its own independent window; its one-second reset cannot erase
+  test measurements. Tests check observer support instead of treating an
+  unsupported observer as zero work.
+- **Electron CPU/memory:** `getAppMetrics` covers Electron's tracked processes.
+  Peak CPU by process type sums processes within each sample before taking a
+  peak. These figures do not include all shell descendants or remote machines.
+- **Runtime metrics:** each connected daemon supplies its own CPU (100% means
+  one core), RSS, event-loop p95/max, and actual ps/lsof process-monitor launches.
+  Runtime CPU remains separate from Electron CPU; remote hosts are identified.
+  The event-loop histogram uses 20 ms resolution, so a roughly 20 ms p95 is not
+  itself evidence of a stall. The first sample establishes a baseline.
+- **Monitor cadence:** activity/port scan rates remain meaningful on Linux,
+  where `/proc` avoids subprocess launches. The background test checks scan
+  cadence using simulated application focus events (E2E windows stay hidden);
+  a zero spawn count alone does not prove battery efficiency.
+- **IPC:** approximate payload sizes and call rates for instrumented sends.
+  Terminal throughput counts incoming output, not xterm rendering completion.
+- **Availability:** a daemon that cannot provide metrics reports an explicit
+  error. Do not interpret missing runtime metrics as zero CPU or zero work.
+
+`window.__catePerf` exposes `frames()`, `longTasks()`,
+`longTasksSupported()`, `renderCounts()`, and `resetWindow()` in profiled builds.
+`resetWindow()` clears only the test measurement window; counters remain
+cumulative so callers can take differences around an action.
+
+Useful counters include `browserGeometryFrame`, `browserGeometryRect`,
+`browserGeometryStyle`, `browserGeometryMicros`, `agentMetadataPoll`,
+`agentMetadataThreads`, and `explorerDirectoryRead`. Geometry reads are shared
+across browser surfaces within a frame. Agent metadata is shared per harness
+partition within each renderer window, with incremental thread updates.
+
+When comparing runs, keep hardware, display refresh rate, app build, panel
+counts, viewport, and workload consistent. Record cold-start and warmed-up
+measurements separately. Short samples and high host-renderer FPS cannot prove
+that a large browser/agent workspace has low memory use or responsive guest UIs.

--- a/docs/workspace-transition-performance.md
+++ b/docs/workspace-transition-performance.md
@@ -1,0 +1,44 @@
+# Workspace transition performance
+
+Local baseline and final run of `e2e/workspace-transition-perf.spec.ts`: two workspaces, 18 visible panels each (8 terminals, 6 populated editors, 3 browsers, 1 T3 guest), eight warm switches.
+
+| Metric | Before | After |
+|---|---:|---:|
+| Median panel readiness | 634 ms | 171 ms |
+| Worst panel readiness | 1007 ms | 213 ms |
+| Median second-frame boundary | 242 ms | 129 ms |
+| Long tasks across eight switches | 12 | 8 |
+| Longest long task | 182 ms | 104 ms |
+| T3 guest recreations | 8 | 0 |
+
+Browser guest IDs and PTY IDs survived every switch in both runs. Readiness improved by approximately 73% in this comparison. Each final switch still had a long task; this is not a claim of frame-perfect switching.
+
+## Implemented changes
+
+- Retain T3 guest surfaces for the two most recently visited workspaces, with immediate cleanup on panel removal and eviction beyond that bound. Keep dock visibility and detached-window ownership explicit.
+- Batch incoming browser-surface measurements and retain guest dimensions while parked.
+- Coalesce global terminal atlas recovery; spread optional WebGL context upgrades across frames while fallback terminal rendering remains available.
+- Preserve two recent explorer trees and expansion/selection state during revalidation; start activation reads immediately.
+- Prevent a stopped/replaced Git monitor from scheduling another poll after an in-flight request completes.
+- Avoid resetting worktree territory canvas dimensions when they have not changed.
+
+## What the test uncovered
+
+A diagnostic CPU profile attributed about 109 ms of self samples to the territory layer’s `sizeActive()` during one warm switch. Setup assigned the same backing-store dimensions repeatedly. The regression test now verifies that setup allocates each dimension once, and an actual width change does not reset the height. CPU-profile timings are diagnostic and were not used for the latency comparison.
+
+The transition counters showed that one workspace recreated six WebGL terminal renderers per return while the other recreated none. In that diagnostic run, the first workspace retained six grants while the other used fallback rendering. The final scheduled-upgrade run recorded six context creations for the first workspace and two for the second. Scheduling context creation across frames reduced the final observed longest long task to 104 ms. Grant fairness remains a separate issue.
+
+## Remaining work
+
+- Six Monaco editor instances are still created per switch, with 24 EditorPanel render commits in the measured window. The editor model cache preserves content, but the keyed workspace shell still recreates the editor UI. Consider bounded editor-instance retention or scheduling initialization after the first useful frame.
+- Editor mounting also redefines the global Monaco theme and writes scratch content back even when unchanged. These are concrete follow-up paths to isolate with counters/profile spans; this run does not separately quantify their cost.
+- The terminal GPU budget remains uneven across inactive and active workspaces. Investigate grant handoff without introducing context churn or glyph corruption.
+- The explorer records two directory reads per switch despite the warm view cache. Trace request reasons and paths before treating the second read as redundant.
+
+## Validation and limits
+
+Build and TypeScript checks passed, as did 72 focused unit tests and six T3 E2E checks covering dock visibility, guest drafts, keyboard focus, detached windows, real conversation workspace switches, and sidebar geometry. The terminal tests and transition benchmark passed again after scheduling GPU upgrades.
+
+T3 uses the deterministic fixture in the performance test, not production conversation history. Frame timing covers one second of settling after readiness; readiness includes automation polling latency. Focus events are simulated because E2E windows remain hidden. Other builds/live tests were observed on the machine during this session, so treat these small local samples as directional evidence, not portable latency guarantees.
+
+Use `CATE_TRANSITION_CPU_PROFILE=1` with an HTML/JSON reporter to retain `transition.cpuprofile`. See [performance.md](performance.md) for commands and metric definitions.

--- a/e2e/perf-stress.spec.ts
+++ b/e2e/perf-stress.spec.ts
@@ -29,9 +29,32 @@ test.beforeAll(async () => {
   ;({ electronApp: app, mainWindow: page } = await launchApp({ perf: true }))
   // Confirm the profiler is actually live before any scenario runs.
   await page.waitForFunction(() => typeof window.__catePerf === 'object', { timeout: 15_000 })
+  expect(await page.evaluate(() => window.__catePerf!.longTasksSupported())).toBe(true)
+
 })
 
-test.afterAll(async () => closeApp(app))
+test.afterAll(async () => { if (app) await closeApp(app) })
+
+test.afterEach(async () => {
+  const testInfo = test.info()
+  if (!page || page.isClosed()) return
+  const metrics = await page.evaluate(async () => ({
+    frames: window.__catePerf!.frames(),
+    longTasks: window.__catePerf!.longTasks(),
+    longTasksSupported: window.__catePerf!.longTasksSupported(),
+    counters: window.__catePerf!.renderCounts(),
+    main: await window.electronAPI!.perfGetSnapshot(),
+  }))
+  await testInfo.attach('performance.json', { body: JSON.stringify(metrics, null, 2), contentType: 'application/json' })
+})
+
+// E2E windows deliberately remain unmapped. Exercise the production focus-event
+// handlers without pretending a hidden window has real OS focus.
+async function setMonitorFocus(focused: boolean): Promise<void> {
+  await app.evaluate(({ app, BrowserWindow }, active) => {
+    app.emit(active ? 'browser-window-focus' : 'browser-window-blur', {}, BrowserWindow.getAllWindows()[0])
+  }, focused)
+}
 
 // -----------------------------------------------------------------------------
 // Measurement harness
@@ -41,6 +64,7 @@ interface Measurement {
   label: string
   secs: number
   fps: number
+  frames: { samples: number; meanMs: number; p95Ms: number; maxMs: number }
   longTasks: { count: number; maxMs: number }
   renders: Record<string, number>
   main: {
@@ -67,6 +91,7 @@ async function measure(label: string, action: () => Promise<void>, settleMs = 40
     t: performance.now(),
     renders: window.__catePerf!.renderCounts(),
     fps: window.__catePerf!.fps(),
+    frames: window.__catePerf!.frames(),
     longTasks: window.__catePerf!.longTasks(),
     main: await window.electronAPI!.perfGetSnapshot(),
   }))
@@ -85,6 +110,7 @@ async function measure(label: string, action: () => Promise<void>, settleMs = 40
     label,
     secs: Math.round(secs * 10) / 10,
     fps: after.fps,
+    frames: after.frames,
     longTasks: after.longTasks,
     renders: perSec(before.renders, after.renders),
     main: after.main
@@ -106,10 +132,11 @@ function report(m: Measurement): void {
     '',
     `──────── PERF: ${m.label}  (${m.secs}s window) ────────`,
     `  fps: ${m.fps}    longtasks: ${m.longTasks.count} (max ${Math.round(m.longTasks.maxMs)}ms)`,
+    `  frame time: p95 ${m.frames.p95Ms.toFixed(1)}ms · max ${m.frames.maxMs.toFixed(1)}ms (${m.frames.samples} samples)`,
     `  renders/s:  ${top(m.renders)}`,
   ]
   if (m.main) {
-    lines.push(`  main cpu: ${m.main.totalCpu}%   terminal: ${m.main.terminal.kbPerSec}KB/s (${m.main.terminal.chunksPerSec} chunks/s)`)
+    lines.push(`  Electron cpu: ${m.main.totalCpu}%   terminal: ${m.main.terminal.kbPerSec}KB/s (${m.main.terminal.chunksPerSec} chunks/s)`)
     lines.push(`  spawns/s:  ${Object.entries(m.main.spawnsPerSec).map(([k, v]) => `${k}=${v}`).join(' ') || '(none)'}`)
     lines.push(`  procs:  ${m.main.procs.slice(0, 4).map((p) => `${p.type} ${p.cpu}%/${p.memMB}MB`).join('  ')}`)
   }
@@ -156,6 +183,21 @@ test('baseline: idle for 2s', async () => {
   report(m)
   // Idle should be calm: no sustained long tasks.
   expect(m.longTasks.count).toBeLessThan(5)
+})
+
+test('profiler retains long tasks across HUD resets', async () => {
+  await page.evaluate(() => {
+    window.__catePerf!.resetWindow()
+    return new Promise<void>((resolve) => setTimeout(() => {
+      const until = performance.now() + 80
+      while (performance.now() < until) { /* deliberate renderer task */ }
+      resolve()
+    }, 0))
+  })
+  await page.waitForTimeout(1200)
+  const tasks = await page.evaluate(() => window.__catePerf!.longTasks())
+  expect(tasks.count).toBeGreaterThan(0)
+  expect(tasks.maxMs).toBeGreaterThanOrEqual(70)
 })
 
 test('canvas pan stress (wheel-pan over a populated canvas)', async () => {
@@ -256,6 +298,7 @@ test('terminal flood (real shell blasting output)', async () => {
     t: performance.now(),
     renders: window.__catePerf!.renderCounts(),
     fps: window.__catePerf!.fps(),
+    frames: window.__catePerf!.frames(),
     longTasks: window.__catePerf!.longTasks(),
   }))
 
@@ -275,6 +318,7 @@ test('terminal flood (real shell blasting output)', async () => {
     label: 'terminal flood (~4M lines, peak)',
     secs: Math.round(secs * 10) / 10,
     fps: after.fps,
+    frames: after.frames,
     longTasks: after.longTasks,
     renders: perSec(before.renders, after.renders),
     main: {
@@ -317,15 +361,19 @@ async function seedToTotal(total: number): Promise<void> {
     have++
   }
   await page.waitForTimeout(500)
+  await setMonitorFocus(true)
 }
 
 interface PeakSample {
   fps: number
+  frames: { samples: number; meanMs: number; p95Ms: number; maxMs: number }
   longTasks: { count: number; maxMs: number }
   renders: Record<string, number>
   perProcCpu: Record<string, number> // peak cpu per process type
   peakTerminalKbPerSec: number
   peakSpawnsTotal: number
+  activityScansPerSec: number
+  runtimeSamples: number
 }
 
 /** Run an action while polling the snapshot for peak per-process CPU. */
@@ -338,6 +386,11 @@ async function measurePeak(durationMs: number, action?: () => Promise<void>): Pr
   const perProcCpu: Record<string, number> = {}
   let peakTerminalKbPerSec = 0
   let peakSpawnsTotal = 0
+  let activityScans = 0
+  let runtimeWindowSecs = 0
+  let runtimeSamples = 0
+  const sampleIds = new Set<number>()
+  const startedAt = Date.now()
   const actionP = action ? action() : Promise.resolve()
 
   const polls = Math.max(1, Math.round(durationMs / 400))
@@ -345,7 +398,19 @@ async function measurePeak(durationMs: number, action?: () => Promise<void>): Pr
     await page.waitForTimeout(400)
     const snap = await page.evaluate(() => window.electronAPI!.perfGetSnapshot())
     if (!snap) continue
-    for (const p of snap.procs) perProcCpu[p.type] = Math.max(perProcCpu[p.type] ?? 0, p.cpu)
+    const byType: Record<string, number> = {}
+    for (const p of snap.procs) byType[p.type] = (byType[p.type] ?? 0) + p.cpu
+    for (const [type, cpu] of Object.entries(byType)) perProcCpu[type] = Math.max(perProcCpu[type] ?? 0, cpu)
+    if (snap.sampledAt && snap.sampledAt >= startedAt && !sampleIds.has(snap.sampledAt)) {
+      sampleIds.add(snap.sampledAt)
+      for (const runtime of snap.runtimes ?? []) {
+        const sample = runtime.sample
+        if (!sample || sample.windowMs <= 0) continue
+        runtimeSamples++
+        runtimeWindowSecs += sample.windowMs / 1000
+        activityScans += (sample.monitorScansPerSec.activity ?? 0) * sample.windowMs / 1000
+      }
+    }
     peakTerminalKbPerSec = Math.max(peakTerminalKbPerSec, snap.terminal.kbPerSec)
     const spawns = Object.values(snap.spawnsPerSec).reduce((a, b) => a + b, 0)
     peakSpawnsTotal = Math.max(peakSpawnsTotal, spawns)
@@ -355,9 +420,10 @@ async function measurePeak(durationMs: number, action?: () => Promise<void>): Pr
   const after = await page.evaluate(() => ({
     renders: window.__catePerf!.renderCounts(),
     fps: window.__catePerf!.fps(),
+    frames: window.__catePerf!.frames(),
     longTasks: window.__catePerf!.longTasks(),
   }))
-  const secs = durationMs / 1000
+  const secs = (Date.now() - startedAt) / 1000
   const perSec = (a: Record<string, number>, b: Record<string, number>): Record<string, number> => {
     const out: Record<string, number> = {}
     for (const k of Object.keys(b)) { const d = (b[k] ?? 0) - (a[k] ?? 0); if (d > 0) out[k] = Math.round(d / secs) }
@@ -365,11 +431,14 @@ async function measurePeak(durationMs: number, action?: () => Promise<void>): Pr
   }
   return {
     fps: after.fps,
+    frames: after.frames,
     longTasks: after.longTasks,
     renders: perSec(before.renders, after.renders),
     perProcCpu,
     peakTerminalKbPerSec,
     peakSpawnsTotal,
+    activityScansPerSec: runtimeWindowSecs ? activityScans / runtimeWindowSecs : 0,
+    runtimeSamples,
   }
 }
 
@@ -382,6 +451,7 @@ function reportPeak(label: string, mounted: number, s: PeakSample): void {
     '',
     `──────── PERF: ${label}  (${mounted} mounted nodes) ────────`,
     `  fps: ${s.fps}    longtasks: ${s.longTasks.count} (max ${Math.round(s.longTasks.maxMs)}ms)`,
+    `  frame time: p95 ${s.frames.p95Ms.toFixed(1)}ms · max ${s.frames.maxMs.toFixed(1)}ms`,
     `  peak cpu by process:  ${procs}`,
     `  terminal: ${s.peakTerminalKbPerSec} KB/s    spawns: ${s.peakSpawnsTotal}/s`,
     `  renders/s:  ${top(s.renders)}`,
@@ -451,7 +521,7 @@ test('big canvas pan with 9 nodes visible', async () => {
 // spawn rate the main profiler counts.
 // =============================================================================
 
-test('idle spawn budget — 9 terminals, app focused', async () => {
+test('idle spawn budget — 9 terminals, focused monitor cadence', async () => {
   await seedToTotal(9)
   await page.evaluate(() => { window.__cateE2E!.setZoom(0.5); window.__cateE2E!.resetViewport() })
   await page.waitForTimeout(800)
@@ -459,55 +529,56 @@ test('idle spawn budget — 9 terminals, app focused', async () => {
   // Sit idle and watch what the monitor spawns. With the 1s activity scan +
   // 5s lsof scan, the steady state for plain shells is a handful of pgrep/ps
   // per terminal per second; nothing should runaway.
+  await setMonitorFocus(true)
+  await page.waitForTimeout(2200)
   const s = await measurePeak(4000)
   reportPeak('9 terminals · idle spawn budget', mounted, s)
   // With the batched single-`ps`-snapshot scan, idle steady state is ~1 ps/s
   // (activity) plus the 5s lsof cycle (ports + per-terminal cwd). The peak in
   // any 2s sampler window is well under 15; the old per-PID fan-out sat at
   // ~18/s for 9 terminals, so this ceiling guards against regressing to it.
+  expect(s.runtimeSamples).toBeGreaterThan(0)
+  expect(s.activityScansPerSec).toBeGreaterThan(0)
   expect(s.peakSpawnsTotal).toBeLessThan(15)
 })
 
-test('backgrounded battery — spawns collapse when the app is unfocused', async () => {
+test('background monitor cadence backs off on simulated focus events', async () => {
   await seedToTotal(9)
   await page.evaluate(() => { window.__cateE2E!.setZoom(0.5); window.__cateE2E!.resetViewport() })
   await page.waitForTimeout(800)
   const mounted = await mountedNodeCount()
 
-  // Baseline: focused. The 1s activity scan forks pgrep (and ps for children)
-  // per terminal, so a populated canvas spawns steadily here.
-  const focused = await measurePeak(3000)
+  // Exercise the focused cadence through the production application event.
+  await setMonitorFocus(true)
+  await page.waitForTimeout(2200)
+  const focused = await measurePeak(4000)
 
-  // Blur every app window — mirrors minimizing / switching to another app.
-  // app.evaluate runs in the MAIN process where the shell monitor lives, so
-  // this drives the very focus state (anyWindowFocused) the cadence keys off.
-  await app.evaluate(({ BrowserWindow }) => {
-    for (const w of BrowserWindow.getAllWindows()) w.blur()
-  })
+  // The windowless harness cannot change native OS focus; use its application
+  // event boundary and measure actual daemon scan work at the resulting cadence.
+  await setMonitorFocus(false)
   // Let the focused-cadence timer that was already armed drain, then sample the
   // backed-off cadence (activity 1s→5s, lsof 5s→15s).
-  await page.waitForTimeout(1500)
+  await page.waitForTimeout(2500)
   const unfocused = await measurePeak(6000)
 
-  // Restore focus so later state (and a human watching) isn't left blurred.
-  await app.evaluate(({ BrowserWindow }) => {
-    const w = BrowserWindow.getAllWindows()[0]
-    if (w) w.focus()
-  })
+  // Restore the focused monitor cadence for later scenarios.
+  await setMonitorFocus(true)
 
   // eslint-disable-next-line no-console
   console.log(`\n──────── PERF: background battery (${mounted} terminals) ────────`)
   // eslint-disable-next-line no-console
-  console.log(`  focused spawns: ${focused.peakSpawnsTotal}/s    unfocused spawns: ${unfocused.peakSpawnsTotal}/s`)
+  console.log(`  focused activity scans: ${focused.activityScansPerSec.toFixed(2)}/s    unfocused: ${unfocused.activityScansPerSec.toFixed(2)}/s`)
   // eslint-disable-next-line no-console
   console.log('────────────────────────────────────────────')
 
-  // The focused baseline must have actually been spawning (proves the path is
+  // The focused baseline must have actually been scanning (proves the path is
   // live and the assertion is meaningful)…
-  expect(focused.peakSpawnsTotal).toBeGreaterThan(0)
-  // …and backgrounding must cut the spawn rate. The 5× cadence back-off means
+  expect(focused.runtimeSamples).toBeGreaterThan(0)
+  expect(unfocused.runtimeSamples).toBeGreaterThan(0)
+  expect(focused.activityScansPerSec).toBeGreaterThan(0)
+  // …and backgrounding must cut the scan rate. The 5× cadence back-off means
   // unfocused should sit well below focused; assert a conservative ≤60%.
-  expect(unfocused.peakSpawnsTotal).toBeLessThan(Math.max(2, focused.peakSpawnsTotal * 0.6))
+  expect(unfocused.activityScansPerSec).toBeLessThan(focused.activityScansPerSec * 0.6)
 })
 
 // =============================================================================
@@ -585,3 +656,37 @@ test('cull selector reuses the cached node sort across viewport changes', async 
   // eval. A per-frame re-sort would push this up toward `evals`.
   expect(sorts).toBeLessThanOrEqual(3)
 })
+
+for (const total of [10, 25]) {
+  test(`browser surface geometry with ${total} overlapping panels`, async () => {
+    const have = await page.locator('[data-browser-surface-slot]').count()
+    for (let index = have; index < total; index++) {
+      await page.evaluate((i) => window.__cateE2E!.createBrowser('about:blank', { x: 20 + (i % 5) * 60, y: 20 + Math.floor(i / 5) * 50 }), index)
+    }
+    await expect(page.locator('[data-browser-surface-slot]')).toHaveCount(total)
+    // Creation avoids overlap; move the cards explicitly to exercise occlusion.
+    await page.evaluate(() => {
+      const browserIds = new Set([...document.querySelectorAll<HTMLElement>('[data-browser-surface-slot]')].map((slot) => slot.dataset.browserSurfaceSlot))
+      window.__cateE2E!.nodes().filter((node) => browserIds.has(node.panelId)).forEach((node, index) => {
+        window.__cateE2E!.moveNode(node.id, { x: 20 + (index % 5) * 60, y: 20 + Math.floor(index / 5) * 50 })
+      })
+    })
+    await page.evaluate(() => { window.__cateE2E!.setZoom(0.4); window.__cateE2E!.resetViewport() })
+    await page.waitForTimeout(1000)
+    await expect(page.locator('[data-browser-surface-visible="true"]')).toHaveCount(total)
+    await expect.poll(() => page.evaluate(() => [...document.querySelectorAll<HTMLElement>('[data-browser-surface-slot]')]
+      .filter((slot) => window.__cateE2E!.browserWebContentsId(slot.dataset.browserSurfaceSlot!) !== null).length), { timeout: 20_000 }).toBe(total)
+    const m = await measure(`${total} browser surfaces · zoom`, async () => {
+      await page.evaluate(async () => {
+        for (let frame = 0; frame < 90; frame++) {
+          window.__cateE2E!.setZoom(0.4 + 0.05 * Math.sin(frame / 12))
+          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+        }
+      })
+    })
+    report(m)
+    expect(m.renders.browserGeometryFrame).toBeGreaterThan(10)
+    expect(m.fps).toBeGreaterThan(20)
+    expect(m.longTasks.maxMs).toBeLessThan(1000)
+  })
+}

--- a/e2e/t3-agent.spec.ts
+++ b/e2e/t3-agent.spec.ts
@@ -905,12 +905,13 @@ test('real T3 lifecycle keeps multiple panels connected across repeated workspac
     agent = i % 2 === 0 ? first : second
     await page.evaluate(id => window.__cateE2E!.selectWorkspace(id), agent.workspaceId)
     await expect(agentWebview()).toHaveAttribute('data-agent-guest-ready', 'true', { timeout: 15_000 })
-    await expect.poll(() => guestEval<boolean>(agentWebview(), 'window.__cateT3Threads?.connected === true').catch(() => false), {timeout: 15_000}).toBe(true)
+    await expect(page.locator(`[data-agent-panel-id="${agent.panelId}"]`)).toHaveAttribute('data-agent-connected', 'true', { timeout: 15_000 })
     expect((await realThreadState())?.id).toBe(i % 2 === 0 ? firstThread : secondThread)
     expect(await guestEval<string>(agentWebview(), 'document.body.innerText')).not.toMatch(/did not survive a server restart|could not establish a WebSocket|Failed to connect/)
     for (const panel of [agent, i % 2 === 0 ? extraFirst : extraSecond]) {
-      const view = page.locator(`webview[data-agent-webview="${panel.panelId}"]`)
-      await expect.poll(() => guestEval<boolean>(view, 'window.__cateT3Threads?.connected === true').catch(() => false)).toBe(true)
+      // Metadata is shared per partition; only its owner has a guest socket.
+      // Verify every consumer receives connected state through the host store.
+      await expect(page.locator(`[data-agent-panel-id="${panel.panelId}"]`)).toHaveAttribute('data-agent-connected', 'true')
     }
     const livePids = JSON.parse(readFileSync(pidPath, 'utf8')).map((r: {pid: number}) => r.pid)
     expect(livePids).toEqual(expect.arrayContaining(originalPids))

--- a/e2e/t3-agent.spec.ts
+++ b/e2e/t3-agent.spec.ts
@@ -96,6 +96,7 @@ test.beforeEach(async ({}, testInfo) => {
 
 
   launchOptions = {
+    perf: testInfo.title.includes('webview geometry'),
     userDataDir: path.join(tempRoot, 'userdata'),
     env: {
       CATE_HARNESS_ROOT: path.join(tempRoot, 'harness'),
@@ -999,4 +1000,90 @@ test('real T3 lifecycle bounds automatic crash recovery and allows an explicit r
   await expect(agentWebview()).toHaveAttribute('data-agent-guest-ready', 'true', {timeout: 15_000})
   await submitRealChat('after explicit retry')
   await waitForRealReply('after explicit retry')
+})
+
+
+test('webview geometry stays aligned for T3 and browsers during layout changes', async () => {
+  await page.evaluate(() => {
+    window.__cateE2E!.setActiveLeftSidebarView(null)
+    window.__cateE2E!.setZoom(0.65)
+    window.__cateE2E!.setViewport({ x: 40, y: 40 })
+  })
+  const ids = await page.evaluate(() => Array.from({ length: 8 }, (_, i) => window.__cateE2E!.createBrowser(
+    'data:text/html,<title>Geometry</title><body>Browser</body>', { x: 1000 + (i % 4) * 120, y: Math.floor(i / 4) * 220 },
+  ).panelId))
+  for (const id of ids) await expect.poll(() => page.evaluate(
+    (panelId) => window.__cateE2E!.browserWebContentsId(panelId), id,
+  ), { timeout: 20_000 }).not.toBeNull()
+
+  await page.evaluate(() => {
+    window.__cateE2E!.setZoom(0.65)
+    window.__cateE2E!.setViewport({ x: 40, y: 40 })
+  })
+  await page.waitForTimeout(350)
+
+  // Real host-coordinate clicks prove the native guest moved too, beyond the
+  // host DOM rectangle. The fixture button sits above the T3 application's UI.
+  await guestEval(agentWebview(), `(() => {
+    const button = document.createElement('button'); button.id = 'geometry-probe';
+    button.style.cssText = 'position:fixed;left:20px;top:20px;width:100px;height:40px;z-index:2147483647';
+    button.textContent = 'Geometry'; window.geometryClicks = 0;
+    button.onclick = () => window.geometryClicks++;
+    document.body.append(button);
+  })()`)
+  await page.locator(`[data-node-id="${agent.nodeId}"]`).click({ position: { x: 60, y: 10 } })
+  let clicks = 0
+  for (const sidebar of ['explorer', null, 'explorer', null] as const) {
+    await electronApp!.evaluate(({ BrowserWindow }, width) => BrowserWindow.getAllWindows()[0].setSize(width, 850), 1200 + clicks * 30)
+    await page.evaluate(({ view, step }) => {
+      window.__cateE2E!.setActiveLeftSidebarView(view)
+      window.__cateE2E!.setZoom([0.65, 0.85, 0.5, 0.65][step])
+      window.__cateE2E!.setViewport({ x: 40 + step * 10, y: 40 + step * 5 })
+    }, { view: sidebar, step: clicks })
+    await page.waitForTimeout(350)
+    await expect.poll(() => page.evaluate(() => {
+      return [...document.querySelectorAll<HTMLElement>('[data-browser-surface-slot]')].every((slot) => {
+        const surface = document.querySelector<HTMLElement>(`[data-browser-surface="${slot.dataset.browserSurfaceSlot}"]`)!
+        if (surface.dataset.browserSurfaceVisible !== 'true') return true
+        const a = slot.getBoundingClientRect(), b = surface.getBoundingClientRect()
+        return Math.abs(a.x - b.x) < 1 && Math.abs(a.y - b.y) < 1 && Math.abs(a.width - b.width) < 1 && Math.abs(a.height - b.height) < 1
+      })
+    })).toBe(true)
+    const target = await agentWebview().evaluate((element) => {
+      const rect = element.getBoundingClientRect()
+      return { x: rect.left + 70 * rect.width / (element as HTMLElement).offsetWidth,
+        y: rect.top + 40 * rect.height / (element as HTMLElement).offsetHeight }
+    })
+    await page.mouse.click(target.x, target.y)
+    await expect.poll(() => guestEval<number>(agentWebview(), 'window.geometryClicks')).toBe(++clicks)
+    const hostSize = await agentWebview().evaluate((element) => ({ width: (element as HTMLElement).offsetWidth, height: (element as HTMLElement).offsetHeight }))
+    await expect.poll(() => guestEval(agentWebview(), '({ width: innerWidth, height: innerHeight })')).toEqual(hostSize)
+  }
+
+  // Count actual tracker passes and measure frame intervals with real guests.
+  const result = await page.evaluate(async () => {
+    const counts = () => (window as any).__catePerf.renderCounts() as Record<string, number>
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const idleStart = counts().browserGeometryFrame ?? 0
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const idleFrames = (counts().browserGeometryFrame ?? 0) - idleStart
+    const before = counts()
+    const intervals: number[] = []
+    let previous = performance.now()
+    for (let i = 0; i < 90; i++) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => {
+        const now = performance.now(); intervals.push(now - previous); previous = now
+        window.__cateE2E!.setViewport({ x: 40 + i, y: 40 + i / 2 }); resolve()
+      }))
+    }
+    const after = counts()
+    intervals.sort((a, b) => a - b)
+    return { idleFrames, panFrames: (after.browserGeometryFrame ?? 0) - (before.browserGeometryFrame ?? 0),
+      rectReads: (after.browserGeometryRect ?? 0) - (before.browserGeometryRect ?? 0),
+      trackerMs: ((after.browserGeometryMicros ?? 0) - (before.browserGeometryMicros ?? 0)) / 1000,
+      p50: intervals[45], p95: intervals[85] }
+  })
+  console.log('Webview geometry: 8 browsers + T3', result)
+  expect(result.idleFrames).toBe(0)
+  expect(result.panFrames).toBeLessThanOrEqual(92)
 })

--- a/e2e/workspace-transition-perf.spec.ts
+++ b/e2e/workspace-transition-perf.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { launchApp, closeApp } from './fixtures/electron-app'
+
+// A warm-switch baseline, deliberately independent of perf-stress's accumulated
+// canvas. T3 uses a deterministic server: this measures guest lifecycle, not the
+// cost of rendering production conversation history. No performance fixes here.
+const MIX = { terminal: 8, editor: 6, browser: 3, agent: 1 }
+const TOTAL = Object.values(MIX).reduce((sum, count) => sum + count, 0)
+interface Workspace {
+  id: string
+  nodes: string[]
+  terminals: string[]
+  editors: string[]
+  browsers: string[]
+  agent: string
+}
+
+async function ready(page: Page, workspace: Workspace): Promise<void> {
+  await page.waitForFunction((ws) => {
+    const h = window.__cateE2E!
+    if (h.selectedWorkspaceId() !== ws.id) return false
+    return ws.nodes.every((id) => {
+      const node = document.querySelector<HTMLElement>(`[data-node-id="${id}"]`)
+      if (!node) return false
+      const rect = node.getBoundingClientRect()
+      return rect.width > 0 && rect.height > 0 && rect.left >= 0 && rect.top >= 0
+        && rect.right <= innerWidth && rect.bottom <= innerHeight
+    }) && ws.terminals.every((id) => h.terminalPtyId(id)
+      && document.querySelector(`[data-node-id="${id}"] .xterm-screen`))
+      && ws.editors.every((id) => document.querySelector(`[data-node-id="${id}"] .monaco-editor textarea`))
+      && ws.browsers.every((id) => h.browserWebContentsId(id) !== null
+        && document.querySelector(`[data-browser-surface="${id}"][data-browser-surface-visible="true"]`))
+      && document.querySelector(`webview[data-agent-webview="${ws.agent}"][data-agent-guest-ready="true"]`)
+  }, workspace, { timeout: 30_000 })
+}
+
+async function guestIds(page: Page, workspace: Workspace) {
+  return page.evaluate((ws) => {
+    const agent = document.querySelector(`webview[data-agent-webview="${ws.agent}"]`) as HTMLElement & { getWebContentsId(): number }
+    return {
+      agent: agent.getWebContentsId(),
+      browsers: ws.browsers.map((id) => window.__cateE2E!.browserWebContentsId(id)),
+      ptys: ws.terminals.map((id) => window.__cateE2E!.terminalPtyId(id)),
+    }
+  }, workspace)
+}
+
+test('warm workspace transitions with 36 mixed panels', async () => {
+  test.setTimeout(180_000)
+  const root = mkdtempSync(path.join(tmpdir(), 'cate-transition-perf-'))
+  let app: ElectronApplication | undefined
+  const samples: Array<Record<string, unknown>> = []
+  try {
+    const launched = await launchApp({ perf: true, env: {
+      CATE_HARNESS_ROOT: path.join(root, 'harness'),
+      CATE_E2E_T3_ENTRY_PATH: path.resolve('e2e/fixtures/fake-t3.cjs'),
+    } })
+    app = launched.electronApp
+    const page = launched.mainWindow
+    await page.waitForFunction(() => !!window.__catePerf)
+    expect(await page.evaluate(() => window.__catePerf!.longTasksSupported())).toBe(true)
+    // Keep all 18 cards genuinely on screen, instead of benchmarking culled DOM.
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0].setSize(1600, 1100))
+    // E2E windows remain hidden: activate production monitor cadence explicitly.
+    await app.evaluate(({ app, BrowserWindow }) => app.emit('browser-window-focus', {}, BrowserWindow.getAllWindows()[0]))
+    const workspaces: Workspace[] = []
+    for (const name of ['A', 'B']) {
+      const folder = path.join(root, name)
+      mkdirSync(folder)
+      execFileSync('git', ['init', '--quiet', folder])
+      for (let i = 0; i < 200; i++) writeFileSync(path.join(folder, `file-${i}.ts`), `export const value = ${i}\n`)
+      const id = await page.evaluate(async (name) => {
+        const h = window.__cateE2E!
+        const id = h.addWorkspace(`Transition ${name}`)
+        await h.selectWorkspace(id)
+        return id
+      }, name)
+      const opened = page.evaluate((folder) => window.__cateE2E!.setWorkspaceRoot(folder), folder)
+      const trust = page.getByRole('button', { name: 'Trust and open' })
+      // Trust may already be inherited by a local test root.
+      await Promise.race([opened, trust.waitFor({ state: 'visible' }).then(() => trust.click())])
+      expect(await opened).toBe(true)
+      const ws = await page.evaluate(({ id, mix }) => {
+        const h = window.__cateE2E!
+        h.openSidebarView('explorer')
+        const point = { x: 20, y: 20 }
+        const terminals = Array.from({ length: mix.terminal }, () => h.createTerminal(point))
+        const editors = Array.from({ length: mix.editor }, () => h.createEditor(point))
+        const url = `data:text/html,${encodeURIComponent('<title>Transition fixture</title><body><input value="preserved browser state"><div style="height:1200px">Browser fixture</div></body>')}`
+        const browsers = Array.from({ length: mix.browser }, () => h.createBrowser(url, point).panelId)
+        const agent = h.createAgent(point).panelId
+        const nodes = h.nodes()
+        const width = Math.max(...nodes.map((n) => n.size.width)) + 40
+        const height = Math.max(...nodes.map((n) => n.size.height)) + 40
+        nodes.forEach((n, i) => h.moveNode(n.id, { x: 20 + (i % 4) * width, y: 20 + Math.floor(i / 4) * height }))
+        h.setZoom(Math.min(0.3, (innerWidth - 500) / (4 * width + 40), (innerHeight - 180) / (5 * height + 40)))
+        h.resetViewport()
+        return { id, nodes: nodes.map((n) => n.id), terminals, editors, browsers, agent }
+      }, { id, mix: MIX })
+      expect(ws.nodes).toHaveLength(TOTAL)
+      await ready(page, ws)
+      // Give every editor real content and terminals a recognizable live buffer.
+      for (const node of ws.editors) {
+        await page.locator(`[data-node-id="${node}"] .monaco-editor textarea`).evaluate((element) => (element as HTMLTextAreaElement).focus())
+        await page.keyboard.insertText(`// transition ${name}\n` + 'const value = 123;\n'.repeat(200))
+      }
+      await page.evaluate((ws) => {
+        for (const node of ws.terminals) window.__cateE2E!.writeTerminal(node, "printf 'transition-ready\\n'\n")
+      }, ws)
+      await expect.poll(() => page.evaluate((ws) => ws.terminals.every((node) => window.__cateE2E!.terminalText(node)?.split('\n').some((line) => line.trim() === 'transition-ready')), ws)).toBe(true)
+      workspaces.push(ws)
+    }
+
+    // Warm both workspaces once. Cold setup/first PTY spawn stays outside the
+    // samples; each measured destination has previously been fully ready.
+    const identities = new Map<string, Awaited<ReturnType<typeof guestIds>>>()
+    for (const ws of workspaces) {
+      await page.evaluate((id) => window.__cateE2E!.selectWorkspace(id), ws.id)
+      await ready(page, ws)
+      identities.set(ws.id, await guestIds(page, ws))
+    }
+    await page.waitForTimeout(2200) // establish daemon profiler baseline
+    const resourcesBefore = await page.evaluate(() => window.electronAPI.perfGetSnapshot())
+    expect(resourcesBefore?.runtimes?.some((r) => r.sample && r.sample.windowMs > 0)).toBe(true)
+
+    // Optional diagnostic run; CPU sampling changes timings, so keep it off
+    // for normal before/after comparisons. Captures the first warm switch.
+    const cpu = process.env.CATE_TRANSITION_CPU_PROFILE === '1' ? await page.context().newCDPSession(page) : null
+    if (cpu) { await cpu.send('Profiler.enable'); await cpu.send('Profiler.start') }
+    for (let step = 0; step < 8; step++) {
+      const ws = workspaces[step % 2]
+      const timing = await page.evaluate(async (ws) => {
+        const perf = window.__catePerf!
+        perf.resetWindow()
+        // Seed frame intervals before switching, otherwise resetWindow's first
+        // rAF would swallow the initial switch stall instead of measuring it.
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+        const counters = perf.renderCounts()
+        const started = performance.now()
+        const selection = window.__cateE2E!.selectWorkspace(ws.id).then(() => performance.now() - started)
+        // A frame boundary is an approximation, not a presented-frame timestamp.
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+        const frameBoundaryMs = performance.now() - started
+        const selectionResolvedMs = await selection
+        return { started, frameBoundaryMs, selectionResolvedMs, counters }
+      }, ws)
+      await ready(page, ws)
+      const readyMs = await page.evaluate((started) => performance.now() - started, timing.started)
+      const ids = await guestIds(page, ws)
+      // Include delayed fit/repaint/observer work after panels become ready.
+      await page.waitForTimeout(1000)
+      const metrics = await page.evaluate((before) => {
+        const p = window.__catePerf!
+        const after = p.renderCounts()
+        return { frames: p.frames(), longTasks: p.longTasks(), counters: Object.fromEntries(
+          Object.entries(after).map(([key, value]) => [key, value - (before[key] ?? 0)]).filter(([, value]) => value !== 0)),
+        }
+      }, timing.counters)
+      const previous = identities.get(ws.id)!
+      const sample = { step, workspace: ws.id, frameBoundaryMs: timing.frameBoundaryMs,
+        selectionResolvedMs: timing.selectionResolvedMs, readyMs, ...metrics,
+        agentGuestRecreated: previous.agent !== ids.agent,
+        browserGuestsPreserved: JSON.stringify(previous.browsers) === JSON.stringify(ids.browsers),
+        ptysPreserved: JSON.stringify(previous.ptys) === JSON.stringify(ids.ptys), ids }
+      samples.push(sample)
+      if (step === 0 && cpu) {
+        const { profile } = await cpu.send('Profiler.stop')
+        await test.info().attach('transition.cpuprofile', { body: JSON.stringify(profile), contentType: 'application/json' })
+        await cpu.detach()
+      }
+      identities.set(ws.id, ids)
+      // Guard the retained-guest and coalesced-repaint fixes. Keep latency
+      // limits broad because absolute timings depend on the test host.
+      expect(sample.agentGuestRecreated).toBe(false)
+      expect(metrics.counters.terminalAtlasPass ?? 0).toBeLessThanOrEqual(8)
+      expect(sample.browserGuestsPreserved).toBe(true)
+      expect(sample.ptysPreserved).toBe(true)
+      expect(metrics.frames.samples).toBeGreaterThan(0)
+      expect(readyMs).toBeLessThan(15_000)
+      expect(metrics.longTasks.maxMs).toBeLessThan(5000)
+    }
+    const resourcesAfter = await page.evaluate(() => window.electronAPI.perfGetSnapshot())
+    await test.info().attach('runtime-snapshots.json', { body: JSON.stringify({ resourcesBefore, resourcesAfter }, null, 2), contentType: 'application/json' })
+    // eslint-disable-next-line no-console
+    console.table(samples.map(({ step, frameBoundaryMs, selectionResolvedMs, readyMs, longTasks, agentGuestRecreated }) =>
+      ({ step, frameBoundaryMs, selectionResolvedMs, readyMs, longTasks, agentGuestRecreated })))
+  } finally {
+    await test.info().attach('workspace-transitions.json', { body: JSON.stringify({ mixPerWorkspace: MIX, workspaces: 2, samples,
+      notes: ['Warm switches; 1s settling window included in frame statistics.', 'Readiness includes automation polling latency.', 'T3 uses fake-t3; no production conversation workload.', 'Focus events simulated; runtime snapshots are boundary samples, not transition peaks.'] }, null, 2), contentType: 'application/json' })
+    if (app) await closeApp(app)
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   // E2E_SKIP_PERF=1 to run only the functional (smoke/drag/dock) specs.
   testIgnore: [
     ...(process.env.E2E_SKIP_PERF
-      ? ['**/perf-stress.spec.ts', '**/worktree-territory-perf.spec.ts']
+      ? ['**/perf-stress.spec.ts', '**/worktree-territory-perf.spec.ts', '**/workspace-transition-perf.spec.ts']
       : []),
     // Public-internet smoke coverage is intentionally opt-in: it verifies the
     // packaged browser against third-party TLS/DNS/HTTP, but external uptime

--- a/src/main/ipc/git-monitor.test.ts
+++ b/src/main/ipc/git-monitor.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, expect, it, vi } from 'vitest'
+const mocks = vi.hoisted(() => ({ handlers: new Map<string, (...args: any[]) => void>(), poll: vi.fn() }))
+vi.mock('electron', () => ({ app: { on: vi.fn() }, ipcMain: { on: (key: string, handler: (...args: any[]) => void) => mocks.handlers.set(key, handler) } }))
+vi.mock('../logger', () => ({ default: { debug: vi.fn(), warn: vi.fn() } }))
+vi.mock('../windowRegistry', () => ({ isAnyWindowFocused: () => true, windowFromEvent: () => ({ id: 1 }), sendToWindow: vi.fn() }))
+vi.mock('../runtime/runtimeManager', () => ({ runtimes: { resolve: () => ({ vcs: { monitorStatus: mocks.poll }, file: { watch: () => vi.fn() } }) } }))
+import { registerHandlers, stopMonitorsForWindow } from './git-monitor'
+import { GIT_MONITOR_START, GIT_MONITOR_STOP } from '../../shared/ipc-channels'
+afterEach(() => { stopMonitorsForWindow(1); vi.useRealTimers() })
+it('does not resurrect a stopped monitor when its in-flight poll completes', async () => {
+  vi.useFakeTimers()
+  let finish!: (value: unknown) => void
+  mocks.poll.mockImplementation(() => new Promise((resolve) => { finish = resolve }))
+  registerHandlers()
+  mocks.handlers.get(GIT_MONITOR_START)!({}, 'workspace', '/tmp/project')
+  expect(mocks.poll).toHaveBeenCalledTimes(1)
+  mocks.handlers.get(GIT_MONITOR_STOP)!({}, 'workspace')
+  finish({ branch: 'main', dirty: false, branches: ['main'] })
+  await vi.advanceTimersByTimeAsync(120_000)
+  expect(mocks.poll).toHaveBeenCalledTimes(1)
+  expect(vi.getTimerCount()).toBe(0)
+})

--- a/src/main/ipc/git-monitor.ts
+++ b/src/main/ipc/git-monitor.ts
@@ -60,6 +60,7 @@ function clearTimer(entry: MonitorEntry): void {
 
 function scheduleNext(entry: MonitorEntry, delayMs: number): void {
   clearTimer(entry)
+  if (activeMonitors.get(entry.workspaceId) !== entry) return
   if (!anyWindowFocused) {
     // Paused while no window has focus — focus handler will re-schedule.
     return
@@ -71,8 +72,10 @@ function scheduleNext(entry: MonitorEntry, delayMs: number): void {
 
 async function tick(entry: MonitorEntry): Promise<void> {
   entry.timer = null
+  if (activeMonitors.get(entry.workspaceId) !== entry) return
   if (!anyWindowFocused) return
   const changed = await pollGitStatus(entry)
+  if (activeMonitors.get(entry.workspaceId) !== entry) return
   if (changed) {
     entry.nextDelayMs = POLL_INTERVAL_MIN_MS
   } else {
@@ -100,7 +103,7 @@ async function pollGitStatus(entry: MonitorEntry): Promise<boolean> {
     const { branch, dirty: isDirty, branches } = await runtime.vcs.monitorStatus(rootPath, { scopeId: workspaceId })
 
     // Stale: a fresher poll started, or the monitor was torn down/restarted.
-    if (entry.pollEpoch !== epoch || !activeMonitors.has(workspaceId)) return false
+    if (entry.pollEpoch !== epoch || activeMonitors.get(workspaceId) !== entry) return false
 
     if (!branch) return false
 
@@ -243,7 +246,7 @@ export function registerHandlers(): void {
       // Coalesce the inbound burst on the next tick before kicking a poll.
       setImmediate(() => {
         entry.fsKickPending = false
-        if (!activeMonitors.has(workspaceId)) return
+        if (activeMonitors.get(workspaceId) !== entry) return
         entry.nextDelayMs = POLL_INTERVAL_MIN_MS
         clearTimer(entry)
         void tick(entry)

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -322,7 +322,7 @@ async function spawnTerminal(
     if (shuttingDown) return
     terminalId = id
     sawData = true
-    countTerminalData(data.length)
+    countTerminalData(data)
     getOrCreateLogger(id).append(data)
 
     const transferState = transferStates.get(id)

--- a/src/main/perf/perfMonitor.test.ts
+++ b/src/main/perf/perfMonitor.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, expect, it, vi } from 'vitest'
+const mocks = vi.hoisted(() => ({ samplePerf: vi.fn() }))
+vi.mock('electron', () => ({
+  app: { getAppMetrics: () => [] },
+  BrowserWindow: { getAllWindows: () => [] },
+}))
+vi.mock('../runtime/runtimeManager', () => ({ runtimes: { connectedRuntimes: () => [{ id: 'local', samplePerf: mocks.samplePerf }] } }))
+afterEach(() => { vi.useRealTimers(); vi.unstubAllEnvs(); vi.restoreAllMocks() })
+
+it('publishes daemon counters atomically and reports unavailable profiling explicitly', async () => {
+  vi.useFakeTimers()
+  vi.stubEnv('CATE_PERF', '1')
+  vi.resetModules()
+  const perf = await import('./perfMonitor')
+  mocks.samplePerf.mockResolvedValue({ pid: 123, windowMs: 2000, monitorSpawnsPerSec: { ps: 1.5 }, monitorScansPerSec: { activity: 1 }, cpu: 2, rssMB: 40, eventLoop: { p95Ms: 20, maxMs: 21 } })
+  perf.startPerfMonitor()
+  perf.countIpc('terminal', 4096)
+  await vi.advanceTimersByTimeAsync(2000)
+  expect(perf.getLatestSnapshot()).toMatchObject({ spawnsPerSec: { ps: 1.5 }, runtimes: [{ id: 'local', sample: { pid: 123 } }] })
+  mocks.samplePerf.mockRejectedValue(new Error('Unknown method'))
+  await vi.advanceTimersByTimeAsync(2000)
+  expect(perf.getLatestSnapshot()).toMatchObject({ spawnsPerSec: {}, runtimes: [{ id: 'local', sample: null, error: 'Unknown method' }] })
+})

--- a/src/main/perf/perfMonitor.ts
+++ b/src/main/perf/perfMonitor.ts
@@ -5,7 +5,7 @@
 // It does two things on a fixed interval:
 //   1. Samples app.getAppMetrics() for per-process CPU% + working-set memory.
 //   2. Drains lightweight counters that instrument the hot paths the perf audit
-//      flagged — subprocess spawns (pgrep/ps/lsof/git), main->renderer IPC bytes
+//      flagged — runtime process-monitor spawns (ps/lsof), main->renderer IPC bytes
 //      per channel, and terminal PTY throughput.
 //
 // The latest snapshot is logged and stored; the renderer HUD pulls it over IPC
@@ -25,7 +25,6 @@ export const PERF_ENABLED = process.env.CATE_PERF === '1'
 const SAMPLE_INTERVAL_MS = 2000
 
 // --- Counters (reset every sample tick) -------------------------------------
-const spawnCounts = new Map<string, number>()
 const ipcByChannel = new Map<string, { bytes: number; count: number }>()
 let terminalBytes = 0
 let terminalChunks = 0
@@ -39,9 +38,9 @@ export function countIpc(channel: string, bytes: number): void {
 }
 
 /** Count one chunk of PTY output forwarded toward the renderer. */
-export function countTerminalData(bytes: number): void {
+export function countTerminalData(data: string): void {
   if (!PERF_ENABLED) return
-  terminalBytes += bytes
+  terminalBytes += Buffer.byteLength(data)
   terminalChunks++
 }
 
@@ -53,66 +52,91 @@ export function getLatestSnapshot(): PerfSnapshot | null {
   return latest
 }
 
-function tick(): void {
-  const secs = SAMPLE_INTERVAL_MS / 1000
-  const focused = BrowserWindow.getAllWindows().some((w) => !w.isDestroyed() && w.isFocused())
+let previousAt = 0
+let sampling = false
+async function tick(): Promise<void> {
+  if (sampling) return
+  sampling = true
+  try {
+    const now = performance.now()
+    const windowMs = now - previousAt
+    previousAt = now
+    const secs = windowMs / 1000
+    const focused = BrowserWindow.getAllWindows().some((w) => !w.isDestroyed() && w.isFocused())
 
-  let totalCpu = 0
-  const procs: PerfProcSample[] = app.getAppMetrics().map((m) => {
-    const cpu = Math.round((m.cpu?.percentCPUUsage ?? 0) * 10) / 10
-    totalCpu += cpu
-    return {
-      type: m.type,
-      pid: m.pid,
-      cpu,
-      // workingSetSize is reported in kilobytes.
-      memMB: Math.round((m.memory?.workingSetSize ?? 0) / 1024),
+    let totalCpu = 0
+    const procs: PerfProcSample[] = app.getAppMetrics().map((m) => {
+      const cpu = Math.round((m.cpu?.percentCPUUsage ?? 0) * 10) / 10
+      totalCpu += cpu
+      return {
+        type: m.type,
+        pid: m.pid,
+        cpu,
+        // workingSetSize is reported in kilobytes.
+        memMB: Math.round((m.memory?.workingSetSize ?? 0) / 1024),
+      }
+    })
+    totalCpu = Math.round(totalCpu * 10) / 10
+
+    const spawnsPerSec: Record<string, number> = {}
+
+    const ipc = Array.from(ipcByChannel.entries())
+      .map(([channel, e]) => ({
+        channel,
+        kbPerSec: Math.round((e.bytes / secs / 1024) * 10) / 10,
+        callsPerSec: Math.round((e.count / secs) * 10) / 10,
+      }))
+      .sort((a, b) => b.kbPerSec - a.kbPerSec)
+
+    const snapshot: PerfSnapshot = {
+      sampledAt: Date.now(),
+      windowMs,
+      focused,
+      totalCpu,
+      procs: procs.sort((a, b) => b.cpu - a.cpu),
+      spawnsPerSec,
+      ipc,
+      terminal: {
+        kbPerSec: Math.round((terminalBytes / secs / 1024) * 10) / 10,
+        chunksPerSec: Math.round((terminalChunks / secs) * 10) / 10,
+      },
     }
-  })
-  totalCpu = Math.round(totalCpu * 10) / 10
 
-  const spawnsPerSec: Record<string, number> = {}
-  for (const [label, n] of spawnCounts) spawnsPerSec[label] = Math.round((n / secs) * 10) / 10
-
-  const ipc = Array.from(ipcByChannel.entries())
-    .map(([channel, e]) => ({
-      channel,
-      kbPerSec: Math.round((e.bytes / secs / 1024) * 10) / 10,
-      callsPerSec: Math.round((e.count / secs) * 10) / 10,
+    ipcByChannel.clear()
+    terminalBytes = 0
+    terminalChunks = 0
+    const { runtimes } = await import('../runtime/runtimeManager')
+    const runtimeSamples = await Promise.all(runtimes.connectedRuntimes().map(async (runtime) => {
+      try {
+        if (!runtime.samplePerf) throw new Error('Runtime profiling unavailable')
+        return { id: runtime.id, sample: await runtime.samplePerf() }
+      } catch (error) {
+        return { id: runtime.id, sample: null, error: error instanceof Error ? error.message : String(error) }
+      }
     }))
-    .sort((a, b) => b.kbPerSec - a.kbPerSec)
+    for (const runtime of runtimeSamples) {
+      for (const [label, rate] of Object.entries(runtime.sample?.monitorSpawnsPerSec ?? {})) {
+        spawnsPerSec[label] = (spawnsPerSec[label] ?? 0) + rate
+      }
+    }
+    latest = { ...snapshot, spawnsPerSec, runtimes: runtimeSamples }
+    // Compact one-line log so it's greppable in the terminal running `npm run dev`.
+    const topIpc = ipc.slice(0, 3).map((c) => `${c.channel}=${c.kbPerSec}KB/s`).join(' ')
+    const spawnStr = Object.entries(spawnsPerSec).map(([k, v]) => `${k}=${v}/s`).join(' ')
+    log.info(
+      '[perf] cpu=%s%% focused=%s term=%sKB/s(%s chunks/s) spawns[%s] ipc[%s]',
+      totalCpu, focused, latest.terminal.kbPerSec, latest.terminal.chunksPerSec, spawnStr, topIpc,
+    )
 
-  latest = {
-    windowMs: SAMPLE_INTERVAL_MS,
-    focused,
-    totalCpu,
-    procs: procs.sort((a, b) => b.cpu - a.cpu),
-    spawnsPerSec,
-    ipc,
-    terminal: {
-      kbPerSec: Math.round((terminalBytes / secs / 1024) * 10) / 10,
-      chunksPerSec: Math.round((terminalChunks / secs) * 10) / 10,
-    },
-  }
 
-  // Compact one-line log so it's greppable in the terminal running `npm run dev`.
-  const topIpc = ipc.slice(0, 3).map((c) => `${c.channel}=${c.kbPerSec}KB/s`).join(' ')
-  const spawnStr = Object.entries(spawnsPerSec).map(([k, v]) => `${k}=${v}/s`).join(' ')
-  log.info(
-    '[perf] cpu=%s%% focused=%s term=%sKB/s(%s chunks/s) spawns[%s] ipc[%s]',
-    totalCpu, focused, latest.terminal.kbPerSec, latest.terminal.chunksPerSec, spawnStr, topIpc,
-  )
-
-  spawnCounts.clear()
-  ipcByChannel.clear()
-  terminalBytes = 0
-  terminalChunks = 0
+  } finally { sampling = false }
 }
 
 export function startPerfMonitor(): void {
   if (!PERF_ENABLED || timer) return
   log.info('[perf] CATE_PERF=1 — resource profiler active (sampling every %dms)', SAMPLE_INTERVAL_MS)
-  timer = setInterval(tick, SAMPLE_INTERVAL_MS)
+  previousAt = performance.now()
+  timer = setInterval(() => { void tick().catch((error) => log.warn('[perf] sample failed: %s', error)) }, SAMPLE_INTERVAL_MS)
   // Don't keep the event loop alive solely for profiling.
   if (typeof timer.unref === 'function') timer.unref()
 }

--- a/src/main/runtime/RemoteRuntime.ts
+++ b/src/main/runtime/RemoteRuntime.ts
@@ -358,6 +358,10 @@ export class RemoteRuntime implements Runtime {
     return this.rpc.call(Methods.removeAllowedRoot, [root, scopeId]) as Promise<void>
   }
 
+  samplePerf(): Promise<import('../../shared/types').RuntimePerfSample> {
+    return this.rpc.call(Methods.perfSnapshot, [], { timeoutMs: 1000 }) as Promise<import('../../shared/types').RuntimePerfSample>
+  }
+
   setExclusions(names: string[]): Promise<void> {
     return this.rpc.call(Methods.setExclusions, [names]) as Promise<void>
   }

--- a/src/main/runtime/runtimeManager.ts
+++ b/src/main/runtime/runtimeManager.ts
@@ -270,6 +270,10 @@ export class RuntimeManager {
     return runtime
   }
 
+  connectedRuntimes(): Runtime[] {
+    return [...this.runtimes.values()].filter((runtime) => this.isConnected(runtime.id))
+  }
+
   has(id: RuntimeId): boolean {
     return this.runtimes.has(id)
   }

--- a/src/main/runtime/types.ts
+++ b/src/main/runtime/types.ts
@@ -462,6 +462,8 @@ export interface VcsHost {
 // ---------------------------------------------------------------------------
 
 export interface Runtime {
+  /** Optional diagnostics; called only while CATE_PERF is enabled. */
+  samplePerf?(): Promise<import('../../shared/types').RuntimePerfSample>
   readonly id: RuntimeId
   readonly process: ProcessHost
   readonly agentHooks: AgentHookHost

--- a/src/main/windowRegistry.ts
+++ b/src/main/windowRegistry.ts
@@ -10,9 +10,9 @@ import { PERF_ENABLED, countIpc } from './perf/perfMonitor'
 function ipcPayloadBytes(args: unknown[]): number {
   let n = 0
   for (const a of args) {
-    if (typeof a === 'string') n += a.length
+    if (typeof a === 'string') n += Buffer.byteLength(a)
     else if (a == null) continue
-    else { try { n += JSON.stringify(a).length } catch { /* circular/unserialisable */ } }
+    else { try { n += Buffer.byteLength(JSON.stringify(a)) } catch { /* circular/unserialisable */ } }
   }
   return n
 }
@@ -191,9 +191,10 @@ export function sendToWindow(windowId: number, channel: string, ...args: unknown
  * Broadcast an IPC message to ALL tracked windows.
  */
 export function broadcastToAll(channel: string, ...args: unknown[]): void {
-  if (PERF_ENABLED) countIpc(channel, ipcPayloadBytes(args))
+  const bytes = PERF_ENABLED ? ipcPayloadBytes(args) : 0
   for (const win of windows.values()) {
     if (!win.isDestroyed()) {
+      if (PERF_ENABLED) countIpc(channel, bytes)
       win.webContents.send(channel, ...args)
     }
   }
@@ -203,8 +204,10 @@ export function broadcastToAll(channel: string, ...args: unknown[]): void {
  * Broadcast an IPC message to all windows EXCEPT the specified one.
  */
 export function broadcastToAllExcept(excludeId: number, channel: string, ...args: unknown[]): void {
+  const bytes = PERF_ENABLED ? ipcPayloadBytes(args) : 0
   for (const [id, win] of windows.entries()) {
     if (id !== excludeId && !win.isDestroyed()) {
+      if (PERF_ENABLED) countIpc(channel, bytes)
       win.webContents.send(channel, ...args)
     }
   }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -93,7 +93,7 @@ export default function App() {
         <PersistentBrowserHostContext.Provider value>
           <DockWindowShell workspaceId={windowParams.workspaceId} />
           <React.Suspense fallback={null}>
-            <BackgroundBrowserHost />
+            <BackgroundBrowserHost workspaceId={windowParams.workspaceId} />
           </React.Suspense>
         </PersistentBrowserHostContext.Provider>
       </WindowTypeContext.Provider>

--- a/src/renderer/canvas/worktree/WorktreeTerritoryLayer.test.tsx
+++ b/src/renderer/canvas/worktree/WorktreeTerritoryLayer.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { expect, it, vi } from 'vitest'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+vi.mock('../../stores/CanvasStoreContext', () => ({ useCanvasStoreApi: () => ({ subscribe: () => () => {} }) }))
+vi.mock('../../stores/uiStore', () => ({ useUIStore: { subscribe: () => () => {} } }))
+vi.mock('../../drag', () => ({ useDragStore: { subscribe: () => () => {} } }))
+vi.mock('./useWorktreeMembership', () => ({ useWorktreeMembership: () => ({ groups: [] }) }))
+vi.mock('./territoryGL', () => ({ createTerritoryGL: () => ({ resize: vi.fn(), dispose: vi.fn() }), buildPrimitives: vi.fn() }))
+import WorktreeTerritoryLayer from './WorktreeTerritoryLayer'
+it('allocates the backing store once during setup and only resizes changed dimensions', () => {
+  vi.stubGlobal('requestAnimationFrame', () => 1)
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  vi.stubGlobal('devicePixelRatio', 1)
+  const widths = vi.spyOn(HTMLCanvasElement.prototype, 'width', 'set')
+  const heights = vi.spyOn(HTMLCanvasElement.prototype, 'height', 'set')
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  try {
+    act(() => root.render(<WorktreeTerritoryLayer containerWidth={800} containerHeight={600} />))
+    expect(widths.mock.calls.filter(([value]) => value === 800)).toHaveLength(1)
+    expect(heights.mock.calls.filter(([value]) => value === 600)).toHaveLength(1)
+    act(() => root.render(<WorktreeTerritoryLayer containerWidth={900} containerHeight={600} />))
+    expect(widths.mock.calls.filter(([value]) => value === 900)).toHaveLength(1)
+    expect(heights.mock.calls.filter(([value]) => value === 600)).toHaveLength(1)
+  } finally { act(() => root.unmount()); host.remove(); vi.restoreAllMocks(); vi.unstubAllGlobals() }
+})

--- a/src/renderer/canvas/worktree/WorktreeTerritoryLayer.tsx
+++ b/src/renderer/canvas/worktree/WorktreeTerritoryLayer.tsx
@@ -161,14 +161,20 @@ const WorktreeTerritoryLayer: React.FC<Props> = ({ containerWidth, containerHeig
     if (backendRef.current === 'gl') {
       const c = glCanvasRef.current
       if (c) {
-        c.width = dw; c.height = dh
+        // Assigning an unchanged dimension still resets the backing store.
+        // Setup calls sizeActive repeatedly; allocate only on a real resize.
+        if (c.width !== dw) c.width = dw
+        if (c.height !== dh) c.height = dh
         c.style.width = w + 'px'; c.style.height = h + 'px'
         glRef.current?.resize(dw, dh)
       }
     } else {
       const c = cpuCanvasRef.current
       if (c) {
-        c.width = dw; c.height = dh
+        // Assigning an unchanged dimension still resets the backing store.
+        // Setup calls sizeActive repeatedly; allocate only on a real resize.
+        if (c.width !== dw) c.width = dw
+        if (c.height !== dh) c.height = dh
         c.style.width = w + 'px'; c.style.height = h + 'px'
         c.getContext('2d')?.setTransform(dpr, 0, 0, dpr, 0, 0)
       }

--- a/src/renderer/lib/e2eHarness.ts
+++ b/src/renderer/lib/e2eHarness.ts
@@ -50,6 +50,7 @@ declare global {
     __cateE2E?: {
       ready: true
       activeCanvasPanelId(): string | null
+      selectedWorkspaceId(): string
       createTerminal(point: Point): string
       createEditor(point: Point): string
       createCanvasPanel(point: Point): string
@@ -527,6 +528,7 @@ export function installE2EHarness(): void {
   window.__cateE2E = {
     ready: true,
     activeCanvasPanelId,
+    selectedWorkspaceId: () => useAppStore.getState().selectedWorkspaceId,
     createTerminal,
     createEditor,
     createCanvasPanel,

--- a/src/renderer/lib/perf/measurementWindow.test.ts
+++ b/src/renderer/lib/perf/measurementWindow.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest'
+import { createMeasurementWindow } from './measurementWindow'
+
+it('keeps benchmark long tasks and frame stalls when the HUD resets', () => {
+  const hud = createMeasurementWindow()
+  const benchmark = createMeasurementWindow()
+  for (const window of [hud, benchmark]) {
+    window.reset(0)
+    for (const time of [0, 10, 20, 120]) window.frame(time)
+    window.longTask(20, 100)
+  }
+  hud.reset(121)
+  expect(hud.longTasks().count).toBe(0)
+  expect(benchmark.longTasks()).toEqual({ count: 1, maxMs: 100 })
+  expect(benchmark.frames()).toEqual({ samples: 3, fps: 25, meanMs: 40, p95Ms: 100, maxMs: 100 })
+  benchmark.reset(130)
+  benchmark.longTask(120, 90) // Observer delivery from the preceding window.
+  expect(benchmark.longTasks().count).toBe(0)
+  expect(benchmark.frames().samples).toBe(0)
+  benchmark.frame(500)
+  benchmark.frame(510)
+  expect(benchmark.frames().meanMs).toBe(10)
+})

--- a/src/renderer/lib/perf/measurementWindow.ts
+++ b/src/renderer/lib/perf/measurementWindow.ts
@@ -1,0 +1,46 @@
+/** Independent, bounded measurement windows for the HUD and automated runs. */
+export function createMeasurementWindow() {
+  let lastFrame: number | undefined
+  let intervals = 0
+  let totalMs = 0
+  let maxMs = 0
+  const histogram = new Map<number, number>()
+  let longTaskCount = 0
+  let longTaskMaxMs = 0
+  let startedAt = 0
+  return {
+    frame(now: number) {
+      if (lastFrame !== undefined) {
+        const ms = now - lastFrame
+        intervals++
+        totalMs += ms
+        maxMs = Math.max(maxMs, ms)
+        // 0.1 ms buckets; exceptionally long gaps share an overflow bucket.
+        const bucket = Math.min(100_000, Math.round(ms * 10))
+        histogram.set(bucket, (histogram.get(bucket) ?? 0) + 1)
+      }
+      lastFrame = now
+    },
+    longTask(startTime: number, duration: number) {
+      if (startTime < startedAt) return
+      longTaskCount++
+      longTaskMaxMs = Math.max(longTaskMaxMs, duration)
+    },
+    longTasks: () => ({ count: longTaskCount, maxMs: longTaskMaxMs }),
+    frames() {
+      let accumulated = 0
+      let p95Ms = 0
+      for (const [bucket, count] of [...histogram].sort((a, b) => a[0] - b[0])) {
+        accumulated += count
+        if (accumulated >= Math.ceil(intervals * 0.95)) { p95Ms = bucket / 10; break }
+      }
+      return { samples: intervals, fps: totalMs > 0 ? intervals * 1000 / totalMs : 0, meanMs: intervals ? totalMs / intervals : 0, p95Ms, maxMs }
+    },
+    reset(now: number) {
+      startedAt = now
+      lastFrame = undefined
+      intervals = totalMs = maxMs = longTaskCount = longTaskMaxMs = 0
+      histogram.clear()
+    },
+  }
+}

--- a/src/renderer/lib/perf/perfClient.ts
+++ b/src/renderer/lib/perf/perfClient.ts
@@ -14,6 +14,7 @@
 // =============================================================================
 
 import { useEffect } from 'react'
+import { createMeasurementWindow } from './measurementWindow'
 
 export const PERF_ENABLED = Boolean(
   typeof window !== 'undefined' &&
@@ -56,33 +57,18 @@ export function useRenderCount(name: string): void {
   })
 }
 
-// --- Long tasks --------------------------------------------------------------
-let longTaskCount = 0
-let longTaskMaxMs = 0
-let longTaskObserver: PerformanceObserver | null = null
+const hudWindow = createMeasurementWindow()
+const testWindow = createMeasurementWindow()
+let longTasksSupported = false
 
-export function getLongTasks(): { count: number; maxMs: number } {
-  return { count: longTaskCount, maxMs: longTaskMaxMs }
-}
-
-// --- FPS ---------------------------------------------------------------------
-let fps = 0
-let frameCount = 0
-let lastFpsAt = 0
-
-export function getFps(): number {
-  return fps
-}
+export const isLongTaskObserverSupported = (): boolean => longTasksSupported
+export const getLongTasks = hudWindow.longTasks
+export const getFrameTimes = hudWindow.frames
+export const getFps = (): number => Math.round(hudWindow.frames().fps)
 
 function frameTick(now: number): void {
-  frameCount++
-  if (lastFpsAt === 0) lastFpsAt = now
-  const elapsed = now - lastFpsAt
-  if (elapsed >= 1000) {
-    fps = Math.round((frameCount * 1000) / elapsed)
-    frameCount = 0
-    lastFpsAt = now
-  }
+  hudWindow.frame(now)
+  testWindow.frame(now)
   requestAnimationFrame(frameTick)
 }
 
@@ -92,6 +78,8 @@ declare global {
   interface Window {
     /** Exposed only under CATE_PERF=1 — read by the e2e perf-stress harness. */
     __catePerf?: {
+      frames(): ReturnType<ReturnType<typeof createMeasurementWindow>['frames']>
+      longTasksSupported(): boolean
       fps(): number
       longTasks(): { count: number; maxMs: number }
       renderCounts(): Record<string, number>
@@ -107,20 +95,23 @@ export function initPerfClient(): void {
 
   // Expose a read API for the e2e perf-stress test (page.evaluate reads these).
   window.__catePerf = {
-    fps: () => fps,
-    longTasks: () => ({ count: longTaskCount, maxMs: longTaskMaxMs }),
+    frames: testWindow.frames,
+    longTasksSupported: () => longTasksSupported,
+    fps: () => Math.round(testWindow.frames().fps),
+    longTasks: testWindow.longTasks,
     renderCounts: () => Object.fromEntries(renderCounts),
-    resetWindow: () => resetPerfWindow(),
+    resetWindow: () => testWindow.reset(performance.now()),
   }
 
   try {
-    longTaskObserver = new PerformanceObserver((list) => {
+    const longTaskObserver = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
-        longTaskCount++
-        if (entry.duration > longTaskMaxMs) longTaskMaxMs = entry.duration
+        hudWindow.longTask(entry.startTime, entry.duration)
+        testWindow.longTask(entry.startTime, entry.duration)
       }
     })
     longTaskObserver.observe({ entryTypes: ['longtask'] })
+    longTasksSupported = PerformanceObserver.supportedEntryTypes.includes('longtask')
   } catch {
     // longtask not supported in this Chromium build — skip silently.
   }
@@ -130,6 +121,5 @@ export function initPerfClient(): void {
 
 /** Reset the per-second rolling counters. The HUD calls this after each read. */
 export function resetPerfWindow(): void {
-  longTaskCount = 0
-  longTaskMaxMs = 0
+  hudWindow.reset(performance.now())
 }

--- a/src/renderer/lib/t3ActivitySubscription.test.ts
+++ b/src/renderer/lib/t3ActivitySubscription.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+import { subscribeT3Activity } from './t3ActivitySubscription'
+import { useT3ActivityStore } from '../stores/t3ActivityStore'
+
+afterEach(() => { vi.useRealTimers(); useT3ActivityStore.setState({ panels: {}, instances: {} }) })
+
+it('shares polling, hands off on owner close, and ignores late responses', async () => {
+  vi.useFakeTimers()
+  const snapshot = { connected: true, revision: 1, sequence: 1, threads: { a: { id: 'a', title: 'A' } } }
+  const guests = [0, 1].map(() => ({ executeJavaScript: vi.fn(async () => snapshot) }))
+  const callbacks = [vi.fn(), vi.fn()]
+  const subscriptions = guests.map((guest, index) => {
+    const panelId = String(index)
+    useT3ActivityStore.getState().bind(panelId, { workspaceId: 'ws', partition: 'repo' })
+    return subscribeT3Activity('repo', { panelId, guest, onSnapshot: callbacks[index] })
+  })
+  try {
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(guests[0].executeJavaScript).toHaveBeenCalledTimes(3)
+    expect(guests[1].executeJavaScript).not.toHaveBeenCalled()
+    expect(callbacks.every((callback) => callback.mock.calls.length > 0)).toBe(true)
+    let release!: (value: typeof snapshot) => void
+    guests[0].executeJavaScript.mockImplementation((script?: string) => script?.startsWith('/* cate-t3-poll */')
+      ? new Promise((resolve) => { release = resolve }) : Promise.resolve(snapshot))
+    await vi.advanceTimersByTimeAsync(1000)
+    subscriptions[0]()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(guests[1].executeJavaScript).toHaveBeenCalledOnce()
+    release({ ...snapshot, sequence: 99, threads: { a: { id: 'a', title: 'Late' } } })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(useT3ActivityStore.getState().instances.repo.threads.a.title).toBe('A')
+  } finally { subscriptions.forEach((stop) => stop()) }
+})
+
+it('does not spin when every guest fails', async () => {
+  vi.useFakeTimers()
+  const stops = [0, 1].map((index) => {
+    const panelId = String(index)
+    useT3ActivityStore.getState().bind(panelId, { workspaceId: 'ws', partition: 'failure' })
+    const guest = { executeJavaScript: vi.fn(async () => { throw new Error('offline') }) }
+    return { guest, stop: subscribeT3Activity('failure', { panelId, guest, onSnapshot: vi.fn() }) }
+  })
+  try {
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(stops.reduce((sum, { guest }) => sum + guest.executeJavaScript.mock.calls.length, 0)).toBeLessThanOrEqual(8)
+  } finally { stops.forEach(({ stop }) => stop()) }
+})

--- a/src/renderer/lib/t3ActivitySubscription.ts
+++ b/src/renderer/lib/t3ActivitySubscription.ts
@@ -1,0 +1,92 @@
+import { t3ThreadPollScript } from './t3ThreadState'
+import { useT3ActivityStore, type T3Snapshot } from '../stores/t3ActivityStore'
+import { perfCount } from './perf/perfClient'
+
+interface Guest { executeJavaScript(script: string): Promise<unknown> }
+interface Consumer { panelId: string; guest: Guest; onSnapshot: (snapshot: T3Snapshot) => void }
+interface Subscription {
+  partition: string
+  consumers: Set<Consumer>
+  failed: Set<Consumer>
+  owner?: Consumer
+  timer?: ReturnType<typeof setTimeout>
+  revision?: number
+  generation: number
+  connected: boolean
+}
+const subscriptions = new Map<string, Subscription>()
+
+function stopOwner(entry: Subscription): void {
+  entry.generation++
+  clearTimeout(entry.timer)
+  const owner = entry.owner
+  entry.owner = undefined
+  entry.revision = undefined
+  if (owner) {
+    try { void owner.guest.executeJavaScript('window.__cateT3Threads?.dispose()').catch(() => {}) } catch { /* detached guest */ }
+  }
+}
+
+async function poll(entry: Subscription): Promise<void> {
+  const owner = entry.owner ?? entry.consumers.values().next().value
+  if (!owner) return
+  entry.owner = owner
+  const generation = entry.generation
+  try {
+    perfCount('agentMetadataPoll')
+    const snapshot = await owner.guest.executeJavaScript(t3ThreadPollScript(entry.revision)) as T3Snapshot | undefined
+    if (generation !== entry.generation) return
+    entry.failed.delete(owner)
+    if (snapshot) {
+      entry.revision = snapshot.revision
+      entry.connected = snapshot.connected
+      perfCount('agentMetadataThreads', Object.keys(snapshot.threads).length)
+      const store = useT3ActivityStore.getState()
+      store.update(entry.partition, snapshot, owner.panelId)
+      const current = useT3ActivityStore.getState().instances[entry.partition]
+      for (const participant of entry.consumers) {
+        if (entry.failed.has(participant)) continue
+        store.setConnected(participant.panelId, snapshot.connected)
+        if (current && snapshot.connected) participant.onSnapshot(current)
+      }
+    }
+  } catch {
+    if (generation !== entry.generation) return
+    entry.failed.add(owner)
+    useT3ActivityStore.getState().setConnected(owner.panelId, false)
+    // Rotate through ready guests, at a bounded cadence even if all fail.
+    entry.consumers.delete(owner)
+    entry.consumers.add(owner)
+    stopOwner(entry)
+    entry.connected = false
+  }
+  entry.timer = setTimeout(() => { void poll(entry) }, 1000)
+}
+
+/** One metadata socket/poll per harness partition in this renderer. Navigating
+ * or closing the owning guest hands off to a sibling without losing metadata. */
+export function subscribeT3Activity(partition: string, consumer: Consumer): () => void {
+  let entry = subscriptions.get(partition)
+  if (!entry) {
+    entry = { partition, consumers: new Set(), failed: new Set(), generation: 0, connected: false }
+    subscriptions.set(partition, entry)
+  }
+  const subscription = entry
+  subscription.consumers.add(consumer)
+  if (!subscription.owner && subscription.consumers.size === 1) void poll(subscription)
+  else if (subscription.connected) {
+    const snapshot = useT3ActivityStore.getState().instances[partition]
+    useT3ActivityStore.getState().setConnected(consumer.panelId, true)
+    if (snapshot) consumer.onSnapshot(snapshot)
+  }
+  return () => {
+    subscription.consumers.delete(consumer)
+    subscription.failed.delete(consumer)
+    if (subscription.owner === consumer || subscription.consumers.size === 0) {
+      stopOwner(subscription)
+      if (subscription.consumers.size) void poll(subscription)
+      else subscriptions.delete(partition)
+    }
+    useT3ActivityStore.getState().setConnected(consumer.panelId, false)
+  }
+}

--- a/src/renderer/lib/t3ThreadState.test.ts
+++ b/src/renderer/lib/t3ThreadState.test.ts
@@ -25,6 +25,8 @@ describe('T3 conversation state', () => {
     class FakeSocket {
       send = vi.fn()
       close = vi.fn()
+      // Capture the guest-created socket so the test can drive server events.
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
       constructor() { socket = this }
     }
     const window: any = { addEventListener: vi.fn() }
@@ -54,17 +56,17 @@ describe('T3 conversation state', () => {
 it('copies thread metadata only when changed and can force a fresh read', () => {
   const state = { connected: true, revision: 7, sequence: 12, threads: { a: { id: 'a', title: 'First' } } }
   const context = { window: { __cateT3Threads: state } }
-  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual(state)
+  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual({ connected: state.connected, revision: state.revision, sequence: state.sequence, threads: state.threads })
   expect(runInNewContext(t3ThreadPollScript(7), context)).toBeUndefined()
   state.threads.a.title = 'Updated'
   state.revision++
-  expect(runInNewContext(t3ThreadPollScript(7), context)).toEqual(state)
+  expect(runInNewContext(t3ThreadPollScript(7), context)).toEqual({ connected: state.connected, revision: state.revision, sequence: state.sequence, threads: state.threads })
   expect(runInNewContext(t3ThreadPollScript(8), context)).toBeUndefined()
   // Disconnects must still reach the host, even with unchanged thread content.
   state.connected = false
   state.revision++
   expect(runInNewContext(t3ThreadPollScript(8), context)?.connected).toBe(false)
-  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual(state)
+  expect(runInNewContext(t3ThreadPollScript(), context)).toEqual({ connected: state.connected, revision: state.revision, sequence: state.sequence, threads: state.threads })
 })
 
 it('installs a single subscription when polling an uninitialized guest', () => {
@@ -77,4 +79,26 @@ it('installs a single subscription when polling an uninitialized guest', () => {
   expect(runInNewContext(t3ThreadPollScript(), context)?.revision).toBe(0)
   for (let i = 0; i < 20; i++) expect(runInNewContext(t3ThreadPollScript(0), context)).toBeUndefined()
   expect(sockets).toHaveBeenCalledOnce()
+})
+
+it('sends changed threads only, includes removals, and recovers a lost poll with a full snapshot', () => {
+  let socket: any
+  // Capture the guest-created socket so the test can drive server events.
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  class FakeSocket { send = vi.fn(); close = vi.fn(); constructor() { socket = this } }
+  const context = { window: { addEventListener: vi.fn(), removeEventListener: vi.fn() }, WebSocket: FakeSocket,
+    location: { origin: 'http://localhost' }, setTimeout: vi.fn(), clearTimeout: vi.fn() }
+  runInNewContext(t3ThreadPollScript(), context)
+  const emit = (event: unknown) => socket.onmessage({ data: JSON.stringify({ _tag: 'Chunk', requestId: 'cate-shell', values: [event] }) })
+  emit({ kind: 'snapshot', snapshot: { snapshotSequence: 1, threads: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }] } })
+  const initial = runInNewContext(t3ThreadPollScript(0), context)
+  expect(Object.keys(initial.threads)).toEqual(['a', 'b'])
+  emit({ kind: 'thread-upserted', sequence: 2, thread: { id: 'b', title: 'Changed' } })
+  const delta = runInNewContext(t3ThreadPollScript(initial.revision), context)
+  expect(delta).toMatchObject({ full: false, threads: { b: { title: 'Changed' } }, sequence: 2 })
+  expect(Object.keys(delta.threads)).toEqual(['b'])
+  // Pretend delivery of the delta failed: the next read must not lose b.
+  expect(Object.keys(runInNewContext(t3ThreadPollScript(initial.revision), context).threads)).toEqual(['a', 'b'])
+  emit({ kind: 'thread-removed', sequence: 3, threadId: 'a' })
+  expect(runInNewContext(t3ThreadPollScript(delta.revision), context)).toMatchObject({ full: false, removed: ['a'], threads: {} })
 })

--- a/src/renderer/lib/t3ThreadState.ts
+++ b/src/renderer/lib/t3ThreadState.ts
@@ -26,7 +26,7 @@ export function t3ThreadActivity(thread: T3Thread): AgentState {
  */
 export const T3_THREAD_SUBSCRIPTION_SCRIPT = `(() => {
   if (window.__cateT3Threads) return;
-  const state = window.__cateT3Threads = { connected: false, threads: {}, revision: 0, sequence: 0 };
+  const state = window.__cateT3Threads = { connected: false, threads: {}, revision: 0, sequence: 0, dirty: new Set(), removed: new Set(), fullPending: true };
   let socket;
   let timer;
   const connect = () => {
@@ -46,10 +46,17 @@ export const T3_THREAD_SUBSCRIPTION_SCRIPT = `(() => {
               hasActionableProposedPlan: t.hasActionableProposedPlan, backgroundLiveness: t.backgroundLiveness });
             if (event.kind === 'snapshot') {
               state.threads = Object.fromEntries(event.snapshot.threads.map(t => [t.id, pick(t)]));
-              state.sequence = event.snapshot.snapshotSequence;
+              state.sequence = event.snapshot.snapshotSequence ?? 0;
+              state.fullPending = true;
+              state.dirty.clear(); state.removed.clear();
               state.connected = true;
-            } else if (event.kind === 'thread-upserted') state.threads[event.thread.id] = pick(event.thread);
-            else if (event.kind === 'thread-removed') delete state.threads[event.threadId];
+            } else if (event.kind === 'thread-upserted') {
+              state.threads[event.thread.id] = pick(event.thread);
+              state.dirty.add(event.thread.id); state.removed.delete(event.thread.id);
+            } else if (event.kind === 'thread-removed') {
+              delete state.threads[event.threadId];
+              state.dirty.delete(event.threadId); state.removed.add(event.threadId);
+            }
             if (typeof event.sequence === 'number') state.sequence = event.sequence;
             state.revision++;
           }
@@ -60,7 +67,12 @@ export const T3_THREAD_SUBSCRIPTION_SCRIPT = `(() => {
     socket.onclose = () => { state.connected = false; state.revision++; timer = setTimeout(connect, 2000); };
     socket.onerror = () => socket.close();
   };
-  window.addEventListener('pagehide', () => { clearTimeout(timer); socket.onclose = null; socket.close(); }, { once: true });
+  const dispose = state.dispose = () => {
+    clearTimeout(timer); socket.onclose = null; socket.close();
+    window.removeEventListener('pagehide', dispose);
+    delete window.__cateT3Threads;
+  };
+  window.addEventListener('pagehide', dispose, { once: true });
   connect();
 })()`
 
@@ -72,6 +84,13 @@ export function t3ThreadPollScript(previousRevision?: number): string {
     ${T3_THREAD_SUBSCRIPTION_SCRIPT};
     const state = window.__cateT3Threads;
     if (state.revision === ${previousRevision === undefined ? 'null' : JSON.stringify(previousRevision)}) return;
-    return { connected: state.connected, threads: state.threads, revision: state.revision, sequence: state.sequence };
+    const previous = ${previousRevision === undefined ? 'null' : JSON.stringify(previousRevision)};
+    const full = previous === null || previous !== state.lastReadRevision || state.fullPending || !state.dirty;
+    const threads = full ? state.threads : Object.fromEntries([...state.dirty].map(id => [id, state.threads[id]]));
+    const result = { connected: state.connected, threads, revision: state.revision, sequence: state.sequence,
+      ...(full ? {} : { full: false, removed: [...state.removed] }) };
+    state.lastReadRevision = state.revision; state.fullPending = false;
+    state.dirty?.clear(); state.removed?.clear();
+    return result;
   })()`
 }

--- a/src/renderer/lib/terminal/terminalDom.ts
+++ b/src/renderer/lib/terminal/terminalDom.ts
@@ -9,6 +9,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { registry, has, type RegistryEntry } from './registryState'
 import { finalizeReconnect } from './terminalLifecycle'
+import { perfCount } from '../perf/perfClient'
 
 /** Panels whose WebGL context was lost — Chromium caps simultaneous WebGL
  *  contexts (~16), and many open terminals (e.g. an agent driving several at
@@ -88,6 +89,7 @@ function webglCeilingReached(): boolean {
  * (besides a cheap refresh) on the canvas renderer fallback.
  */
 export function forceWebglRepaint(): void {
+  perfCount('terminalAtlasPass')
   for (const entry of registry.values()) {
     try {
       entry.webglAddon?.clearTextureAtlas()
@@ -96,6 +98,21 @@ export function forceWebglRepaint(): void {
       /* renderer mid-dispose — ignore */
     }
   }
+}
+
+// Recovery must still clear all users of the shared atlas, but simultaneous
+// attaches share one pass per frame instead of each clearing the entire window.
+let repaintFrame: number | null = null
+let repaintFramesRemaining = 0
+function scheduleWebglRepaint(frames = 1): void {
+  repaintFramesRemaining = Math.max(repaintFramesRemaining, frames)
+  if (repaintFrame !== null) return
+  const repaint = () => {
+    repaintFrame = null
+    forceWebglRepaint()
+    if (--repaintFramesRemaining > 0) repaintFrame = requestAnimationFrame(repaint)
+  }
+  repaintFrame = requestAnimationFrame(repaint)
 }
 
 /**
@@ -131,6 +148,7 @@ function createWebglAddon(panelId: string): void {
   const entry = registry.get(panelId)
   if (!entry || entry.webglAddon) return
   try {
+    perfCount('terminalWebglCreate')
     const newWebgl = new WebglAddon()
     newWebgl.onContextLoss(() => {
       try { newWebgl.dispose() } catch { /* ignore */ }
@@ -147,12 +165,32 @@ function createWebglAddon(panelId: string): void {
     entry.webglAddon = newWebgl
     // The DOM renderer may have laid out the shared glyph atlas differently;
     // resync every terminal so this fresh WebGL renderer doesn't start desynced.
-    forceWebglRepaint()
+    scheduleWebglRepaint()
   } catch {
     // Context creation failed outright — DOM fallback; don't retry, release slot.
     webglDisabledPanels.add(panelId)
     releaseWebglGrant(panelId)
   }
+}
+
+// Context/shader creation is synchronous even when a grant is already held.
+// On workspace return, spread optional GPU upgrades across frames; xterm's
+// fallback renderer remains usable throughout. Coalesce repeated attaches.
+const queuedWebglUpgrades = new Set<string>()
+let upgradeFrame: number | null = null
+function scheduleWebglUpgrade(panelId: string): void {
+  queuedWebglUpgrades.add(panelId)
+  if (upgradeFrame !== null) return
+  const next = () => {
+    upgradeFrame = null
+    const id = queuedWebglUpgrades.values().next().value
+    if (id === undefined) return
+    queuedWebglUpgrades.delete(id)
+    const entry = registry.get(id)
+    if (entry?.terminal.element?.isConnected) void maybeUpgradeToWebgl(id)
+    if (queuedWebglUpgrades.size) upgradeFrame = requestAnimationFrame(next)
+  }
+  upgradeFrame = requestAnimationFrame(next)
 }
 
 /**
@@ -350,7 +388,7 @@ export function attach(panelId: string, container: HTMLDivElement): void {
   // context grant from main, so we never create a context we weren't allotted —
   // that's what used to leave over-limit terminals blank. Denied grants stay on
   // the DOM renderer. Fire-and-forget: attach() must stay synchronous.
-  void maybeUpgradeToWebgl(panelId)
+  scheduleWebglUpgrade(panelId)
 
   // Fit after the next frame — the container may still be mid-layout during
   // the sync DOM append (e.g. WebGL canvas initialization).  Retry up to 5
@@ -403,11 +441,7 @@ export function attach(panelId: string, container: HTMLDivElement): void {
     // while hidden against a stale DPR/size, so the first paint can be blank or
     // garbled until the atlas is rebuilt at the live DPR. The extra frames
     // cover a window still settling its size/DPR on the first painted frame.
-    forceWebglRepaint()
-    requestAnimationFrame(() => {
-      forceWebglRepaint()
-      requestAnimationFrame(() => forceWebglRepaint())
-    })
+    scheduleWebglRepaint(3)
 
     // Now that the xterm is sized to its real container, replay captured
     // scrollback and release the main-side PTY buffer. Order matters:

--- a/src/renderer/panels/AgentPanel.tsx
+++ b/src/renderer/panels/AgentPanel.tsx
@@ -267,6 +267,7 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
       className="flex h-full w-full flex-col bg-surface-4"
       data-agent-panel-id={panelId}
       data-agent-phase={state.phase}
+      data-agent-connected={t3Connection === true}
     >
       <div className="relative min-h-0 flex-1">
         {state.phase === 'ready' && guestReady && t3Connection === false && (

--- a/src/renderer/panels/AgentPanel.tsx
+++ b/src/renderer/panels/AgentPanel.tsx
@@ -1,6 +1,6 @@
 import { LoadingState } from '../ui/Spinner'
-import { t3ThreadPollScript } from '../lib/t3ThreadState'
-import { useT3ActivityStore, type T3Snapshot } from '../stores/t3ActivityStore'
+import { subscribeT3Activity } from '../lib/t3ActivitySubscription'
+import { useT3ActivityStore } from '../stores/t3ActivityStore'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ArrowClockwise, ChatsCircle } from '@phosphor-icons/react'
 import type { AgentPanelProps } from './types'
@@ -253,28 +253,13 @@ export default function AgentPanel({ panelId, workspaceId, nodeId }: AgentPanelP
     if (state.phase !== 'ready' || !guestReady) return
     const guest = webviewRef.current
     if (!guest) return
-    const store = useT3ActivityStore.getState()
-    let cancelled = false
-    let timer: ReturnType<typeof setTimeout>
-    let previousRevision: number | undefined
-    const poll = async () => {
-      try {
-        const snapshot = await guest.executeJavaScript(t3ThreadPollScript(previousRevision)) as T3Snapshot | undefined
-        if (cancelled) return
-        if (snapshot) {
-          previousRevision = snapshot.revision
-          store.update(state.partition, snapshot, panelId)
-          const thread = threadId ? snapshot.threads[threadId] : undefined
-          if (snapshot.connected && thread?.title) useAppStore.getState().updatePanelTitleFromAgent(workspaceId, panelId, thread.title)
-        }
-      } catch {
-        previousRevision = undefined
-        if (!cancelled) store.update(state.partition, { connected: false, threads: {}, revision: -1 }, panelId)
-      }
-      if (!cancelled) timer = setTimeout(poll, 1000)
-    }
-    void poll()
-    return () => { cancelled = true; clearTimeout(timer) }
+    return subscribeT3Activity(state.partition, {
+      panelId, guest,
+      onSnapshot: (snapshot) => {
+        const thread = threadId ? snapshot.threads[threadId] : undefined
+        if (thread?.title) useAppStore.getState().updatePanelTitleFromAgent(workspaceId, panelId, thread.title)
+      },
+    })
   }, [state, guestReady, threadId, panelId, workspaceId])
 
   return (

--- a/src/renderer/panels/BackgroundBrowserHost.test.tsx
+++ b/src/renderer/panels/BackgroundBrowserHost.test.tsx
@@ -6,6 +6,8 @@ import type { WorkspaceState } from '../../shared/types'
 
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
+vi.mock('./AgentPanel', () => ({ default: ({ panelId }: { panelId: string }) => <div data-retained-agent={panelId} /> }))
+
 vi.mock('./BrowserPanel', () => ({
   default: ({ panelId, workspaceId }: { panelId: string; workspaceId: string }) => (
     <div data-browser-panel={panelId} data-workspace={workspaceId} />
@@ -56,13 +58,14 @@ afterEach(() => {
 })
 
 describe('BackgroundBrowserHost', () => {
-  it('mounts every browser once and exposes only the surface with a visible slot', () => {
+  it('mounts every browser once and exposes only the surface with a visible slot', async () => {
     act(() => root.render(
       <PersistentBrowserHostContext.Provider value>
         <SurfaceSlot />
         <BackgroundBrowserHost />
       </PersistentBrowserHostContext.Provider>,
     ))
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)) })
     expect(host.querySelector('[data-browser-surface="browser-one"]')?.getAttribute('data-browser-surface-visible')).toBe('true')
     expect(host.querySelector('[data-browser-surface="browser-two"]')?.getAttribute('data-browser-surface-visible')).toBe('false')
   })
@@ -79,4 +82,19 @@ describe('BackgroundBrowserHost', () => {
     act(() => useAppStore.setState({ selectedWorkspaceId: 'one' }))
     expect(host.querySelector('[data-browser-panel="browser-one"]')).toBe(original)
   })
+})
+
+it('retains T3 for a warm return and evicts the least recent workspace', async () => {
+  const all = ['one', 'two', 'three'].map((id) => ({ ...workspace(id), panels: {
+    [`agent-${id}`]: { id: `agent-${id}`, type: 'agent' as const, title: 'Agent', isDirty: false },
+  } }))
+  act(() => { useAppStore.setState({ workspaces: all }); root.render(<BackgroundBrowserHost />) })
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)) })
+  const original = host.querySelector('[data-retained-agent="agent-one"]')
+  expect(original).not.toBeNull()
+  act(() => useAppStore.setState({ selectedWorkspaceId: 'two' }))
+  act(() => useAppStore.setState({ selectedWorkspaceId: 'one' }))
+  expect(host.querySelector('[data-retained-agent="agent-one"]')).toBe(original)
+  act(() => useAppStore.setState({ selectedWorkspaceId: 'three' }))
+  expect(host.querySelector('[data-retained-agent="agent-two"]')).toBeNull()
 })

--- a/src/renderer/panels/BackgroundBrowserHost.tsx
+++ b/src/renderer/panels/BackgroundBrowserHost.tsx
@@ -1,21 +1,23 @@
 // =============================================================================
-// BackgroundBrowserHost — owns each main-window browser guest for its lifetime.
+// BackgroundBrowserHost — persistent browser guests and recently used T3 guests.
 //
 // BrowserPanel renders once into a stable external container which never moves
 // or disconnects. The visible shell contributes only a geometry slot; the
 // registry aligns the fixed container to it, including the canvas transform.
-// Inactive surfaces are moved off-screen visually, keeping the same guest
+// Inactive surfaces are parked without resizing, keeping the same guest
 // webContents, DOM, history and form state across workspace transitions.
 // =============================================================================
 
-import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import { lazy, memo, Suspense, useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useAppStore } from '../stores/appStore'
 import BrowserPanel from './BrowserPanel'
 import { registerBrowserSurface } from './browserSurfaceRegistry'
 import type { PanelState } from '../../shared/types'
 
-function PersistentBrowserSurface({
+const AgentPanel = lazy(() => import('./AgentPanel'))
+
+const PersistentBrowserSurface = memo(function PersistentBrowserSurface({
   workspaceId,
   panel,
   backgroundRoot,
@@ -38,7 +40,7 @@ function PersistentBrowserSurface({
   useLayoutEffect(() => () => container.remove(), [container])
 
   return createPortal(
-    <BrowserPanel
+    panel.type === 'agent' ? <Suspense fallback={null}><AgentPanel panelId={panel.id} workspaceId={workspaceId} /></Suspense> : <BrowserPanel
       panelId={panel.id}
       workspaceId={workspaceId}
       tabs={panel.tabs!}
@@ -47,10 +49,14 @@ function PersistentBrowserSurface({
     />,
     container,
   )
-}
+})
 
-export default function BackgroundBrowserHost(): React.ReactElement | null {
+export default function BackgroundBrowserHost({ workspaceId }: { workspaceId?: string }): React.ReactElement | null {
   const workspaces = useAppStore((state) => state.workspaces)
+  const selected = useAppStore((state) => workspaceId ?? state.selectedWorkspaceId)
+  // Bound retained T3 UIs. Closing/removing panels still unmounts immediately.
+  const [recent, setRecent] = useState([selected])
+  if (recent[0] !== selected) setRecent([selected, ...recent.filter((id) => id !== selected)].slice(0, 2))
   const [backgroundRoot, setBackgroundRoot] = useState<HTMLDivElement | null>(null)
   const setRootRef = useCallback((element: HTMLDivElement | null) => {
     setBackgroundRoot(element)
@@ -58,12 +64,11 @@ export default function BackgroundBrowserHost(): React.ReactElement | null {
   const browsers = useMemo(() => workspaces.flatMap((workspace) => (
     Object.values(workspace.panels)
       .filter((panel) => (
-        panel.type === 'browser'
-        && Boolean(panel.tabs?.length)
-        && Boolean(panel.activeTabId)
+        (panel.type === 'browser' && Boolean(panel.tabs?.length) && Boolean(panel.activeTabId))
+        || (panel.type === 'agent' && recent.includes(workspace.id))
       ))
       .map((panel) => ({ workspaceId: workspace.id, panel }))
-  )), [workspaces])
+  )), [workspaces, recent])
 
   if (browsers.length === 0) return null
 

--- a/src/renderer/panels/CanvasPanel.tsx
+++ b/src/renderer/panels/CanvasPanel.tsx
@@ -15,7 +15,7 @@ import CanvasToolbar from '../canvas/CanvasToolbar'
 import WelcomePage from '../ui/WelcomePage'
 import { NodeErrorBoundary } from '../ui/NodeErrorBoundary'
 import type { PanelType, Point, DockLayoutNode, WindowDockState } from '../../shared/types'
-import { useAppStore, useSelectedWorkspace, type PanelPlacement } from '../stores/appStore'
+import { useAppStore, type PanelPlacement } from '../stores/appStore'
 import type { StoreApi } from 'zustand'
 import { useKeepMountedPanelIds } from './keepMountedPanels'
 import { ensureWorkspaceFolder } from '../hooks/useShortcuts'
@@ -30,6 +30,7 @@ import {
 } from './nodeDockRegistry'
 import { getPanelDef } from '../panels/registry'
 import { inheritedWorktreeFromSelection } from '../lib/inheritWorktree'
+import { useShallow } from 'zustand/react/shallow'
 import { activeDockPanelId } from '../../shared/collectPanelIds'
 import { PanelConnectionLayer } from '../canvas/PanelConnectionLayer'
 
@@ -50,15 +51,17 @@ interface CanvasPanelProps {
 // CanvasNodeWrapper — reads its own node slice so re-renders stay local
 // ---------------------------------------------------------------------------
 
-const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, renderPanelContent }: {
+const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, workspaceId, renderPanelContent }: {
   nodeId: string
   canvasPanelId: string
+  workspaceId: string
   renderPanelContent?: (panelId: string, nodeId: string, zoomLevel: number) => React.ReactNode
 }) => {
   useRenderCount('CanvasNodeWrapper')
   const node = useCanvasStoreContext((s) => s.nodes[nodeId])
   const isFocused = useCanvasStoreContext((s) => focusedNodeId(s) === nodeId)
-  const currentWorkspace = useSelectedWorkspace()
+  const firstPanelId = node ? activeDockPanelId(node.dockLayout) : undefined
+  const title = useAppStore((s) => firstPanelId ? s.workspaces.find((w) => w.id === workspaceId)?.panels[firstPanelId]?.title : undefined)
   const canvasStoreApi = useCanvasStoreApi()
 
   // ------------------------------------------------------------------
@@ -128,25 +131,22 @@ const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, renderPanelConten
   // Watch the workspace's panels record reactively so a panel that's
   // added later (e.g. async restore) doesn't get pruned by an early run.
   // ------------------------------------------------------------------
-  const workspacePanels = useAppStore(
-    (s) => s.workspaces.find((w) => w.id === useAppStore.getState().selectedWorkspaceId)?.panels,
-  )
-  useEffect(() => {
-    if (!workspacePanels) return
-    const layout = dockStoreApi.getState().zones.center.layout
-    if (!layout) return
-    const collectOrphans = (n: DockLayoutNode): string[] => {
-      if (n.type === 'tabs') return n.panelIds.filter((id) => !workspacePanels[id])
-      const out: string[] = []
-      for (const c of n.children) out.push(...collectOrphans(c))
-      return out
+  const orphans = useAppStore(useShallow((s) => {
+    const panels = s.workspaces.find((w) => w.id === workspaceId)?.panels
+    const missing: string[] = []
+    const visit = (layout: DockLayoutNode): void => {
+      if (layout.type === 'tabs') {
+        for (const id of layout.panelIds) if (panels && !panels[id]) missing.push(id)
+      } else for (const child of layout.children) visit(child)
     }
-    const orphans = collectOrphans(layout)
-    if (orphans.length === 0) return
+    if (node?.dockLayout) visit(node.dockLayout)
+    return missing
+  }))
+  useEffect(() => {
     for (const id of orphans) {
       try { dockStoreApi.getState().undockPanel(id) } catch { /* ignore */ }
     }
-  }, [workspacePanels, dockStoreApi])
+  }, [orphans, dockStoreApi])
 
   // Read the live zoom lazily so this callback identity stays STABLE across
   // zoom frames — re-rendering it on every frame would re-render CanvasNode.
@@ -160,8 +160,6 @@ const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, renderPanelConten
 
   if (!node) return null
 
-  const firstPanelId = activeDockPanelId(node.dockLayout)
-  const firstPanel = firstPanelId ? currentWorkspace?.panels[firstPanelId] : undefined
 
   return (
     <NodeErrorBoundary nodeId={node.id}>
@@ -170,7 +168,7 @@ const CanvasNodeWrapper = React.memo(({ nodeId, canvasPanelId, renderPanelConten
         isFocused={isFocused}
         dockStoreApi={dockStoreApi}
         renderPanel={renderPanel}
-        title={firstPanel?.title}
+        title={title}
       />
     </NodeErrorBoundary>
   )
@@ -293,6 +291,7 @@ export default function CanvasPanel({ panelId, workspaceId, renderPanelContent }
               key={nId}
               nodeId={nId}
               canvasPanelId={panelId}
+              workspaceId={workspaceId}
               renderPanelContent={renderPanelContent}
             />
           ))}

--- a/src/renderer/panels/EditorPanel.tsx
+++ b/src/renderer/panels/EditorPanel.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import type { ReactNode } from 'react'
 import { Check, Copy, FolderOpen } from '@phosphor-icons/react'
-import { useRenderCount } from '../lib/perf/perfClient'
+import { perfCount, useRenderCount } from '../lib/perf/perfClient'
 import log from '../lib/logger'
 import * as monaco from 'monaco-editor'
 import ReactMarkdown from 'react-markdown'
@@ -333,6 +333,7 @@ export default function EditorPanel({
     const fontSize = useSettingsStore.getState().editorFontSize
     const fontFamily = resolveEditorFontFamily(useSettingsStore.getState().editorFontFamily)
 
+    perfCount('editorCreate')
     const editor = monaco.editor.create(containerRef.current, {
       theme: CATE_MONACO_THEME,
       fontFamily,

--- a/src/renderer/panels/PanelHost.test.tsx
+++ b/src/renderer/panels/PanelHost.test.tsx
@@ -106,3 +106,16 @@ describe('PanelHost', () => {
     })
   })
 })
+
+it('updates only changed leaf content without invalidating the canvas render callback', () => {
+  const panels = { canvas: panel('canvas', 'canvas'), a: panel('a', 'editor'), b: panel('b', 'editor') }
+  registryMocks.renderPanelComponent.mockImplementation((record: PanelState, context: PanelRenderContext) => {
+    if (record.type === 'canvas') return <>{context.renderPanelContent?.('a', 'na', 1)}{context.renderPanelContent?.('b', 'nb', 1)}</>
+    return <span>{record.title}</span>
+  })
+  act(() => root.render(<PanelHost panelId="canvas" panels={panels} workspaceId="ws" />))
+  registryMocks.renderPanelComponent.mockClear()
+  act(() => root.render(<PanelHost panelId="canvas" panels={{ ...panels, a: { ...panels.a, title: 'Changed' } }} workspaceId="ws" />))
+  expect(registryMocks.renderPanelComponent.mock.calls.map(([record]) => record.id)).toEqual(['a'])
+  expect(host.textContent).toBe('Changedb')
+})

--- a/src/renderer/panels/PanelHost.tsx
+++ b/src/renderer/panels/PanelHost.tsx
@@ -53,7 +53,7 @@ const PanelContent = memo(function PanelContent({
 
   if (!panel) return null
   if (!allowCanvas && !getPanelDef(panel.type).canLiveOnCanvas) return null
-  if (panel.type === 'browser' && persistentBrowserHost) {
+  if ((panel.type === 'browser' || panel.type === 'agent') && persistentBrowserHost) {
     return <BrowserPanelSurfaceSlot panelId={panel.id} />
   }
   const content = renderPanelComponent(panel, {

--- a/src/renderer/panels/PanelHost.tsx
+++ b/src/renderer/panels/PanelHost.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { createContext, memo, useCallback, useContext } from 'react'
 import type { PanelState } from '../../shared/types'
 import { getPanelDef, renderPanelComponent } from './registry'
 import { PanelSuspense } from './PanelSuspense'
@@ -13,30 +13,42 @@ interface PanelHostProps {
   allowCanvas?: boolean
 }
 
+// Context carries records through a canvas without changing its render callback.
+// Leaf hosts consume it, then memoize content on their own panel record.
+const PanelRecordsContext = createContext<Record<string, PanelState>>({})
+
+export function PanelHost({ panels, panelId, ...props }: PanelHostProps): React.ReactElement {
+  return <PanelRecordsContext.Provider value={panels}>
+    <PanelContent panel={panels[panelId]} {...props} />
+  </PanelRecordsContext.Provider>
+}
+
+function ChildPanelHost({ panelId, ...props }: Omit<PanelHostProps, 'panels'>): React.ReactElement {
+  const panels = useContext(PanelRecordsContext)
+  return <PanelContent panel={panels[panelId]} {...props} />
+}
+
 /** The sole renderer for panel records, shared by main and detached windows. */
-export function PanelHost({
-  panelId,
-  panels,
+const PanelContent = memo(function PanelContent({
+  panel,
   workspaceId,
   nodeId = '',
   zoomLevel = 1,
   allowCanvas = true,
-}: PanelHostProps): React.ReactElement | null {
+}: Omit<PanelHostProps, 'panels' | 'panelId'> & { panel?: PanelState }): React.ReactElement | null {
   const persistentBrowserHost = useContext(PersistentBrowserHostContext)
-  const panel = panels[panelId]
   const renderPanelContent = useCallback(
     (childPanelId: string, childNodeId: string, childZoom: number) => (
-      <PanelHost
+      <ChildPanelHost
         key={childPanelId}
         panelId={childPanelId}
-        panels={panels}
         workspaceId={workspaceId}
         nodeId={childNodeId}
         zoomLevel={childZoom}
         allowCanvas={false}
       />
     ),
-    [panels, workspaceId],
+    [workspaceId],
   )
 
   if (!panel) return null
@@ -51,4 +63,4 @@ export function PanelHost({
     renderPanelContent,
   })
   return content ? <PanelSuspense key={panel.id}>{content}</PanelSuspense> : null
-}
+})

--- a/src/renderer/panels/browserSurfaceRegistry.test.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.test.tsx
@@ -1,0 +1,173 @@
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserPanelSurfaceSlot, registerBrowserSurface } from './browserSurfaceRegistry'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let host: HTMLDivElement
+let surface: HTMLDivElement
+let root: Root
+let cleanup: () => void
+let rect: DOMRect
+let frames: Map<number, FrameRequestCallback>
+let observers: Array<{ targets: Set<Element>; callback: ResizeObserverCallback }>
+
+async function frame() {
+  await act(async () => { await Promise.resolve() })
+  const pending = [...frames.values()]
+  frames.clear()
+  act(() => pending.forEach((callback) => callback(0)))
+}
+
+beforeEach(() => {
+  frames = new Map()
+  observers = []
+  let id = 0
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.set(++id, callback)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (frameId: number) => frames.delete(frameId))
+  vi.stubGlobal('ResizeObserver', class {
+    targets = new Set<Element>()
+    constructor(public callback: ResizeObserverCallback) { observers.push(this) }
+    observe(element: Element) { this.targets.add(element) }
+    disconnect() { this.targets.clear() }
+  })
+  host = document.createElement('div')
+  surface = document.createElement('div')
+  document.body.append(host, surface)
+  root = createRoot(host)
+  act(() => root.render(<div data-layout><aside /><main><BrowserPanelSurfaceSlot panelId="browser" /></main></div>))
+  const slot = host.querySelector<HTMLElement>('[data-browser-surface-slot]')!
+  rect = new DOMRect(100, 40, 300, 200)
+  vi.spyOn(slot, 'getBoundingClientRect').mockImplementation(() => rect)
+  Object.defineProperties(slot, {
+    offsetWidth: { get: () => 300 },
+    offsetHeight: { get: () => 200 },
+  })
+  cleanup = registerBrowserSurface('browser', surface, null)
+})
+
+afterEach(() => {
+  cleanup()
+  act(() => root.unmount())
+  host.remove()
+  surface.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('browser surface layout tracking', () => {
+  it('follows sidebar-driven ancestor resize while the slot size stays unchanged', async () => {
+    await frame()
+    rect = new DOMRect(250, 40, 300, 200)
+    const ancestor = host.querySelector('main')!
+    const watching = observers.filter((observer) => observer.targets.has(ancestor))
+    expect(watching).toHaveLength(1)
+    watching.forEach((observer) => observer.callback([], {} as ResizeObserver))
+    await frame()
+    expect(surface.style.left).toBe('250px')
+    expect(surface.style.width).toBe('300px')
+  })
+
+  it('follows sibling layout changes and ancestor child insertion', async () => {
+    await frame()
+    rect = new DOMRect(60, 70, 300, 200)
+    host.querySelector('aside')!.style.width = '60px'
+    await frame()
+    expect(surface.style.left).toBe('60px')
+    rect = new DOMRect(60, 100, 300, 200)
+    host.querySelector('[data-layout]')!.prepend(document.createElement('header'))
+    await frame()
+    expect(surface.style.top).toBe('100px')
+  })
+
+  it('tracks animated transforms through the final frame without more DOM mutations', async () => {
+    await frame()
+    const ancestor = host.querySelector('main')!
+    const animation = { playState: 'running', effect: { getKeyframes: () => [{ transform: 'scale(1)' }] } }
+    Object.assign(ancestor, { getAnimations: () => [animation] })
+    ancestor.dispatchEvent(new Event('transitionrun', { bubbles: true }))
+    rect = new DOMRect(120, 50, 240, 160)
+    await frame()
+    expect(surface.style.transform).toBe('scale(0.8, 0.8)')
+    expect(frames.size).toBe(1)
+    rect = new DOMRect(150, 60, 150, 100)
+    animation.playState = 'finished'
+    await frame()
+    expect(surface.style.left).toBe('150px')
+    expect(surface.style.transform).toBe('scale(0.5, 0.5)')
+    expect(frames.size).toBe(0)
+  })
+
+  it('does not poll layout for decorative T3 activity pulses', async () => {
+    await frame()
+    const ancestor = host.querySelector('main')!
+    const getAnimations = vi.fn(() => [{ playState: 'running', effect: { getKeyframes: () => [{ offset: 0, computedOffset: 0, easing: 'linear', outlineColor: 'red' }] } }])
+    Object.assign(ancestor, { getAnimations })
+    ancestor.dispatchEvent(new Event('animationstart', { bubbles: true }))
+    await frame()
+    expect(getAnimations).toHaveBeenCalledTimes(1)
+    expect(frames.size).toBe(0)
+  })
+
+  it('shares observers and layout reads across eight surfaces, with no idle writes', async () => {
+    const ids = ['browser', ...Array.from({ length: 7 }, (_, i) => `extra-${i}`)]
+    act(() => root.render(<main style={{ overflow: 'hidden' }}>{ids.map((id, i) => (
+      <div key={id} data-node-id={id} style={{ zIndex: i + 1 }}><BrowserPanelSurfaceSlot panelId={id} /></div>
+    ))}</main>))
+    for (const element of host.querySelectorAll<HTMLElement>('main, [data-node-id], [data-browser-surface-slot]')) {
+      vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rect)
+      Object.defineProperties(element, { offsetWidth: { get: () => 300 }, offsetHeight: { get: () => 200 } })
+    }
+    const extras = ids.slice(1).map((id) => {
+      const container = document.createElement('div')
+      document.body.append(container)
+      return { container, dispose: registerBrowserSurface(id, container, null) }
+    })
+    try {
+      await frame()
+      await frame()
+      expect(observers.filter((observer) => observer.targets.size)).toHaveLength(1)
+      expect(frames.size).toBe(0)
+      for (const element of host.querySelectorAll<HTMLElement>('[data-node-id]')) vi.mocked(element.getBoundingClientRect).mockClear()
+      const styles = vi.spyOn(window, 'getComputedStyle')
+      const writes: MutationRecord[] = []
+      const mutation = new MutationObserver((records) => writes.push(...records))
+      for (const container of [surface, ...extras.map((entry) => entry.container)]) mutation.observe(container, { attributes: true })
+      window.dispatchEvent(new Event('resize'))
+      window.dispatchEvent(new Event('resize'))
+      expect(frames.size).toBe(1)
+      await frame()
+      const targets = styles.mock.calls.map(([element]) => element)
+      expect(targets.length).toBeGreaterThan(8)
+      expect(new Set(targets).size).toBe(targets.length)
+      for (const element of host.querySelectorAll<HTMLElement>('[data-node-id]')) {
+        expect(vi.mocked(element.getBoundingClientRect).mock.calls.length).toBeLessThanOrEqual(1)
+      }
+      await Promise.resolve()
+      expect(writes).toHaveLength(0)
+      expect(frames.size).toBe(0)
+      mutation.disconnect()
+    } finally {
+      for (const entry of extras) { entry.dispose(); entry.container.remove() }
+    }
+  })
+
+  it('updates on scroll and window resize, and cancels pending work on cleanup', async () => {
+    await frame()
+    rect = new DOMRect(100, 10, 300, 200)
+    host.querySelector('main')!.dispatchEvent(new Event('scroll'))
+    await frame()
+    expect(surface.style.top).toBe('10px')
+    rect = new DOMRect(110, 20, 300, 200)
+    window.dispatchEvent(new Event('resize'))
+    await frame()
+    expect(surface.style.left).toBe('110px')
+    window.dispatchEvent(new Event('resize'))
+    cleanup()
+    expect(frames.size).toBe(0)
+    expect(observers.every((observer) => observer.targets.size === 0)).toBe(true)
+  })
+})

--- a/src/renderer/panels/browserSurfaceRegistry.test.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.test.tsx
@@ -171,3 +171,12 @@ describe('browser surface layout tracking', () => {
     expect(observers.every((observer) => observer.targets.size === 0)).toBe(true)
   })
 })
+
+it('parks a mounted guest without changing its logical viewport size', async () => {
+  await frame()
+  const width = surface.style.width, height = surface.style.height
+  act(() => root.render(<div />))
+  expect(surface.dataset.browserSurfaceVisible).toBe('false')
+  expect(surface.style.width).toBe(width)
+  expect(surface.style.height).toBe(height)
+})

--- a/src/renderer/panels/browserSurfaceRegistry.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.tsx
@@ -150,7 +150,7 @@ function surfaceClipPath(
 
 type SurfaceStyles = Pick<CSSStyleDeclaration,
   'position' | 'left' | 'top' | 'width' | 'height' | 'transform' | 'transformOrigin'
-  | 'clipPath' | 'opacity' | 'pointerEvents' | 'zIndex'>
+  | 'clipPath' | 'opacity' | 'pointerEvents' | 'zIndex' | 'visibility'>
 
 function writeSurface(surface: SurfaceEntry, visible: boolean, styles: Partial<SurfaceStyles>): void {
   const { container } = surface
@@ -166,8 +166,8 @@ function writeSurface(surface: SurfaceEntry, visible: boolean, styles: Partial<S
 
 function parkSurface(surface: SurfaceEntry): void {
   writeSurface(surface, false, {
-    position: 'fixed', left: '-20000px', top: '0', width: '1200px', height: '800px',
-    transform: 'none', clipPath: 'none', opacity: '0', pointerEvents: 'none',
+    position: 'fixed', left: '-20000px', top: '0', width: surface.styles.width ?? '1200px', height: surface.styles.height ?? '800px',
+    transform: 'none', clipPath: 'none', opacity: '0', pointerEvents: 'none', visibility: 'hidden',
   })
 }
 
@@ -196,6 +196,7 @@ function measureSurface(panelId: string, geometry: FrameGeometry): () => void {
   const node = slot.closest<HTMLElement>('[data-node-id]')
   const nodeZIndex = node ? geometry.style(node).zIndex : 'auto'
   return () => writeSurface(surface, true, {
+    visibility: 'visible',
     position: 'fixed', left: `${rect.left}px`, top: `${rect.top}px`,
     width: `${logicalWidth}px`, height: `${logicalHeight}px`, transformOrigin: '0 0',
     transform: `scale(${rect.width / logicalWidth}, ${rect.height / logicalHeight})`,
@@ -308,9 +309,10 @@ function watchSurfaces(): void {
 }
 
 function refreshSurfaces(panelId: string): void {
-  // Only this lifecycle edge needs an immediate write; batch shared observer
-  // rebuilding and all other surfaces into the next frame.
-  if (surfaces.has(panelId)) measureSurface(panelId, frameGeometry())()
+  // Hide removed/new slots immediately, but measure all incoming slots together
+  // before the next paint. Per-slot reads here bypassed the shared frame cache.
+  const surface = surfaces.get(panelId)
+  if (surface && (!slots.has(panelId) || !surface.styles.width)) parkSurface(surface)
   rebuildTracking = true
   if (surfaces.size === 0) watchSurfaces()
   else schedule()

--- a/src/renderer/panels/browserSurfaceRegistry.tsx
+++ b/src/renderer/panels/browserSurfaceRegistry.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useCallback, useRef } from 'react'
+import { PERF_ENABLED, perfCount } from '../lib/perf/perfClient'
 
 interface SurfaceEntry {
   container: HTMLDivElement
-  cleanup: (() => void) | null
-  frame: number | null
+  styles: Partial<SurfaceStyles>
 }
 
 const slots = new Map<string, HTMLDivElement>()
@@ -15,6 +15,42 @@ interface SurfaceRect {
   right: number
   bottom: number
 }
+
+// All surfaces share one read phase per frame. DOM reads are cached before any
+// output styles are written, including ancestors shared by different slots.
+function frameGeometry() {
+  const rects = new Map<Element, DOMRect>()
+  const styles = new Map<Element, CSSStyleDeclaration>()
+  const layers = new Map<Element, Array<{ element: HTMLElement; z: number }>>()
+  const rect = (element: Element): DOMRect => {
+    if (!rects.has(element)) {
+      perfCount('browserGeometryRect')
+      rects.set(element, element.getBoundingClientRect())
+    }
+    return rects.get(element)!
+  }
+  const style = (element: Element): CSSStyleDeclaration => {
+    if (!styles.has(element)) {
+      perfCount('browserGeometryStyle')
+      styles.set(element, getComputedStyle(element))
+    }
+    return styles.get(element)!
+  }
+  const nodes = (layer: Element) => {
+    if (!layers.has(layer)) {
+      const entries = Array.from(layer.children).flatMap((element) => {
+        if (!(element instanceof HTMLElement) || !element.hasAttribute('data-node-id')) return []
+        const css = style(element)
+        if (css.display === 'none' || css.visibility === 'hidden' || Number.parseFloat(css.opacity || '1') <= 0) return []
+        return [{ element, z: Number.parseFloat(css.zIndex) }]
+      })
+      layers.set(layer, entries)
+    }
+    return layers.get(layer)!
+  }
+  return { rect, style, nodes }
+}
+type FrameGeometry = ReturnType<typeof frameGeometry>
 
 const CLIPPING_OVERFLOWS = new Set(['auto', 'clip', 'hidden', 'scroll'])
 
@@ -28,7 +64,7 @@ function intersectRects(a: SurfaceRect, b: SurfaceRect): SurfaceRect | null {
   return rect.right > rect.left && rect.bottom > rect.top ? rect : null
 }
 
-function clippingRect(slot: HTMLElement, rect: DOMRect): SurfaceRect | null {
+function clippingRect(slot: HTMLElement, rect: DOMRect, geometry: FrameGeometry): SurfaceRect | null {
   let visible: SurfaceRect | null = intersectRects(rect, {
     left: 0,
     top: 0,
@@ -36,7 +72,7 @@ function clippingRect(slot: HTMLElement, rect: DOMRect): SurfaceRect | null {
     bottom: window.innerHeight,
   })
   for (let element = slot.parentElement; visible && element; element = element.parentElement) {
-    const style = getComputedStyle(element)
+    const style = geometry.style(element)
     const shorthand = style.overflow.trim().split(/\s+/)
     const overflowX = style.overflowX && style.overflowX !== 'visible'
       ? style.overflowX
@@ -47,7 +83,7 @@ function clippingRect(slot: HTMLElement, rect: DOMRect): SurfaceRect | null {
     const clipsX = CLIPPING_OVERFLOWS.has(overflowX)
     const clipsY = CLIPPING_OVERFLOWS.has(overflowY)
     if (!clipsX && !clipsY) continue
-    const ancestor = element.getBoundingClientRect()
+    const ancestor = geometry.rect(element)
     visible = intersectRects(visible, {
       left: clipsX ? ancestor.left : visible.left,
       top: clipsY ? ancestor.top : visible.top,
@@ -67,8 +103,9 @@ function surfaceClipPath(
   rect: DOMRect,
   logicalWidth: number,
   logicalHeight: number,
+  geometry: FrameGeometry,
 ): string | null {
-  const visible = clippingRect(slot, rect)
+  const visible = clippingRect(slot, rect, geometry)
   if (!visible) return null
 
   const scaleX = rect.width / logicalWidth
@@ -86,22 +123,11 @@ function surfaceClipPath(
   // Punch out higher nodes and let their real DOM show through those regions.
   const node = slot.closest<HTMLElement>('[data-node-id]')
   const nodeLayer = node?.parentElement
-  const nodeZIndex = node ? Number.parseFloat(getComputedStyle(node).zIndex) : Number.NaN
+  const nodeZIndex = node ? Number.parseFloat(geometry.style(node).zIndex) : Number.NaN
   const occluders = nodeLayer && Number.isFinite(nodeZIndex)
-    ? Array.from(nodeLayer.children)
-      .filter((element): element is HTMLElement => (
-        element instanceof HTMLElement
-        && element !== node
-        && element.hasAttribute('data-node-id')
-      ))
-      .filter((element) => {
-        const style = getComputedStyle(element)
-        return Number.parseFloat(style.zIndex) > nodeZIndex
-          && style.display !== 'none'
-          && style.visibility !== 'hidden'
-          && Number.parseFloat(style.opacity || '1') > 0
-      })
-      .map((element) => intersectRects(visible, element.getBoundingClientRect()))
+    ? geometry.nodes(nodeLayer)
+      .filter((entry) => entry.element !== node && entry.z > nodeZIndex)
+      .map((entry) => intersectRects(visible, geometry.rect(entry.element)))
       .filter((value): value is SurfaceRect => value !== null)
       .map(local)
     : []
@@ -122,131 +148,184 @@ function surfaceClipPath(
   return `path(evenodd, "${path}")`
 }
 
-function parkSurface(surface: SurfaceEntry): void {
+type SurfaceStyles = Pick<CSSStyleDeclaration,
+  'position' | 'left' | 'top' | 'width' | 'height' | 'transform' | 'transformOrigin'
+  | 'clipPath' | 'opacity' | 'pointerEvents' | 'zIndex'>
+
+function writeSurface(surface: SurfaceEntry, visible: boolean, styles: Partial<SurfaceStyles>): void {
   const { container } = surface
-  container.dataset.browserSurfaceVisible = 'false'
-  container.style.position = 'fixed'
-  container.style.left = '-20000px'
-  container.style.top = '0'
-  container.style.width = '1200px'
-  container.style.height = '800px'
-  container.style.transform = 'none'
-  container.style.clipPath = 'none'
-  container.style.opacity = '0'
-  container.style.pointerEvents = 'none'
+  if (container.dataset.browserSurfaceVisible !== String(visible)) container.dataset.browserSurfaceVisible = String(visible)
+  for (const key of Object.keys(styles) as Array<keyof SurfaceStyles>) {
+    const value = styles[key]!
+    // Compare requested values; CSSOM normalizes e.g. scale(1, 1) to scale(1).
+    if (surface.styles[key] === value) continue
+    container.style[key] = value
+    surface.styles[key] = value
+  }
 }
 
-function updateSurface(panelId: string): void {
+function parkSurface(surface: SurfaceEntry): void {
+  writeSurface(surface, false, {
+    position: 'fixed', left: '-20000px', top: '0', width: '1200px', height: '800px',
+    transform: 'none', clipPath: 'none', opacity: '0', pointerEvents: 'none',
+  })
+}
+
+function measureSurface(panelId: string, geometry: FrameGeometry): () => void {
   const surface = surfaces.get(panelId)
   const slot = slots.get(panelId)
   if (!surface || !slot?.isConnected) {
-    if (surface) parkSurface(surface)
-    return
+    return () => { if (surface) parkSurface(surface) }
   }
 
-  const rect = slot.getBoundingClientRect()
+  const rect = geometry.rect(slot)
   const logicalWidth = slot.offsetWidth || rect.width
   const logicalHeight = slot.offsetHeight || rect.height
   const visible = rect.width > 0
     && rect.height > 0
-    && getComputedStyle(slot).visibility !== 'hidden'
+    && geometry.style(slot).visibility !== 'hidden'
   if (!visible || logicalWidth <= 0 || logicalHeight <= 0) {
-    parkSurface(surface)
-    return
+    return () => parkSurface(surface)
   }
 
-  const clipPath = surfaceClipPath(slot, rect, logicalWidth, logicalHeight)
+  const clipPath = surfaceClipPath(slot, rect, logicalWidth, logicalHeight, geometry)
   if (!clipPath) {
-    parkSurface(surface)
-    return
+    return () => parkSurface(surface)
   }
 
   const node = slot.closest<HTMLElement>('[data-node-id]')
-  const nodeZIndex = node ? getComputedStyle(node).zIndex : 'auto'
-  const { container } = surface
-  container.dataset.browserSurfaceVisible = 'true'
-  container.style.position = 'fixed'
-  container.style.left = `${rect.left}px`
-  container.style.top = `${rect.top}px`
-  container.style.width = `${logicalWidth}px`
-  container.style.height = `${logicalHeight}px`
-  container.style.transformOrigin = '0 0'
-  container.style.transform = `scale(${rect.width / logicalWidth}, ${rect.height / logicalHeight})`
-  container.style.clipPath = clipPath
-  container.style.zIndex = nodeZIndex === 'auto' ? '1' : nodeZIndex
-  container.style.opacity = '1'
-  container.style.pointerEvents = 'auto'
+  const nodeZIndex = node ? geometry.style(node).zIndex : 'auto'
+  return () => writeSurface(surface, true, {
+    position: 'fixed', left: `${rect.left}px`, top: `${rect.top}px`,
+    width: `${logicalWidth}px`, height: `${logicalHeight}px`, transformOrigin: '0 0',
+    transform: `scale(${rect.width / logicalWidth}, ${rect.height / logicalHeight})`,
+    clipPath, zIndex: nodeZIndex === 'auto' ? '1' : nodeZIndex,
+    opacity: '1', pointerEvents: 'auto',
+  })
 }
 
-function watchSurface(panelId: string): void {
-  const surface = surfaces.get(panelId)
-  if (!surface) return
-  surface.cleanup?.()
-  surface.cleanup = null
-  const slot = slots.get(panelId)
-  updateSurface(panelId)
-  if (!slot) return
+let frame: number | null = null
+let cleanupTracking: (() => void) | null = null
+let rebuildTracking = false
+let tracked = new Set<HTMLElement>()
+const animatedElements = new Set<HTMLElement>()
+const geometryAnimations = new Map<HTMLElement, Animation[]>()
 
-  const schedule = (): void => {
-    if (surface.frame !== null) return
-    surface.frame = requestAnimationFrame(() => {
-      surface.frame = null
-      updateSurface(panelId)
-    })
+// Color, shadow and activity-pulse animations must never start a geometry loop.
+const GEOMETRY_PROPERTIES = /^(transform|translate|rotate|scale|perspective|offsetPath|offsetDistance|offsetRotate|left|top|right|bottom|width|height|minWidth|maxWidth|minHeight|maxHeight|margin|padding|border.*Width|inset|flex|gap|rowGap|columnGap|grid|fontSize|lineHeight|display|visibility|opacity|clipPath|zIndex)/
+function refreshAnimations(): void {
+  for (const element of animatedElements) {
+    const animations = (element.getAnimations?.() ?? []).filter((animation) => (
+      animation.playState === 'running'
+      && (animation.effect as KeyframeEffect | null)?.getKeyframes().some((keyframe) => (
+        Object.keys(keyframe).some((property) => GEOMETRY_PROPERTIES.test(property))
+      ))
+    ))
+    if (animations.length) geometryAnimations.set(element, animations)
+    else geometryAnimations.delete(element)
+  }
+  animatedElements.clear()
+}
+
+function schedule(): void {
+  if (frame !== null || surfaces.size === 0) return
+  frame = requestAnimationFrame(() => {
+    frame = null
+    const started = PERF_ENABLED ? performance.now() : 0
+    if (rebuildTracking) watchSurfaces()
+    refreshAnimations()
+    perfCount('browserGeometryFrame')
+    const geometry = frameGeometry()
+    const writes = [...surfaces.keys()].map((id) => measureSurface(id, geometry))
+    for (const write of writes) write()
+    // Animated transforms produce no further mutations or resize notifications.
+    for (const [element, animations] of geometryAnimations) {
+      if (!animations.some((animation) => animation.playState === 'running')) geometryAnimations.delete(element)
+    }
+    if (PERF_ENABLED) perfCount('browserGeometryMicros', Math.round((performance.now() - started) * 1000))
+    if (geometryAnimations.size) schedule()
+  })
+}
+
+function watchSurfaces(): void {
+  cleanupTracking?.()
+  cleanupTracking = null
+  rebuildTracking = false
+  tracked = new Set()
+  animatedElements.clear()
+  geometryAnimations.clear()
+  if (surfaces.size === 0) {
+    if (frame !== null) cancelAnimationFrame(frame)
+    frame = null
+    return
   }
   const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(schedule)
-  resize?.observe(slot)
   const mutation = typeof MutationObserver === 'undefined' ? null : new MutationObserver((records) => {
-    // A new/removed canvas node changes the occlusion set. Rebuild observers so
-    // subsequent z-order and geometry changes on the new siblings are tracked.
-    if (records.some((record) => record.type === 'childList')) {
-      watchSurface(panelId)
-      return
-    }
+    if (records.some((record) => record.type === 'childList')) rebuildTracking = true
+    for (const record of records) animatedElements.add(record.target as HTMLElement)
     schedule()
   })
-  for (let element: HTMLElement | null = slot; element; element = element.parentElement) {
-    mutation?.observe(element, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] })
-  }
-  const node = slot.closest<HTMLElement>('[data-node-id]')
-  const nodeLayer = node?.parentElement
-  if (nodeLayer) {
-    // nodeLayer is also one of the ancestors observed above. Calling observe()
-    // again replaces that target's options, so retain attribute observation:
-    // its transform changes on every canvas pan/zoom frame.
-    mutation?.observe(nodeLayer, {
-      attributes: true,
-      attributeFilter: ['style', 'class', 'aria-hidden'],
-      childList: true,
-    })
-    for (const sibling of Array.from(nodeLayer.children)) {
-      if (!(sibling instanceof HTMLElement) || !sibling.hasAttribute('data-node-id')) continue
-      mutation?.observe(sibling, { attributes: true, attributeFilter: ['style', 'class', 'aria-hidden'] })
-      resize?.observe(sibling)
+  const ancestors = new Set<HTMLElement>()
+  for (const id of surfaces.keys()) {
+    for (let element: HTMLElement | null = slots.get(id) ?? null; element; element = element.parentElement) {
+      if (ancestors.has(element)) break
+      ancestors.add(element)
     }
   }
+  const outputs = [...surfaces.values()].map((entry) => entry.container)
+  const observe = (element: HTMLElement, childList: boolean): void => {
+    if (tracked.has(element)) return
+    tracked.add(element)
+    animatedElements.add(element)
+    resize?.observe(element)
+    mutation?.observe(element, {
+      attributes: true, attributeFilter: ['style', 'class', 'aria-hidden', 'hidden'], childList,
+    })
+  }
+  for (const element of ancestors) observe(element, true)
+  for (const element of ancestors) {
+    for (const sibling of Array.from(element.parentElement?.children ?? [])) {
+      if (sibling instanceof HTMLElement && !outputs.some((output) => sibling.contains(output))) observe(sibling, false)
+    }
+  }
+  const onAnimation = (event: Event): void => {
+    const element = event.target as HTMLElement
+    if (!tracked.has(element)) return
+    animatedElements.add(element)
+    schedule()
+  }
+  const animationEvents = ['transitionrun', 'transitionend', 'transitioncancel', 'animationstart', 'animationend', 'animationcancel']
+  for (const event of animationEvents) window.addEventListener(event, onAnimation, true)
   window.addEventListener('resize', schedule)
   window.addEventListener('scroll', schedule, true)
-  surface.cleanup = () => {
+  cleanupTracking = () => {
     resize?.disconnect()
     mutation?.disconnect()
+    for (const event of animationEvents) window.removeEventListener(event, onAnimation, true)
     window.removeEventListener('resize', schedule)
     window.removeEventListener('scroll', schedule, true)
-    if (surface.frame !== null) cancelAnimationFrame(surface.frame)
-    surface.frame = null
   }
+}
+
+function refreshSurfaces(panelId: string): void {
+  // Only this lifecycle edge needs an immediate write; batch shared observer
+  // rebuilding and all other surfaces into the next frame.
+  if (surfaces.has(panelId)) measureSurface(panelId, frameGeometry())()
+  rebuildTracking = true
+  if (surfaces.size === 0) watchSurfaces()
+  else schedule()
 }
 
 function registerSlot(panelId: string, element: HTMLDivElement): void {
   if (slots.get(panelId) === element) return
   slots.set(panelId, element)
-  watchSurface(panelId)
+  refreshSurfaces(panelId)
 }
 
 function unregisterSlot(panelId: string, element: HTMLDivElement): void {
   if (slots.get(panelId) !== element) return
   slots.delete(panelId)
-  watchSurface(panelId)
+  refreshSurfaces(panelId)
 }
 
 export const PersistentBrowserHostContext = createContext(false)
@@ -256,16 +335,14 @@ export function registerBrowserSurface(
   container: HTMLDivElement,
   backgroundRoot: HTMLDivElement | null,
 ): () => void {
-  const existing = surfaces.get(panelId)
-  existing?.cleanup?.()
   if (backgroundRoot && container.parentElement !== backgroundRoot) backgroundRoot.appendChild(container)
-  const surface: SurfaceEntry = { container, cleanup: null, frame: null }
+  const surface: SurfaceEntry = { container, styles: {} }
   surfaces.set(panelId, surface)
-  watchSurface(panelId)
+  refreshSurfaces(panelId)
   return () => {
     if (surfaces.get(panelId) !== surface) return
-    surface.cleanup?.()
     surfaces.delete(panelId)
+    refreshSurfaces(panelId)
   }
 }
 

--- a/src/renderer/sidebar/FileExplorer.performance.test.tsx
+++ b/src/renderer/sidebar/FileExplorer.performance.test.tsx
@@ -1,0 +1,49 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, expect, it, vi } from 'vitest'
+import type { FsWatchEvent } from '../lib/fs/fsWatchManager'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+const mocks = vi.hoisted(() => ({ watch: vi.fn(), read: vi.fn(), open: vi.fn() }))
+vi.mock('../lib/fs/fsWatchManager', () => ({ watchFsRoot: mocks.watch }))
+vi.mock('../stores/gitStatusStore', () => ({ useGitTreeFor: () => undefined }))
+vi.mock('../stores/appStore', () => ({ useAppStore: (selector: (state: unknown) => unknown) => selector({ selectedWorkspaceId: 'ws', createTerminal: vi.fn(), removeWorkspace: vi.fn() }) }))
+vi.mock('../lib/fs/fileRouting', () => ({ openFileAsPanel: mocks.open }))
+import { FileExplorer } from './FileExplorer'
+
+afterEach(() => vi.useRealTimers())
+
+it('expands through the shared queue, refreshes one directory, and navigates virtual rows', async () => {
+  vi.useFakeTimers()
+  let event!: (value: FsWatchEvent) => void
+  mocks.watch.mockImplementation((_root, callback) => { event = callback; return vi.fn() })
+  const file = (path: string, isDirectory = false) => ({ path, name: path.split('/').pop(), isDirectory, fileExtension: 'ts' })
+  let extra = false
+  mocks.read.mockImplementation(async (path: string) => path === '/repo'
+    ? [file('/repo/a', true), file('/repo/b', true)]
+    : Array.from({ length: 1000 + (extra ? 1 : 0) }, (_, index) => file(`${path}/${index}.ts`)))
+  Object.assign(window, { electronAPI: { fsReadDir: mocks.read, onSettingsChanged: () => vi.fn() } })
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  try {
+    await act(async () => { root.render(<FileExplorer rootPath="/repo" />) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(150) })
+    await act(async () => host.querySelector<HTMLElement>('[data-filepath="/repo/a"]')!.click())
+    expect(host.querySelectorAll('[data-filepath]').length).toBeLessThan(40)
+    expect(host.querySelector('[data-filepath="/repo/a/0.ts"]')).not.toBeNull()
+    mocks.read.mockClear()
+    await act(async () => {
+      event({ type: 'update', path: '/repo/a/0.ts' })
+      extra = true
+      event({ type: 'create', path: '/repo/a/1000.ts' })
+      await vi.advanceTimersByTimeAsync(150)
+    })
+    expect(mocks.read.mock.calls).toEqual([['/repo/a', 'ws']])
+    const scroll = host.querySelector<HTMLElement>('[data-sidebar-keynav]')!
+    for (let index = 0; index < 40; index++) {
+      await act(async () => scroll.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })))
+    }
+    expect(host.querySelector('[data-filepath="/repo/a/39.ts"]')).not.toBeNull()
+  } finally { await act(async () => root.unmount()); host.remove() }
+})

--- a/src/renderer/sidebar/FileExplorer.performance.test.tsx
+++ b/src/renderer/sidebar/FileExplorer.performance.test.tsx
@@ -47,3 +47,33 @@ it('expands through the shared queue, refreshes one directory, and navigates vir
     expect(host.querySelector('[data-filepath="/repo/a/39.ts"]')).not.toBeNull()
   } finally { await act(async () => root.unmount()); host.remove() }
 })
+
+it('paints a warm expanded tree while revalidation is still pending', async () => {
+  const file = (path: string, isDirectory = false) => ({ path, name: path.split('/').pop(), isDirectory, fileExtension: 'ts' })
+  mocks.watch.mockReturnValue(vi.fn())
+  let hold = false
+  const pending: Array<(value: unknown[]) => void> = []
+  mocks.read.mockImplementation((path: string) => {
+    if (hold) return new Promise((resolve) => pending.push(resolve))
+    return Promise.resolve(path === '/warm-a' ? [file('/warm-a/sub', true)]
+      : path === '/warm-a/sub' ? [file('/warm-a/sub/leaf.ts')] : [file('/warm-b/other.ts')])
+  })
+  Object.assign(window, { electronAPI: { fsReadDir: mocks.read, onSettingsChanged: () => vi.fn() } })
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  try {
+    await act(async () => root.render(<FileExplorer rootPath="/warm-a" />))
+    await act(async () => host.querySelector<HTMLElement>('[data-filepath="/warm-a/sub"]')!.click())
+    expect(host.querySelector('[data-filepath="/warm-a/sub/leaf.ts"]')).not.toBeNull()
+    await act(async () => root.render(<FileExplorer rootPath="/warm-b" />))
+    hold = true
+    await act(async () => root.render(<FileExplorer rootPath="/warm-a" />))
+    expect(pending.length).toBeGreaterThan(0)
+    expect(host.querySelector('[data-filepath="/warm-a/sub/leaf.ts"]')).not.toBeNull()
+  } finally {
+    await act(async () => root.unmount())
+    pending.forEach((resolve) => resolve([]))
+    host.remove()
+  }
+})

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -4,9 +4,11 @@
 // =============================================================================
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import log from '../lib/logger'
 import { ArrowClockwise, FilePlus, FolderPlus, MagnifyingGlass, X } from '@phosphor-icons/react'
 import type { FileTreeNode as FileTreeNodeType } from '../../shared/types'
+import { VirtualFileRows, type VirtualFileRowsHandle } from './VirtualFileRows'
+import { createExplorerRefresh } from './explorerRefresh'
+import { perfCount } from '../lib/perf/perfClient'
 import { FileTreeNode } from './FileTreeNode'
 import { CreateFileForm } from './CreateFileForm'
 import { isNavKey, resolveTreeNavAction } from './treeKeyboardNav'
@@ -58,7 +60,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
   //  - expandedPaths: directory paths the user has expanded.
   //  - childrenCache: each loaded directory's children (one fsReadDir level),
   //    keyed by stable path so it survives root re-renders. Re-read on reload by
-  //    refreshExpandedChildren so a move/create/delete reflects on-disk state
+  //    the refresh queue so a move/create/delete reflects on-disk state
   //    instead of showing stale children (e.g. a moved file lingering as a copy).
   //  - loadingPaths: directories currently being read (drives the "…" spinner).
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
@@ -74,16 +76,23 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
   const rootCreateInputRef = useRef<HTMLInputElement>(null)
   const lastSelectedPath = useRef<string | null>(null)
   const treeContainerRef = useRef<HTMLDivElement>(null)
-  const cleanupRef = useRef<(() => void) | null>(null)
-  const reloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const virtualRowsRef = useRef<VirtualFileRowsHandle>(null)
+  const [editingPaths, setEditingPaths] = useState<Set<string>>(new Set())
+  const onEditingChange = useCallback((path: string, editing: boolean) => {
+    setEditingPaths((previous) => {
+      if (previous.has(path) === editing) return previous
+      const next = new Set(previous)
+      if (editing) next.add(path); else next.delete(path)
+      return next
+    })
+  }, [])
+
   const rootPathRef = useRef(rootPath)
+  const childrenCacheRef = useRef(childrenCache)
+  const childRequests = useRef(new Map<string, Promise<void>>())
+  childrenCacheRef.current = childrenCache
+  const refreshRef = useRef<ReturnType<typeof createExplorerRefresh<FileTreeNodeType[]>> | null>(null)
   const createSeqRef = useRef(0)
-  const loadRetryTimerRef = useRef<number | null>(null)
-  // Mirror of expandedPaths so the stable loadTree/refresh callbacks can read the
-  // current set without taking it as a dependency (which would re-create the
-  // fs-watch effect on every expand/collapse).
-  const expandedPathsRef = useRef(expandedPaths)
-  useEffect(() => { expandedPathsRef.current = expandedPaths }, [expandedPaths])
 
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId)
 
@@ -158,10 +167,6 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
     return merged
   }, [filter, expandedPaths])
 
-  const isPathVisible = useMemo(
-    () => (filter ? (path: string) => filter.visible.has(path) : undefined),
-    [filter],
-  )
 
   // Flat, top-to-bottom list of every visible row: root nodes plus the children
   // of each expanded folder. Drives keyboard navigation and shift-click ranges.
@@ -183,6 +188,8 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
     return out
   }, [nodes, effectiveExpanded, childrenCache, filter])
 
+  const flatPaths = useMemo(() => flatRows.map((row) => row.path), [flatRows])
+
   const flatIndexByPath = useMemo(
     () => new Map(flatRows.map((r, i) => [r.path, i] as const)),
     [flatRows],
@@ -193,23 +200,23 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
   // ---------------------------------------------------------------------------
 
   // Lazily read a directory's children into the cache (one fsReadDir level).
-  const ensureChildrenLoaded = useCallback(async (path: string) => {
-    if (!window.electronAPI || childrenCache.has(path)) return
-    setLoadingPaths((s) => new Set(s).add(path))
-    try {
-      const entries = await window.electronAPI.fsReadDir(path, selectedWorkspaceId)
-      setChildrenCache((prev) => new Map(prev).set(path, entries))
-    } catch {
-      // Cache an empty array so an unreadable folder doesn't retry-loop.
-      setChildrenCache((prev) => new Map(prev).set(path, []))
-    } finally {
-      setLoadingPaths((s) => {
-        const n = new Set(s)
-        n.delete(path)
-        return n
+  const ensureChildrenLoaded = useCallback((path: string): Promise<void> => {
+    if (childrenCacheRef.current.has(path)) return Promise.resolve()
+    const pending = childRequests.current.get(path)
+    if (pending) return pending
+    const refresh = refreshRef.current
+    if (!refresh) return Promise.resolve()
+    setLoadingPaths((previous) => new Set(previous).add(path))
+    const request = refresh.request(path).finally(() => {
+      if (refreshRef.current !== refresh) return
+      childRequests.current.delete(path)
+      setLoadingPaths((previous) => {
+        const next = new Set(previous); next.delete(path); return next
       })
-    }
-  }, [childrenCache, selectedWorkspaceId])
+    })
+    childRequests.current.set(path, request)
+    return request
+  }, [])
 
   const expand = useCallback(async (path: string) => {
     setExpandedPaths((s) => (s.has(path) ? s : new Set(s).add(path)))
@@ -230,151 +237,76 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
     else void expand(path)
   }, [expandedPaths, expand, collapse])
 
-  // Re-read the children of every currently-expanded folder from disk and prune
-  // any expanded paths that no longer exist. Called after a (re)load so reloads,
-  // fs-watch events, and create/move/delete reflect on-disk state. Expansion
-  // itself is preserved across reloads (only vanished paths are dropped). Reads
-  // expandedPaths via a ref so this callback stays stable for loadTree.
-  const refreshExpandedChildren = useCallback(async () => {
-    if (!window.electronAPI) return
-    const paths = [...expandedPathsRef.current]
-    if (paths.length === 0) {
-      // Nothing expanded → drop stale cache so a later expand reads fresh.
-      setChildrenCache((prev) => (prev.size === 0 ? prev : new Map()))
-      return
-    }
-    const results = await Promise.all(
-      paths.map(async (p) => {
-        try {
-          return [p, await window.electronAPI!.fsReadDir(p, selectedWorkspaceId)] as const
-        } catch {
-          return [p, null] as const // null = path gone / unreadable
-        }
-      }),
-    )
-    // Rebuild the cache from the expanded set only; collapsed folders re-read on
-    // next expand. Orphaned entries (parent pruned) are simply not walked.
-    setChildrenCache(() => {
-      const next = new Map<string, FileTreeNodeType[]>()
-      for (const [p, kids] of results) {
-        if (kids) next.set(p, kids)
-      }
-      return next
-    })
-    setExpandedPaths((prev) => {
-      let changed = false
-      const next = new Set(prev)
-      for (const [p, kids] of results) {
-        if (kids === null && next.has(p)) {
-          next.delete(p)
-          changed = true
-        }
-      }
-      return changed ? next : prev
-    })
-  }, [selectedWorkspaceId])
-
-  // ---------------------------------------------------------------------------
-  // Load tree
-  // ---------------------------------------------------------------------------
-
-  const loadTree = useCallback(async (dirPath: string, attempt = 0) => {
-    if (!window.electronAPI) return
-
-    setIsLoading(true)
-    try {
-      const entries = await window.electronAPI.fsReadDir(dirPath, selectedWorkspaceId)
-
-      // Git decorations are owned by gitStatusStore (see useGitTreeFor above);
-      // loadTree only refreshes the on-disk file structure now.
-      setNodes(entries)
-      // Re-read every expanded folder so the refreshed root read propagates the
-      // whole way down the tree (and prune folders that vanished on disk).
-      void refreshExpandedChildren()
-      setIsLoading(false)
-    } catch (err) {
-      // The read was rejected (e.g. the root path isn't registered as an allowed
-      // root in main yet — see FS_READ_RETRIES note). Retry a few times before
-      // giving up, but bail if the root changed underneath us in the meantime.
-      if (attempt < FS_READ_RETRIES && rootPathRef.current === dirPath) {
-        loadRetryTimerRef.current = window.setTimeout(
-          () => loadTree(dirPath, attempt + 1),
-          FS_READ_RETRY_DELAY_MS,
-        )
-        return
-      }
-      log.warn('[file-explorer] Load tree failed:', err)
-      setNodes([])
-      setIsLoading(false)
-    }
-  }, [refreshExpandedChildren, selectedWorkspaceId])
-
-  // ---------------------------------------------------------------------------
-  // Watch for filesystem changes
-  // ---------------------------------------------------------------------------
-
+  // All filesystem-triggered reads share one queue. Preserve untouched cache
+  // entries so unrelated branches retain their identities.
   useEffect(() => {
     rootPathRef.current = rootPath
-
-    // Clean up previous watcher
-    if (cleanupRef.current) {
-      cleanupRef.current()
-      cleanupRef.current = null
-    }
-
-    // Cancel any in-flight load retry from a previous root.
-    if (loadRetryTimerRef.current !== null) {
-      window.clearTimeout(loadRetryTimerRef.current)
-      loadRetryTimerRef.current = null
-    }
-
+    childRequests.current.clear()
+    setNodes([])
+    setChildrenCache(new Map())
+    setExpandedPaths(new Set())
+    setSelectedPaths(new Set())
+    setLoadingPaths(new Set())
     if (!rootPath || !window.electronAPI) return
-
-    // Initial load
-    loadTree(rootPath)
-
-    // Watch via the shared refcounted manager (one underlying watcher per root,
-    // multiplexed) so the Explorer and the Search view's git-tree watcher don't
-    // tear down each other's subscription. Coalesce bursts (e.g. a build writing
-    // many files) with a short trailing debounce.
-    const scheduleReload = () => {
-      if (rootPathRef.current !== rootPath) return
-      if (reloadTimerRef.current) clearTimeout(reloadTimerRef.current)
-      reloadTimerRef.current = setTimeout(() => {
-        reloadTimerRef.current = null
-        if (rootPathRef.current === rootPath) loadTree(rootPath)
-      }, 150)
-    }
-    const releaseWatch = watchFsRoot(rootPath, scheduleReload, selectedWorkspaceId)
-
-    // Reload when the exclusions list changes so hidden/shown folders update
-    // without a relaunch.
-    const unsubscribeSettings = window.electronAPI.onSettingsChanged((key) => {
-      if (key === 'fileExclusions' && rootPathRef.current === rootPath) {
-        loadTree(rootPath)
-      }
+    let disposed = false
+    setIsLoading(true)
+    const refresh = createExplorerRefresh<FileTreeNodeType[]>({
+      root: rootPath,
+      loaded: () => [...childrenCacheRef.current.keys(), ...childRequests.current.keys()],
+      read: async (path) => {
+        for (let attempt = 0; ; attempt++) {
+          try {
+            perfCount('explorerDirectoryRead')
+            if (disposed) return []
+            return await window.electronAPI.fsReadDir(path, selectedWorkspaceId)
+          } catch (error) {
+            if (disposed || path !== rootPath || attempt >= FS_READ_RETRIES) throw error
+            await new Promise<void>((resolve) => setTimeout(resolve, FS_READ_RETRY_DELAY_MS))
+          }
+        }
+      },
+      apply: (path, entries) => {
+        if (path === rootPath) { setNodes(entries ?? []); setIsLoading(false) }
+        else setChildrenCache((previous) => {
+          const next = new Map(previous)
+          if (entries) next.set(path, entries)
+          else next.delete(path)
+          childrenCacheRef.current = next
+          return next
+        })
+        if (!entries) setExpandedPaths((previous) => {
+          if (!previous.has(path)) return previous
+          const next = new Set(previous); next.delete(path); return next
+        })
+      },
+      remove: (path) => {
+        const normalized = path.replace(/\\/g, '/')
+        const under = (key: string) => {
+          const value = key.replace(/\\/g, '/')
+          return value === normalized || value.startsWith(normalized + '/')
+        }
+        setChildrenCache((previous) => new Map([...previous].filter(([key]) => !under(key))))
+        setExpandedPaths((previous) => new Set([...previous].filter((key) => !under(key))))
+      },
     })
-
-    cleanupRef.current = () => {
-      if (reloadTimerRef.current) {
-        clearTimeout(reloadTimerRef.current)
-        reloadTimerRef.current = null
-      }
+    refreshRef.current = refresh
+    refresh.refresh([rootPath])
+    const releaseWatch = watchFsRoot(rootPath, refresh.event, selectedWorkspaceId)
+    const unsubscribeSettings = window.electronAPI.onSettingsChanged((key) => {
+      if (key === 'fileExclusions') refresh.refresh([rootPath, ...childrenCacheRef.current.keys()])
+    })
+    return () => {
+      disposed = true
+      refresh.dispose()
+      refreshRef.current = null
       releaseWatch()
       unsubscribeSettings()
     }
+  }, [rootPath, selectedWorkspaceId])
 
-    return () => {
-      if (cleanupRef.current) {
-        cleanupRef.current()
-        cleanupRef.current = null
-      }
-      if (loadRetryTimerRef.current !== null) {
-        window.clearTimeout(loadRetryTimerRef.current)
-        loadRetryTimerRef.current = null
-      }
-    }
-  }, [rootPath, loadTree, selectedWorkspaceId])
+  const loadTree = useCallback((_dirPath: string) => {
+    refreshRef.current?.refresh([rootPath, ...childrenCacheRef.current.keys()])
+  }, [rootPath])
 
   // Inline Explorer search is a lightweight name-only tree filter ("filter on
   // type"). Full content search now lives in the dedicated Search view.
@@ -433,11 +365,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
   const moveCursorTo = useCallback((path: string) => {
     setSelectedPaths(new Set([path]))
     lastSelectedPath.current = path
-    requestAnimationFrame(() => {
-      treeContainerRef.current
-        ?.querySelector<HTMLElement>(`[data-filepath="${CSS.escape(path)}"]`)
-        ?.scrollIntoView({ block: 'nearest' })
-    })
+    virtualRowsRef.current?.reveal(path)
   }, [])
 
   const handleFileOpen = useCallback(
@@ -536,6 +464,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
     const targetDir = getSelectedDir()
     if (targetDir && targetDir !== rootPath) {
       // Delegate creation to the selected folder's FileTreeNode
+      virtualRowsRef.current?.reveal(targetDir)
       createSeqRef.current++
       setCreateRequest({ type, targetDir, seq: createSeqRef.current })
     } else {
@@ -740,7 +669,7 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
       ) : (
         <div
           ref={treeContainerRef}
-          className="flex-1 overflow-y-auto py-1 outline-none"
+          className="relative flex-1 overflow-y-auto py-1 outline-none"
           // Focusable + tagged so Delete/Backspace (incl. Cmd+Backspace) deletes
           // the selection here instead of being swallowed by the canvas-level
           // shortcut handler. Focused explicitly from onSelect (draggable rows
@@ -781,29 +710,37 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
           {isFiltering && flatRows.length === 0 ? (
             <div className="flex items-center justify-center py-4 text-xs text-muted">No matches</div>
           ) : (
-            nodes.map((node) => (
-              <FileTreeNode
-                key={node.path}
-                node={node}
-                depth={0}
-                git={gitTree}
-                selectedPaths={selectedPaths}
-                expandedPaths={effectiveExpanded}
-                childrenCache={childrenCache}
-                loadingPaths={loadingPaths}
-                onSelect={handleSelect}
-                onFileOpen={handleFileOpen}
-                onToggleExpand={toggleExpand}
-                onExpand={expand}
-                onDeletePaths={deletePaths}
-                onTreeChanged={handleReload}
-                rootPath={rootPath}
-                workspaceId={selectedWorkspaceId}
-                isPathVisible={isPathVisible}
-                createRequest={createRequest}
-                onCreateRequestHandled={() => setCreateRequest(null)}
-              />
-            ))
+            <VirtualFileRows
+              ref={virtualRowsRef}
+              scrollRef={treeContainerRef}
+              paths={flatPaths}
+              pinned={new Set([...editingPaths, ...(createRequest ? [createRequest.targetDir] : [])])}
+              renderRow={(index) => {
+                const { node, depth } = flatRows[index]
+                return <FileTreeNode
+                  key={node.path}
+                  flat
+                  onEditingChange={onEditingChange}
+                  node={node}
+                  depth={depth}
+                  git={gitTree}
+                  selectedPaths={selectedPaths}
+                  expandedPaths={effectiveExpanded}
+                  childrenCache={childrenCache}
+                  loadingPaths={loadingPaths}
+                  onSelect={handleSelect}
+                  onFileOpen={handleFileOpen}
+                  onToggleExpand={toggleExpand}
+                  onExpand={expand}
+                  onDeletePaths={deletePaths}
+                  onTreeChanged={handleReload}
+                  rootPath={rootPath}
+                  workspaceId={selectedWorkspaceId}
+                  createRequest={createRequest}
+                  onCreateRequestHandled={() => setCreateRequest(null)}
+                />
+              }}
+            />
           )}
 
           {/* Inline create input for root-level creation (from empty space context menu) */}

--- a/src/renderer/sidebar/FileExplorer.tsx
+++ b/src/renderer/sidebar/FileExplorer.tsx
@@ -51,6 +51,16 @@ interface FlatRow {
   node: FileTreeNodeType
 }
 
+interface ExplorerView {
+  nodes: FileTreeNodeType[]
+  children: Map<string, FileTreeNodeType[]>
+  expanded: Set<string>
+  selected: Set<string>
+}
+// Two recently visited roots paint immediately while their loaded directories
+// revalidate. Keep the cache bounded independently of the number of workspaces.
+const recentExplorerViews = new Map<string, ExplorerView>()
+
 export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeControl }) => {
   const [nodes, setNodes] = useState<FileTreeNodeType[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -239,17 +249,21 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
 
   // All filesystem-triggered reads share one queue. Preserve untouched cache
   // entries so unrelated branches retain their identities.
+  const viewRef = useRef<ExplorerView>({ nodes, children: childrenCache, expanded: expandedPaths, selected: selectedPaths })
   useEffect(() => {
     rootPathRef.current = rootPath
+    const cacheKey = `${selectedWorkspaceId}:${rootPath}`
+    const cached = recentExplorerViews.get(cacheKey)
     childRequests.current.clear()
-    setNodes([])
-    setChildrenCache(new Map())
-    setExpandedPaths(new Set())
-    setSelectedPaths(new Set())
+    setNodes(cached?.nodes ?? [])
+    setChildrenCache(cached?.children ?? new Map())
+    childrenCacheRef.current = cached?.children ?? new Map()
+    setExpandedPaths(cached?.expanded ?? new Set())
+    setSelectedPaths(cached?.selected ?? new Set())
     setLoadingPaths(new Set())
     if (!rootPath || !window.electronAPI) return
     let disposed = false
-    setIsLoading(true)
+    setIsLoading(!cached)
     const refresh = createExplorerRefresh<FileTreeNodeType[]>({
       root: rootPath,
       loaded: () => [...childrenCacheRef.current.keys(), ...childRequests.current.keys()],
@@ -290,12 +304,16 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
       },
     })
     refreshRef.current = refresh
-    refresh.refresh([rootPath])
+    void refresh.request(rootPath)
+    if (cached) refresh.refresh(cached.children.keys())
     const releaseWatch = watchFsRoot(rootPath, refresh.event, selectedWorkspaceId)
     const unsubscribeSettings = window.electronAPI.onSettingsChanged((key) => {
       if (key === 'fileExclusions') refresh.refresh([rootPath, ...childrenCacheRef.current.keys()])
     })
     return () => {
+      recentExplorerViews.delete(cacheKey)
+      recentExplorerViews.set(cacheKey, viewRef.current)
+      while (recentExplorerViews.size > 2) recentExplorerViews.delete(recentExplorerViews.keys().next().value!)
       disposed = true
       refresh.dispose()
       refreshRef.current = null
@@ -303,6 +321,9 @@ export const FileExplorer: React.FC<FileExplorerProps> = ({ rootPath, scopeContr
       unsubscribeSettings()
     }
   }, [rootPath, selectedWorkspaceId])
+  useEffect(() => {
+    viewRef.current = { nodes, children: childrenCache, expanded: expandedPaths, selected: selectedPaths }
+  }, [nodes, childrenCache, expandedPaths, selectedPaths])
 
   const loadTree = useCallback((_dirPath: string) => {
     refreshRef.current?.refresh([rootPath, ...childrenCacheRef.current.keys()])

--- a/src/renderer/sidebar/FileTreeNode.tsx
+++ b/src/renderer/sidebar/FileTreeNode.tsx
@@ -104,6 +104,8 @@ interface CreateRequest {
 }
 
 interface FileTreeNodeProps {
+  flat?: boolean
+  onEditingChange?: (path: string, editing: boolean) => void
   node: FileTreeNodeType
   depth: number
   /** Git decorations for the whole tree (undefined outside a git repo). */
@@ -138,6 +140,8 @@ interface FileTreeNodeProps {
 }
 
 export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
+  flat = false,
+  onEditingChange,
   node,
   depth,
   git,
@@ -163,6 +167,10 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   const isLoading = loadingPaths.has(node.path)
   const [isRenaming, setIsRenaming] = useState(false)
   const [isCreating, setIsCreating] = useState<'file' | 'folder' | null>(null)
+  useEffect(() => {
+    onEditingChange?.(node.path, isRenaming || Boolean(isCreating))
+    return () => onEditingChange?.(node.path, false)
+  }, [node.path, isRenaming, isCreating, onEditingChange])
   const [renameValue, setRenameValue] = useState(node.name)
   const [createValue, setCreateValue] = useState('')
   const [isDragOver, setIsDragOver] = useState(false)
@@ -318,10 +326,11 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     if (node.isDirectory) {
       void onExpand(node.path)
     }
+    onEditingChange?.(node.path, true)
     setCreateValue('')
     setIsCreating(type)
     setTimeout(() => createInputRef.current?.focus(), 0)
-  }, [node.isDirectory, node.path, onExpand])
+  }, [node.isDirectory, node.path, onExpand, onEditingChange])
 
   // Handle external create requests (from header buttons targeting a selected folder)
   const lastHandledSeqRef = useRef(0)
@@ -469,7 +478,10 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
   if (isPathVisible && !isPathVisible(node.path)) return null
 
   return (
-    <div>
+    <div className={flat ? 'relative' : undefined}>
+      {flat && Array.from({ length: depth }, (_, index) => (
+        <div key={index} className="absolute top-0 bottom-0 w-px bg-surface-5 pointer-events-none" style={{ left: index * 16 + 13 }} />
+      ))}
       {/* Node row */}
       <div
         data-filepath={node.path}
@@ -561,7 +573,7 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
       )}
 
       {/* Expanded children */}
-      {node.isDirectory && isExpanded && (
+      {!flat && node.isDirectory && isExpanded && (
         <div className="relative">
           <div
             className="absolute top-0 bottom-0 w-px bg-surface-5 pointer-events-none"

--- a/src/renderer/sidebar/VirtualFileRows.test.tsx
+++ b/src/renderer/sidebar/VirtualFileRows.test.tsx
@@ -1,0 +1,32 @@
+import React, { act, createRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { expect, it } from 'vitest'
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { VirtualFileRows, type VirtualFileRowsHandle } from './VirtualFileRows'
+
+it('bounds mounted rows, reveals keyboard targets, and retains offscreen editors', () => {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  const scroll = createRef<HTMLDivElement>()
+  const handle = createRef<VirtualFileRowsHandle>()
+  const paths = Array.from({ length: 5000 }, (_, i) => `file-${i}`)
+  const render = (pinned: Set<string>) => <div ref={scroll}>
+    <VirtualFileRows ref={handle} paths={paths} scrollRef={scroll} pinned={pinned}
+      renderRow={(index) => <input defaultValue={paths[index]} data-file={paths[index]} />} />
+  </div>
+  try {
+    act(() => root.render(render(new Set(['file-0']))))
+    expect(host.querySelectorAll('input').length).toBeLessThan(40)
+    const editing = host.querySelector<HTMLInputElement>('[data-file="file-0"]')!
+    editing.value = 'unfinished rename'
+    act(() => handle.current!.reveal('file-4999'))
+    expect(host.querySelector('[data-file="file-4999"]')).not.toBeNull()
+    expect(host.querySelector('[data-file="file-0"]')).toBe(editing)
+    expect(editing.value).toBe('unfinished rename')
+    expect(host.querySelectorAll('input').length).toBeLessThan(40)
+    act(() => root.render(render(new Set())))
+    expect(host.querySelector('[data-file="file-0"]')).toBeNull()
+  } finally { act(() => root.unmount()); host.remove() }
+})

--- a/src/renderer/sidebar/VirtualFileRows.tsx
+++ b/src/renderer/sidebar/VirtualFileRows.tsx
@@ -1,0 +1,111 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+export interface VirtualFileRowsHandle { reveal(path: string): void }
+interface Props {
+  paths: string[]
+  scrollRef: React.RefObject<HTMLDivElement>
+  pinned: ReadonlySet<string>
+  renderRow: (index: number) => React.ReactNode
+}
+const ROW_HEIGHT = 32
+const OVERSCAN = 6
+
+/** Variable row heights retain inline create/rename flows. Only the viewport,
+ * overscan, and actively edited rows remain mounted. Keyboard ordering remains
+ * owned by the explorer's full flat model. */
+export const VirtualFileRows = forwardRef<VirtualFileRowsHandle, Props>(function VirtualFileRows({ paths, scrollRef, pinned, renderRow }, ref) {
+  const [viewport, setViewport] = useState({ top: 0, height: 600 })
+  const [heights, setHeights] = useState<Map<string, number>>(new Map())
+  const elements = useRef(new Map<string, HTMLDivElement>())
+  const observer = useRef<ResizeObserver | null>(null)
+  const list = useRef<HTMLDivElement>(null)
+  const offsets = useMemo(() => {
+    const result = [0]
+    for (const path of paths) result.push(result[result.length - 1] + (heights.get(path) ?? ROW_HEIGHT))
+    return result
+  }, [paths, heights])
+
+  useLayoutEffect(() => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    const update = () => setViewport({ top: Math.max(0, scroll.scrollTop - (list.current?.offsetTop ?? 0)), height: scroll.clientHeight || 600 })
+    update()
+    scroll.addEventListener('scroll', update, { passive: true })
+    const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(update)
+    resize?.observe(scroll)
+    return () => { scroll.removeEventListener('scroll', update); resize?.disconnect() }
+  }, [scrollRef])
+
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return
+    const resize = new ResizeObserver((entries) => {
+      setHeights((previous) => {
+        let next = previous
+        for (const entry of entries) {
+          const path = (entry.target as HTMLElement).dataset.virtualPath!
+          const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height
+          if (height > 0 && (previous.get(path) ?? ROW_HEIGHT) !== height) {
+            if (next === previous) next = new Map(previous)
+            next.set(path, height)
+          }
+        }
+        return next
+      })
+    })
+    observer.current = resize
+    for (const element of elements.current.values()) resize.observe(element)
+    return () => { resize.disconnect(); observer.current = null }
+  }, [])
+
+  useEffect(() => {
+    const live = new Set(paths)
+    setHeights((previous) => {
+      if ([...previous.keys()].every((path) => live.has(path))) return previous
+      return new Map([...previous].filter(([path]) => live.has(path)))
+    })
+  }, [paths])
+
+  useImperativeHandle(ref, () => ({
+    reveal(path) {
+      const index = paths.indexOf(path)
+      const scroll = scrollRef.current
+      if (index < 0 || !scroll) return
+      const base = list.current?.offsetTop ?? 0
+      const top = offsets[index] + base
+      const bottom = offsets[index + 1] + base
+      if (top < scroll.scrollTop) scroll.scrollTop = top
+      else if (bottom > scroll.scrollTop + scroll.clientHeight) scroll.scrollTop = Math.max(0, bottom - (scroll.clientHeight || 600))
+      setViewport({ top: Math.max(0, scroll.scrollTop - base), height: scroll.clientHeight || 600 })
+    },
+  }), [paths, offsets, scrollRef])
+
+  const register = useCallback((path: string, element: HTMLDivElement | null) => {
+    const old = elements.current.get(path)
+    if (old) observer.current?.unobserve(old)
+    if (element) { elements.current.set(path, element); observer.current?.observe(element) }
+    else elements.current.delete(path)
+  }, [])
+  // Binary-search the first row intersecting the viewport.
+  let low = 0
+  let high = paths.length
+  while (low < high) {
+    const middle = (low + high) >>> 1
+    if (offsets[middle + 1] <= viewport.top) low = middle + 1
+    else high = middle
+  }
+  const start = Math.max(0, low - OVERSCAN)
+  let end = low
+  while (end < paths.length && offsets[end] < viewport.top + viewport.height) end++
+  end = Math.min(paths.length, end + OVERSCAN)
+  const indices = new Set(Array.from({ length: Math.max(0, end - start) }, (_, i) => start + i))
+  for (const path of pinned) { const index = paths.indexOf(path); if (index >= 0) indices.add(index) }
+
+  return <div ref={list} className="relative" style={{ height: offsets[offsets.length - 1] }} data-virtual-file-rows>
+    {[...indices].sort((a, b) => a - b).map((index) => (
+      <div key={paths[index]} ref={(element) => register(paths[index], element)} data-virtual-path={paths[index]}
+        style={{ position: 'absolute', display: 'flow-root', top: offsets[index], left: 0, right: 0 }}>
+        {renderRow(index)}
+      </div>
+    ))}
+  </div>
+})

--- a/src/renderer/sidebar/explorerRefresh.test.ts
+++ b/src/renderer/sidebar/explorerRefresh.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { createExplorerRefresh } from './explorerRefresh'
+
+afterEach(() => vi.useRealTimers())
+
+it('reads only affected loaded directories and ignores content-only edits', async () => {
+  vi.useFakeTimers()
+  const read = vi.fn(async () => ['file'])
+  const apply = vi.fn()
+  const remove = vi.fn()
+  const queue = createExplorerRefresh({ root: '/repo', loaded: () => ['/repo/a', '/repo/b'], read, apply, remove })
+  queue.event({ type: 'update', path: '/repo/a/file' })
+  queue.event({ type: 'create', path: '/repo/a/new' })
+  queue.event({ type: 'delete', path: '/repo/a/old' })
+  queue.event({ type: 'create', path: '/repository/unrelated' })
+  await vi.advanceTimersByTimeAsync(150)
+  expect(read.mock.calls).toEqual([['/repo/a']])
+  expect(apply).toHaveBeenCalledWith('/repo/a', ['file'])
+  expect(remove).toHaveBeenCalledWith('/repo/a/old')
+  queue.dispose()
+})
+
+it('retains changes during in-flight reads, caps concurrency, and drops disposed results', async () => {
+  vi.useFakeTimers()
+  const releases: Array<() => void> = []
+  const read = vi.fn(() => new Promise<string[]>((resolve) => releases.push(() => resolve(['new']))))
+  const apply = vi.fn()
+  const queue = createExplorerRefresh({ root: '/repo', loaded: () => [], read, apply, remove: vi.fn() })
+  queue.refresh(['/repo/a', '/repo/b', '/repo/c', '/repo/d', '/repo/e'])
+  await vi.advanceTimersByTimeAsync(150)
+  expect(read).toHaveBeenCalledTimes(4)
+  queue.refresh(['/repo/a'])
+  releases.splice(0).forEach((release) => release())
+  await vi.advanceTimersByTimeAsync(0)
+  expect(read).toHaveBeenCalledTimes(6)
+  expect(apply.mock.calls.map(([path]) => path)).not.toContain('/repo/a')
+  queue.dispose()
+  releases.forEach((release) => release())
+  await vi.advanceTimersByTimeAsync(0)
+  expect(apply).toHaveBeenCalledTimes(3)
+})

--- a/src/renderer/sidebar/explorerRefresh.ts
+++ b/src/renderer/sidebar/explorerRefresh.ts
@@ -1,0 +1,86 @@
+import type { FsWatchEvent } from '../lib/fs/fsWatchManager'
+
+/** Coalesced, bounded, single-flight directory refreshes. Events arriving during
+ * a read are retained for a follow-up pass; disposal suppresses stale results. */
+export function createExplorerRefresh<T>(options: {
+  root: string
+  loaded: () => Iterable<string>
+  read: (path: string) => Promise<T>
+  apply: (path: string, value: T | null) => void
+  remove: (path: string) => void
+}) {
+  const pending = new Set<string>()
+  const inFlight = new Set<string>()
+  const removedInFlight = new Set<string>()
+  const waiters = new Map<string, Array<() => void>>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let running = false
+  let disposed = false
+  const normalize = (path: string) => path.replace(/\\/g, '/').replace(/\/$/, '')
+  const root = normalize(options.root)
+  const flush = async () => {
+    timer = undefined
+    if (running || disposed) return
+    running = true
+    try {
+      while (pending.size && !disposed) {
+        const paths = [...pending].slice(0, 4)
+        paths.forEach((path) => pending.delete(path))
+        await Promise.all(paths.map(async (path) => {
+          inFlight.add(path)
+          let value: T | null = null
+          try { value = await options.read(path) } catch { /* deleted/unreadable */ }
+          inFlight.delete(path)
+          const removed = removedInFlight.delete(path)
+          if (!disposed && !pending.has(path)) {
+            if (!removed) options.apply(path, value)
+            for (const resolve of waiters.get(path) ?? []) resolve()
+            waiters.delete(path)
+          }
+        }))
+      }
+    } finally { running = false }
+  }
+  const refresh = (paths: Iterable<string>) => {
+    for (const path of paths) pending.add(path)
+    if (!disposed && !running && timer === undefined) timer = setTimeout(() => { void flush() }, 150)
+  }
+  return {
+    refresh,
+    request(path: string): Promise<void> {
+      if (disposed) return Promise.resolve()
+      const result = new Promise<void>((resolve) => {
+        const existing = waiters.get(path) ?? []
+        existing.push(resolve)
+        waiters.set(path, existing)
+      })
+      pending.add(path)
+      clearTimeout(timer)
+      void flush()
+      return result
+    },
+    event(event: FsWatchEvent) {
+      const path = normalize(event.path)
+      if (path !== root && !path.startsWith(root + '/')) return
+      const loaded = new Map([...options.loaded()].map((dir) => [normalize(dir), dir]))
+      loaded.set(root, options.root)
+      if (event.type === 'delete') {
+        options.remove(event.path)
+        for (const directory of inFlight) {
+          const normalized = normalize(directory)
+          if (normalized === path || normalized.startsWith(path + '/')) removedInFlight.add(directory)
+        }
+      }
+      // File-content updates do not change directory membership. Directory
+      // updates from watchers still invalidate that directory when loaded.
+      const target = event.type === 'update' ? path : path.substring(0, path.lastIndexOf('/'))
+      const directory = loaded.get(target)
+      if (directory) refresh([directory])
+    },
+    dispose() {
+      disposed = true; pending.clear(); clearTimeout(timer)
+      for (const callbacks of waiters.values()) for (const resolve of callbacks) resolve()
+      waiters.clear()
+    },
+  }
+}

--- a/src/renderer/stores/t3ActivityStore.test.ts
+++ b/src/renderer/stores/t3ActivityStore.test.ts
@@ -27,3 +27,16 @@ it('rejects stale snapshots and isolates a disconnected guest from sibling panel
   expect(state.panels.a.connected).toBe(true)
   expect(state.panels.b.connected).toBe(false)
 })
+
+it('applies ordered deltas without replacing unchanged threads or notifying on duplicate sequences', () => {
+  const store = useT3ActivityStore.getState()
+  store.update('repo', { connected: true, revision: 1, sequence: 1, threads: { a: { id: 'a', title: 'A' }, b: { id: 'b', title: 'B' } } })
+  const a = useT3ActivityStore.getState().instances.repo.threads.a
+  store.update('repo', { connected: true, revision: 2, sequence: 2, full: false, threads: { b: { id: 'b', title: 'New' } } })
+  expect(useT3ActivityStore.getState().instances.repo.threads.a).toBe(a)
+  const previous = useT3ActivityStore.getState()
+  store.update('repo', { connected: true, revision: 99, sequence: 2, threads: {} })
+  expect(useT3ActivityStore.getState()).toBe(previous)
+  store.update('repo', { connected: true, revision: 3, sequence: 3, full: false, threads: {}, removed: ['b'] })
+  expect(useT3ActivityStore.getState().instances.repo.threads).toEqual({ a })
+})

--- a/src/renderer/stores/t3ActivityStore.ts
+++ b/src/renderer/stores/t3ActivityStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { T3Thread } from '../lib/t3ThreadState'
 
-export interface T3Snapshot { connected: boolean; threads: Record<string, T3Thread>; revision: number; sequence?: number }
+export interface T3Snapshot { connected: boolean; threads: Record<string, T3Thread>; revision: number; sequence?: number; full?: boolean; removed?: string[] }
 interface Binding { workspaceId: string; partition: string; threadId?: string; connected?: boolean }
 interface T3ActivityStore {
   // Partition hashes runtime + checkout. Thread ids are only unique within that instance.
@@ -9,6 +9,7 @@ interface T3ActivityStore {
   panels: Record<string, Binding>
   bind: (panelId: string, binding: Binding) => void
   unbind: (panelId: string) => void
+  setConnected: (panelId: string, connected: boolean) => void
   update: (partition: string, snapshot: T3Snapshot, panelId?: string) => void
 }
 export const useT3ActivityStore = create<T3ActivityStore>((set) => ({
@@ -20,6 +21,10 @@ export const useT3ActivityStore = create<T3ActivityStore>((set) => ({
     if (partition && !Object.values(panels).some((p) => p.partition === partition)) delete instances[partition]
     return { panels, instances }
   }),
+  setConnected: (panelId, connected) => set((s) => {
+    const panel = s.panels[panelId]
+    return !panel || panel.connected === connected ? s : { panels: { ...s.panels, [panelId]: { ...panel, connected } } }
+  }),
   update: (partition, snapshot, panelId) => set((s) => {
     const binding = panelId ? s.panels[panelId] : undefined
     if (panelId && binding?.partition !== partition) return s
@@ -27,9 +32,15 @@ export const useT3ActivityStore = create<T3ActivityStore>((set) => ({
       ? { ...s.panels, [panelId]: { ...binding, connected: snapshot.connected } } : s.panels
     const previous = s.instances[partition]
     // Connections are per guest; thread state is shared and ordered by T3's sequence.
-    const accept = snapshot.connected && (!previous || (snapshot.sequence ?? 0) >= (previous.sequence ?? 0))
-    const instances = accept && JSON.stringify(previous) !== JSON.stringify(snapshot)
-      ? { ...s.instances, [partition]: snapshot } : s.instances
+    const accept = snapshot.connected && (!previous || (snapshot.sequence !== undefined && previous.sequence !== undefined
+      ? snapshot.sequence > previous.sequence
+      : snapshot.revision > previous.revision))
+    let instances = s.instances
+    if (accept) {
+      const threads = snapshot.full === false ? { ...previous?.threads, ...snapshot.threads } : snapshot.threads
+      for (const id of snapshot.removed ?? []) delete threads[id]
+      instances = { ...s.instances, [partition]: { connected: true, revision: snapshot.revision, sequence: snapshot.sequence, threads } }
+    }
     return panels === s.panels && instances === s.instances ? s : { panels, instances }
   }),
 }))

--- a/src/renderer/ui/PerfHud.tsx
+++ b/src/renderer/ui/PerfHud.tsx
@@ -15,7 +15,9 @@ import {
   PERF_ENABLED,
   getRenderCounts,
   getLongTasks,
+  isLongTaskObserverSupported,
   getFps,
+  getFrameTimes,
   resetPerfWindow,
 } from '../lib/perf/perfClient'
 
@@ -40,6 +42,7 @@ export default function PerfHud(): JSX.Element | null {
   const [visible, setVisible] = useState(true)
   const [snap, setSnap] = useState<PerfSnapshot | null>(null)
   const [fps, setFps] = useState(0)
+  const [frames, setFrames] = useState({ p95Ms: 0, maxMs: 0 })
   const [longTasks, setLongTasks] = useState({ count: 0, maxMs: 0 })
   const [renderRates, setRenderRates] = useState<RenderRate[]>([])
 
@@ -72,6 +75,7 @@ export default function PerfHud(): JSX.Element | null {
       const lt = getLongTasks()
       if (alive) {
         setFps(getFps())
+        setFrames(getFrameTimes())
         setLongTasks(lt)
         setRenderRates(rates.slice(0, 8))
       }
@@ -112,7 +116,7 @@ export default function PerfHud(): JSX.Element | null {
       <div className="flex gap-3 mb-1">
         <span className={fpsColor}>{fps} fps</span>
         <span className={longTasks.count > 0 ? 'text-amber-300' : 'text-zinc-400'}>
-          longtasks {longTasks.count}{longTasks.maxMs ? ` (max ${Math.round(longTasks.maxMs)}ms)` : ''}
+          {isLongTaskObserverSupported() ? `longtasks ${longTasks.count}` : 'longtasks unavailable'}{longTasks.maxMs ? ` (max ${Math.round(longTasks.maxMs)}ms)` : ''}
         </span>
       </div>
 
@@ -120,7 +124,7 @@ export default function PerfHud(): JSX.Element | null {
       {snap ? (
         <>
           <div className="text-zinc-400 mt-1.5 border-t border-subtle pt-1">
-            main · cpu <span className="text-zinc-100">{snap.totalCpu}%</span> ·{' '}
+            Electron · cpu <span className="text-zinc-100">{snap.totalCpu}%</span> ·{' '}
             {snap.focused ? 'focused' : <span className="text-amber-300">backgrounded</span>}
           </div>
           {snap.procs.slice(0, 5).map((p) => (
@@ -135,7 +139,7 @@ export default function PerfHud(): JSX.Element | null {
 
           {Object.keys(snap.spawnsPerSec).length > 0 && (
             <>
-              <div className="text-zinc-400 mt-1.5">subprocess spawns/s</div>
+              <div className="text-zinc-400 mt-1.5">runtime monitor spawns/s</div>
               {Object.entries(snap.spawnsPerSec).map(([k, v]) => (
                 <div key={k} className="flex justify-between text-zinc-300">
                   <span>{k}</span><span className={v > 2 ? 'text-amber-300' : 'text-zinc-400'}>{v}</span>
@@ -160,10 +164,17 @@ export default function PerfHud(): JSX.Element | null {
         <div className="text-zinc-500 mt-1">sampling main process…</div>
       )}
 
+      <div className="text-zinc-400">frame p95 {frames.p95Ms.toFixed(1)}ms · max {frames.maxMs.toFixed(1)}ms</div>
+      {snap?.runtimes?.map(({ id, sample, error }) => (
+        <div key={id} className="text-zinc-400 mt-1">
+          {id}: {sample ? `${sample.cpu.toFixed(1)}% core · ${Math.round(sample.rssMB)}MB RSS · loop p95 ${sample.eventLoop.p95Ms.toFixed(1)}ms` : `unavailable (${error})`}
+        </div>
+      ))}
+
       {/* Renderer render rates */}
       {renderRates.length > 0 && (
         <>
-          <div className="text-zinc-400 mt-1.5 border-t border-subtle pt-1">renders/s</div>
+          <div className="text-zinc-400 mt-1.5 border-t border-subtle pt-1">renders / work counters per second</div>
           {renderRates.map((r) => (
             <div key={r.name} className="flex justify-between text-zinc-300">
               <span className="truncate mr-2">{r.name}</span>

--- a/src/runtime/capabilities/process.ts
+++ b/src/runtime/capabilities/process.ts
@@ -9,6 +9,7 @@
 // shell + env). lsof-based cwd resolution is POSIX-only (null elsewhere).
 // =============================================================================
 
+import { countMonitorScan, countMonitorSpawn } from '../perf'
 import type { IPty } from 'node-pty'
 import os from 'os'
 import { execFile } from 'child_process'
@@ -40,6 +41,7 @@ const isLinux = process.platform === 'linux'
 /** ONE `ps` snapshot of the whole process table, indexed for tree walks. */
 function snapshotProcessTreePs(): Promise<ProcTree> {
   return new Promise((resolve) => {
+    countMonitorSpawn('ps')
     execFile('ps', ['-axo', 'pid=,ppid=,comm='], {
       encoding: 'utf-8',
       timeout: 3000,
@@ -81,6 +83,7 @@ function cwdForPid(pid: number): Promise<string | null> {
   if (process.platform === 'win32') return Promise.resolve(null)
   if (isLinux) return getCwdProc(pid)
   return new Promise((resolve) => {
+    countMonitorSpawn('lsof')
     execFile('lsof', ['-a', '-d', 'cwd', '-p', `${pid}`, '-Fn'], { encoding: 'utf-8', timeout: 2000 }, (err, stdout) => {
       if (err || !stdout) { return resolve(null) }
       const nameLine = stdout.split('\n').find((l) => l.startsWith('n'))
@@ -374,6 +377,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
     },
 
     async scanActivity(ids: string[]): Promise<Record<string, PtyActivity>> {
+      countMonitorScan('activity')
       const owned = ids
         // A suspended pty's process tree is frozen (SIGSTOP) — skip it so we
         // don't scan a stale snapshot of a stopped tree.
@@ -395,6 +399,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
     },
 
     async scanPorts(ids: string[]): Promise<Record<string, number[]>> {
+      countMonitorScan('ports')
       const owned = ids
         .map((id) => ({ id, pid: ptys.get(id)?.pid }))
         .filter((e): e is { id: string; pid: number } => e.pid != null)
@@ -426,6 +431,7 @@ export function createProcessCapability(deps: ProcessDeps): ProcessCapability {
       return new Promise((resolve) => {
         // `-a` ANDs the network filter with `-p <pids>` so lsof inspects ONLY
         // these process trees (without it lsof ORs the filters → whole system).
+        countMonitorSpawn('lsof')
         execFile('lsof', ['-iTCP', '-sTCP:LISTEN', '-P', '-n', '-a', '-p', pids.join(','), '-F', 'pn'], {
           timeout: 5000,
         }, (err, stdout) => {

--- a/src/runtime/perf.test.ts
+++ b/src/runtime/perf.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, it, vi } from 'vitest'
+
+vi.mock('node:perf_hooks', () => ({ monitorEventLoopDelay: () => ({ enable: vi.fn(), reset: vi.fn(), percentile: () => 20_000_000, max: 30_000_000 }) }))
+afterEach(() => vi.restoreAllMocks())
+
+it('enables counting explicitly and uses the actual sample interval', async () => {
+  vi.resetModules()
+  const { countMonitorScan, countMonitorSpawn, sampleRuntimePerf } = await import('./perf')
+  let now = 1000
+  vi.spyOn(performance, 'now').mockImplementation(() => now)
+  countMonitorSpawn('ps')
+  expect(sampleRuntimePerf().monitorSpawnsPerSec).toEqual({})
+  countMonitorSpawn('ps')
+  countMonitorSpawn('lsof')
+  countMonitorScan('activity')
+  now += 4000
+  const sample = sampleRuntimePerf()
+  expect(sample.windowMs).toBe(4000)
+  expect(sample.monitorSpawnsPerSec).toEqual({ ps: 0.25, lsof: 0.25 })
+  expect(sample.monitorScansPerSec).toEqual({ activity: 0.25 })
+  expect(sample.eventLoop).toEqual({ p95Ms: 20, maxMs: 30 })
+  now += 2000
+  expect(sampleRuntimePerf().monitorSpawnsPerSec).toEqual({})
+})

--- a/src/runtime/perf.ts
+++ b/src/runtime/perf.ts
@@ -1,0 +1,47 @@
+import { monitorEventLoopDelay } from 'node:perf_hooks'
+import type { RuntimePerfSample } from '../shared/types'
+
+let enabled = false
+const spawns = new Map<string, number>()
+const scans = new Map<string, number>()
+let previousAt = 0
+let previousCpu = process.cpuUsage()
+let delay: ReturnType<typeof monitorEventLoopDelay> | undefined
+
+/** Counts actual process-monitor launches, on the host that executes them. */
+export function countMonitorSpawn(command: string): void {
+  if (enabled) spawns.set(command, (spawns.get(command) ?? 0) + 1)
+}
+
+export function countMonitorScan(kind: string): void {
+  if (enabled) scans.set(kind, (scans.get(kind) ?? 0) + 1)
+}
+
+/** Profiling is enabled by an explicit RPC; normal daemon sessions pay no
+ * timer/observer cost. The first sample establishes the measurement baseline. */
+export function sampleRuntimePerf(): RuntimePerfSample {
+  const now = performance.now()
+  const cpu = process.cpuUsage()
+  const windowMs = enabled ? now - previousAt : 0
+  const sample: RuntimePerfSample = {
+    pid: process.pid,
+    platform: process.platform,
+    windowMs,
+    cpu: windowMs > 0 ? ((cpu.user - previousCpu.user + cpu.system - previousCpu.system) / (windowMs * 10)) : 0,
+    rssMB: process.memoryUsage().rss / 1024 / 1024,
+    monitorScansPerSec: Object.fromEntries([...scans].map(([name, count]) => [name, windowMs > 0 ? count * 1000 / windowMs : 0])),
+    monitorSpawnsPerSec: Object.fromEntries([...spawns].map(([name, count]) => [name, windowMs > 0 ? count * 1000 / windowMs : 0])),
+    eventLoop: { p95Ms: (delay?.percentile(95) ?? 0) / 1e6, maxMs: (delay?.max ?? 0) / 1e6 },
+  }
+  if (!enabled) {
+    enabled = true
+    delay = monitorEventLoopDelay({ resolution: 20 })
+    delay.enable()
+  }
+  delay?.reset()
+  spawns.clear()
+  scans.clear()
+  previousAt = now
+  previousCpu = cpu
+  return sample
+}

--- a/src/runtime/protocol.ts
+++ b/src/runtime/protocol.ts
@@ -63,6 +63,7 @@ export type AnyFrame = ClientFrame | ServerFrame
 
 export const Methods = {
   ping: 'ping',
+  perfSnapshot: 'perf.snapshot',
 
   validatePath: 'validatePath',
   validatePathStrict: 'validatePathStrict',

--- a/src/runtime/rpcServer.ts
+++ b/src/runtime/rpcServer.ts
@@ -10,6 +10,7 @@
 // capability set built inside the daemon (see index.ts / buildDaemonRuntime).
 // =============================================================================
 
+import { sampleRuntimePerf } from './perf'
 import { FrameDecoder, serializeFrame } from './jsonl'
 import {
   RUNTIME_PROTOCOL_VERSION,
@@ -114,6 +115,7 @@ export class RpcServer {
     const a = (i: number) => (p[i] ?? undefined) as FileAccessContext | undefined
 
     switch (method) {
+      case Methods.perfSnapshot: return sampleRuntimePerf()
       case Methods.ping:
         return 'pong'
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1709,13 +1709,30 @@ export interface PerfProcSample {
   memMB: number
 }
 
+/** Runtime-daemon CPU uses one core = 100%; remote hosts stay separate from
+ * Electron app metrics. Spawn counts cover ps/lsof process-monitor commands. */
+export interface RuntimePerfSample {
+  pid: number
+  platform: string
+  windowMs: number
+  cpu: number
+  rssMB: number
+  monitorSpawnsPerSec: Record<string, number>
+  monitorScansPerSec: Record<string, number>
+  eventLoop: { p95Ms: number; maxMs: number }
+}
+
 export interface PerfSnapshot {
+  /** Wall-clock sample boundary; distinguishes fresh samples from repeated reads. */
+  sampledAt?: number
   /** Sampling window in ms; all rates below are per-second. */
   windowMs: number
   focused: boolean
   totalCpu: number
   procs: PerfProcSample[]
+  /** Actual runtime process-monitor launches, summed across sampled hosts. */
   spawnsPerSec: Record<string, number>
+  runtimes?: Array<{ id: string; sample: RuntimePerfSample | null; error?: string }>
   ipc: Array<{ channel: string; kbPerSec: number; callsPerSec: number }>
   terminal: { kbPerSec: number; chunksPerSec: number }
 }


### PR DESCRIPTION
Browser and T3 panels could become misaligned when opening or closing the sidebar, and returning to a populated workspace recreated T3 guests and triggered bursts of renderer work. This change keeps surfaces aligned through layout changes and reduces the cost of warm workspace switches.

- Share browser geometry reads and batch writes, observe sidebar/ancestor layout changes, and preserve guest dimensions while parked.
- Retain T3 guests for the two most recently used workspaces, preserving dock visibility, keyboard focus, and detached-window ownership.
- Share incremental T3 metadata polling, isolate panel renders, virtualize the explorer, and retain recent explorer trees while revalidating them.
- Coalesce terminal atlas recovery and schedule optional WebGL upgrades across frames; avoid redundant territory-canvas backing-store resets.
- Prevent stopped Git monitors from restarting after an in-flight poll completes.
- Repair runtime spawn/scan accounting and add daemon CPU/RSS/event-loop metrics, frame distributions, independent long-task windows, JSON attachments, and optional CPU profiles.

The new transition test uses two workspaces with 18 visible panels each and measures eight warm switches. The recorded local comparison improved median panel readiness from 634 ms to 171 ms, worst readiness from 1,007 ms to 213 ms, and the longest long task from 182 ms to 104 ms. T3 guest recreation fell from eight switches to zero; browser guests and PTYs remained intact. These small local samples use a deterministic T3 fixture and are directional evidence, not portable latency guarantees. Monaco recreation and uneven WebGL grants remain documented follow-ups.

See `docs/performance.md` for reproduction instructions and `docs/workspace-transition-performance.md` for the measurements, CPU-profile findings, and limitations.

Validation:
- Production app/runtime builds, TypeScript, and targeted ESLint.
- Final PR branch: 71 focused unit tests passed across the run and isolated retry (one initial module-import timeout); the 36-panel transition E2E passed on the exact branch.
- Focused unit coverage for retained guests, Git monitor teardown, geometry, territory allocation, terminal lifecycle, explorer caching/virtualization, panel rendering, and profiling.
- All 14 original performance scenarios passed during the initial PR validation.
- Transition and T3 E2E coverage checks guest/PTY preservation, sidebar alignment, docking, drafts, keyboard focus, detached windows, and real conversation workspace switches.
