### PR TITLE
Fix agent status during approved commands

### DIFF
--- a/src/renderer/lib/agent/agentScreenDetector.test.ts
+++ b/src/renderer/lib/agent/agentScreenDetector.test.ts
@@ -210,6 +210,19 @@ describe('agent activity coordinator (hook FSM + presence edges)', () => {
     expect(state()).toBe('running')
   })
 
+  it('Codex PreToolUse keeps the sidebar running for an approved bash command', () => {
+    noteAgentPresence(PTY, true)
+    noteAgentHookEvent(hookEvent('turn-start', 'codex'))
+    noteAgentHookEvent(hookEvent('permission-wait', 'codex'))
+    expect(state()).toBe('waitingForInput')
+
+    noteAgentHookEvent(hookEvent('turn-resume', 'codex', { hook_event_name: 'PreToolUse' }))
+    expect(state()).toBe('running')
+
+    noteAgentPresence(PTY, true)
+    expect(state()).toBe('running')
+  })
+
   it('a Kiro Ctrl-C ends only its known active turn and stays silent', () => {
     noteAgentPresence(PTY, true)
     noteAgentHookEvent(hookEvent('turn-start', 'kiro'))

--- a/src/renderer/lib/agent/agentStatus.integration.test.ts
+++ b/src/renderer/lib/agent/agentStatus.integration.test.ts
@@ -168,6 +168,32 @@ describe('coding-agent hook status integration', () => {
     expect(state()).toBe('running')
   })
 
+  it('codex resumes when an approved bash command starts', () => {
+    emit('codex', { hook_event_name: 'UserPromptSubmit', session_id: SESSION, turn_id: 'turn-1' })
+    emit('codex', {
+      hook_event_name: 'PermissionRequest', session_id: SESSION, turn_id: 'turn-1', tool_name: 'Bash',
+    })
+    expect(state()).toBe('waitingForInput')
+
+    emit('codex', {
+      hook_event_name: 'PreToolUse', session_id: SESSION, turn_id: 'turn-1', tool_name: 'Bash',
+    })
+    expect(state()).toBe('running')
+  })
+
+  it('claude-code resumes when an approved bash command starts', () => {
+    emit('claude-code', { hook_event_name: 'UserPromptSubmit', session_id: SESSION })
+    emit('claude-code', {
+      hook_event_name: 'PermissionRequest', session_id: SESSION, tool_name: 'Bash',
+    })
+    expect(state()).toBe('waitingForInput')
+
+    emit('claude-code', {
+      hook_event_name: 'PreToolUse', session_id: SESSION, tool_name: 'Bash',
+    })
+    expect(state()).toBe('running')
+  })
+
   it.each(permissionFixtures)(
     '$agentId resumes as soon as the user submits a permission answer',
     ({ agentId, turnStart, permissionWait }) => {

--- a/src/runtime/capabilities/agentHookContracts.itest.ts
+++ b/src/runtime/capabilities/agentHookContracts.itest.ts
@@ -21,10 +21,9 @@
 //             reason=clear) + SessionStart(source=clear, new id). Works in
 //             -p and TUI.
 //             Permission-wait: PermissionRequest fires immediately before the
-//             approval UI. StopFailure closes API/error turns.
-//             PostToolUse fires once the approved tool FINISHES (denial
-//             produces none). Cate therefore resumes earlier from the user's
-//             terminal submission.
+//             approval UI. PreToolUse follows approval immediately before
+//             execution; PostToolUse fires once the tool finishes. StopFailure
+//             closes API/error turns.
 //   codex   · JSON-on-stdin hooks configured in <project root>/.codex/
 //             hooks.json (repo scope, discovered by codex itself —
 //             launch-method independent, unlike the six per-invocation -c
@@ -47,8 +46,9 @@
 //             Permission-wait: PermissionRequest hook (session_id, turn_id,
 //             tool_name, tool_input) — fires in exec mode too, where the
 //             unanswerable approval is then auto-rejected and the turn Stops.
-//             PostToolUse (label post_tool_use) fires only after an executed
-//             command finishes; Cate resumes earlier from terminal input.
+//             PreToolUse fires after approval, immediately before execution;
+//             PostToolUse fires only after the command finishes. Cate uses
+//             either as a resume edge, plus terminal input for older versions.
 //             Interrupt closes user-cancelled turns with the same turn_id.
 //   cursor  · JSON-on-stdin hooks configured in <workspace>/.cursor/hooks.json
 //             (project scope, discovered by the CLI itself; hooks landed in
@@ -427,9 +427,9 @@ describe.skipIf(!LIVE || !hasBin('claude'))('claude hook contract', () => {
     'ElicitationResult', 'ConfigChange', 'InstructionsLoaded', 'MessageDisplay',
   ]
 
-  /** The seven events claudeSpec actually injects in the shipped product. */
+  /** The eight events claudeSpec actually injects in the shipped product. */
   const SHIPPED_CLAUDE_EVENTS = [
-    'SessionStart', 'UserPromptSubmit', 'PermissionRequest', 'PostToolUse',
+    'SessionStart', 'UserPromptSubmit', 'PermissionRequest', 'PreToolUse', 'PostToolUse',
     'Stop', 'StopFailure', 'SessionEnd',
   ]
 
@@ -581,9 +581,9 @@ describe.skipIf(!LIVE || !hasBin('claude'))('claude hook contract', () => {
   })
 
   // PermissionRequest fires immediately before Claude displays an approval
-  // prompt. Approving runs the tool, so PostToolUse marks the turn as back in
-  // flight before it finally Stops.
-  test('TUI: PermissionRequest while blocked; approval resumes via PostToolUse', { retry: 1, timeout: 420_000 }, async () => {
+  // prompt. Approving runs PreToolUse before execution and PostToolUse after
+  // completion, so long-running commands resume at their actual start.
+  test('TUI: PermissionRequest while blocked; approval resumes via PreToolUse', { retry: 1, timeout: 420_000 }, async () => {
     const cwd = makeCwd('claude-perm')
     const eventsFile = join(cwd, 'events.jsonl')
     const bridge = writeBridge(cwd)
@@ -617,13 +617,16 @@ describe.skipIf(!LIVE || !hasBin('claude'))('claude hook contract', () => {
     expect(replayAgentState('claude-code', tid, events()), 'the workspace overview shows Claude awaiting approval')
       .toBe('waitingForInput')
 
-    // Approve (Enter accepts the highlighted "Yes"): the tool runs, PostToolUse
-    // pushes the back-in-flight signal, then the turn completes with Stop.
+    // Approve (Enter accepts the highlighted "Yes"): PreToolUse pushes the
+    // back-in-flight signal before the tool runs, then the turn completes.
     await tui.send('')
     expect(
       replayAgentState('claude-code', tid, events(), { permissionAnswered: true }),
       'submitting the approval resumes the overview before PostToolUse',
     ).toBe('running')
+    await tui.waitFor(() => byName(events(), 'PreToolUse').length > 0, 120_000, 'PreToolUse after approval')
+    expect(byName(events(), 'PreToolUse')[0].payload.session_id).toBe(id)
+    expect(byName(events(), 'PreToolUse')[0].payload.tool_name).toBe('Bash')
     await tui.waitFor(() => byName(events(), 'PostToolUse').length > 0, 120_000, 'PostToolUse after approval')
     expect(byName(events(), 'PostToolUse')[0].payload.session_id).toBe(id)
     expect(byName(events(), 'PostToolUse')[0].payload.tool_name).toBe('Bash')
@@ -751,6 +754,7 @@ describe.skipIf(!LIVE || !hasBin('codex'))('codex hook contract', () => {
     ['SessionStart', 'session_start'],
     ['UserPromptSubmit', 'user_prompt_submit'],
     ['PermissionRequest', 'permission_request'],
+    ['PreToolUse', 'pre_tool_use'],
     ['PostToolUse', 'post_tool_use'],
     ['Stop', 'stop'],
     ['Interrupt', 'interrupt'],

--- a/src/runtime/capabilities/agentHooks.test.ts
+++ b/src/runtime/capabilities/agentHooks.test.ts
@@ -179,7 +179,7 @@ describe('agentHooks capability', () => {
     expect((await post(url, tokenFor('rpty-other'), { agentId: 'claude-code', terminalId: 'rpty-9', payload: claudeStart })).status).toBe(401)
     // Unknown agent / untracked payload / missing terminal id → accepted, dropped.
     await post(url, tokenFor('rpty-9'), { agentId: 'nope', terminalId: 'rpty-9', payload: claudeStart })
-    await post(url, tokenFor('rpty-9'), { agentId: 'claude-code', terminalId: 'rpty-9', payload: { hook_event_name: 'PreToolUse' } })
+    await post(url, tokenFor('rpty-9'), { agentId: 'claude-code', terminalId: 'rpty-9', payload: { hook_event_name: 'PreCompact' } })
     await post(url, tokenFor(''), { agentId: 'claude-code', terminalId: '', payload: claudeStart })
     await new Promise((r) => setTimeout(r, 100))
     expect(events.length).toBe(1)
@@ -239,7 +239,7 @@ describe('agentHooks capability', () => {
     await waitFor(() => events.length === 1)
 
     // A payload that normalizes to null still proves the agent is alive.
-    await post(url, tokenFor('rpty-p'), { agentId: 'claude-code', terminalId: 'rpty-p', pid: 4242, payload: { hook_event_name: 'PreToolUse' } })
+    await post(url, tokenFor('rpty-p'), { agentId: 'claude-code', terminalId: 'rpty-p', pid: 4242, payload: { hook_event_name: 'PreCompact' } })
     await waitFor(() => calls.length === 2)
     expect(events.length).toBe(1) // still no normalized event
 
@@ -383,6 +383,7 @@ describe('agentHooks capability', () => {
     expect(Object.keys(claudeSettings.hooks)).toContain('Stop')
     expect(Object.keys(claudeSettings.hooks)).toContain('StopFailure')
     expect(Object.keys(claudeSettings.hooks)).toContain('PermissionRequest')
+    expect(Object.keys(claudeSettings.hooks)).toContain('PreToolUse')
     expect(Object.keys(claudeSettings.hooks)).not.toContain('Notification')
 
     // codex discovers <project>/.codex/hooks.json itself (repo scope) — the
@@ -391,6 +392,7 @@ describe('agentHooks capability', () => {
       hooks: Record<string, Array<{ hooks: Array<{ command: string; timeout: number }> }>>
     }
     expect(Object.keys(codexHooks.hooks)).toContain('PermissionRequest')
+    expect(Object.keys(codexHooks.hooks)).toContain('PreToolUse')
     expect(codexHooks.hooks.Interrupt[0].hooks[0].timeout).toBe(3)
     const { dir } = await cap.endpoint()
     expect(codexHooks.hooks.SessionStart[0].hooks[0]).toMatchObject({

--- a/src/shared/agentHooks.test.ts
+++ b/src/shared/agentHooks.test.ts
@@ -40,12 +40,15 @@ describe('claude spec', () => {
 
   const file = spec.projectFiles![0]
 
-  test('creates .claude/settings.local.json with the bridge on all seven hook events', () => {
+  test('creates .claude/settings.local.json with the bridge on all eight hook events', () => {
     expect(file.relPath).toBe('.claude/settings.local.json')
     const out = file.build(null, ctx)!
     const parsed = JSON.parse(out) as { hooks: Record<string, Array<{ hooks: Array<{ type: string; command: string }> }>> }
     expect(Object.keys(parsed.hooks).sort()).toEqual(
-      ['PermissionRequest', 'PostToolUse', 'SessionEnd', 'SessionStart', 'Stop', 'StopFailure', 'UserPromptSubmit'].sort(),
+      [
+        'PermissionRequest', 'PostToolUse', 'PreToolUse', 'SessionEnd',
+        'SessionStart', 'Stop', 'StopFailure', 'UserPromptSubmit',
+      ].sort(),
     )
     for (const groups of Object.values(parsed.hooks)) {
       expect(groups).toHaveLength(1)
@@ -113,7 +116,13 @@ describe('claude spec', () => {
     ).toBeNull()
   })
 
-  test('PostToolUse maps to turn-resume (approval resolution / ordinary tool call)', () => {
+  test('PreToolUse and PostToolUse map to turn-resume', () => {
+    expect(norm('claude-code', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'touch needs-approval.txt' },
+      ...base,
+    })?.kind).toBe('turn-resume')
     const resume = norm('claude-code', {
       hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
@@ -137,7 +146,7 @@ describe('codex spec', () => {
       hooks: Record<string, Array<{ hooks: Array<{ type: string; command: string; timeout: number }> }>>
     }
     expect(Object.keys(parsed.hooks).sort()).toEqual(
-      ['Interrupt', 'PermissionRequest', 'PostToolUse', 'SessionStart', 'Stop', 'UserPromptSubmit'].sort(),
+      ['Interrupt', 'PermissionRequest', 'PostToolUse', 'PreToolUse', 'SessionStart', 'Stop', 'UserPromptSubmit'].sort(),
     )
     expect(parsed.hooks.Interrupt).toEqual([
       { hooks: [{ type: 'command', command: ctx.bridgeCommand, timeout: 3 }] },
@@ -212,6 +221,10 @@ describe('codex spec', () => {
     expect(perm?.kind).toBe('permission-wait')
     expect(perm?.turnId).toBe('turn-1')
     expect(perm?.raw.turn_id).toBe('turn-1')
+    expect(
+      norm('codex', { hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'touch x' }, ...base })
+        ?.kind,
+    ).toBe('turn-resume')
     expect(
       norm('codex', { hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_input: { command: 'touch x' }, ...base })
         ?.kind,

--- a/src/shared/agentHooks.ts
+++ b/src/shared/agentHooks.ts
@@ -341,7 +341,7 @@ export function agentHookFolder(agentId: AgentId): string | null {
 
 const CLAUDE_EVENTS = [
   'SessionStart', 'UserPromptSubmit', 'PermissionRequest',
-  'PostToolUse', 'Stop', 'StopFailure', 'SessionEnd',
+  'PreToolUse', 'PostToolUse', 'Stop', 'StopFailure', 'SessionEnd',
 ]
 
 const claudeSpec: AgentHookSpec = {
@@ -372,9 +372,12 @@ const claudeSpec: AgentHookSpec = {
     switch (p.hook_event_name) {
       case 'SessionStart': return { kind: 'session-start', ...base }
       case 'UserPromptSubmit': return { kind: 'turn-start', ...base }
+      // PermissionRequest precedes the approval UI; PreToolUse follows the
+      // resolved approval immediately before execution. This also covers
+      // approvals granted by another hook, where no terminal Enter occurs.
+      case 'PreToolUse': return { kind: 'turn-resume', ...base }
       // Fires after EVERY executed tool call. This confirms the turn is still
-      // active, but is too late to represent approval resolution: an approved
-      // long-running tool fires it only after finishing.
+      // active and remains a fallback resume edge for older Claude versions.
       case 'PostToolUse': return { kind: 'turn-resume', ...base }
       case 'Stop': return { kind: 'turn-end', ...base }
       case 'StopFailure': return { kind: 'turn-end', ...base }
@@ -415,7 +418,9 @@ export function codexTrustedHash(label: string, command: string, timeout: number
 /** hooks.json event keys (CamelCase). Codex's own trust-state keys use
  *  snake_case labels of these same events — a codex quirk the live suite's
  *  trust harness mirrors. */
-const CODEX_EVENTS = ['SessionStart', 'UserPromptSubmit', 'PermissionRequest', 'PostToolUse', 'Stop', 'Interrupt']
+const CODEX_EVENTS = [
+  'SessionStart', 'UserPromptSubmit', 'PermissionRequest', 'PreToolUse', 'PostToolUse', 'Stop', 'Interrupt',
+]
 
 const CODEX_HOOK_TIMEOUT = 60
 
@@ -450,9 +455,12 @@ const codexSpec: AgentHookSpec = {
       case 'Stop': return { kind: 'turn-end', ...base }
       case 'Interrupt': return { kind: 'turn-end', ...base }
       case 'PermissionRequest': return { kind: 'permission-wait', ...base }
+      // Fires after an approval is resolved and immediately before the tool
+      // starts. This clears permission-wait while a long-running command is
+      // executing instead of leaving the UI blocked until PostToolUse.
+      case 'PreToolUse': return { kind: 'turn-resume', ...base }
       // Fires after EVERY executed tool call. This confirms the turn is still
-      // active, but is too late to represent approval resolution: an approved
-      // long-running tool fires it only after finishing.
+      // active and remains a fallback resume edge for older Codex versions.
       case 'PostToolUse': return { kind: 'turn-resume', ...base }
       // SessionEnd never fires (pinned live) — no mapping on purpose.
       default: return null


### PR DESCRIPTION
## Summary
- subscribe to Codex and Claude Code PreToolUse hooks
- resume the workspace sidebar status when an approved command begins
- retain existing terminal-input and post-tool fallback behavior
- add normalization, hook-generation, FSM, integration, and live-contract coverage

## Verification
- npx vitest run src/shared/agentHooks.test.ts src/renderer/lib/agent/agentScreenDetector.test.ts src/renderer/lib/agent/agentStatus.integration.test.ts src/runtime/capabilities/agentHooks.test.ts src/runtime/capabilities/process.agentStatus.test.ts
- npm run build