### PR TITLE
chore(release): prepare 2.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.0.0-beta.3] - 2026-09-12
+
+This beta adds visual relationships between panels and new branch maintenance controls while improving docked panels, embedded agents, and canvas alignment.
+
+### Added
+
+- **Panel relationships**: connect panels from the canvas, choose how related context is shared with agents, and preserve those connections across sessions and panel transfers.
+- **Branch maintenance**: refresh branch state and clean up branches from Source Control, with runtime and CLI support for the underlying repository operations.
+
+### Changed
+
+- **Docked panel continuity**: preserve panel DOM state while changing dock layouts so embedded surfaces remain mounted through layout transitions.
+
+### Fixed
+
+- **Embedded T3 reliability**: prevent provider process leaks, keep agent surfaces aligned during canvas movement, and render glass-surface text crisply.
+- **Canvas and repository polish**: keep worktree territories aligned when moving between displays and correct the Changes icon alignment.
+
 ## [2.0.0-beta.2] - 2026-09-11
 
 This beta sharpens canvas, screenshot, file-preview, and dock workflows while improving responsiveness and agent reliability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cate",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cate",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "productName": "Cate",
   "description": "An infinite zoomable canvas IDE",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- update the release version to 2.0.0-beta.3
- document panel relations, branch maintenance, dock continuity, and T3/canvas fixes

## Verification
- npm run build
- npm run typecheck
- npm test (3821 passed, one filesystem watcher timeout; isolated rerun passed)
- npm run lint (baseline: 15 pre-existing errors on main)