### PR TITLE
Preserve dock panel DOM through layout changes

### DIFF
--- a/src/renderer/docking/DockLayoutRenderer.tsx
+++ b/src/renderer/docking/DockLayoutRenderer.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
-import type { DockLayoutNode, DockTabStack as DockTabStackNode, PanelType } from '../../shared/types'
+import React, { useLayoutEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import type { DockLayoutNode, DockSplitNode, DockTabStack as DockTabStackNode, PanelType } from '../../shared/types'
 import { layoutMinimum } from './splitSizing'
 import DockSplitContainer from './DockSplitContainer'
 
@@ -9,23 +10,75 @@ interface DockLayoutRendererProps {
   getPanelType?: (panelId: string) => PanelType | undefined
 }
 
+function collectTabStacks(node: DockLayoutNode): DockTabStackNode[] {
+  if (node.type === 'tabs') return [node]
+  return node.children.flatMap(collectTabStacks)
+}
+
+function DockTabSlot({ host }: { host: HTMLDivElement }) {
+  const slotRef = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    const slot = slotRef.current
+    if (!slot) return
+    slot.appendChild(host)
+    return () => {
+      if (host.parentNode === slot) slot.removeChild(host)
+    }
+  }, [host])
+  return <div ref={slotRef} className="h-full w-full min-h-0 min-w-0" />
+}
+
 /** Shared recursive renderer for window docks and canvas-node mini-docks. */
 export default function DockLayoutRenderer({ layout, renderTabs, getPanelType }: DockLayoutRendererProps) {
   const minimum = layoutMinimum(layout, getPanelType)
-  const renderNode = (node: DockLayoutNode, isRoot: boolean): React.ReactNode => {
-    if (node.type === 'tabs') return renderTabs(node, isRoot)
+  const hostsRef = useRef(new Map<string, HTMLDivElement>())
+  const stacks = collectTabStacks(layout)
+  const stackIds = new Set(stacks.map((stack) => stack.id))
+  for (const id of hostsRef.current.keys()) {
+    if (!stackIds.has(id)) hostsRef.current.delete(id)
+  }
+  for (const stack of stacks) {
+    if (hostsRef.current.has(stack.id)) continue
+    const host = document.createElement('div')
+    host.className = 'h-full w-full min-h-0 min-w-0'
+    hostsRef.current.set(stack.id, host)
+  }
+  const renderNode = (node: DockLayoutNode): React.ReactNode => {
+    if (node.type === 'tabs') return <DockTabSlot host={hostsRef.current.get(node.id)!} />
     return (
       <DockSplitContainer
         key={node.id}
         node={node}
-        renderNode={(child) => renderNode(child, false)}
+        renderNode={renderNode}
         getPanelType={getPanelType}
       />
     )
   }
-  return <div data-dock-viewport className="h-full w-full min-h-0 min-w-0 overflow-auto">
-    <div style={{ width: '100%', height: '100%', minWidth: minimum.width, minHeight: minimum.height }}>
-      {renderNode(layout, true)}
+
+  // Keep the root component and keyed pane stable for the common first split.
+  // Portals above the mutable layout tree also preserve tab-stack instances
+  // when nested splits are introduced or collapsed around them.
+  const root: DockSplitNode = layout.type === 'split' ? layout : {
+    type: 'split',
+    id: '__dock_root__',
+    direction: 'horizontal',
+    children: [layout],
+    ratios: [1],
+  }
+  return <>
+    <div data-dock-viewport className="h-full w-full min-h-0 min-w-0 overflow-auto">
+      <div style={{ width: '100%', height: '100%', minWidth: minimum.width, minHeight: minimum.height }}>
+        <DockSplitContainer
+          node={root}
+          renderNode={renderNode}
+          getPanelType={getPanelType}
+        />
+      </div>
     </div>
-  </div>
+    {stacks.map((stack) => createPortal(
+      renderTabs(stack, layout.type === 'tabs' && stack.id === layout.id),
+      hostsRef.current.get(stack.id)!,
+      stack.id,
+    ))}
+  </>
 }

--- a/src/renderer/docking/SurfacePanels.test.tsx
+++ b/src/renderer/docking/SurfacePanels.test.tsx
@@ -138,6 +138,89 @@ it('opens the picker from the split button and closes its placeholder through th
   expect(collectPanelIds(dock.getState().zones.center.layout)).toHaveLength(2)
 })
 
