### PR TITLE
Fix changes icon alignment

### DIFF
--- a/src/renderer/canvas/AgentChangesPill.test.tsx
+++ b/src/renderer/canvas/AgentChangesPill.test.tsx
@@ -9,6 +9,18 @@ vi.mock('../stores/appStore', () => ({ useAppStore: { getState: () => ({ getWork
 import { AgentChangesPill } from './AgentChangesPill'
 
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+it('does not reserve label spacing while the changes chip is collapsed', () => {
+  const host = document.createElement('div')
+  const root = createRoot(host)
+  try {
+    act(() => root.render(<AgentChangesPill panel={{ id: 'panel', type: 'agent', title: 'Agent' } as PanelState} workspaceId="ws" />))
+    const button = host.querySelector<HTMLButtonElement>('[aria-label="Open agent changes"]')!
+    expect(button.classList).toContain('gap-0')
+    expect(button.classList).toContain('hover:gap-1')
+  } finally { act(() => root.unmount()) }
+})
+
 it.each(['terminal', 'agent'] as const)('opens the same panel-filtered picker from a %s chip', async (type) => {
   h.open.mockClear()
   const host = document.createElement('div')

--- a/src/renderer/canvas/AgentChangesPill.tsx
+++ b/src/renderer/canvas/AgentChangesPill.tsx
@@ -9,7 +9,7 @@ export function AgentChangesPill({ panel, workspaceId }: { panel: PanelState; wo
   const [error, setError] = useState('')
   return <>
     <button type="button" aria-label="Open agent changes" title={error || 'Changes from this panel'} disabled={busy}
-      className="group inline-flex h-[18px] items-center gap-1 rounded-full bg-surface-3 px-1 text-secondary hover:text-primary disabled:opacity-50"
+      className="group inline-flex h-[18px] items-center gap-0 rounded-full bg-surface-3 px-1 text-secondary transition-[gap] hover:gap-1 hover:text-primary disabled:opacity-50"
       onMouseDown={(event) => event.stopPropagation()}
       onClick={async (event) => {
         event.stopPropagation()


### PR DESCRIPTION
## Summary
- remove the reserved label gap while the Changes pill is collapsed
- restore the gap on hover as the label expands
- add regression coverage for the collapsed spacing

## Verification
- npm test -- --run src/renderer/canvas/AgentChangesPill.test.tsx
- npm run build