### PR TITLE
Fix Keep Awake toggle failing through the preload bridge

### DIFF
--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -3,6 +3,7 @@ import type { ElectronAPI } from '../shared/electron-api'
 import {
   DIALOG_SAVE_FILE,
   DIALOG_TERMINAL_LINK_OPEN,
+  KEEP_AWAKE_TOGGLE,
   MENU_POPUP_BAR_ITEM,
   TERMINAL_DATA,
   TERMINAL_RESIZE,
@@ -65,6 +66,17 @@ beforeEach(() => {
 })
 
 describe('electronAPI preload bridge', () => {
+  it('exposes the keep-awake toggle and returns its IPC result', async () => {
+    electron.invoke.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+    expect(await api.toggleKeepAwake()).toBe(true)
+    expect(await api.toggleKeepAwake()).toBe(false)
+    expect(electron.invoke.mock.calls).toEqual([
+      [KEEP_AWAKE_TOGGLE],
+      [KEEP_AWAKE_TOGGLE],
+    ])
+  })
+
   it('forwards invoke arguments and returns the original IPC promise', () => {
     const ipcResult = Promise.resolve('done')
     electron.invoke.mockReturnValueOnce(ipcResult)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -795,6 +795,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return ipcRenderer.invoke(WINDOW_SET_TITLE, title)
   },
 
+  toggleKeepAwake(): Promise<boolean> {
+    return ipcRenderer.invoke(KEEP_AWAKE_TOGGLE)
+  },
   getKeepAwake(): Promise<boolean> {
     return ipcRenderer.invoke(KEEP_AWAKE_GET)
   },


### PR DESCRIPTION
Clicking Keep Awake failed because the renderer called `toggleKeepAwake()`, which was missing from the preload bridge. Restore the method so the toolbar button and keyboard action reach the existing main-process power-save handler.

Add a preload regression test covering both enabled and disabled IPC results. The test reproduced `api.toggleKeepAwake is not a function` before the fix.

Validation:
- All 14 targeted preload, keep-awake handler, and toolbar tests pass.
- `npm run typecheck` passes.
- `git diff --check` passes.
