### PR TITLE
Fix duplicate worktree colors during initial sync

### DIFF
--- a/src/renderer/lib/worktreeSync.test.tsx
+++ b/src/renderer/lib/worktreeSync.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null),
+  })
+})
+
+import { useAppStore } from '../stores/appStore'
+import { syncWorktrees, type GitWorktree } from './worktreeSync'
+
+const ROOT = '/repo'
+const FEATURE = `${ROOT}/.cate/worktrees/feature`
+const THIRD = `${ROOT}/.cate/worktrees/third`
+const initialAppState = useAppStore.getState()
+
+function gitWorktree(path: string, branch: string): GitWorktree {
+  return { path, branch, isBare: false, isCurrent: path === ROOT }
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    ...initialAppState,
+    workspaces: [{
+      id: 'ws',
+      name: 'Repo',
+      color: '',
+      rootPath: ROOT,
+      panels: {},
+    }],
+    selectedWorkspaceId: 'ws',
+  }, true)
+  ;(window as unknown as { electronAPI: unknown }).electronAPI = {
+    gitIsRepo: vi.fn().mockResolvedValue(true),
+    gitWorktreeList: vi.fn().mockResolvedValue([
+      gitWorktree(ROOT, 'main'),
+      gitWorktree(FEATURE, 'feature'),
+    ]),
+  }
+})
+
+afterEach(() => {
+  useAppStore.setState(initialAppState, true)
+})
+
+describe('syncWorktrees', () => {
+  it('assigns distinct colors when the primary and first secondary worktree are discovered together', async () => {
+    await syncWorktrees('ws')
+
+    const firstSync = useAppStore.getState().workspaces[0].worktrees ?? []
+    expect(firstSync.map((worktree) => worktree.path)).toEqual([ROOT, FEATURE])
+    expect(new Set(firstSync.map((worktree) => worktree.color)).size).toBe(2)
+
+    vi.mocked(window.electronAPI.gitWorktreeList).mockResolvedValueOnce([
+      gitWorktree(ROOT, 'main'),
+      gitWorktree(FEATURE, 'feature'),
+      gitWorktree(THIRD, 'third'),
+    ])
+    await syncWorktrees('ws')
+
+    const secondSync = useAppStore.getState().workspaces[0].worktrees ?? []
+    expect(secondSync.map((worktree) => worktree.path)).toEqual([ROOT, FEATURE, THIRD])
+    expect(new Set(secondSync.map((worktree) => worktree.color)).size).toBe(3)
+  })
+})

--- a/src/renderer/lib/worktreeSync.ts
+++ b/src/renderer/lib/worktreeSync.ts
@@ -59,9 +59,9 @@ export async function syncWorktrees(workspaceId: string): Promise<WorktreeSyncRe
   store.ensurePrimaryWorktree(workspaceId)
 
   // Re-read after ensurePrimaryWorktree so we diff against the freshest list.
-  const current = store.workspaces.find((w) => w.id === workspaceId)
+  const current = useAppStore.getState().workspaces.find((w) => w.id === workspaceId)
   if (current) {
-    const existing = current.worktrees ?? []
+    let existing = current.worktrees ?? []
     // Match on a normalized key, not raw strings: git reports forward-slash
     // paths while rootPath/stored paths use the native separator, so on Windows
     // raw `===` would never match and every worktree would be re-added.
@@ -78,6 +78,7 @@ export async function syncWorktrees(workspaceId: string): Promise<WorktreeSyncRe
           color: pickWorktreeColor(existing),
         }
         store.upsertWorktree(workspaceId, meta)
+        existing = [...existing, meta]
       }
     }
   }


### PR DESCRIPTION
## Summary
- re-read workspace state after ensuring the primary worktree
- include newly discovered worktrees when selecting subsequent colors
- add regression coverage for the primary-to-two-worktree transition and a later third worktree

## Verification
- `npx vitest run src/renderer/lib/worktreeSync.test.tsx src/renderer/stores/worktreeColors.test.tsx`
- `npm run typecheck`
- `npm run build`