+it('keeps the existing panel mounted when creating the first split', () => {
+  const mounted = vi.fn()
+  const unmounted = vi.fn()
+  function PanelContent() {
+    React.useEffect(() => {
+      mounted()
+      return unmounted
+    }, [])
+    return <div>Canvas content</div>
+  }
+  function StableDock() {
+    const workspace = useAppStore((s) => s.workspaces[0])
+    return <DockStoreProvider store={dock}>
+      <DockZone position="center" workspaceId="test"
+        renderPanel={(id) => id === 'original' ? <PanelContent /> : <div>{workspace.panels[id]?.title}</div>}
+        getPanelTitle={(id) => workspace.panels[id]?.title ?? ''}
+        onClosePanel={(id) => useAppStore.getState().closePanel('test', id)}
+      />
+    </DockStoreProvider>
+  }
+
+  act(() => root.render(<StableDock />))
+  expect(mounted).toHaveBeenCalledTimes(1)
+  act(() => host.querySelector<HTMLButtonElement>('[aria-label="Split Right"]')!.click())
+  expect(mounted).toHaveBeenCalledTimes(1)
+  expect(unmounted).not.toHaveBeenCalled()
+})
+
+it('keeps panels mounted through nested split creation and collapse', () => {
+  const mounts = new Map<string, number>()
+  const unmounts = new Map<string, number>()
+  function PanelContent({ id }: { id: string }) {
+    React.useEffect(() => {
+      mounts.set(id, (mounts.get(id) ?? 0) + 1)
+      return () => { unmounts.set(id, (unmounts.get(id) ?? 0) + 1) }
+    }, [id])
+    return <div data-stable-panel={id}>{id} content</div>
+  }
+  function StableDock() {
+    const workspace = useAppStore((s) => s.workspaces[0])
+    return <DockStoreProvider store={dock}>
+      <DockZone position="center" workspaceId="test"
+        renderPanel={(id) => <PanelContent id={id} />}
+        getPanelTitle={(id) => workspace.panels[id]?.title ?? ''}
+      />
+    </DockStoreProvider>
+  }
+  const addPanel = (id: string) => useAppStore.setState((state) => ({
+    workspaces: [{ ...state.workspaces[0], panels: {
+      ...state.workspaces[0].panels,
+      [id]: { id, type: 'terminal', title: id, isDirty: false },
+    } }],
+  }))
+
+  act(() => root.render(<StableDock />))
+  const originalElement = host.querySelector('[data-stable-panel="original"]')
+  act(() => {
+    addPanel('right')
+    dock.getState().dockPanel('right', 'center', { type: 'split', stackId, edge: 'right' })
+  })
+  const rightElement = host.querySelector('[data-stable-panel="right"]')
+  expect(mounts.get('original')).toBe(1)
+  expect(mounts.get('right')).toBe(1)
+
+  act(() => {
+    addPanel('below')
+    dock.getState().dockPanel('below', 'center', { type: 'split', stackId, edge: 'bottom' })
+  })
+  expect(mounts.get('original')).toBe(1)
+  expect(mounts.get('right')).toBe(1)
+  expect(unmounts.size).toBe(0)
+  expect(host.querySelector('[data-stable-panel="original"]')).toBe(originalElement)
+  expect(host.querySelector('[data-stable-panel="right"]')).toBe(rightElement)
+
+  act(() => dock.getState().undockPanel('below'))
+  expect(mounts.get('original')).toBe(1)
+  expect(mounts.get('right')).toBe(1)
+  expect(unmounts.get('original')).toBeUndefined()
+  expect(unmounts.get('right')).toBeUndefined()
+  expect(host.querySelector('[data-stable-panel="original"]')).toBe(originalElement)
+  expect(host.querySelector('[data-stable-panel="right"]')).toBe(rightElement)
+})
+
 it('places the new-tab menu after the last tab and creates only the selected type', () => {
   act(() => root.render(<FullDock />))
   const button = host.querySelector<HTMLButtonElement>('[aria-label="New Tab"]')!


### PR DESCRIPTION
## Summary

- keep dock tab stacks mounted independently from the mutable split-layout tree
- preserve existing canvas, terminal, and editor DOM through first splits, nested perpendicular splits, and split collapse
- retain existing root-tab behavior while moving stable DOM hosts between layout slots

## Verification

- `npx vitest run --project renderer` (106 files, 658 tests before base refresh)
- `npx vitest run src/renderer/docking/SurfacePanels.test.tsx src/renderer/docking/DockSplitContainer.drag.test.tsx`
- `npm run typecheck`
- `npm run build`

## Dependency

Stacked on #669 (`fix/t3-canvas-pan-lag`) so this PR contains only the dock DOM-stability changes.