### PR TITLE
fix: prevent T3 provider process leaks

### DIFF
--- a/src/main/t3Agent/providerProfile.test.ts
+++ b/src/main/t3Agent/providerProfile.test.ts
@@ -55,8 +55,9 @@ describe('T3 provider profile', () => {
         claudeAgent: { enabled: true },
         cursor: { enabled: true },
         grok: { enabled: false, binaryPath: '/bin/grok' },
-        opencode: { enabled: true },
+        opencode: { enabled: false },
       },
+      cateProviderDefaultsVersion: 1,
     })
   })
 
@@ -67,10 +68,24 @@ describe('T3 provider profile', () => {
     expect(isProviderSecretFile('provider-env-example.txt')).toBe(false)
   })
 
-  it('makes Grok opt-in and preserves subsequent explicit enablement', () => {
+  it('makes process-launching providers opt-in and preserves subsequent explicit enablement', () => {
     const defaults = applyCateProviderDefaults({})
-    expect(defaults.providers).toMatchObject({ grok: { enabled: false }, codex: { enabled: true } })
-    expect(applyCateProviderDefaults({ providers: { grok: { enabled: true } } }).providers)
-      .toMatchObject({ grok: { enabled: true } })
+    expect(defaults.providers).toMatchObject({
+      grok: { enabled: false },
+      opencode: { enabled: false },
+      codex: { enabled: true },
+    })
+    expect(applyCateProviderDefaults({
+      cateProviderDefaultsVersion: 1,
+      providers: { grok: { enabled: true }, opencode: { enabled: true } },
+    }).providers).toMatchObject({ grok: { enabled: true }, opencode: { enabled: true } })
+  })
+
+  it('migrates the old bare OpenCode default but preserves configured OpenCode', () => {
+    expect(applyCateProviderDefaults({ providers: { opencode: { enabled: true } } }).providers)
+      .toMatchObject({ opencode: { enabled: false } })
+    expect(applyCateProviderDefaults({
+      providers: { opencode: { enabled: true, binaryPath: '/bin/opencode' } },
+    }).providers).toMatchObject({ opencode: { enabled: true, binaryPath: '/bin/opencode' } })
   })
 })

