### PR TITLE
Fix coffee toggle to keep the display awake

### DIFF
--- a/src/main/ipc/keepAwake.test.ts
+++ b/src/main/ipc/keepAwake.test.ts
@@ -32,11 +32,11 @@ beforeEach(() => {
 })
 
 describe('keep awake', () => {
-  it('starts disabled, shares one blocker, and broadcasts changes to all windows', () => {
+  it('starts disabled, shares one display-sleep blocker, and broadcasts changes to all windows', () => {
     expect(invoke(KEEP_AWAKE_GET)).toBe(false)
     expect(invoke(KEEP_AWAKE_SET, true)).toBe(true)
     expect(invoke(KEEP_AWAKE_SET, true)).toBe(true)
-    expect(mocks.start).toHaveBeenCalledExactlyOnceWith('prevent-app-suspension')
+    expect(mocks.start).toHaveBeenCalledExactlyOnceWith('prevent-display-sleep')
     expect(invoke(KEEP_AWAKE_GET)).toBe(true)
     expect(mocks.broadcast).toHaveBeenLastCalledWith(KEEP_AWAKE_CHANGED, true)
 

--- a/src/main/ipc/keepAwake.ts
+++ b/src/main/ipc/keepAwake.ts
@@ -15,7 +15,7 @@ export function registerKeepAwakeHandlers(): void {
   ipcMain.handle(KEEP_AWAKE_SET, (_event, enabled: boolean) => {
     if (typeof enabled !== 'boolean') throw new TypeError('Expected a boolean')
     if (enabled) {
-      if (!isEnabled()) blockerId = powerSaveBlocker.start('prevent-app-suspension')
+      if (!isEnabled()) blockerId = powerSaveBlocker.start('prevent-display-sleep')
     } else {
       stop()
     }


### PR DESCRIPTION
The coffee toggle currently keeps the system active but still allows the screen to turn off. Switch the power-save blocker to `prevent-display-sleep` so enabling it keeps both the system and display awake. Disabling the toggle or quitting Cate still releases the blocker.

Updated the existing test to require a display-sleep blocker.

Validation: `npm test -- src/main/ipc/keepAwake.test.ts` — all 3 tests passed. Physical display idle behavior has not been manually tested.