--- a/src/main/t3Agent/providerProfile.ts
+++ b/src/main/t3Agent/providerProfile.ts
@@ -1,6 +1,7 @@
 import { T3_AGENTS } from '../../shared/agents'
 
 const PROVIDER_SETTING_KEYS = [
+  'cateProviderDefaultsVersion',
   'providers',
   'providerInstances',
   'usageLimitSources',
@@ -11,26 +12,40 @@ const PROVIDER_SETTING_KEYS = [
 ] as const
 
 const CATE_DEFAULT_PROVIDER_KEYS = T3_AGENTS.map((agent) => agent.t3.driverId)
+const CATE_PROVIDER_DEFAULTS_VERSION = 1
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-/** Grok is opt-in because its CLI can launch interactive authentication. Keep
- * explicit user choices intact once a provider has been configured. */
+/** Grok and OpenCode are opt-in because probing them can launch CLI processes.
+ * Keep explicit user choices intact once a provider has been configured. */
 export function applyCateProviderDefaults(settings: Record<string, unknown>): Record<string, unknown> {
   const currentProviders = isRecord(settings.providers) ? settings.providers : {}
-  let changed = !isRecord(settings.providers)
+  const needsOpenCodeMigration = settings.cateProviderDefaultsVersion !== CATE_PROVIDER_DEFAULTS_VERSION
+  let changed = !isRecord(settings.providers) || needsOpenCodeMigration
   const providers = { ...currentProviders }
 
   for (const key of CATE_DEFAULT_PROVIDER_KEYS) {
     const current = providers[key]
+    if (
+      key === 'opencode'
+      && needsOpenCodeMigration
+      && isRecord(current)
+      && current.enabled === true
+      && Object.keys(current).every((setting) => setting === 'enabled')
+    ) {
+      providers[key] = { enabled: false }
+      continue
+    }
     if (isRecord(current) && typeof current.enabled === 'boolean') continue
-    providers[key] = { ...(isRecord(current) ? current : {}), enabled: key !== 'grok' }
+    providers[key] = { ...(isRecord(current) ? current : {}), enabled: key !== 'grok' && key !== 'opencode' }
     changed = true
   }
 
-  return changed ? { ...settings, providers } : settings
+  return changed
+    ? { ...settings, cateProviderDefaultsVersion: CATE_PROVIDER_DEFAULTS_VERSION, providers }
+    : settings
 }
 
 export function extractProviderProfile(settings: Record<string, unknown>): Record<string, unknown> {

--- a/src/runtime/capabilities/server.reap.test.ts
+++ b/src/runtime/capabilities/server.reap.test.ts
@@ -80,7 +80,37 @@ it('isolates E2E server bookkeeping from the installed app even with the same da
   vi.stubEnv('CATE_E2E_USER_DATA', '/tmp/cate-private-test/userdata')
   const testApp = serverPidFilePath('local')
   expect(testApp).not.toBe(installed)
-  expect(testApp).toBe(path.join('/tmp/cate-private-test/userdata', 'cate-runtime', 'ext-servers-local.json'))
+  expect(testApp).toBe(path.join('/tmp/cate-private-test/userdata', 'cate-runtime', `ext-servers-local-${process.pid}.json`))
+})
+
+it('killAll preserves bookkeeping owned by another capability with the same daemon id', async () => {
+  const first = createServerCapability({ daemonId: DAEMON_ID })
+  const second = createServerCapability({ daemonId: DAEMON_ID })
+  let firstExited!: () => void
+  let secondExited!: () => void
+  const firstExit = new Promise<void>(resolve => { firstExited = resolve })
+  const secondExit = new Promise<void>(resolve => { secondExited = resolve })
+  try {
+    const options = (id: string) => ({
+      id,
+      command: [process.execPath, '-e', "require('http').createServer((q,s)=>s.end('alive')).listen(process.env.PORT,'127.0.0.1')"],
+      cwd: process.cwd(), env: {}, portEnv: 'PORT', readyPath: '/', readyTimeoutMs: 5000,
+    })
+    const firstHandle = await first.start(options('first'), () => {}, () => firstExited())
+    const secondHandle = await second.start(options('second'), () => {}, () => secondExited())
+
+    first.killAll()
+    await firstExit
+
+    expect(JSON.parse(fs.readFileSync(serverPidFilePath(DAEMON_ID), 'utf8')))
+      .toEqual([expect.objectContaining({ pid: secondHandle.pid })])
+    expect(isAlive(firstHandle.pid)).toBe(false)
+    expect(isAlive(secondHandle.pid)).toBe(true)
+  } finally {
+    first.killAll()
+    second.killAll()
+    await Promise.allSettled([firstExit, secondExit])
+  }
 })
 
 

--- a/src/runtime/capabilities/server.ts
+++ b/src/runtime/capabilities/server.ts
@@ -37,18 +37,21 @@ export interface ServerDeps {
   daemonId?: string
 }
 
-/** Where this daemon records its live server children's pids, so a NEXT run for
- *  the same host can reap any it left orphaned (e.g. after a hard crash that
- *  skipped killAll). Keyed by the daemon id — stable across restarts for one
- *  host. Lives under the system temp dir (always writable, cleared on reboot). */
-export function serverPidFilePath(daemonId: string): string {
+function serverPidFileStem(daemonId: string): { root: string; stem: string } {
   // Sanitize the id into a safe filename component (ids are app-controlled, but
   // keep it defensive — they can contain path-ish characters).
   const safe = daemonId.replace(/[^a-zA-Z0-9_.-]/g, '_') || 'default'
-  const pidRoot = process.env.CATE_E2E === '1' && process.env.CATE_E2E_USER_DATA
+  const root = process.env.CATE_E2E === '1' && process.env.CATE_E2E_USER_DATA
     ? process.env.CATE_E2E_USER_DATA
     : os.tmpdir()
-  return path.join(pidRoot, 'cate-runtime', `ext-servers-${safe}.json`)
+  return { root: path.join(root, 'cate-runtime'), stem: `ext-servers-${safe}` }
+}
+
+/** Where this daemon records its live server children's pids. The owner pid
+ * keeps concurrent installed/dev Cate runtimes from overwriting each other. */
+export function serverPidFilePath(daemonId: string, ownerPid = process.pid): string {
+  const { root, stem } = serverPidFileStem(daemonId)
+  return path.join(root, `${stem}-${ownerPid}.json`)
 }
 
 interface PidRecord { pid: number; id: string; startedAt: number; ownerPid?: number }
@@ -75,26 +78,35 @@ function writePidFile(file: string, records: PidRecord[]): void {
  * another daemon uses the same id. Legacy records without an owner retain the
  * previous cleanup behavior. PID reuse can conservatively defer orphan cleanup. */
 export function reapOrphanServers(daemonId: string): void {
-  const file = serverPidFilePath(daemonId)
-  const retained: PidRecord[] = []
-  for (const rec of readPidFile(file)) {
-    if (rec.pid <= 0) continue
-    if (rec.ownerPid && rec.ownerPid > 0) {
-      try {
-        process.kill(rec.ownerPid, 0)
-        retained.push(rec)
-        continue
-      } catch (error) {
-        // Only ESRCH proves the owner is gone; lack of permission does not.
-        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+  const { root, stem } = serverPidFileStem(daemonId)
+  let files: string[] = []
+  try {
+    files = fs.readdirSync(root)
+      .filter((name) => name === `${stem}.json` || (name.startsWith(`${stem}-`) && name.endsWith('.json')))
+      .map((name) => path.join(root, name))
+  } catch { return }
+
+  for (const file of files) {
+    const retained: PidRecord[] = []
+    for (const rec of readPidFile(file)) {
+      if (rec.pid <= 0) continue
+      if (rec.ownerPid && rec.ownerPid > 0) {
+        try {
+          process.kill(rec.ownerPid, 0)
           retained.push(rec)
           continue
+        } catch (error) {
+          // Only ESRCH proves the owner is gone; lack of permission does not.
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+            retained.push(rec)
+            continue
+          }
         }
       }
+      try { process.kill(rec.pid, 'SIGKILL') } catch { /* ESRCH or perms: already gone */ }
     }
-    try { process.kill(rec.pid, 'SIGKILL') } catch { /* ESRCH or perms: already gone */ }
+    writePidFile(file, retained)
   }
-  writePidFile(file, retained)
 }
 
 /** A built server capability plus a killAll() so the daemon reaps every live
@@ -265,13 +277,15 @@ export function createServerCapability(deps: ServerDeps = {}): ServerCapability 
     },
 
     killAll(): void {
+      const ownedPids = new Set<number>()
       for (const child of children.values()) {
+        if (child.pid) ownedPids.add(child.pid)
         try { child.kill('SIGKILL') } catch { /* gone */ }
       }
       children.clear()
-      // Clean shutdown: drop the whole pid file so the next run has nothing stale
-      // to reap (the children we just killed are gone).
-      writePidFile(pidFile, [])
+      // Multiple runtime daemons can share an id. Remove only this capability's
+      // children so another daemon's live server remains discoverable/reapable.
+      writePidFile(pidFile, readPidFile(pidFile).filter((record) => !ownedPids.has(record.pid)))
     },
   }
 }


### PR DESCRIPTION
## Summary

- make OpenCode opt-in so provider discovery does not launch it for unused installations
- migrate the old bare auto-enabled OpenCode setting while preserving configured and subsequently enabled providers
- isolate external-server PID bookkeeping per runtime process so installed, development, and worktree Cate instances cannot overwrite each other
- continue reaping legacy shared PID records and preserve sibling runtime records during shutdown

## Verification

- npx vitest run src/main/t3Agent/providerProfile.test.ts src/runtime/capabilities/server.reap.test.ts src/runtime/capabilities/server.test.ts
- npm run build
- git diff --check